### PR TITLE
feat(runner/build): add error message for missing dist

### DIFF
--- a/cli/tauri.js/runner.js
+++ b/cli/tauri.js/runner.js
@@ -2,7 +2,7 @@ const
   chokidar = require('chokidar')
 const debounce = require('lodash.debounce')
 const path = require('path')
-const { readFileSync, writeFileSync } = require('fs-extra')
+const { readFileSync, writeFileSync, existsSync } = require('fs-extra')
 
 const
   { spawn } = require('./helpers/spawn')
@@ -134,7 +134,12 @@ class Runner {
     const inlinedAssets = []
 
     return new Promise((resolve, reject) => {
-      new Inliner(path.join(indexDir, 'index.html'), (err, html) => {
+      const distIndexPath = path.join(indexDir, 'index.html')
+      if (!existsSync(distIndexPath)) {
+        warn(`Error: cannot find index.html in "${indexDir}". Did you forget to build your web code or update the build.distDir in tauri.conf.js?`)
+        reject(new Error('Could not find index.html in dist dir.'))
+      }
+      new Inliner(distIndexPath, (err, html) => {
         if (err) {
           reject(err)
         } else {


### PR DESCRIPTION
If `distDir/index.html` cannot be found, print a helpful error message
Previously, a TypeError would occur

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
