### PR TITLE
fix(ci): Install webkit2gtk on ubuntu when building smoke tests via prod

### DIFF
--- a/.github/workflows/build-smoke-tests.yml
+++ b/.github/workflows/build-smoke-tests.yml
@@ -28,6 +28,11 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
           toolchain: stable
+    - name: install webkit2gtk (ubuntu only)
+      if: matrix.platform == 'ubuntu-latest'
+      run: |
+           sudo apt-get update
+           sudo apt-get install -y webkit2gtk-4.0
     - name: cache rust bin
       id: cache_rust_bin
       uses: actions/cache@v1


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The `via-prod` jobs are silently failing on Ubuntu (somehow, GitHub Actions thinks that the job passed even though it [failed](https://github.com/tauri-apps/tauri/pull/187/checks?check_run_id=357905199#step:11:107)) because `webkit2gtk` isn't installed