### PR TITLE
feat(tauri.js) add microsoft edge version to the info output

### DIFF
--- a/.changes/tauri-info-windows.md
+++ b/.changes/tauri-info-windows.md
@@ -1,0 +1,5 @@
+---
+"tauri.js": patch
+---
+
+Improve the `tauri info` output on Windows, including the Microsoft Edge version.

--- a/cli/tauri.js/src/api/info.ts
+++ b/cli/tauri.js/src/api/info.ts
@@ -1,10 +1,11 @@
+
 import toml from '@tauri-apps/toml'
 import chalk from 'chalk'
-import { sync as spawn } from 'cross-spawn'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { appDir, tauriDir } from '../helpers/app-paths'
+import { sync as spawn } from 'cross-spawn'
 import { TauriConfig } from './../types/config'
 import { CargoLock, CargoManifest } from '../types/cargo'
 import nonWebpackRequire from '../helpers/non-webpack-require'
@@ -183,12 +184,22 @@ module.exports = () => {
     ),
     section: true
   })
+  if (os.platform() === 'win32') {
+    const { stdout } = spawn('REG', ['QUERY', 'HKEY_CLASSES_root\\AppX3xxs313wwkfjhythsb8q46xdsq8d2cvv\\Application', '/v', 'ApplicationName'])
+    const match = /{(\S+)}/g.exec(stdout.toString())
+    if (match) {
+      const edgeString = match[1]
+      printInfo({ key: 'Microsoft Edge', value: edgeString.split('?')[0].replace('Microsoft.MicrosoftEdge_', '') })
+    }
+  }
+
   printInfo({ key: 'Node.js environment', section: true })
   printInfo({ key: '  Node.js', value: chalk.green(process.version.slice(1)) })
   printInfo({
     key: '  tauri.js',
     value: chalk.green(version)
   })
+
   printInfo({ key: 'Rust environment', section: true })
   printInfo({
     key: '  rustc',
@@ -199,9 +210,11 @@ module.exports = () => {
     value: getVersion('cargo', [], output => output.split(' ')[1])
   })
   printInfo({ key: '  tauri-bundler', value: getVersion('cargo', ['tauri-bundler']) })
+
   printInfo({ key: 'Global packages', section: true })
   printInfo({ key: '  NPM', value: getVersion('npm') })
   printInfo({ key: '  yarn', value: getVersion('yarn') })
+
   printInfo({ key: 'App directory structure', section: true })
 
   const tree = dirTree(appDir)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `latest` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
