### PR TITLE
fix: tauri-bundler should ignore command output's invalid utf8 chars instead of panic when executing `CheckNetIsolation LoopbackExempt -s`

### DIFF
--- a/cli/tauri-bundler/src/main.rs
+++ b/cli/tauri-bundler/src/main.rs
@@ -118,9 +118,7 @@ fn run() -> crate::Result<()> {
           panic!("Failed to execute CheckNetIsolation LoopbackExempt -s");
         }
 
-        let output_str = String::from_utf8(exempt_output.stdout)
-          .map_err(|_| anyhow::anyhow!("failed to convert LoopbackExempt output to String"))?
-          .to_lowercase();
+        let output_str = String::from_utf8_lossy(&exempt_output.stdout).to_lowercase();
         if !output_str.contains("win32webviewhost_cw5n1h2txyewy") {
           println!("Running Loopback command");
           Command::new("powershell")


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `latest` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

My environment is:

tauri-bundler: 0.8.4
OS: windows 10 chinese simplified

command `yarn tauri build` outputs:

```
[tauri]: running build
 app:spawn Running "cargo tauri-bundler --features embedded-server --release" +0ms

error: failed to convert LoopbackExempt output to String
  Caused by: failed to convert LoopbackExempt output to String

 app:spawn Command "cargo" failed with exit code: 1 +1ms

 app:tauri (runner) ⚠️  [FAIL] Cargo CLI has failed +0ms

 app:tauri Shutting down tauri process... +0ms
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The root cause is, `CheckNetIsolation LoopbackExempt -s` output:

```
列出环回免除的 AppContainer

[1] -----------------------------------------------------------------
    名称: microsoft.win32webviewhost_cw5n1h2txyewy
    SID:  S-1-15-2-1310292540-1029022339-4008023048-2190398717-53961996-4257829345-603366646

[2] -----------------------------------------------------------------
    名称: microsoft.microsoftedge_8wekyb3d8bbwe
    SID:  S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194

[3] -----------------------------------------------------------------
    名称: AppContainer NOT FOUND
    SID:  S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194-4043415302-551583165-304772019-4009825106

[4] -----------------------------------------------------------------
    名称: 001
    SID:  S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194-4256926629-1688279915-2739229046-3928706915

完成。
```

rust code: `String::from_utf8(exempt_output.stdout)` strangely return utf8 encoding error, and since we only need to check whether `win32webviewhost_cw5n1h2txyewy` is in the output, so, just ignore the invalid utf8 chars is ok.

