### PR TITLE
"support" bundling AppImage when building in a container

### DIFF
--- a/cli/tauri-bundler/src/bundle/templates/appimage
+++ b/cli/tauri-bundler/src/bundle/templates/appimage
@@ -33,4 +33,9 @@ mksquashfs {{app_name}}.AppDir {{app_name}}.squashfs -root-owned -noappend
 
 wget -q -O appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || wget -q -O appimagetool https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage
 chmod +x appimagetool
-./appimagetool {{app_name}}.AppDir {{app_name}}.AppImage
+if lsmod | grep -q fuse; then
+  ./appimagetool {{app_name}}.AppDir {{app_name}}.AppImage
+else
+  ./appimagetool --appimage-extract
+  ./squashfs-root/AppRun {{app_name}}.AppDir {{app_name}}.AppImage
+fi

--- a/cli/tauri-bundler/src/bundle/templates/appimage
+++ b/cli/tauri-bundler/src/bundle/templates/appimage
@@ -38,4 +38,5 @@ if lsmod | grep -q fuse; then
 else
   ./appimagetool --appimage-extract
   ./squashfs-root/AppRun {{app_name}}.AppDir {{app_name}}.AppImage
+  rm -rf ./squashfs-root
 fi


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `latest` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

As discussed in [this AppImage bug report](https://github.com/AppImage/AppImageKit/issues/405), Using `appimagetool` under Docker (and friends) as an executable won't work because AppImage executes its bundle by FUSE mounting the embedded squashfs file system - and this does not work in a container becase FUSE is a kernel feature that is hard (and likely not a good idea anyway) to access from a container.

As the above discussion recommends, it is actually simple to workaround the problem by manually extracting the AppImage file system to a local directory and running it from there.

This drive-by PR adds a test using `lsmod` to see if we have fuse supported available in the kernel, and if not - uses the `--appimage-extract` workaround to run the AppImage tool. I have tested this patch by building [tauri-theia](https://github.com/tauri-apps/tauri-theia) under docker.

The `lsmod` detection is probably not ideal, but I'm not sure what other detection method would work better - I thought using an environment variable to trigger the new behavior, but Docker itself does not provide any such identifying environment variable so discovery by builders might be a problem.

Let me know if this feature is interesting but you want a different implementation and I can see what I can do better.
