### PR TITLE
chore(workflow): publish perf and prettying

### DIFF
--- a/.github/workflows/release-cargo.yml
+++ b/.github/workflows/release-cargo.yml
@@ -41,15 +41,15 @@ jobs:
         with:
           ref: master
           toolchain: stable
-      - name: install webkit2gtk
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y webkit2gtk-4.0
       - name: get version
         working-directory: ${{ matrix.package.path }}
         run: echo ::set-env name=PACKAGE_VERSION::$(sed -nE 's/^\s*version = "(.*?)"/\1/p' Cargo.toml)
       - name: check published version
         run: echo ::set-env name=PUBLISHED_VERSION::$(cargo search ${{ matrix.package.registryName }} --limit 1 | sed -nE 's/^[^"]*"//; s/".*//1p' -)
+      - name: install webkit2gtk
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y webkit2gtk-4.0
       - name: cargo login
         if: env.PACKAGE_VERSION != env.PUBLISHED_VERSION
         run: cargo login ${{ secrets.crate_token }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -51,12 +51,15 @@ jobs:
         working-directory: ${{ matrix.package.path }}
         run: |
           echo "# Yarn Audit Results" | tee -a ${{runner.workspace }}/notes.md
-          echo "\n<details>" >> ${{runner.workspace }}/notes.md
-          echo "<summary>click to view</summary>\n" >> ${{runner.workspace }}/notes.md
+          echo "" >> ${{runner.workspace }}/notes.md
+          echo "<details>" >> ${{runner.workspace }}/notes.md
+          echo "<summary>click to view</summary>" >> ${{runner.workspace }}/notes.md
+          echo "" >> ${{runner.workspace }}/notes.md
           echo "\`\`\`" >> ${{runner.workspace }}/notes.md
           yarn audit 2>&1 | tee -a ${{runner.workspace }}/notes.md
           echo "\`\`\`" >> ${{runner.workspace }}/notes.md
-          echo "</details>\n" >> ${{runner.workspace }}/notes.md
+          echo "</details>" >> ${{runner.workspace }}/notes.md
+          echo "" >> ${{runner.workspace }}/notes.md
       - name: Publish ${{ matrix.package.name }}
         if: env.PACKAGE_VERSION != env.PUBLISHED_VERSION
         working-directory: ${{ matrix.package.path }}


### PR DESCRIPTION
The newlines, `/n`, weren't working in our yarn audit collapse widget sequence. Switch that to empty echos.

Also the cargo publish sequence switches the installation of webkit to _after_ we check if a publish needs to be preformed. This will speed up the early exit if a package doesn't need to publish. It will be noticeable as we are now only publishing one at a time.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
