### PR TITLE
fix(cli): tell user of missing lockfile or manifest during info

### DIFF
--- a/.changes/cli_info_toml_error_handling.md
+++ b/.changes/cli_info_toml_error_handling.md
@@ -1,0 +1,5 @@
+---
+"tauri.js": patch
+---
+
+Handle and communicate missing lockfile and/or manifest while reading versions during `tauri info`


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**
- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**
- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Expands on the fix in #674.  It will handle any error (like it did before the original change for #610) except it won't swallow them.  The original block was wrapped in an empty `try { ... } catch(_) {}` which I didn't replicate in the code replacing it.  This new fix will handle any read error for toml files, and communicate when the expected files are missing when attempted to be read.

![no lockfile](https://user-images.githubusercontent.com/3301043/84599512-73530680-ae27-11ea-9bec-4908d43c3923.png)

![no manifest no lockfile](https://user-images.githubusercontent.com/3301043/84599517-764df700-ae27-11ea-9c2f-c7ed54636c63.png)

It will also now read the manifest along with the lockfile so that it can communicate a missing manifest even if there is a lockfile.

![image](https://user-images.githubusercontent.com/3301043/84599741-2bcd7a00-ae29-11ea-9de0-ae08061cd293.png)

