### PR TITLE
fix: add working directory to wix's shortcut

### DIFF
--- a/.changes/wix-working-directory.md
+++ b/.changes/wix-working-directory.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Set the Windows installer (WiX) `WorkingDirectory` field to `INSTALLDIR` so the app can read paths relatively (previously resolving to `C:\Windows\System32`).

--- a/cli/tauri-bundler/src/bundle/templates/main.wxs
+++ b/cli/tauri-bundler/src/bundle/templates/main.wxs
@@ -103,7 +103,8 @@
                     Name="{{{product_name}}}"
                     Description="Runs {{{product_name}}}"
                     Target="[!Path]"
-                    Icon="ProductIcon">
+                    Icon="ProductIcon"
+                    WorkingDirectory="INSTALLDIR">
                     <ShortcutProperty Key="System.AppUserModel.ID" Value="{{{manufacturer}}}"/>
                 </Shortcut>
                 <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

In this screenshot, the one on the left is a shortcut that I created manually and on the right is the shortcut created by wix at `C:\ProgramData\Microsoft\Windows\StartMenu\Programs\<app-name>\`

![image](https://user-images.githubusercontent.com/48618675/93112849-c0f63e00-f6b8-11ea-800b-872bef2ace7d.png)

you can see that the shortcut created by wix doesn't have its `Start in (working directory)` field set, so it will default to `C:\Windows\System32` which will introduce errors when the app tries to read paths relatively.
