### PR TITLE
to enable custom port

### DIFF
--- a/cli/tauri.js/src/helpers/tauri-config.ts
+++ b/cli/tauri.js/src/helpers/tauri-config.ts
@@ -31,7 +31,8 @@ const getTauriConfig = (cfg: Partial<TauriConfig>): TauriConfig => {
       ctx: {},
       tauri: {
         embeddedServer: {
-          active: true
+          active: true,
+          port: "3000"
         },
         bundle: {
           active: true,

--- a/cli/tauri.js/src/types/config.schema.json
+++ b/cli/tauri.js/src/types/config.schema.json
@@ -401,6 +401,7 @@
               "type": "boolean"
             },
             "port": {
+              "description": "enable custom port, instead of using random port",
               "type": "string"
             }
           },

--- a/cli/tauri.js/src/types/config.schema.json
+++ b/cli/tauri.js/src/types/config.schema.json
@@ -399,6 +399,9 @@
             "active": {
               "description": "whether we should use the embedded-server or the no-server mode",
               "type": "boolean"
+            },
+            "port": {
+              "type": "string"
             }
           },
           "type": "object"

--- a/cli/tauri.js/src/types/config.ts
+++ b/cli/tauri.js/src/types/config.ts
@@ -223,6 +223,7 @@ export interface TauriConfig {
        * whether we should use the embedded-server or the no-server mode
        */
       active?: boolean
+      port?: string
     }
     /**
      * tauri bundler configuration

--- a/cli/tauri.js/src/types/config.validator.ts
+++ b/cli/tauri.js/src/types/config.validator.ts
@@ -409,6 +409,9 @@ export const TauriConfigSchema = {
             "active": {
               "description": "whether we should use the embedded-server or the no-server mode",
               "type": "boolean"
+            },
+            "port": {
+              "type": "string"
             }
           },
           "type": "object"

--- a/cli/tauri.js/src/types/config.validator.ts
+++ b/cli/tauri.js/src/types/config.validator.ts
@@ -411,6 +411,7 @@ export const TauriConfigSchema = {
               "type": "boolean"
             },
             "port": {
+              "description": "enable custom port, instead of using random port",
               "type": "string"
             }
           },


### PR DESCRIPTION
current validator doesn't enable port config, with this patch would have allow the config, however this doesn't include the runner changes... runner might need changes too.

#778 

