### PR TITLE
chore(renovate): top level disable completely turns it off

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "extends": ["config:base"],
   "schedule": "after 3am on Wednesday",
-  "enabled": false,
-  "rebaseConflictedPrs": false,
   "ignorePaths": [],
   "labels": ["chore"],
   "enabledManagers": ["cargo", "npm"],
@@ -11,6 +9,10 @@
   },
   "packageRules": [
     {
+      "packagePatterns": ["*"],
+      "enabled": false
+    },
+    {
       "enabled": true,
       "paths": ["tauri/**"],
       "groupName": "Tauri Core",
@@ -18,7 +20,8 @@
       "commitMessagePrefix": "chore(deps)",
       "lockFileMaintenance": {
         "enabled": true
-      }
+      },
+      "rebaseConflictedPrs": false
     },
     {
       "enabled": true,
@@ -28,7 +31,8 @@
       "commitMessagePrefix": "chore(deps)",
       "lockFileMaintenance": {
         "enabled": true
-      }
+      },
+      "rebaseConflictedPrs": false
     },
     {
       "enabled": true,
@@ -38,7 +42,8 @@
       "commitMessagePrefix": "chore(deps)",
       "lockFileMaintenance": {
         "enabled": true
-      }
+      },
+      "rebaseConflictedPrs": false
     },
     {
       "enabled": true,
@@ -48,7 +53,8 @@
       "commitMessagePrefix": "chore(deps)",
       "lockFileMaintenance": {
         "enabled": true
-      }
+      },
+      "rebaseConflictedPrs": false
     },
     {
       "enabled": true,


### PR DESCRIPTION
I've accidentally disabled renovate. We need to instead disable in a package rule per https://github.com/renovatebot/config-help/issues/86 .

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
