### PR TITLE
fix: #1038 Call Reclect.has before Reflect.deleteProperty

### DIFF
--- a/cli/tauri.js/api-src/tauri.ts
+++ b/cli/tauri.js/api-src/tauri.ts
@@ -44,7 +44,7 @@ function transformCallback(
 
   Object.defineProperty(window, identifier, {
     value: (result: any) => {
-      if (once) {
+      if (once && Reflect.has(window, identifier)) {
         Reflect.deleteProperty(window, identifier)
       }
 
@@ -67,11 +67,15 @@ async function promisified<T>(args: any): Promise<T> {
   return await new Promise((resolve, reject) => {
     const callback = transformCallback((e) => {
       resolve(e)
-      Reflect.deleteProperty(window, error)
+      if(Reflect.has(window, error)) {
+        Reflect.deleteProperty(window, error)
+      }
     }, true)
     const error = transformCallback((e) => {
       reject(e)
-      Reflect.deleteProperty(window, callback)
+      if(Reflect.has(window, callback)) {
+        Reflect.deleteProperty(window, callback)
+      }
     }, true)
 
     invoke({

--- a/cli/tauri.js/api-src/tauri.ts
+++ b/cli/tauri.js/api-src/tauri.ts
@@ -67,13 +67,13 @@ async function promisified<T>(args: any): Promise<T> {
   return await new Promise((resolve, reject) => {
     const callback = transformCallback((e) => {
       resolve(e)
-      if(Reflect.has(window, error)) {
+      if (Reflect.has(window, error)) {
         Reflect.deleteProperty(window, error)
       }
     }, true)
     const error = transformCallback((e) => {
       reject(e)
-      if(Reflect.has(window, callback)) {
+      if (Reflect.has(window, callback)) {
         Reflect.deleteProperty(window, callback)
       }
     }, true)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x ] No


**The PR fulfills these requirements:**

- [ x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The problem seems to be that the call to remove the callback from the window is being called twice. Usually this is not a problem, but it seems to be a problem in Safari because it is throwing a `TypeError: Unable to delete property.`