### PR TITLE
fix(bundler) missing newline in deb desktop file generation (fix: #899, #925)

### DIFF
--- a/.changes/998-bundler-newline.md
+++ b/.changes/998-bundler-newline.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+add a newline after Categories in deb .desktop file generation to fix issues #899 and #925.

--- a/cli/tauri-bundler/src/bundle/deb_bundle.rs
+++ b/cli/tauri-bundler/src/bundle/deb_bundle.rs
@@ -193,7 +193,7 @@ fn generate_desktop_file(settings: &Settings, data_dir: &Path) -> crate::Result<
   writeln!(file, "[Desktop Entry]")?;
   writeln!(file, "Encoding=UTF-8")?;
   if let Some(category) = settings.app_category() {
-    write!(file, "Categories={}", category.gnome_desktop_categories())?;
+    writeln!(file, "Categories={}", category.gnome_desktop_categories())?;
   }
   if !settings.short_description().is_empty() {
     writeln!(file, "Comment={}", settings.short_description())?;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
fixes https://github.com/tauri-apps/tauri/issues/899 and https://github.com/tauri-apps/tauri/issues/925
- [X] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [X] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
the generated desktop file didn't work properly (especially if no `short_description` was given) since the newline was missing and the next line ended up as a category.