### PR TITLE
feature(tauri-bundler): add start menu shortcut on windows

### DIFF
--- a/cli/tauri-bundler/src/bundle/templates/main.wxs
+++ b/cli/tauri-bundler/src/bundle/templates/main.wxs
@@ -39,21 +39,23 @@
 
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
-                <Directory Id="APPLICATIONFOLDER" Name="{{{product_name}}}">
-                    <Component Id="Path" Guid="{{{path_component_guid}}}" Win64="$(var.Win64)" KeyPath="yes">
-                        <File Id="PathFile" Source="{{{app_exe_source}}}" />
-                    </Component>
-                    {{#each external_binaries as |external_bin| ~}}
-                    <Component Id="{{ external_bin.id }}" Guid="{{external_bin.guid}}" Win64="$(var.Win64)" KeyPath="yes">
-                        <File Id="PathFile_{{ external_bin.id }}" Source="{{external_bin.path}}" />
-                    </Component>
-                    {{/each~}}
-                    {{{resources}}}
-                </Directory>
+                <Directory Id="APPLICATIONFOLDER" Name="{{{product_name}}}"/>
+            </Directory>
+            <Directory Id="ProgramMenuFolder">
+                <Directory Id="ApplicationProgramsFolder" Name="{{{product_name}}}"/>
             </Directory>
         </Directory>
 
         <DirectoryRef Id="APPLICATIONFOLDER">
+            <Component Id="Path" Guid="{{{path_component_guid}}}" Win64="$(var.Win64)">
+                <File Id="Path" Source="{{{app_exe_source}}}" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            {{#each external_binaries as |external_bin| ~}}
+            <Component Id="{{ external_bin.id }}" Guid="{{external_bin.guid}}" Win64="$(var.Win64)">
+                <File Id="Path_{{ external_bin.id }}" Source="{{external_bin.path}}"  KeyPath="yes"/>
+            </Component>
+            {{/each~}}
+            {{{resources}}}
             <Component Id="CMP_ReadFileShortcut"
                 Guid="1AF06B42-CD42-4AED-959F-36DB5E512046">
 
@@ -63,10 +65,10 @@
 						  Target="[System64Folder]msiexec.exe"
 						  Arguments="/x [ProductCode]" />
 
-				<RemoveFolder Id="RemoveDIR_Shortcuts"
+				<RemoveFolder Id="APPLICATIONFOLDER"
 							  On="uninstall" />
 
-				<RegistryValue Root="HKCU"
+				<RegistryValue Root="HKCR"
 							   Key="Software\{{{manufacturer}}}\{{{product_name}}}"
 							   Name="installed"
 							   Type="integer"
@@ -74,6 +76,18 @@
 							   KeyPath="yes" />
             
             </Component>
+        </DirectoryRef>
+
+        <DirectoryRef Id="ApplicationProgramsFolder">
+            <Component Id="ApplicationShortcut" Guid="81ccebd8-b769-4bed-bdbd-0340f9f7cad1">
+                <Shortcut Id="ApplicationStartMenuShortcut" 
+                    Name="{{{product_name}}}"
+                    Description="Runs {{{product_name}}}"
+                    Target="[!Path]"
+                    Icon="ProductIcon"/>
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+                <RegistryValue Root="HKCU" Key="Software\{{{manufacturer}}}\{{{product_name}}}" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+           </Component>
         </DirectoryRef>
 
         <Feature
@@ -93,7 +107,9 @@
             <Feature Id="ShortcutsFeature"
 			 Title="Shortcuts"
 			 Level="1">
-			<ComponentRef Id="CMP_ReadFileShortcut" />
+            <ComponentRef Id="Path"/>
+            <ComponentRef Id="CMP_ReadFileShortcut" />
+            <ComponentRef Id="ApplicationShortcut" />
 		    </Feature>
 
             <Feature


### PR DESCRIPTION
This modifies the Wix xml template to add a start menu shortcut on install. I also reorganized a tad, and changed the registry root on the uninstall shortcut to be either user or system as msi can be either (which removes the existing warning we had).

This is also believed to be the last remaining item for the [guijs Windows build](https://github.com/Akryum/guijs/issues/34).

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
ref: https://wixtoolset.org/documentation/manual/v3/howtos/files_and_registry/create_start_menu_shortcut.html