### PR TITLE
fix(tauri.js): Bump lodash to 4.17.19

### DIFF
--- a/.changes/bump-lodash.md
+++ b/.changes/bump-lodash.md
@@ -1,0 +1,5 @@
+---
+"tauri.js": patch
+---
+
+Bump `lodash` to 4.17.19

--- a/cli/tauri.js/package.json
+++ b/cli/tauri.js/package.json
@@ -63,7 +63,7 @@
     "is-png": "2.0.0",
     "isbinaryfile": "4.0.6",
     "jsdom": "16.2.2",
-    "lodash": "4.17.18",
+    "lodash": "4.17.19",
     "minimist": "1.2.5",
     "ms": "2.1.2",
     "png2icons": "2.0.1",
@@ -127,7 +127,7 @@
     "webpack-node-externals": "1.7.2"
   },
   "resolutions": {
-    "**/lodash": ">=4.17.18"
+    "**/lodash": ">=4.17.19"
   },
   "husky": {
     "hooks": {

--- a/cli/tauri.js/package.json
+++ b/cli/tauri.js/package.json
@@ -63,7 +63,7 @@
     "is-png": "2.0.0",
     "isbinaryfile": "4.0.6",
     "jsdom": "16.2.2",
-    "lodash": "4.17.15",
+    "lodash": "4.17.18",
     "minimist": "1.2.5",
     "ms": "2.1.2",
     "png2icons": "2.0.1",
@@ -125,6 +125,9 @@
     "webpack": "4.43.0",
     "webpack-cli": "3.3.12",
     "webpack-node-externals": "1.7.2"
+  },
+  "resolutions": {
+    "**/lodash": ">=4.17.18"
   },
   "husky": {
     "hooks": {

--- a/cli/tauri.js/yarn.lock
+++ b/cli/tauri.js/yarn.lock
@@ -6570,10 +6570,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.18, lodash@>=4.17.18, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.18"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.18.tgz#5c5f072c5c02f386378dd3f6325b529376210427"
-  integrity sha512-au4L1q0HKcaaa37qOdpWWhwzDnB/taYJfRiKULnaT+Ml9UaBIjJ2SOJMeLtSeeLT+zUdyFMm0+ts+j4eeuUpIA==
+lodash@4.17.19, lodash@>=4.17.19, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 log-symbols@^4.0.0:
   version "4.0.0"

--- a/cli/tauri.js/yarn.lock
+++ b/cli/tauri.js/yarn.lock
@@ -6570,10 +6570,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.17.15, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@4.17.18, lodash@>=4.17.18, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+  version "4.17.18"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.18.tgz#5c5f072c5c02f386378dd3f6325b529376210427"
+  integrity sha512-au4L1q0HKcaaa37qOdpWWhwzDnB/taYJfRiKULnaT+Ml9UaBIjJ2SOJMeLtSeeLT+zUdyFMm0+ts+j4eeuUpIA==
 
 log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Dependency security update

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `latest` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This PR bumps `lodash` to 4.17.19, resolving the audit failures. Pipelines may fail for the time being since some databases have not marked versions >=4.17.16 as safe.