### PR TITLE
fix(publish): Use `yarn audit` instead of `npm audit`

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: ${{ matrix.package.path }}
         run: |
           echo "# NPM Audit Results" | tee -a ${{runner.workspace }}/notes.md
-          npm audit 2>&1 | tee -a ${{runner.workspace }}/notes.md
+          yarn audit 2>&1 | tee -a ${{runner.workspace }}/notes.md
       - name: Publish ${{ matrix.package.name }}
         if: env.PACKAGE_VERSION != env.PUBLISHED_VERSION
         working-directory: ${{ matrix.package.path }}
@@ -78,7 +78,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_npm_release.outputs.upload_url }} 
+          upload_url: ${{ steps.create_npm_release.outputs.upload_url }}
           asset_path: ./${{ matrix.package.path }}/${{ matrix.package.registryName }}-${{ env.PACKAGE_VERSION }}.tgz
           asset_name: ${{ matrix.package.registryName }}-${{ env.PACKAGE_VERSION }}.tgz
           asset_content_type: application/x-gtar


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In projects that use Yarn, `yarn audit` should be used for dependency audits. Using `npm audit` will fail since Yarn projects do not have `npm-shrinkwrap.json` or `package-lock.json` files.