### PR TITLE
disable tests that fail on default windows installs

### DIFF
--- a/tauri-api/src/command.rs
+++ b/tauri-api/src/command.rs
@@ -93,9 +93,9 @@ pub fn binary_command(binary_name: String) -> crate::Result<String> {
 #[cfg(test)]
 mod test {
   use super::*;
-  use crate::Error;
   use std::io;
 
+  #[cfg(not(windows))]
   #[test]
   // test the get_output function with a unix cat command.
   fn test_cmd_output() {
@@ -115,9 +115,12 @@ mod test {
     }
   }
 
+  #[cfg(not(windows))]
   #[test]
   // test the failure case for get_output
   fn test_cmd_fail() {
+    use crate::Error;
+
     // queue up a string with cat in it.
     let cmd = String::from("cat");
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: tests

**Does this PR introduce a breaking change?** (check one)
- [x] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
`cat` is not available as a command on a default windows install. This disables the commands tests that use `cat` during tests.  It also disables `test_cmd_fail` even though it passes, because the test is testing the wrong thing in this case.