### PR TITLE
feat(tauri) read config overriden by the node CLI

### DIFF
--- a/cli/tauri.js/src/helpers/tauri-config.ts
+++ b/cli/tauri.js/src/helpers/tauri-config.ts
@@ -41,8 +41,7 @@ module.exports = (cfg: Partial<TauriConfig>): TauriConfig => {
           title: pkg.productName
         },
         security: {
-          csp:
-            "default-src data: filesystem: ws: http: https: 'unsafe-eval' 'unsafe-inline'"
+          csp: "default-src blob: data: filesystem: ws: http: https: 'unsafe-eval' 'unsafe-inline'"
         },
         edge: {
           active: true
@@ -63,6 +62,7 @@ module.exports = (cfg: Partial<TauriConfig>): TauriConfig => {
 
   process.env.TAURI_DIST_DIR = appPaths.resolve.app(config.build.distDir)
   process.env.TAURI_DIR = appPaths.tauriDir
+  process.env.TAURI_CONFIG = JSON.stringify(config)
 
   return config
 }

--- a/tauri/src/app/runner.rs
+++ b/tauri/src/app/runner.rs
@@ -8,9 +8,9 @@ pub(crate) fn run(application: &mut crate::App) {
     content = if config.build.dev_path.starts_with("http") {
       web_view::Content::Url(config.build.dev_path)
     } else {
-      let dev_path = std::path::Path::new(env!("TAURI_DIST_DIR")).join("index.tauri.html");
+      let dev_path = std::path::Path::new(&config.build.dev_path).join("index.tauri.html");
       web_view::Content::Html(
-        std::fs::read_to_string(dev_path).expect("failed to build index.tauri.html"),
+        std::fs::read_to_string(dev_path).expect("failed to read index.tauri.html"),
       )
     };
   }

--- a/tauri/src/config.rs
+++ b/tauri/src/config.rs
@@ -105,10 +105,10 @@ fn default_build() -> BuildConfig {
 }
 
 pub fn get() -> Config {
-  match std::env::var("TAURI_CONFIG") {
-    Ok(config) => serde_json::from_str(&config)
+  match option_env!("TAURI_CONFIG") {
+    Some(config) => serde_json::from_str(config)
       .expect("failed to parse TAURI_CONFIG env"),
-    Err(_) => serde_json::from_str(include_str!(concat!(env!("TAURI_DIR"), "/tauri.conf.json")))
+    None => serde_json::from_str(include_str!(concat!(env!("TAURI_DIR"), "/tauri.conf.json")))
       .expect("failed to read tauri.conf.json")
   }
 }

--- a/tauri/src/config.rs
+++ b/tauri/src/config.rs
@@ -105,6 +105,10 @@ fn default_build() -> BuildConfig {
 }
 
 pub fn get() -> Config {
-  serde_json::from_str(include_str!(concat!(env!("TAURI_DIR"), "/tauri.conf.json")))
-    .expect("failed to read tauri.conf.json")
+  match std::env::var("TAURI_CONFIG") {
+    Ok(config) => serde_json::from_str(&config)
+      .expect("failed to parse TAURI_CONFIG env"),
+    Err(_) => serde_json::from_str(include_str!(concat!(env!("TAURI_DIR"), "/tauri.conf.json")))
+      .expect("failed to read tauri.conf.json")
+  }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This allows the Rust side to read the correct config (the Node CLI manipulates the config from `tauri.conf.json`). 