### PR TITLE
feat(builder): enable OSX sidecar from finder

### DIFF
--- a/examples/vue/quasar-app/src-tauri/src/main.rs
+++ b/examples/vue/quasar-app/src-tauri/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
           .spawn()
           .expect("Failed to spawn packaged node")
           .stdout.expect("Failed to get packaged node stdout");
+
         let reader = std::io::BufReader::new(stdout);
 
         reader


### PR DESCRIPTION
There is an issue on OSX where the $PATH environments are not available to an APP if you open it from the Finder, although it does have the $PATH if you open it from the console. This PR enhances the Builder with a bootstrapping shell script that injects the $PATH, essentially invoking the App from a terminal. It adds approximately 200 bytes to the bundle size. :(

- [x] Bugfix

**Does this PR introduce a breaking change?** 
- [x] No


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch and _not_ the `master` branch