### PR TITLE
feat(bundler): hide output from shell scripts unless --verbose is passed (fixes #888)

### DIFF
--- a/.changes/bundler-script-output.md
+++ b/.changes/bundler-script-output.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Hide external scripts output unless `--verbose` is passed.

--- a/cli/tauri-bundler/src/bundle/appimage_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/appimage_bundle.rs
@@ -91,8 +91,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let mut cmd = Command::new(&sh_file);
   cmd.current_dir(output_path);
 
-  common::print_info("running build_appimage.sh")?;
-  common::execute_with_output(&mut cmd)
+  common::execute_silently(&mut cmd)
     .map_err(|_| crate::Error::ShellScriptError("error running build_appimage.sh".to_owned()))?;
 
   remove_dir_all(&package_dir)?;

--- a/cli/tauri-bundler/src/bundle/appimage_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/appimage_bundle.rs
@@ -74,7 +74,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   // create the shell script file in the target/ folder.
   let sh_file = output_path.join("build_appimage.sh");
-  common::print_bundling(format!("{:?}", &appimage_path).as_str())?;
+  common::print_bundling(&appimage_path.file_name().unwrap().to_str().unwrap())?;
   write(&sh_file, temp)?;
 
   // chmod script for execution

--- a/cli/tauri-bundler/src/bundle/appimage_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/appimage_bundle.rs
@@ -92,10 +92,14 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   cmd.current_dir(output_path);
 
   common::execute_with_verbosity(&mut cmd, &settings).map_err(|_| {
-    crate::Error::ShellScriptError(
-      "error running build_appimage.sh, try running with --verbose to see command output"
-        .to_owned(),
-    )
+    crate::Error::ShellScriptError(format!(
+      "error running appimage.sh{}",
+      if settings.is_verbose() {
+        ""
+      } else {
+        ", try running with --verbose to see command output"
+      }
+    ))
   })?;
 
   remove_dir_all(&package_dir)?;

--- a/cli/tauri-bundler/src/bundle/appimage_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/appimage_bundle.rs
@@ -91,8 +91,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let mut cmd = Command::new(&sh_file);
   cmd.current_dir(output_path);
 
-  common::execute_with_verbosity(&mut cmd, &settings)
-    .map_err(|_| crate::Error::ShellScriptError("error running build_appimage.sh".to_owned()))?;
+  common::execute_with_verbosity(&mut cmd, &settings).map_err(|_| {
+    crate::Error::ShellScriptError(
+      "error running build_appimage.sh, try running with --verbose to see command output"
+        .to_owned(),
+    )
+  })?;
 
   remove_dir_all(&package_dir)?;
   Ok(vec![appimage_path])

--- a/cli/tauri-bundler/src/bundle/appimage_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/appimage_bundle.rs
@@ -91,7 +91,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let mut cmd = Command::new(&sh_file);
   cmd.current_dir(output_path);
 
-  common::execute_silently(&mut cmd)
+  common::execute_with_verbosity(&mut cmd, &settings)
     .map_err(|_| crate::Error::ShellScriptError("error running build_appimage.sh".to_owned()))?;
 
   remove_dir_all(&package_dir)?;

--- a/cli/tauri-bundler/src/bundle/common.rs
+++ b/cli/tauri-bundler/src/bundle/common.rs
@@ -290,6 +290,21 @@ pub fn execute_with_output(cmd: &mut Command) -> crate::Result<()> {
   }
 }
 
