### PR TITLE
refactor(tauri.js): Fix ESLint errors in src/api/tauricon.ts

### DIFF
--- a/cli/tauri.js/.eslintrc.js
+++ b/cli/tauri.js/.eslintrc.js
@@ -48,6 +48,7 @@ module.exports = {
     'security/detect-possible-timing-attacks': 'error',
     'security/detect-pseudoRandomBytes': 'error',
     'space-before-function-paren': 'off',
+    '@typescript-eslint/default-param-last': 'off',
     '@typescript-eslint/strict-boolean-expressions': 0,
     '@typescript-eslint/space-before-function-paren': [
       'error',

--- a/cli/tauri.js/src/api/tauricon.ts
+++ b/cli/tauri.js/src/api/tauricon.ts
@@ -61,7 +61,7 @@ const checkSrc = async (src: string): Promise<boolean | sharp.Sharp> => {
       process.exit(1)
     } else {
       const buffer = await readChunk(src, 0, 8)
-      if (isPng(buffer) === true) {
+      if (isPng(buffer)) {
         return (image = sharp(src))
       } else {
         image = false
@@ -309,7 +309,7 @@ const tauricon = (exports.tauricon = {
       // prevent overlay or pure
       block = true
     }
-    if (block === true || options.splashscreen_type === 'generate') {
+    if (block || options.splashscreen_type === 'generate') {
       await this.validate(src, target)
       if (!image) {
         process.exit(1)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [x] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Resolves ESLint errors in `tauricon.ts` and disables [`@typescript-eslint/default-param-last`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/default-param-last.md) (I'm happy to re-enable it if desired)