### PR TITLE
chore(workflow): order cargo publish and limit to 1

### DIFF
--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -13,15 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         package:
           - name: tauri-bundler
             registryName: tauri-bundler
             path: cli/tauri-bundler
             publishPath: cli/tauri-bundler/target/package # not in workspace so target folder is nested
-          - name: tauri-core
-            registryName: tauri
-            path: tauri
+          - name: tauri-utils
+            registryName: tauri-utils
+            path: tauri-utils
             publishPath: target/package
           - name: tauri-api
             registryName: tauri-api
@@ -31,9 +32,9 @@ jobs:
             registryName: tauri-updater
             path: tauri-updater
             publishPath: target/package
-          - name: tauri-utils
-            registryName: tauri-utils
-            path: tauri-utils
+          - name: tauri-core
+            registryName: tauri
+            path: tauri
             publishPath: target/package
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We were running into race conditions where one package depended on another being published. Limit to only allow one publish at a time, and sort based on dependencies to (hopefully) eliminate the race condition.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
