### PR TITLE
fix(bundler): Return nonzero exit code when errors occur

### DIFF
--- a/cli/tauri-cli/src/bundle/common.rs
+++ b/cli/tauri-cli/src/bundle/common.rs
@@ -237,7 +237,7 @@ pub fn print_error(error: &crate::Error) -> crate::Result<()> {
       writeln!(output, "{:?}", backtrace)?;
     }
     output.flush()?;
-    Ok(())
+    std::process::exit(1)
   }
 }
 

--- a/cli/tauri-cli/src/bundle/common.rs
+++ b/cli/tauri-cli/src/bundle/common.rs
@@ -225,7 +225,7 @@ pub fn print_error(error: &crate::Error) -> crate::Result<()> {
       writeln!(output, "{:?}", backtrace)?;
     }
     output.flush()?;
-    Ok(())
+    std::process::exit(1)
   } else {
     let mut output = io::stderr();
     write!(output, "error:")?;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Fixes #231 
Fixes #202 (already closed)

This should fix the issues where CI builds pass when they should actually fail (see above issues for context).

I was originally looking at the JS/TS side and wondered if `process.exit()` was causing processes to exit with `0`, but when I tried changing that the error was still not solved. After digging through the Rust side I came across these areas:

https://github.com/tauri-apps/tauri/blob/f800daaf442a5a6a6304b25f2b49c08963966e13/cli/tauri-cli/src/main.rs#L65-L68
https://github.com/tauri-apps/tauri/blob/f800daaf442a5a6a6304b25f2b49c08963966e13/cli/tauri-cli/src/main.rs#L156


It turns out that `bundle::print_error` was actually swallowing the errors:
https://github.com/tauri-apps/tauri/blob/f800daaf442a5a6a6304b25f2b49c08963966e13/cli/tauri-cli/src/bundle/common.rs#L228


This fix was tested by running a command that [used to succeed](https://github.com/tauri-apps/tauri/pull/214/checks?check_run_id=363576771#step:14:133) and now properly fails:
![image](https://user-images.githubusercontent.com/19519564/71460117-81797180-2778-11ea-9538-695261516de9.png)
![image](https://user-images.githubusercontent.com/19519564/71460248-154b3d80-2779-11ea-87aa-749e86d68fe2.png)


