### PR TITLE
feat(workflow) update helper cargo-check scripts

### DIFF
--- a/.scripts/cargo-check.ps1
+++ b/.scripts/cargo-check.ps1
@@ -1,14 +1,59 @@
-Write-Output "Checking tauri crates"
+#!/usr/bin/env pwsh
+# note: you can pass in the cargo sub-commands used to check manually.
+# allowed commands: check, clippy, fmt, test
+# default: clippy, fmt, test
 
+# set the script arguments if none are found
+if(-Not $args) {
+  $args=@("clippy","fmt","test")
+}
 
-$commands=@("clippy","test")
-$features=@("no-server","embedded-server")
-foreach ($command in $commands) {
-  foreach ($feature in $features) {
-    Write-Output "[$command][$feature] checking tauri"
-    cargo $command --manifest-path tauri/Cargo.toml --all-targets --features "$feature,cli,all-api"
+# exit the script early if the last command returned an error
+function check_error {
+  if($LASTEXITCODE -ne 0 ) {
+    Exit $LASTEXITCODE
+  }
+}
+
+# run n+1 times, where n is the amount of mutually exclusive features.
+# the extra run is for all the crates without mutually exclusive features.
+# as many features as possible are enabled at for each command
+function mutex {
+  $command, $_args = $args
+
+  foreach ($feature in @("no-server","embedded-server")) {
+    Write-Output "[$command][$feature] tauri"
+    cargo $command --manifest-path tauri/Cargo.toml --all-targets --features "$feature,cli,all-api" $_args
+    check_error
   }
 
-  Write-Output "[$command] checking other crates"
-  cargo $command --workspace --exclude tauri --all-targets --all-features
+  Write-Output "[$command] other crates"
+  cargo $command --workspace --exclude tauri --all-targets --all-features $_args
+  check_error
+}
+
+foreach ($command in $args) {
+  Switch ($command) {
+    "check" {
+      mutex check
+      break
+    }
+    "test" {
+      mutex test
+      break
+    }
+    "clippy" {
+      mutex clippy "--" -D warnings
+      break
+    }
+    "fmt" {
+      Write-Output "[$command] checking formatting"
+      cargo fmt "--" --check
+      check_error
+    }
+    default {
+      Write-Output "[cargo-check.ps1] Unknown cargo sub-command: $command"
+      Exit 1
+    }
+  }
 }

--- a/.scripts/cargo-check.sh
+++ b/.scripts/cargo-check.sh
@@ -1,16 +1,47 @@
 #!/usr/bin/env sh
+# note: you can pass in the cargo sub-commands used to check manually.
+# allowed commands: check, clippy, fmt, test
+# default: clippy, fmt, test
+
+# exit the script early if any of the commands return an error
 set -e
 
-echo "Checking tauri crates"
+# set the script arguments if none are found
+if [ -z "$*" ]; then
+  set -- "clippy" "fmt" "test"
+fi
 
-for command in "clippy" "test"
-do
-  for feature in "no-server" "embedded-server"
-  do
-    echo "[$command][$feature] checking tauri"
-    cargo "$command" --manifest-path tauri/Cargo.toml --all-targets --features "$feature,cli,all-api"
+# run n+1 times, where n is the amount of mutually exclusive features.
+# the extra run is for all the crates without mutually exclusive features.
+# as many features as possible are enabled at for each command
+mutex() {
+  command=$1
+  shift 1
+
+  for feature in "no-server" "embedded-server"; do
+    echo "[$command][$feature] tauri"
+    cargo "$command" --manifest-path tauri/Cargo.toml --all-targets --features "$feature,cli,all-api" "$@"
   done
 
-  echo "[$command] checking other crates"
-  cargo "$command" --workspace --exclude tauri --all-targets --all-features
+  echo "[$command] other crates"
+  cargo "$command" --workspace --exclude tauri --all-targets --all-features "$@"
+}
+
+for command in "$@"; do
+  case "$command" in
+  check | test)
+    mutex "$command"
+    ;;
+  clippy)
+    mutex clippy -- -D warnings
+    ;;
+  fmt)
+    echo "[$command] checking formatting"
+    cargo fmt -- --check
+    ;;
+  *)
+    echo "[cargo-check.sh] Unknown cargo sub-command: $command"
+    exit 1
+    ;;
+  esac
 done


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This is a very nice improvement to the `cargo-check` script helpers.
1. The `cargo` commands ran now run identically to how they run in CI
2. The PowerShell script now exits early on error
3. Default commands ran now includes a `fmt` check
4. Able to pass in sub-commands you want ran as arguments to the script.  e.g. `cargo-check.sh fmt clippy` to run only run the format check and clippy (in that order). This is useful if we decide to use these on the CI so that we can keep jobs separate but still use the same script.

Just running the script without parameters gives you a CI-like experience for the cargo workspace projects. We could use this script directly in CI (if we decide remove the nice `actions-rs/clippy` action that puts clippy output next to file diffs) to get an exact CI experience (for the cargo workspace projects)