### PR TITLE
Don't recurse directories while displaying tree during info command

### DIFF
--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -18,7 +18,7 @@ interface DirInfo {
 }
 
 /* eslint-disable security/detect-non-literal-fs-filename */
-function dirTree(filename: string): DirInfo {
+function dirTree(filename: string, recurse = true): DirInfo {
   const stats = fs.lstatSync(filename)
   const info: DirInfo = {
     path: filename,
@@ -27,9 +27,11 @@ function dirTree(filename: string): DirInfo {
 
   if (stats.isDirectory()) {
     info.type = 'folder'
-    info.children = fs.readdirSync(filename).map(function(child: string) {
-      return dirTree(filename + '/' + child)
-    })
+    if (recurse) {
+      info.children = fs.readdirSync(filename).map(function(child: string) {
+        return dirTree(filename + '/' + child, false)
+      })
+    }
   } else {
     info.type = 'file'
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**
- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The `tauri info` command displays the directories in the application dir. It only displays 1 directory deep, but the function finding them recurses all subdirectories. Limiting finding directories to 1 layer deep significantly reduces time to display the folder from 9900ms to 4ms on my machine.

This change keeps the ability to recurse in the future when wanted. The current code does not use the children beyond 1 layer deep.