### PR TITLE
set timeout on `yarn test` in Github Actions

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -58,6 +58,7 @@ jobs:
       with:
         fetch-depth: 3
     - name: test
+      timeout-minutes: 15
       run: |
            cd ./cli/tauri.js
            yarn


### PR DESCRIPTION
It has been hanging on MacOS builds. Although we would want to fix this hang long term. This is a temporary way to deal with it and prevent future occurrences of swamping the CI. It would be surprising if jest tests ran longer than 15 minutes.

**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
