### PR TITLE
chore: package .crate as part of publish step

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -33,13 +33,13 @@
           "command": "echo \"\\`\\`\\`\"",
           "dryRunCommand": true,
           "pipe": true
-        },
-        {
-          "command": "cargo package --no-verify --allow-dirty",
-          "dryRunCommand": true
         }
-      ],
-      "publish": [
+      ]
+      "publish": [,
+        {
+          "command": "cargo package --allow-dirty",
+          "dryRunCommand": true
+        },
         {
           "command": "echo \"# Cargo Publish\"",
           "dryRunCommand": true,


### PR DESCRIPTION
It is very strict about checking that the deps version specified is published. That means we need to have inter-repo deps already published before we hit this step, and therefore cannot do it as part of the prepublish step.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