+pub fn execute_silently(cmd: &mut Command) -> crate::Result<()> {
+  let mut child = cmd
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .spawn()
+    .expect("failed to spawn command");
+
+  let status = child.wait()?;
+  if status.success() {
+    Ok(())
+  } else {
+    Err(anyhow::anyhow!("command failed").into())
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::{copy_dir, create_file, is_retina, resource_relpath, symlink_file};

--- a/cli/tauri-bundler/src/bundle/dmg_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/dmg_bundle.rs
@@ -116,7 +116,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     .args(vec![dmg_name.as_str(), bundle_name.as_str()]);
 
   common::print_info("running bundle_dmg.sh")?;
-  common::execute_with_output(&mut cmd)
+  common::execute_with_verbosity(&mut cmd, &settings)
     .map_err(|_| crate::Error::ShellScriptError("error running bundle_dmg.sh".to_owned()))?;
 
   fs::rename(bundle_dir.join(dmg_name), dmg_path.clone())?;

--- a/cli/tauri-bundler/src/bundle/dmg_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/dmg_bundle.rs
@@ -116,8 +116,11 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     .args(vec![dmg_name.as_str(), bundle_name.as_str()]);
 
   common::print_info("running bundle_dmg.sh")?;
-  common::execute_with_verbosity(&mut cmd, &settings)
-    .map_err(|_| crate::Error::ShellScriptError("error running bundle_dmg.sh".to_owned()))?;
+  common::execute_with_verbosity(&mut cmd, &settings).map_err(|_| {
+    crate::Error::ShellScriptError(
+      "error running bundle_dmg.sh, try running with --verbose to see command output".to_owned(),
+    )
+  })?;
 
   fs::rename(bundle_dir.join(dmg_name), dmg_path.clone())?;
   Ok(vec![bundle_path, dmg_path])

--- a/cli/tauri-bundler/src/bundle/dmg_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/dmg_bundle.rs
@@ -117,9 +117,14 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   common::print_info("running bundle_dmg.sh")?;
   common::execute_with_verbosity(&mut cmd, &settings).map_err(|_| {
-    crate::Error::ShellScriptError(
-      "error running bundle_dmg.sh, try running with --verbose to see command output".to_owned(),
-    )
+    crate::Error::ShellScriptError(format!(
+      "error running bundle_dmg.sh{}",
+      if settings.is_verbose() {
+        ""
+      } else {
+        ", try running with --verbose to see command output"
+      }
+    ))
   })?;
 
   fs::rename(bundle_dir.join(dmg_name), dmg_path.clone())?;

--- a/cli/tauri-bundler/src/bundle/settings.rs
+++ b/cli/tauri-bundler/src/bundle/settings.rs
@@ -281,6 +281,8 @@ pub struct Settings {
   project_out_directory: PathBuf,
   /// whether we should build the app with release mode or not.
   is_release: bool,
+  /// whether or not to enable verbose logging
+  is_verbose: bool,
   /// the bundle settings.
   bundle_settings: BundleSettings,
   /// the binaries to bundle.
@@ -326,6 +328,7 @@ impl Settings {
       None => None,
     };
     let is_release = matches.is_present("release");
+    let is_verbose = matches.is_present("verbose");
     let target = match matches.value_of("target") {
       Some(triple) => Some((triple.to_string(), TargetInfo::from_str(triple)?)),
       None => None,
@@ -433,6 +436,7 @@ impl Settings {
       target,
       features,
       is_release,
+      is_verbose,
       project_out_directory: target_dir,
       binaries,
       bundle_settings,
@@ -584,6 +588,11 @@ impl Settings {
   /// it's being compiled in debug mode.
   pub fn is_release_build(&self) -> bool {
     self.is_release
+  }
+
+  /// Returns true if verbose logging is enabled
+  pub fn is_verbose(&self) -> bool {
+    self.is_verbose
   }
 
   /// Returns the bundle name, which is either package.metadata.bundle.name or package.name

--- a/cli/tauri-bundler/src/bundle/wix.rs
+++ b/cli/tauri-bundler/src/bundle/wix.rs
@@ -361,7 +361,7 @@ fn run_candle(
     .current_dir(build_path);
 
   common::print_info("running candle.exe")?;
-  common::execute_with_output(&mut cmd).map_err(|_| crate::Error::CandleError)
+  common::execute_with_verbosity(&mut cmd, &settings).map_err(|_| crate::Error::CandleError)
 }
 
 /// Runs the Light.exe file. Light takes the generated code from Candle and produces an MSI Installer.
@@ -391,7 +391,7 @@ fn run_light(
     .current_dir(build_path);
 
   common::print_info(format!("running light to produce {}", output_path.display()).as_str())?;
-  common::execute_with_output(&mut cmd)
+  common::execute_with_verbosity(&mut cmd, &settings)
     .map(|_| output_path.to_path_buf())
     .map_err(|_| crate::Error::LightError)
 }

--- a/cli/tauri-bundler/src/bundle/wix.rs
+++ b/cli/tauri-bundler/src/bundle/wix.rs
@@ -370,6 +370,7 @@ fn run_light(
   build_path: &Path,
   wixobjs: &[&str],
   output_path: &Path,
+  settings: &Settings,
 ) -> crate::Result<PathBuf> {
   let light_exe = wix_toolset_path.join("light.exe");
 
@@ -512,7 +513,8 @@ pub fn build_wix_app_installer(
     &wix_toolset_path,
     &output_path,
     &wixobjs,
-    &app_installer_dir(settings)?,
+    &app_installer_dir(&settings)?,
+    &settings,
   )?;
 
   Ok(target)

--- a/cli/tauri-bundler/src/bundle/wix.rs
+++ b/cli/tauri-bundler/src/bundle/wix.rs
@@ -361,7 +361,16 @@ fn run_candle(
     .current_dir(build_path);
 
   common::print_info("running candle.exe")?;
-  common::execute_with_verbosity(&mut cmd, &settings).map_err(|_| crate::Error::CandleError)
+  common::execute_with_verbosity(&mut cmd, &settings).map_err(|_| {
+    crate::Error::ShellScriptError(format!(
+      "error running candle.exe{}",
+      if settings.is_verbose() {
+        ""
+      } else {
+        ", try running with --verbose to see command output"
+      }
+    ))
+  })
 }
 
 /// Runs the Light.exe file. Light takes the generated code from Candle and produces an MSI Installer.
@@ -394,7 +403,16 @@ fn run_light(
   common::print_info(format!("running light to produce {}", output_path.display()).as_str())?;
   common::execute_with_verbosity(&mut cmd, &settings)
     .map(|_| output_path.to_path_buf())
-    .map_err(|_| crate::Error::LightError)
+    .map_err(|_| {
+      crate::Error::ShellScriptError(format!(
+        "error running light.exe{}",
+        if settings.is_verbose() {
+          ""
+        } else {
+          ", try running with --verbose to see command output"
+        }
+      ))
+    })
 }
 
 // fn get_icon_data() -> crate::Result<()> {

--- a/cli/tauri-bundler/src/error.rs
+++ b/cli/tauri-bundler/src/error.rs
@@ -55,10 +55,6 @@ pub enum Error {
   HashError,
   #[error("Architecture Error: `{0}`")]
   ArchError(String),
-  #[error("Error running Candle.exe")]
-  CandleError,
-  #[error("Error running Light.exe")]
-  LightError,
   #[error(
     "Couldn't get tauri config; please specify the TAURI_CONFIG or TAURI_DIR environment variables"
   )]

--- a/cli/tauri-bundler/src/main.rs
+++ b/cli/tauri-bundler/src/main.rs
@@ -98,6 +98,10 @@ fn run() -> crate::Result<()> {
             .long("version")
             .short("v")
             .help("Read the version of the bundler"),
+        ).arg(
+          Arg::with_name("verbose")
+            .long("verbose")
+            .help("Enable verbose output"),
         ),
     )
     .get_matches();

--- a/cli/tauri.js/bin/tauri-build.js
+++ b/cli/tauri.js/bin/tauri-build.js
@@ -4,9 +4,10 @@ const argv = parseArgs(process.argv.slice(2), {
   alias: {
     h: 'help',
     d: 'debug',
-    t: 'target'
+    t: 'target',
+    v: 'verbose'
   },
-  boolean: ['h', 'd']
+  boolean: ['h', 'd', 'v']
 })
 
 if (argv.help) {
@@ -19,6 +20,7 @@ if (argv.help) {
     --help, -h     Displays this message
     --debug, -d    Builds with the debug flag
     --target, -t   Comma-separated list of target triples to build against
+    --verbose, -v  Enable verbose logging
   `)
   process.exit(0)
 }
@@ -30,7 +32,8 @@ async function run () {
     ctx: {
       debug: argv.debug,
       target: argv.target
-    }
+    },
+    verbose: argv.verbose
   }).promise
 }
 

--- a/cli/tauri.js/src/runner.ts
+++ b/cli/tauri.js/src/runner.ts
@@ -271,6 +271,7 @@ class Runner {
           )
         ]
           .concat(cfg.ctx.debug ? [] : ['--release'])
+          .concat(cfg.verbose ? ['--verbose'] : [])
           .concat(target ? ['--target', target] : [])
       })
 

--- a/cli/tauri.js/src/types/config.schema.json
+++ b/cli/tauri.js/src/types/config.schema.json
@@ -492,6 +492,10 @@
         "window"
       ],
       "type": "object"
+    },
+    "verbose": {
+      "description": "Whether or not to enable verbose logging",
+      "type": "boolean"
     }
   },
   "required": [

--- a/cli/tauri.js/src/types/config.ts
+++ b/cli/tauri.js/src/types/config.ts
@@ -294,6 +294,10 @@ export interface TauriConfig {
       [key: string]: any
     }
   }
+  /**
+   * Whether or not to enable verbose logging
+   */
+  verbose?: boolean
 }
 
 export default TauriConfig

--- a/cli/tauri.js/src/types/config.validator.ts
+++ b/cli/tauri.js/src/types/config.validator.ts
@@ -502,6 +502,10 @@ export const TauriConfigSchema = {
         "window"
       ],
       "type": "object"
+    },
+    "verbose": {
+      "description": "Whether or not to enable verbose logging",
+      "type": "boolean"
     }
   },
   "required": [


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

As per #888, I think the platform build scripts' output is way too verbose. This PR will hide all the output from those scripts so that they match the behavior of pure rust bundlers.

## To Do:

- [x] Provide a configuration to show the script's output
- [x] Show output on error (`stderr` always shows some info text for some reason, even on success)

Rather than fix stderr, I just added a notice about `--verbose` if the script fails (dmg/appimage only)