### PR TITLE
Helper scripts to run cargo clippy + test for all features

### DIFF
--- a/.scripts/cargo-check.ps1
+++ b/.scripts/cargo-check.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = "Stop"
+Write-Output "Checking tauri crates"
+
+
+$commands=@("clippy","test")
+$features=@("no-server","embedded-server")
+foreach ($command in $commands) {
+  foreach ($feature in $features) {
+    Write-Output "[$command][$feature] checking tauri"
+    cargo $command --manifest-path tauri/Cargo.toml --all-targets --features "$feature,cli,all-api"
+  }
+
+  Write-Output "[$command] checking other crates"
+  cargo $command --workspace --exclude tauri --all-targets --all-features
+}

--- a/.scripts/cargo-check.ps1
+++ b/.scripts/cargo-check.ps1
@@ -1,4 +1,3 @@
-$ErrorActionPreference = "Stop"
 Write-Output "Checking tauri crates"
 
 

--- a/.scripts/cargo-check.sh
+++ b/.scripts/cargo-check.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -e
+
+echo "Checking tauri crates"
+
+for command in "clippy" "test"
+do
+  for feature in "no-server" "embedded-server"
+  do
+    echo "[$command][$feature] checking tauri"
+    cargo "$command" --manifest-path tauri/Cargo.toml --all-targets --features "$feature,cli,all-api"
+  done
+
+  echo "[$command] checking other crates"
+  cargo "$command" --workspace --exclude tauri --all-targets --all-features
+done


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Runs clippy + tests on all the crates in the workspace.  Crates with mutually exclusive features (`tauri`) are run separately, and for each mutually exclusive feature.  This was inspired by having #850 pass CI checks, but actually fail some of the tests due to features not being enabled (`tauri/cli` in this case).  I didn't even notice this until I typo'd `--all-targets` as `--all-features`.

We also may want to look at doing something similar in CI because some other features besides `cli` might be slipping through the cracks