### PR TITLE
inject css with template string to allow for line breaks

### DIFF
--- a/.changes/load-asset-css.md
+++ b/.changes/load-asset-css.md
@@ -2,4 +2,4 @@
 "tauri": patch
 ---
 
-make sure css content injected is inside a string and not injected raw
+Make sure CSS content loaded with the `loadAsset` API is inside a template string and not injected raw.

--- a/tauri/src/endpoints/asset.rs
+++ b/tauri/src/endpoints/asset.rs
@@ -73,7 +73,7 @@ pub fn load(
                   else
                       css.appendChild(document.createTextNode(content))
                   document.getElementsByTagName("head")[0].appendChild(css);
-                }})("{css}")
+                }})(`{css}`)
               "#,
               css = asset_str
             ));


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [x] No

**The PR fulfills these requirements:**
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
No change file because there hasn't been a release since the last commit that changed this behavior. (e3e2e3920833627400ee7a5b000dc6e51d8d332b)

An alternative solution would to be implement a struct `JsStringLiteral` with a `fmt::Display` that escapes all forbidden codepoints detailed in the spec: https://www.ecma-international.org/ecma-262/#sec-literals-string-literals
An approach very similar to this was previously used to escape css content injected inside of the webview crate. (the one before `webview_official`)

Template string literal fix seems to be by far the simplest change to fix it.  All browsers that tauri supports (the webview browsers) have had support for them for the past 3-4+ years.

I didn't catch this during e3e2e3920833627400ee7a5b000dc6e51d8d332b because my css was minified with no newlines.
