### PR TITLE
Created .gitignore to ignore WixTools

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+# compiling on windows donwloads WixTools to src-tauri
+**/src-tauri/WixTools/


### PR DESCRIPTION
Compiling on windows downloads WixTools to src-tauri/WixTools folder.
We don't want that polluting our repo