### PR TITLE
fix(cli): info get tauri

### DIFF
--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -129,11 +129,9 @@ function printAppInfo(tauriDir: string): void {
     if (tauri) {
       if (typeof tauri === 'string') {
         tauriVersion = chalk.green(tauri)
-      }
-      if (tauri.version) {
+      } else if (tauri.version) {
         tauriVersion = chalk.green(tauri.version)
-      }
-      if (tauri.path) {
+      } else if (tauri.path) {
         try {
           const tauriTomlPath = path.resolve(
             tauriDir,
@@ -149,6 +147,8 @@ function printAppInfo(tauriDir: string): void {
         } catch (_) {
           tauriVersion = chalk.red('unknown')
         }
+      } else {
+        tauriVersion = chalk.red('unknown')
       }
     }
   }

--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -6,7 +6,7 @@ import os from 'os'
 import path from 'path'
 import { appDir, tauriDir } from '../helpers/app-paths'
 import { TauriConfig } from './../types/config'
-import { CargoLock, CargoManifest } from '../types/cargo'
+import { CargoLock, CargoManifest, CargoToml } from '../types/cargo'
 import nonWebpackRequire from '../helpers/non-webpack-require'
 import { version } from '../../package.json'
 
@@ -72,9 +72,13 @@ function printInfo(info: Info): void {
   )
 }
 
-function readTomlFile<T extends CargoLock | CargoManifest>(path: string): T {
-  const file = fs.readFileSync(path).toString()
-  return toml.parse(file) as unknown as T
+function readTomlFile<T extends CargoLock | CargoManifest>(filepath: string): T {
+  if (fs.existsSync(filepath)) {
+    const file = fs.readFileSync(filepath).toString()
+    return toml.parse(file) as unknown as T
+  } else {
+    return false as unknown as T
+  }
 }
 
 function printAppInfo(tauriDir: string): void {
@@ -82,41 +86,73 @@ function printAppInfo(tauriDir: string): void {
 
   const lockPath = path.join(tauriDir, 'Cargo.lock')
   const lockContents = readTomlFile<CargoLock>(lockPath)
-  const tauriPackages = lockContents.package.filter(pkg => pkg.name === 'tauri')
+  let tauriPackages
+  let tauriVersion
 
-  let tauriVersion: string
-  if (tauriPackages.length <= 0) {
-    tauriVersion = chalk.red('unknown')
-  } else if (tauriPackages.length === 1) {
-    tauriVersion = chalk.green(tauriPackages[0].version)
+  if (lockContents) {
+    tauriPackages = lockContents.package.filter(pkg => pkg.name === 'tauri')
+    if (tauriPackages.length <= 0) {
+      tauriVersion = chalk.red('unknown')
+    } else if (tauriPackages.length === 1) {
+      tauriVersion = chalk.green(tauriPackages[0].version)
+    } else {
+      // there are multiple `tauri` packages in the lockfile
+      // load and check the manifest version to display alongside the found versions
+      const manifestPath = path.join(tauriDir, 'Cargo.toml')
+      const manifestContent = readTomlFile<CargoManifest>(manifestPath)
+
+      const manifestVersion = (): string => {
+        const tauri = manifestContent.dependencies.tauri
+        if (tauri) {
+          if (typeof tauri === 'string') {
+            return chalk.yellow(tauri)
+          } else if (tauri.version) {
+            return chalk.yellow(tauri.version)
+          } else if (tauri.path) {
+            const manifestPath = path.resolve(tauriDir, tauri.path, 'Cargo.toml')
+            const manifestContent = readTomlFile<CargoManifest>(manifestPath)
+            const pathVersion = chalk.yellow(manifestContent.package.version)
+            return `path:${tauri.path} [${pathVersion}]`
+          }
+        }
+        return chalk.red('unknown')
+      }
+
+      const versions = tauriPackages.map(p => p.version).join(', ')
+      tauriVersion = `${manifestVersion()} (${chalk.yellow(versions)})`
+    }
   } else {
-    // there are multiple `tauri` packages in the lockfile
-    // load and check the manifest version to display alongside the found versions
-    const manifestPath = path.join(tauriDir, 'Cargo.toml')
-    const manifestContent = readTomlFile<CargoManifest>(manifestPath)
-
-    const manifestVersion = (): string => {
-      const tauri = manifestContent.dependencies.tauri
-      if (tauri) {
-        if (typeof tauri === 'string') {
-          return chalk.yellow(tauri)
-        } else if (tauri.version) {
-          return chalk.yellow(tauri.version)
-        } else if (tauri.path) {
-          const manifestPath = path.resolve(tauriDir, tauri.path, 'Cargo.toml')
-          const manifestContent = readTomlFile<CargoManifest>(manifestPath)
-          const pathVersion = chalk.yellow(manifestContent.package.version)
-          return `path:${tauri.path} [${pathVersion}]`
+    const tomlPath = path.join(tauriDir, 'Cargo.toml')
+    const tomlFile = fs.readFileSync(tomlPath).toString()
+    const tomlContents = toml.parse(tomlFile) as any as CargoToml
+    const tauri = tomlContents.dependencies.tauri
+    if (tauri) {
+      if (typeof tauri === 'string') {
+        tauriVersion = chalk.green(tauri)
+      }
+      if (tauri.version) {
+        tauriVersion = chalk.green(tauri.version)
+      }
+      if (tauri.path) {
+        try {
+          const tauriTomlPath = path.resolve(
+            tauriDir,
+            tauri.path,
+            'Cargo.toml'
+          )
+          const tauriTomlFile = fs.readFileSync(tauriTomlPath).toString()
+          const tauriTomlContents = toml.parse(tauriTomlFile) as any as CargoToml
+          tauriVersion = chalk.green(
+            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+            `${tauriTomlContents.package.version} (from source)`
+          )
+        } catch (_) {
+          tauriVersion = chalk.red('unknown')
         }
       }
-      return chalk.red('unknown')
     }
-
-    const versions = tauriPackages.map(p => p.version).join(', ')
-    tauriVersion = `${manifestVersion()} (${chalk.yellow(versions)})`
   }
-
-  printInfo({ key: '  tauri', value: tauriVersion })
+  printInfo({ key: '  tauri.rs', value: tauriVersion })
 
   try {
     const tauriMode = (config: TauriConfig): string => {

--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -6,7 +6,7 @@ import os from 'os'
 import path from 'path'
 import { appDir, tauriDir } from '../helpers/app-paths'
 import { TauriConfig } from './../types/config'
-import { CargoLock, CargoManifest, CargoToml } from '../types/cargo'
+import { CargoLock, CargoManifest } from '../types/cargo'
 import nonWebpackRequire from '../helpers/non-webpack-require'
 import { version } from '../../package.json'
 
@@ -124,7 +124,7 @@ function printAppInfo(tauriDir: string): void {
   } else {
     const tomlPath = path.join(tauriDir, 'Cargo.toml')
     const tomlFile = fs.readFileSync(tomlPath).toString()
-    const tomlContents = toml.parse(tomlFile) as any as CargoToml
+    const tomlContents = toml.parse(tomlFile) as any as CargoManifest
     const tauri = tomlContents.dependencies.tauri
     if (tauri) {
       if (typeof tauri === 'string') {
@@ -141,7 +141,7 @@ function printAppInfo(tauriDir: string): void {
             'Cargo.toml'
           )
           const tauriTomlFile = fs.readFileSync(tauriTomlPath).toString()
-          const tauriTomlContents = toml.parse(tauriTomlFile) as any as CargoToml
+          const tauriTomlContents = toml.parse(tauriTomlFile) as any as CargoManifest
           tauriVersion = chalk.green(
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
             `${tauriTomlContents.package.version} (from source)`

--- a/cli/tauri.js/src/types/cargo.ts
+++ b/cli/tauri.js/src/types/cargo.ts
@@ -4,7 +4,7 @@ export interface CargoTomlDependency {
 }
 
 export interface CargoManifest {
-  dependencies: { [k: string]: CargoManifestDependency }
+  dependencies: { [k: string]: string | CargoManifestDependency }
   package: { version: string }
 }
 

--- a/cli/tauri.js/src/types/cargo.ts
+++ b/cli/tauri.js/src/types/cargo.ts
@@ -1,3 +1,13 @@
+export interface CargoToml {
+  dependencies: { [k: string]: CargoTomlDependency }
+  package: { version: string }
+}
+
+export interface CargoTomlDependency {
+  version?: string
+  path?: string
+}
+
 export interface CargoManifest {
   dependencies: { [k: string]: string | CargoManifestDependency }
   package: { version: string }

--- a/cli/tauri.js/src/types/cargo.ts
+++ b/cli/tauri.js/src/types/cargo.ts
@@ -1,15 +1,10 @@
-export interface CargoToml {
-  dependencies: { [k: string]: CargoTomlDependency }
-  package: { version: string }
-}
-
 export interface CargoTomlDependency {
   version?: string
   path?: string
 }
 
 export interface CargoManifest {
-  dependencies: { [k: string]: string | CargoManifestDependency }
+  dependencies: { [k: string]: CargoManifestDependency }
   package: { version: string }
 }
 

--- a/cli/tauri.js/src/types/cargo.ts
+++ b/cli/tauri.js/src/types/cargo.ts
@@ -1,8 +1,3 @@
-export interface CargoTomlDependency {
-  version?: string
-  path?: string
-}
-
 export interface CargoManifest {
   dependencies: { [k: string]: string | CargoManifestDependency }
   package: { version: string }


### PR DESCRIPTION
This PR fixes the case when `tauri info` is run and a project has not yet created a `Cargo.lock`.
Closes #610. 

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
