### PR TITLE
fix(tauri) ensure css content is loaded inside a string

### DIFF
--- a/.changes/load-asset-css.md
+++ b/.changes/load-asset-css.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+make sure css content injected is inside a string and not injected raw

--- a/tauri/src/endpoints/asset.rs
+++ b/tauri/src/endpoints/asset.rs
@@ -65,15 +65,15 @@ pub fn load(
           if asset_type == "stylesheet" {
             webview_ref.eval(&format!(
               r#"
-                (function () {{
+                (function (content) {{
                   var css = document.createElement('style')
                   css.type = 'text/css'
-                  if (css.styleSheet)  
-                      css.styleSheet.cssText = {css}
-                  else  
-                      css.appendChild(document.createTextNode({css}))
+                  if (css.styleSheet)
+                      css.styleSheet.cssText = content
+                  else
+                      css.appendChild(document.createTextNode(content))
                   document.getElementsByTagName("head")[0].appendChild(css);
-                }})()
+                }})("{css}")
               "#,
               css = asset_str
             ));


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [x] No

**The PR fulfills these requirements:**
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
CSS assets cannot load with `loadAsset` because the CSS content is being injected raw.  This change
1. injects CSS content inside of a string
2. reduces interpolation to a single instance