### PR TITLE
chore(workflow): tauri-bundler path considering workspace

### DIFF
--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -18,23 +18,23 @@ jobs:
           - name: tauri-bundler
             registryName: tauri-bundler
             path: cli/tauri-bundler
-            publishPath: /target/package
+            publishPath: cli/tauri-bundler/target/package # not in workspace so target folder is nested
           - name: tauri-core
             registryName: tauri
             path: tauri
-            publishPath: /target/package
+            publishPath: target/package
           - name: tauri-api
             registryName: tauri-api
             path: tauri-api
-            publishPath: /target/package
+            publishPath: target/package
           - name: tauri-updater
             registryName: tauri-updater
             path: tauri-updater
-            publishPath: /target/package
+            publishPath: target/package
           - name: tauri-utils
             registryName: tauri-utils
             path: tauri-utils
-            publishPath: /target/package
+            publishPath: target/package
     steps:
       - uses: actions/checkout@v2
         with:
@@ -59,14 +59,9 @@ jobs:
           TAURI_DIST_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/dist
           TAURI_DIR: ${{ runner.workspace }}/tauri/tauri/test/fixture/src-tauri
         run: |
-          echo "package dir:"
-          ls
           cargo package --no-verify
           echo "We will publish:" $PACKAGE_VERSION
           echo "This is current latest:" $PUBLISHED_VERSION
-          echo "post package dir:"
-          cd ${{ matrix.publishPath }}
-          ls
       - name: cargo audit
         if: env.PACKAGE_VERSION != env.PUBLISHED_VERSION
         working-directory: ${{ matrix.package.path }}


### PR DESCRIPTION
`tauri-bundler` is not in the main cargo workspace so the target directory is not in the top level. Update the publishPath to compensate.

Also removing a couple extraneous things that aren't needed either. We had an extra '/' and we don't need to bother showing the directory within the `cargo package` command.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
