### PR TITLE
feat(tauri.js/init): set appName in api instead of bin

### DIFF
--- a/cli/tauri.js/bin/tauri-init.js
+++ b/cli/tauri.js/bin/tauri-init.js
@@ -1,17 +1,7 @@
 const parseArgs = require('minimist')
 const inquirer = require('inquirer')
-const {
-  resolve
-} = require('path')
-const {
-  readFileSync,
-  writeFileSync
-} = require('fs')
-const {
-  merge,
-  kebabCase
-} = require('lodash')
-const toml = require('@tauri-apps/toml')
+const { resolve } = require('path')
+const { merge } = require('lodash')
 
 /**
  * @type {object}
@@ -130,6 +120,7 @@ async function runInit(config = {}) {
     force: argv.f || null,
     logging: argv.l || null,
     tauriPath: argv.t || null,
+    appName: appName || argv.A || null,
     customConfig: merge(configOptions, {
       build: {
         distDir: argv.D,
@@ -142,18 +133,6 @@ async function runInit(config = {}) {
       }
     })
   })
-
-  if (appName || argv.A) {
-    const manifestPath = resolve(directory, 'src-tauri/Cargo.toml')
-    const cargoManifest = toml.parse(readFileSync(manifestPath).toString())
-    let binName = kebabCase(appName || argv.A)
-    cargoManifest.package.name = binName
-    cargoManifest.package['default-run'] = binName
-    if (cargoManifest.bin && cargoManifest.bin.length) {
-      cargoManifest.bin[0].name = binName
-    }
-    writeFileSync(manifestPath, toml.stringify(cargoManifest))
-  }
 
   const {
     installDependencies

--- a/cli/tauri.js/src/api/init.ts
+++ b/cli/tauri.js/src/api/init.ts
@@ -1,5 +1,10 @@
 import { TauriConfig } from 'types'
 import { inject } from '../template'
+import { resolve } from 'path'
+import toml, { JsonMap } from '@tauri-apps/toml'
+import { readFileSync, writeFileSync } from 'fs'
+import { kebabCase } from 'lodash'
+import { CargoManifest } from 'src/types/cargo'
 
 module.exports = (args: {
   directory: string
@@ -7,8 +12,9 @@ module.exports = (args: {
   logging: boolean
   tauriPath?: string
   customConfig?: Partial<TauriConfig>
+  appName?: string
 }): boolean => {
-  return inject(
+  const injectResult = inject(
     args.directory,
     'all',
     {
@@ -18,4 +24,16 @@ module.exports = (args: {
     },
     args.customConfig
   )
+  if (args.appName) {
+    const manifestPath = resolve(args.directory, 'src-tauri/Cargo.toml')
+    const cargoManifest = toml.parse(readFileSync(manifestPath).toString()) as unknown as CargoManifest
+    const binName = kebabCase(args.appName)
+    cargoManifest.package.name = binName
+    cargoManifest.package['default-run'] = binName
+    if (cargoManifest.bin?.length) {
+      cargoManifest.bin[0].name = binName
+    }
+    writeFileSync(manifestPath, toml.stringify(cargoManifest as unknown as JsonMap))
+  }
+  return injectResult
 }

--- a/cli/tauri.js/src/types/cargo.ts
+++ b/cli/tauri.js/src/types/cargo.ts
@@ -1,6 +1,10 @@
 export interface CargoManifest {
   dependencies: { [k: string]: string | CargoManifestDependency }
-  package: { version: string }
+  package: { version: string, name: string, 'default-run': string }
+  bin: Array<{
+    name: string
+    path: string
+  }>
 }
 
 export interface CargoManifestDependency {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

By making `appName` a parameter in the init api function and setting it there instead of in the bin file, users of the api (like the vue cli plugin) can easily set a custom app name.
