### PR TITLE
only enable renovate for certain folders

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "enabled": false,
   "rebaseConflictedPrs": false,
   "ignorePaths": [],
+  "labels: ["chore"],
   "enabledManagers": ["cargo", "npm"],
   "cargo": {
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": ["config:base"],
   "schedule": "after 3am on Wednesday",
+  "enabled": false,
   "rebaseConflictedPrs": false,
   "ignorePaths": [],
   "enabledManagers": ["cargo", "npm"],
@@ -9,6 +10,47 @@
   },
   "packageRules": [
     {
+      "enabled": true,
+      "paths": ["tauri/**"],
+      "groupName": "Tauri Core",
+      "groupSlug": "allTauriCore",
+      "commitMessagePrefix": "chore(deps)",
+      "lockFileMaintenance": {
+        "enabled": true
+      }
+    },
+    {
+      "enabled": true,
+      "paths": ["tauri-api/**"],
+      "groupName": "Tauri API",
+      "groupSlug": "allTauriAPI",
+      "commitMessagePrefix": "chore(deps)",
+      "lockFileMaintenance": {
+        "enabled": true
+      }
+    },
+    {
+      "enabled": true,
+      "paths": ["cli/tauri-cli/**"],
+      "groupName": "Tauri Bundler",
+      "groupSlug": "allTauriBundler",
+      "commitMessagePrefix": "chore(deps)",
+      "lockFileMaintenance": {
+        "enabled": true
+      }
+    },
+    {
+      "enabled": true,
+      "paths": ["cli/tauri.js/**"],
+      "groupName": "Tauri JS CLI",
+      "groupSlug": "allTauriJSCLI",
+      "commitMessagePrefix": "chore(deps)",
+      "lockFileMaintenance": {
+        "enabled": true
+      }
+    },
+    {
+      "enabled": true,
       "paths": ["examples/react/gatsby*/**"],
       "groupName": "Gatsby Examples",
       "groupSlug": "allGatsby",
@@ -21,6 +63,7 @@
       "rebaseConflictedPrs": true
     },
     {
+      "enabled": true,
       "paths": ["examples/react/create-react-app*/**"],
       "groupName": "CRA Examples",
       "groupSlug": "allCRA",
@@ -33,6 +76,7 @@
       "rebaseConflictedPrs": true
     },
     {
+      "enabled": true,
       "paths": ["examples/react/next*/**"],
       "groupName": "Next.js Examples",
       "groupSlug": "allNextjs",
@@ -45,6 +89,7 @@
       "rebaseConflictedPrs": true
     },
     {
+      "enabled": true,
       "paths": ["examples/vue/**"],
       "groupName": "Vue Examples",
       "groupSlug": "allVue",
@@ -57,6 +102,7 @@
       "rebaseConflictedPrs": true
     },
     {
+      "enabled": true,
       "paths": ["examples/vanillajs/**"],
       "groupName": "VanillaJS Examples",
       "groupSlug": "allVanilla",
@@ -69,6 +115,7 @@
       "rebaseConflictedPrs": true
     },
     {
+      "enabled": true,
       "paths": ["examples/svelte/**"],
       "groupName": "Svelte Examples",
       "groupSlug": "allSvelte",

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "enabled": false,
   "rebaseConflictedPrs": false,
   "ignorePaths": [],
-  "labels: ["chore"],
+  "labels": ["chore"],
   "enabledManagers": ["cargo", "npm"],
   "cargo": {
     "enabled": true


### PR DESCRIPTION
This also groups these folders that PRs will be opened per folder rather than per dep (less noisy).

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
