### PR TITLE
feat(tauri.js) add beforeDevCommand and beforeBuildCommand configs

### DIFF
--- a/cli/tauri.js/src/helpers/spawn.ts
+++ b/cli/tauri.js/src/helpers/spawn.ts
@@ -43,7 +43,7 @@ export const spawnSync = (
   cmd: string,
   params: string[],
   cwd: string,
-  onFail: () => void
+  onFail?: () => void
 ): void => {
   log(`[sync] Running "${cmd} ${params.join(' ')}"`)
   log()

--- a/cli/tauri.js/src/template/defaultConfig.ts
+++ b/cli/tauri.js/src/template/defaultConfig.ts
@@ -1,7 +1,9 @@
 export default {
   build: {
     distDir: '../dist',
-    devPath: 'http://localhost:4000'
+    devPath: 'http://localhost:4000',
+    beforeDevCommand: '',
+    beforeBuildCommand: ''
   },
   ctx: {},
   tauri: {

--- a/cli/tauri.js/src/types/config.ts
+++ b/cli/tauri.js/src/types/config.ts
@@ -5,6 +5,8 @@ export interface TauriConfig {
   build: {
     distDir: string
     devPath: string
+    beforeDevCommand?: string
+    beforeBuildCommand?: string
   }
   ctx: {
     prod?: boolean


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

sometimes we're a little bit lazy and don't want to run something to start our dev server or build our JS code, so I just implemented this config, inspired by @nothingismagick 