### PR TITLE
fix(examples): Ensure examples use tauri from source instead of crates.io

### DIFF
--- a/examples/react/create-react-app/src-tauri/Cargo.toml
+++ b/examples/react/create-react-app/src-tauri/Cargo.toml
@@ -27,7 +27,10 @@ serde_derive = "1.0"
 tiny_http = "0.6"
 phf = "0.7.24"
 includedir = "0.5.0"
-tauri = { version = "0.2.0", features = [ "edge" ] }
+
+  [dependencies.tauri]
+  path = "../../../../tauri"
+  features = [ "edge" ]
 
 [features]
 dev-server = [ "tauri/dev-server" ]

--- a/examples/react/next.js/src-tauri/Cargo.toml
+++ b/examples/react/next.js/src-tauri/Cargo.toml
@@ -27,7 +27,10 @@ serde_derive = "1.0"
 tiny_http = "0.6"
 phf = "0.7.24"
 includedir = "0.5.0"
-tauri = { version = "0.2.0", features = [ "edge" ] }
+
+  [dependencies.tauri]
+  path = "../../../../tauri"
+  features = [ "edge" ]
 
 [features]
 dev-server = [ "tauri/dev-server" ]

--- a/examples/svelte/svelte-app/src-tauri/Cargo.toml
+++ b/examples/svelte/svelte-app/src-tauri/Cargo.toml
@@ -27,7 +27,10 @@ serde_derive = "1.0"
 tiny_http = "0.6"
 phf = "0.7.24"
 includedir = "0.5.0"
-tauri = { version = "0.2.0", features = [ "edge" ] }
+
+  [dependencies.tauri]
+  path = "../../../../tauri"
+  features = [ "edge" ]
 
 [features]
 dev-server = [ "tauri/dev-server" ]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Change to examples

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The examples, which are also used as tests to ensure PRs don't break builds, should depend on the latest version of Tauri instead of the one published on crates.io. Some of the examples currently depend on v0.2.0 instead of the latest one from source. This means that changes to tauri that could potentially break the example projects may go unnoticed until the next version is released.