### PR TITLE
fix: tauri past changelog had incorrect versions

### DIFF
--- a/tauri/CHANGELOG.md
+++ b/tauri/CHANGELOG.md
@@ -10,11 +10,13 @@
     This means that you do not need to serialize your response manually or deal with String quotes anymore.
     As part of this refactor, the event::emit function also supports impl Serialize instead of String.
 
-## [0.7.1]
+## [0.6.2]
 
 -   Fixes the Windows build with the latest Windows SDK.
 
-## [0.7.0]
+## [0.6.1] (Not Published)
+
+## [0.6.0]
 
 -   Adds a command line interface option to tauri apps, configurable under tauri.conf.json > tauri > cli.
 -   Fixes no-server mode not running on another machine due to fs::read_to_string usage instead of the include_str macro.


### PR DESCRIPTION
**description**
It appears that the crossover with tauri.js also led to skipping 0.6.1 tauri crate publish.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `latest` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
