### PR TITLE
fix(tauri): make github action envs absolute for extra path level in runner.rs

### DIFF
--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -9,9 +9,7 @@ on:
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
-    env:
-      TAURI_DIST_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/dist
-      TAURI_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/src-tauri
+
     steps:
       - uses: actions/checkout@v2
       - name: install webkit2gtk
@@ -22,3 +20,6 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          TAURI_DIST_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/dist
+          TAURI_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/src-tauri

--- a/.github/workflows/check-on-push.yml
+++ b/.github/workflows/check-on-push.yml
@@ -10,8 +10,8 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     env:
-      TAURI_DIST_DIR: tauri/test/fixture/dist
-      TAURI_DIR: ../test/fixture/src-tauri
+      TAURI_DIST_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/dist
+      TAURI_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/src-tauri
     steps:
       - uses: actions/checkout@v2
       - name: install webkit2gtk

--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -12,8 +12,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      TAURI_DIST_DIR: tauri/test/fixture/dist
-      TAURI_DIR: ../test/fixture/src-tauri
+      TAURI_DIST_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/dist
+      TAURI_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/src-tauri
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -27,14 +27,14 @@ jobs:
           cd ./tauri
           cargo build
         env:
-          TAURI_DIST_DIR: ../../test/fixture/dist
-          TAURI_DIR: ../test/fixture/src-tauri
+          TAURI_DIST_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/dist
+          TAURI_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/src-tauri
       - name: test
         run: |
           cargo test
         env:
-          TAURI_DIST_DIR: ../../test/fixture/dist
-          TAURI_DIR: ../test/fixture/src-tauri
+          TAURI_DIST_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/dist
+          TAURI_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/src-tauri
 
   build-tauri-bundler:
     runs-on: ${{ matrix.platform }}

--- a/tauri/src/app/runner.rs
+++ b/tauri/src/app/runner.rs
@@ -63,7 +63,7 @@ pub(crate) fn run(application: &mut App) -> crate::Result<()> {
   #[cfg(feature = "dev-server")]
   webview
     .handle()
-    .dispatch(|_webview| _webview.eval(include_str!(concat!("../", env!("TAURI_DIR"), "/tauri.js"))))?;
+    .dispatch(|_webview| _webview.eval(include_str!(concat!(env!("TAURI_DIR"), "/tauri.js"))))?;
 
   // spawn the embedded server on our server url
   #[cfg(feature = "embedded-server")]
@@ -237,7 +237,7 @@ fn build_webview(
     // inject the tauri.js entry point
     webview
     .handle()
-    .dispatch(|_webview| _webview.eval(include_str!(concat!("../", env!("TAURI_DIR"), "/tauri.js"))))?;
+    .dispatch(|_webview| _webview.eval(include_str!(concat!(env!("TAURI_DIR"), "/tauri.js"))))?;
   }
   
   Ok(webview)

--- a/tauri/src/app/runner.rs
+++ b/tauri/src/app/runner.rs
@@ -63,7 +63,7 @@ pub(crate) fn run(application: &mut App) -> crate::Result<()> {
   #[cfg(feature = "dev-server")]
   webview
     .handle()
-    .dispatch(|_webview| _webview.eval(include_str!(concat!(env!("TAURI_DIR"), "/tauri.js"))))?;
+    .dispatch(|_webview| _webview.eval(include_str!(concat!("../", env!("TAURI_DIR"), "/tauri.js"))))?;
 
   // spawn the embedded server on our server url
   #[cfg(feature = "embedded-server")]
@@ -237,7 +237,7 @@ fn build_webview(
     // inject the tauri.js entry point
     webview
     .handle()
-    .dispatch(|_webview| _webview.eval(include_str!(concat!(env!("TAURI_DIR"), "/tauri.js"))))?;
+    .dispatch(|_webview| _webview.eval(include_str!(concat!("../", env!("TAURI_DIR"), "/tauri.js"))))?;
   }
   
   Ok(webview)


### PR DESCRIPTION
This file is one folder deeper than the other files which reference this env. This env is a relative folder reference so we need to concat an extra folder traversal into it.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
