### PR TITLE
detect version shorthand during `tauri info`

### DIFF
--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -80,7 +80,7 @@ function printAppInfo(tauriDir: string): void {
     const tauriVersion = (): string => {
       const tauri = tomlContents.dependencies.tauri
       if (tauri) {
-        if (typeof tauri === "string") {
+        if (typeof tauri === 'string') {
           return chalk.green(tauri)
         }
         if (tauri.version) {

--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -80,6 +80,9 @@ function printAppInfo(tauriDir: string): void {
     const tauriVersion = (): string => {
       const tauri = tomlContents.dependencies.tauri
       if (tauri) {
+        if (typeof tauri === "string") {
+          return chalk.green(tauri)
+        }
         if (tauri.version) {
           return chalk.green(tauri.version)
         }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When editing your `Cargo.toml`, you might clean up the `tauri = { version = "0.5.2" }` to just `tauri = "0.5"` since the inline table is kind of useless in this position.  This fix allows version shorthand.