### PR TITLE
chore: update rust docs on release

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,53 @@
+name: update-docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**/package.json'
+      - '.github/workflows/**'
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout tauri
+        uses: actions/checkout@v2
+        with:
+          path: tauri
+      - name: checkout tauri-docs
+        uses: actions/checkout@v2
+        with:
+          repository: tauri-apps/tauri-docs
+          path: tauri-docs
+      - name: install webkit2gtk
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y webkit2gtk-4.0
+      - name: generate rust docs
+        working-directory: tauri
+        run: cargo doc --no-deps
+      - name: run rustdocusaurus
+        uses: tauri-apps/rustdocusaurus/github-action@master
+        with:
+          originPath: ./tauri/target/doc/
+          targetPath: ./tauri-docs/docs/api/rust/
+          sidebarPath: ./tauri-docs/sidebars.json
+          linksRoot: /docs/api/rust/
+          cratesToProcess: "tauri,tauri_api,tauri_utils"
+      - name: git config
+        run: |
+          git config --global user.name "${{ github.event.pusher.name }}"
+          git config --global user.email "${{ github.event.pusher.email }}"
+      - name: create pull request for updated docs
+        uses: tauri-apps/create-pull-request@v2.8.0
+        working-directory: tauri-docs
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: ${{ github.event.head_commit.message }}
+          branch: docs/release
+          title: Update Docs
+          labels: "new release"
+          body: |
+            These are the updated docs from the most recent release.

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -42,10 +42,9 @@ jobs:
           git config --global user.email "${{ github.event.pusher.email }}"
       - name: create pull request for updated docs
         uses: tauri-apps/create-pull-request@v2.8.0
-        working-directory: tauri-docs
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: ${{ github.event.head_commit.message }}
+          commit-message: "chore(docs): Update Rust docs"
           branch: docs/release
           title: Update Docs
           labels: "new release"


### PR DESCRIPTION
**Description**

This workflow should open a PR to `tauri-docs` with updated rust docs on ever release.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This replaces https://github.com/tauri-apps/tauri-docs/pull/78 which addresses part of https://github.com/tauri-apps/tauri-docs/issues/77.