### PR TITLE
fix(js-cli): Provide a helpful error message if devPath is not specified

### DIFF
--- a/cli/tauri.js/runner.js
+++ b/cli/tauri.js/runner.js
@@ -42,6 +42,10 @@ class Runner {
 
     this.devPath = devPath
 
+    if (!devPath) {
+      return Promise.reject(Error('devPath not specified, please check your tauri.conf.js'))
+    }
+
     const args = ['--path', devPath.startsWith('http') ? devPath : path.resolve(appDir, devPath)]
     const features = ['dev']
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Currently, running `tauri dev` when a `devPath` is not specified in `tauri.conf.js` returns the following error:

```
(node:10828) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'startsWith' of undefined
    at Runner.run (/Users/rajiv/.config/yarn/global/node_modules/tauri/runner.js:45:37)
    at Object.<anonymous> (/Users/rajiv/.config/yarn/global/node_modules/tauri/bin/tauri-dev.js:34:7)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Module.require (internal/modules/cjs/loader.js:852:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at tauri (/Users/rajiv/.config/yarn/global/node_modules/tauri/bin/tauri.js:33:5)
    at Object.<anonymous> (/Users/rajiv/.config/yarn/global/node_modules/tauri/bin/tauri.js:40:1)

```

Providing a message such as `Error: devPath not specified, please check your tauri.conf.js` will help users figure out what's wrong without having to look through the source code of the CLI to find what `Cannot read property 'startsWith' of undefined` means.