### PR TITLE
Fix cli no prompt for app-name cli arg

### DIFF
--- a/.changes/980-fix-appname-cli-arg.md
+++ b/.changes/980-fix-appname-cli-arg.md
@@ -1,0 +1,5 @@
+---
+"tauri.js": patch
+---
+
+* Make interactive prompt not ask for app name supplied as cli arg

--- a/cli/tauri.js/bin/tauri-create.js
+++ b/cli/tauri.js/bin/tauri-create.js
@@ -91,7 +91,8 @@ const getOptionsInteractive = (argv) => {
         type: 'input',
         name: 'appName',
         message: 'What is your app name?',
-        default: defaultAppName
+        default: defaultAppName,
+        when: !argv.A
       },
       {
         type: 'input',


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [X] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
