### PR TITLE
fix: #1018 Force IPv4 on wget requests

### DIFF
--- a/.changes/wget-fix.md
+++ b/.changes/wget-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Force IPv4 on `wget` so AppImage bundling doesn't hang.

--- a/cli/tauri-bundler/src/bundle/templates/appimage
+++ b/cli/tauri-bundler/src/bundle/templates/appimage
@@ -9,7 +9,7 @@ cp -r ../deb/{{bundle_name}}/data/usr {{app_name}}.AppDir
 
 cd {{app_name}}.AppDir
 
-wget -q -O AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || wget -q -O AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-aarch64
+wget -q -O -4 AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || wget -q -O -4 AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-aarch64
 chmod +x AppRun
 
 cp usr/share/icons/hicolor/256x256/apps/{{app_name}}.png {{app_name}}.png
@@ -31,7 +31,7 @@ mv {{app_name}}.desktop {{app_name}}.AppDir/{{app_name}}.desktop
 
 mksquashfs {{app_name}}.AppDir {{app_name}}.squashfs -root-owned -noappend
 
-wget -q -O appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || wget -q -O appimagetool https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage
+wget -q -O -4 appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || wget -q -O -4 appimagetool https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage
 chmod +x appimagetool
 if lsmod | grep -q fuse; then
   ./appimagetool {{app_name}}.AppDir {{app_name}}.AppImage

--- a/cli/tauri-bundler/src/bundle/templates/appimage
+++ b/cli/tauri-bundler/src/bundle/templates/appimage
@@ -9,7 +9,7 @@ cp -r ../deb/{{bundle_name}}/data/usr {{app_name}}.AppDir
 
 cd {{app_name}}.AppDir
 
-wget -q -O -4 AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || wget -q -O -4 AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-aarch64
+wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-aarch64
 chmod +x AppRun
 
 cp usr/share/icons/hicolor/256x256/apps/{{app_name}}.png {{app_name}}.png
@@ -31,7 +31,7 @@ mv {{app_name}}.desktop {{app_name}}.AppDir/{{app_name}}.desktop
 
 mksquashfs {{app_name}}.AppDir {{app_name}}.squashfs -root-owned -noappend
 
-wget -q -O -4 appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || wget -q -O -4 appimagetool https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage
+wget -q -4 -O appimagetool https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || wget -q -4 -O appimagetool https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage
 chmod +x appimagetool
 if lsmod | grep -q fuse; then
   ./appimagetool {{app_name}}.AppDir {{app_name}}.AppImage


### PR DESCRIPTION
`wget` sometimes doesn't handle IPv6 well and DNS server may resolve the domain to IPv6 so it'll be better to force IPv4.

https://serverfault.com/questions/290315/why-is-wget-hanging

Resolves #1018 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

