### PR TITLE
fix(tauri.js) windows Edge blank screen on tauri dev

### DIFF
--- a/.changes/fix-edge-blank.md
+++ b/.changes/fix-edge-blank.md
@@ -1,0 +1,7 @@
+---
+"tauri.js": patch
+"tauri-api": patch
+---
+
+Fixes Edge blank screen on Windows when running `tauri dev` (Tauri crashing window due to Edge reloading app because of missing Content-Type header).
+

--- a/cli/tauri.js/src/runner.ts
+++ b/cli/tauri.js/src/runner.ts
@@ -116,6 +116,16 @@ class Runner {
             writeFileSync(path.join(indexDir, 'index.html'), bodyStr)
             self.__parseHtml(cfg, indexDir, false)
               .then(({ html }) => {
+                const headers: { [key: string]: string } = {}
+                if(proxyRes.headers['content-type']) {
+                  headers['content-type'] = proxyRes.headers['content-type']
+                } else {
+                  const charsetMatch = /charset="(\S+)"/g.exec(bodyStr)
+                  if (charsetMatch) {
+                    headers['content-type'] = `'text/html; charset=${charsetMatch[1]}`
+                  }
+                }
+                res.writeHead(200, headers)
                 res.end(html)
               }).catch(err => {
                 res.writeHead(500, JSON.stringify(err))

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 /// use tauri_api::rpc::format_callback;
 /// // callback with a string argument
 /// let cb = format_callback("callback-function-name", "the string response");
-/// assert_eq!(cb, r#"window["callback-function-name"]("the string response")"#);
+/// assert!(cb.contains(r#"window["callback-function-name"]("the string response")"#));
 /// ```
 ///
 /// ```
@@ -23,7 +23,7 @@ use std::fmt::Display;
 /// let cb = format_callback("callback-function-name", serde_json::to_value(&MyResponse {
 ///   value: "some value".to_string()
 /// }).expect("failed to serialize"));
-/// assert_eq!(cb, r#"window["callback-function-name"]({"value":"some value"})"#);
+/// assert!(cb.contains(r#"window["callback-function-name"]({"value":"some value"})"#));
 /// ```
 pub fn format_callback<T: Into<JsonValue>, S: AsRef<str> + Display>(
   function_name: S,
@@ -58,11 +58,11 @@ pub fn format_callback<T: Into<JsonValue>, S: AsRef<str> + Display>(
 /// use tauri_api::rpc::format_callback_result;
 /// let res: Result<u8, &str> = Ok(5);
 /// let cb = format_callback_result(res, "success_cb".to_string(), "error_cb".to_string()).expect("failed to format");
-/// assert_eq!(cb, r#"window["success_cb"](5)"#);
+/// assert!(cb.contains(r#"window["success_cb"](5)"#));
 ///
 /// let res: Result<&str, &str> = Err("error message here");
 /// let cb = format_callback_result(res, "success_cb".to_string(), "error_cb".to_string()).expect("failed to format");
-/// assert_eq!(cb, r#"window["error_cb"]("error message here")"#);
+/// assert!(cb.contains(r#"window["error_cb"]("error message here")"#));
 /// ```
 pub fn format_callback_result<T: Serialize, E: Serialize>(
   result: Result<T, E>,

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -29,7 +29,17 @@ pub fn format_callback<T: Into<JsonValue>, S: AsRef<str> + Display>(
   function_name: S,
   arg: T,
 ) -> String {
-  format!(r#"window["{}"]({})"#, function_name, arg.into().to_string())
+  format!(
+    r#"
+      if (window["{fn}"]) {{
+        window["{fn}"]({arg})
+      }} else {{
+        console.warn("[TAURI] Couldn't find callback id {fn} in window. This happens when the app is reloaded while Rust is running an asynchronous operation.")
+      }}
+    "#,
+    fn = function_name,
+    arg = arg.into().to_string()
+  )
 }
 
 /// Formats a Result type to its Promise response.

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -88,7 +88,11 @@ mod test {
     if f != "" && a != "" {
       // call format callback
       let fc = format_callback(f.clone(), a.clone());
-      fc == format!(r#"window["{}"]({})"#, f, serde_json::Value::String(a))
+      fc.contains(&format!(
+        r#"window["{}"]({})"#,
+        f,
+        serde_json::Value::String(a),
+      ))
     } else {
       true
     }
@@ -104,11 +108,10 @@ mod test {
       Err(e) => (ec, e),
     };
 
-    resp
-      == format!(
-        r#"window["{}"]({})"#,
-        function,
-        serde_json::Value::String(value),
-      )
+    resp.contains(&format!(
+      r#"window["{}"]({})"#,
+      function,
+      serde_json::Value::String(value),
+    ))
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `latest` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Previously, the proxied index.html response didn't have a Content-Type header, so Edge refreshes the app, causing a `Object doesn't support property or method ${uid()` because the window transformedCallbacks were cleared.