### PR TITLE
use cargo lockfile for tauri dependency during `tauri info`. close #610

### DIFF
--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -6,7 +6,7 @@ import os from 'os'
 import path from 'path'
 import { appDir, tauriDir } from '../helpers/app-paths'
 import { TauriConfig } from './../types/config'
-import { CargoToml } from './../types/cargo'
+import { CargoLock, CargoManifest } from '../types/cargo'
 import nonWebpackRequire from '../helpers/non-webpack-require'
 import { version } from '../../package.json'
 
@@ -70,44 +70,51 @@ function printInfo(info: Info): void {
   )
 }
 
+function readTomlFile<T extends CargoLock | CargoManifest>(path: string): T {
+  const file = fs.readFileSync(path).toString()
+  return toml.parse(file) as unknown as T
+}
+
 function printAppInfo(tauriDir: string): void {
   printInfo({ key: 'App', section: true })
 
-  try {
-    const tomlPath = path.join(tauriDir, 'Cargo.toml')
-    const tomlFile = fs.readFileSync(tomlPath).toString()
-    const tomlContents = toml.parse(tomlFile) as any as CargoToml
+  const lockPath = path.join(tauriDir, 'Cargo.lock')
+  const lockContents = readTomlFile<CargoLock>(lockPath)
+  const tauriPackages = lockContents.package.filter(pkg => pkg.name === 'tauri')
 
-    const tauriVersion = (): string => {
-      const tauri = tomlContents.dependencies.tauri
+  let tauriVersion: string
+  if (tauriPackages.length <= 0) {
+    tauriVersion = chalk.red('unknown')
+  } else if (tauriPackages.length === 1) {
+    tauriVersion = chalk.green(tauriPackages[0].version)
+  } else {
+    // there are multiple `tauri` packages in the lockfile
+    // load and check the manifest version to display alongside the found versions
+    const manifestPath = path.join(tauriDir, 'Cargo.toml')
+    const manifestContent = readTomlFile<CargoManifest>(manifestPath)
+
+    const manifestVersion = (): string => {
+      const tauri = manifestContent.dependencies.tauri
       if (tauri) {
         if (typeof tauri === 'string') {
-          return chalk.green(tauri)
-        }
-        if (tauri.version) {
-          return chalk.green(tauri.version)
-        }
-        if (tauri.path) {
-          try {
-            const tauriTomlPath = path.resolve(
-              tauriDir,
-              tauri.path,
-              'Cargo.toml'
-            )
-            const tauriTomlFile = fs.readFileSync(tauriTomlPath).toString()
-            const tauriTomlContents = toml.parse(tauriTomlFile) as any as CargoToml
-            return chalk.green(
-              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              `${tauriTomlContents.package.version} (from source)`
-            )
-          } catch (_) {}
+          return chalk.yellow(tauri)
+        } else if (tauri.version) {
+          return chalk.yellow(tauri.version)
+        } else if (tauri.path) {
+          const manifestPath = path.resolve(tauriDir, tauri.path, 'Cargo.toml')
+          const manifestContent = readTomlFile<CargoManifest>(manifestPath)
+          const pathVersion = chalk.yellow(manifestContent.package.version)
+          return `path:${tauri.path} [${pathVersion}]`
         }
       }
       return chalk.red('unknown')
     }
 
-    printInfo({ key: '  tauri', value: tauriVersion() })
-  } catch (_) {}
+    const versions = tauriPackages.map(p => p.version).join(', ')
+    tauriVersion = `${manifestVersion()} (${chalk.yellow(versions)})`
+  }
+
+  printInfo({ key: '  tauri', value: tauriVersion })
 
   try {
     const tauriMode = (config: TauriConfig): string => {

--- a/cli/tauri.js/src/runner.ts
+++ b/cli/tauri.js/src/runner.ts
@@ -16,7 +16,7 @@ import onShutdown from './helpers/on-shutdown'
 import { spawn, spawnSync } from './helpers/spawn'
 import { exec } from 'child_process'
 import { TauriConfig } from './types/config'
-import { CargoToml } from './types/cargo'
+import { CargoManifest } from './types/cargo'
 import getTauriConfig from './helpers/tauri-config'
 import httpProxy from 'http-proxy'
 import chalk from 'chalk'
@@ -69,7 +69,7 @@ class Runner {
       ls.stdout && ls.stdout.pipe(process.stdout)
     }
 
-    const tomlContents = this.__getManifest() as any as CargoToml
+    const tomlContents = this.__getManifest() as any as CargoManifest
     this.__whitelistApi(cfg, tomlContents)
     this.__rewriteManifest(tomlContents as any as JsonMap)
 

--- a/cli/tauri.js/src/types/cargo.ts
+++ b/cli/tauri.js/src/types/cargo.ts
@@ -1,9 +1,18 @@
-export interface CargoToml {
-  dependencies: { [k: string]: string | CargoTomlDependency }
+export interface CargoManifest {
+  dependencies: { [k: string]: string | CargoManifestDependency }
   package: { version: string }
 }
 
-export interface CargoTomlDependency {
+export interface CargoManifestDependency {
   version: string
   path: string
+}
+
+export interface CargoLock {
+  package: [CargoLockPackage]
+}
+
+export interface CargoLockPackage {
+  name: string
+  version: string
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes. Issue #610
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
As mentioned in the issue, the new possibility is multiple versions found in the lockfile. This looks like:
![new_format](https://user-images.githubusercontent.com/3301043/84333443-9f7b3880-ab44-11ea-9cd7-338144dd5b2f.png)

I marked this as non-breaking as it only changes the possible output of the `tauri info` command, which I didn't see as a non-breaking guarantee. This could break something that parses the output and strictly expects only a semver string or `"unknown"`.
