### PR TITLE
Fix typos referring to CLI args in init command

### DIFF
--- a/.changes/921-fix-cli-args.md
+++ b/.changes/921-fix-cli-args.md
@@ -1,0 +1,6 @@
+---
+"tauri.js": patch
+---
+
+Fix command line arguments -W (window title) and -P (dev server uri) to work as intended.
+

--- a/cli/tauri.js/bin/tauri-init.js
+++ b/cli/tauri.js/bin/tauri-init.js
@@ -128,7 +128,7 @@ async function runInit(config = {}) {
       },
       tauri: {
         window: {
-          title: argv.w
+          title: argv.W
         }
       }
     })

--- a/cli/tauri.js/bin/tauri-init.js
+++ b/cli/tauri.js/bin/tauri-init.js
@@ -124,7 +124,7 @@ async function runInit(config = {}) {
     customConfig: merge(configOptions, {
       build: {
         distDir: argv.D,
-        devPath: argv.p
+        devPath: argv.P
       },
       tauri: {
         window: {


### PR DESCRIPTION
The devPath config variable is set to a non-existent command line arg
`argv.p`, it should be `argv.P`

So if the devPath is set via a command line argument, it defaults
to the default value:

```
/home/projects/example2
⟩ yarn tauri init -P http://THISDOESNOTHING
yarn run v1.22.4
$ /home/projects/example2/node_modules/.bin/tauri init -P http://THISDOESNOTHING
[tauri]: running init
? What is your app name? example2
? What should the window title be? Tauri App
? Where are your web assets (HTML/CSS/JS) located, relative to the "<current dir>/src-tauri" folder that will be created? ../dist
 dependency:manager Installing missing dependencies... +0ms
 dependency:cargo-commands "tauri-bundler" is already installed +18ms
 app:spawn [sync] Running "cargo generate-lockfile" +2ms

    Updating crates.io index
 dependency:crates "tauri" is already installed +941ms
 dependency:npm-packages "tauri" is already installed +1s
Done in 6.35s.

/home/projects/example2
⟩ cat ./src-tauri/tauri.conf.json | grep THISDOESNOTHING

/home/projects/example2
```

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [X] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number) -- **N/A**
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
