### PR TITLE
chore(readme): rename rust cli to bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Tauri is a tool for building tiny, blazing fast binaries for all major desktop p
 
 | Component | Version | Lin | Win | Mac |
 |-----------|---------|-----|-----|-----|
-| tauri.js  | ![](https://img.shields.io/npm/v/tauri.svg)         |✅|✅|✅|
-| tauri     | ![](https://img.shields.io/crates/v/tauri.svg)      |✅|✅|✅|
-| tauri CLI | ![](https://img.shields.io/crates/v/tauri-cli.svg)  |✅|✅|✅ |
+| tauri.js CLI | ![](https://img.shields.io/npm/v/tauri.svg)         |✅|✅|✅|
+| tauri core    | ![](https://img.shields.io/crates/v/tauri.svg)      |✅|✅|✅|
+| tauri bundler | ![](https://img.shields.io/crates/v/tauri-cli.svg)  |✅|✅|✅ |
 
 ## Who Tauri is For
 Because of the way Tauri has been built and can be extended, developers
@@ -48,7 +48,7 @@ What will you make?
 Tauri has five major components:
 - [Node.js CLI](https://github.com/tauri-apps/tauri/tree/dev/cli/tauri.js) for creating, developing and building apps
 - [Rust Core](https://github.com/tauri-apps/tauri/tree/dev/tauri) for binding to the low level WEBVIEW and providing a tree-shakeable API
-- [Rust CLI](https://github.com/tauri-apps/tauri/tree/dev/cli/tauri-cli) for manufacturing the final binaries
+- [Rust Bundler](https://github.com/tauri-apps/tauri/tree/dev/cli/tauri-cli) for manufacturing the final binaries
 - [Rust Bindings](https://github.com/Boscop/web-view) for Webviews
 - [Webview](https://github.com/Boscop/web-view/tree/master/webview-sys)
 Low level library for creating and interfacing with OS "native" webviews


### PR DESCRIPTION
This should resolve some challenges with understanding the parts of tauri, especially why there are multiple CLIs. Until we have a rust-only CLI, or naming convention should probably refer to the bundler everywhere.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

Documentation

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
