### PR TITLE
don't remove link attributes on html rewrite when in dev

### DIFF
--- a/cli/tauri.js/src/runner.ts
+++ b/cli/tauri.js/src/runner.ts
@@ -318,10 +318,12 @@ class Runner {
 
       const domInterceptor = cfg.tauri.embeddedServer.active ? undefined : (dom: JSDOM) => {
         const document = dom.window.document
-        document.querySelectorAll('link').forEach((link: HTMLLinkElement) => {
-          link.removeAttribute('rel')
-          link.removeAttribute('as')
-        })
+        if (!cfg.ctx.dev) {
+          document.querySelectorAll('link').forEach((link: HTMLLinkElement) => {
+            link.removeAttribute('rel')
+            link.removeAttribute('as')
+          })
+        }
       }
 
       if ((!cfg.ctx.dev && cfg.tauri.embeddedServer.active) || !inlinerEnabled) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**

When running with the embedded server off, `tauri dev` will still remove attributes from `<link>`s even though we are trying to run these files from the server.  This change will make sure that the attributes are not removed during dev `cfg.ctx.dev`.