### PR TITLE
build(task-runner): add self-documented task runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ Cargo.lock
 # doing this because of how our tests currently (naively) drop the tauri.conf.js in that folder
 # todo: needs a proper fic
 /cli/tauri.js/tauri.conf.js
+
+# doing this because the task-runner (`mask prepare`) will clone gh:tauri-apps/examples
+/examples

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,8 @@ members = [
   "tauri",
   "tauri-api",
   "tauri-updater",
-  "tauri-utils"
+  "tauri-utils",
+]
+exclude = [
+  "examples",
 ]

--- a/maskfile.md
+++ b/maskfile.md
@@ -33,7 +33,9 @@ case "$PWD" in
   yarn && yarn tauri:source dev
 ;;
 */rust/*)
-  cargo web deploy && cd ..
+  cargo web deploy
+  [ $example = `basename $(dirname $PWD)` ] && cd ..
+
   yarn add tauri@link:../../../cli/tauri.js
   yarn && yarn tauri dev
 ;; 

--- a/maskfile.md
+++ b/maskfile.md
@@ -1,0 +1,69 @@
+# Shorthand Commands
+
+## prepare
+> Setup all stuffs needed for runing the examples
+
+```sh
+git clone --recursive git@github.com:tauri-apps/examples.git \
+|| cd examples && git pull; cd .. 		# always prepare up-to-date examples in case it's already available
+source .scripts/init_env.sh
+
+cargo build
+cargo install --path cli/tauri-bundler --force
+cargo install cargo-web 			# used by example rust/yew
+
+cd cli/tauri.js
+yarn && yarn build
+```
+
+## run
+
+### run example (example)
+> Run specific example in dev mode
+
+```sh
+source .scripts/init_env.sh
+shopt -s globstar
+
+cd examples/**/$example 2>/dev/null \
+|| cd examples/**/$example/$example 	# workaround for rust/yew/todomvc/todomvc 
+
+case "$PWD" in
+*/node/*)
+  yarn && yarn tauri:source dev
+;;
+*/rust/*)
+  cargo web deploy && cd ..
+  yarn add tauri@link:../../../cli/tauri.js
+  yarn && yarn tauri dev
+;; 
+*)
+  echo unknown project $(dirname $example)/$example 
+;; 
+esac
+```
+
+## list
+
+### list examples
+> List all available examples
+
+```sh
+find examples/*/*/* -maxdepth 0 -type d -not -path '*.git*' \
+-exec sh -c 'echo $(basename $(dirname {}))/$(basename {})' \;
+```
+
+## clean
+> Remove installed dependencies and reset examples in case something gone wrong
+
+```sh
+cargo uninstall tauri-bundler
+cargo clean
+
+shopt -s globstar
+rm -r **/node_modules
+
+cd examples
+git checkout -- . 	# discard all unstaged changes
+git clean -dfX 		# remove all untracked files & directories
+```

--- a/maskfile.md
+++ b/maskfile.md
@@ -18,6 +18,8 @@ yarn && yarn build
 
 ## run
 
+![tauri-mask-run-example](https://user-images.githubusercontent.com/4953069/75866011-00ed8600-5e37-11ea-9106-3cb104a05f80.gif)
+
 ### run example (example)
 > Run specific example in dev mode
 

--- a/maskfile.md
+++ b/maskfile.md
@@ -5,8 +5,10 @@
 
 ```sh
 git clone --recursive git@github.com:tauri-apps/examples.git \
-|| cd examples && git pull; cd .. 		# always prepare up-to-date examples in case it's already available
-source .scripts/init_env.sh
+|| (cd examples && git pull origin master; cd ..) 		# always prepare up-to-date examples in case it's already available
+
+export TAURI_DIST_DIR=$PWD/tauri/test/fixture/dist
+export TAURI_DIR=$PWD/tauri/test/fixture/src-tauri
 
 cargo build
 cargo install --path cli/tauri-bundler --force
@@ -28,7 +30,7 @@ source .scripts/init_env.sh
 shopt -s globstar
 
 cd examples/**/$example 2>/dev/null \
-|| cd examples/**/$example/$example 	# workaround for rust/yew/todomvc/todomvc 
+|| cd examples/**/$example/$example 	# workaround for rust/yew/todomvc/todomvc
 
 case "$PWD" in
 */node/*)
@@ -40,10 +42,10 @@ case "$PWD" in
 
   yarn add tauri@link:../../../cli/tauri.js
   yarn && yarn tauri dev
-;; 
+;;
 *)
-  echo unknown project $(dirname $example)/$example 
-;; 
+  echo unknown project $(dirname $example)/$example
+;;
 esac
 ```
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [x] Other, please describe: developer experience for contributor or maintainer

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
As a new/first contributor, I have difficulty to check the small changes that I made is correct, especially when I want to check if it works on the [examples repo](https://github.com/tauri-apps/examples). I'm choosing [mask](https://github.com/jakedeichert/mask) because it's markdown which can be used as some sort of recipe. (also I'm more familiar with `mask` codebase)
![tauri-mask-run-example](https://user-images.githubusercontent.com/4953069/75866011-00ed8600-5e37-11ea-9106-3cb104a05f80.gif)