### PR TITLE
fix(bundler): Fix DMG script

### DIFF
--- a/cli/tauri-cli/src/bundle/settings.rs
+++ b/cli/tauri-cli/src/bundle/settings.rs
@@ -73,6 +73,8 @@ const ALL_PACKAGE_TYPES: &[PackageType] = &[
   PackageType::WindowsMsi,
   PackageType::OsxBundle,
   PackageType::Rpm,
+  #[cfg(feature = "dmg")]
+  PackageType::Dmg,
 ];
 
 #[derive(Clone, Debug)]

--- a/cli/tauri-cli/src/bundle/templates/bundle_dmg
+++ b/cli/tauri-cli/src/bundle/templates/bundle_dmg
@@ -34,7 +34,7 @@ sleep 5
 bless --folder "${MOUNT_DIR}" -label "${MACOS_APP_NAME}"
 
 test -d "${MOUNT_DIR}/.background" || mkdir "${MOUNT_DIR}/.background"
-cp ../../icons/bg.png "${MOUNT_DIR}"/.background/bg.png
+test -f ../../icons/bg.png && cp ../../icons/bg.png "${MOUNT_DIR}"/.background/bg.png
 
 # I couldn't get DeRez and Rez to work. Leaving it here in case its helpful in the future.
 ### DeRez -only icns "${MOUNT_DIR}/.VolumeIcon.icns" > "${MOUNT_DIR}/.VolumeIcon.rsrc"
@@ -46,7 +46,7 @@ VERSION=$(sw_vers -productVersion | cut -d'.' -f2)
 
 if [ "$VERSION" -gt 12 ]; then
   echo "Using SIPS v10.13+"
-  sips --i "${MOUNT_DIR}/.VolumeIcon.icns" # 10.13+
+  sips -i "${MOUNT_DIR}/.VolumeIcon.icns" # 10.13+
 else
     echo "Using SIPS v10.12-"
   sips --addIcon "${MOUNT_DIR}/.VolumeIcon.icns"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
- Fix `sips` command
- Copy `seticon` from templates folder
- Only `cp bg.png` if it exists

This should fix the script for now, but I think it could become difficult to maintain in the future. We might want to look into using a package such as [`create-dmg`](https://github.com/sindresorhus/create-dmgl) or [`node-appdmg`](https://github.com/LinusU/node-appdmg) instead