### PR TITLE
Implement HttpRequestBuilder for HttpRequestOptions (#651)

### DIFF
--- a/tauri-api/src/http.rs
+++ b/tauri-api/src/http.rs
@@ -66,6 +66,146 @@ pub struct HttpRequestOptions {
   pub response_type: Option<ResponseType>,
 }
 
+/// The builder for HttpRequestOptions.
+///
+/// # Examples
+/// ```
+/// # use tauri_api::http::{ HttpRequestBuilder, HttpRequestOptions, make_request, ResponseType };
+/// # fn main() {
+/// let mut builder = HttpRequestBuilder::new("GET", "http://example.com");
+/// let option = builder.response_type(ResponseType::Text)
+///                     .follow_redirects(false)
+///                     .build();
+///
+/// if let Ok(response) = make_request(option) {
+///   println!("Response: {}", response);
+/// } else {
+///   println!("Something Happened!");
+/// }
+/// # }
+/// ```
+pub struct HttpRequestBuilder {
+  /// The request method (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, CONNECT or TRACE)
+  pub method: String,
+  /// The request URL
+  pub url: String,
+  /// The request query params
+  pub params: Option<HashMap<String, Value>>,
+  /// The request headers
+  pub headers: Option<HashMap<String, Value>>,
+  /// The request body
+  pub body: Option<Value>,
+  /// Whether to follow redirects or not
+  pub follow_redirects: Option<bool>,
+  /// Max number of redirections to follow
+  pub max_redirections: Option<u32>,
+  /// Connect timeout for the request
+  pub connect_timeout: Option<u64>,
+  /// Read timeout for the request
+  pub read_timeout: Option<u64>,
+  /// Timeout for the whole request
+  pub timeout: Option<u64>,
+  /// Whether the request will announce that it accepts compression
+  pub allow_compression: Option<bool>,
+  /// The body type (defaults to Auto)
+  pub body_type: Option<BodyType>,
+  /// The response type (defaults to Json)
+  pub response_type: Option<ResponseType>,
+}
+
+impl HttpRequestBuilder {
+  pub fn new(method: impl Into<String>, url: impl Into<String>) -> Self {
+    Self {
+      method: method.into(),
+      url: url.into(),
+      params: None,
+      headers: None,
+      body: None,
+      follow_redirects: None,
+      max_redirections: None,
+      connect_timeout: None,
+      read_timeout: None,
+      timeout: None,
+      allow_compression: None,
+      body_type: None,
+      response_type: None,
+    }
+  }
+
+  pub fn params(mut self, params: HashMap<String, Value>) -> Self {
+    self.params = Some(params);
+    self
+  }
+
+  pub fn headers(mut self, headers: HashMap<String, Value>) -> Self {
+    self.headers = Some(headers);
+    self
+  }
+
+  pub fn body(mut self, body: Value) -> Self {
+    self.body = Some(body);
+    self
+  }
+
+  pub fn follow_redirects(mut self, follow_redirects: bool) -> Self {
+    self.follow_redirects = Some(follow_redirects);
+    self
+  }
+
+  pub fn max_redirections(mut self, max_redirections: u32) -> Self {
+    self.max_redirections = Some(max_redirections);
+    self
+  }
+
+  pub fn connect_timeout(mut self, connect_timeout: u64) -> Self {
+    self.connect_timeout = Some(connect_timeout);
+    self
+  }
+
+  pub fn read_timeout(mut self, read_timeout: u64) -> Self {
+    self.read_timeout = Some(read_timeout);
+    self
+  }
+
+  pub fn timeout(mut self, timeout: u64) -> Self {
+    self.timeout = Some(timeout);
+    self
+  }
+
+  pub fn allow_compression(mut self, allow_compression: bool) -> Self {
+    self.allow_compression = Some(allow_compression);
+    self
+  }
+
+  pub fn body_type(mut self, body_type: BodyType) -> Self {
+    self.body_type = Some(body_type);
+    self
+  }
+
+  pub fn response_type(mut self, response_type: ResponseType) -> Self {
+    self.response_type = Some(response_type);
+    self
+  }
+
+  pub fn build(self) -> HttpRequestOptions {
+    HttpRequestOptions {
+      method: self.method,
+      url: self.url,
+      params: self.params,
+      headers: self.headers,
+      body: self.body,
+      follow_redirects: self.follow_redirects,
+      max_redirections: self.max_redirections,
+      connect_timeout: self.connect_timeout,
+      read_timeout: self.read_timeout,
+      timeout: self.timeout,
+      allow_compression: self.allow_compression,
+      body_type: self.body_type,
+      response_type: self.response_type,
+    }
+  }
+}
+
 /// Executes an HTTP request
 ///
 /// The response will be transformed to String,


### PR DESCRIPTION
This pull request will add `HttpRequestBuilder`,
described at "alternatives you've considered" section in https://github.com/tauri-apps/tauri/issues/651.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
both arguments in `new` method takes `impl Into<String>` instead of `String` so you can pass url or method as `&str`, which can be helpful in various cases (e.g. when URL is already hard-coded in the codebase as `const` or `static`)
```rust
static SOME_URL: &str = "http://example.com";

let builder = HttpRequestBuilder::new("GET", SOME_URL); // I can write without clone!
```
