### PR TITLE
fix: revert failed publish of #1024

### DIFF
--- a/.changes/delete-property.md
+++ b/.changes/delete-property.md
@@ -1,0 +1,5 @@
+---
+"tauri.js": patch
+---
+
+Fixes `Reflect.deleteProperty` on promisified API calls failing with `Unable to delete property` by making it configurable.

--- a/.changes/dirs.md
+++ b/.changes/dirs.md
@@ -1,0 +1,6 @@
+---
+"tauri-bundler": patch
+"tauri-api": patch
+---
+
+`dirs` crate is unmaintained, now using `dirs-next` instead.

--- a/.changes/missing-features.md
+++ b/.changes/missing-features.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch"
+---
+
+Adds missing APIs features from `allowlist` to the tauri crate's manifest file.

--- a/.changes/path-api.md
+++ b/.changes/path-api.md
@@ -1,0 +1,6 @@
+---
+"tauri.js": minor
+"tauri": minor
+---
+
+Adds a path resolution API (e.g. getting the download directory or resolving a path to the home directory).

--- a/.changes/rust-update.md
+++ b/.changes/rust-update.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Update minimum Rust version to 1.42.0 due to a dependency update.

--- a/.changes/wget-fix.md
+++ b/.changes/wget-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Force IPv4 on `wget` so AppImage bundling doesn't hang.

--- a/.changes/wix-working-directory.md
+++ b/.changes/wix-working-directory.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Set the Windows installer (WiX) `WorkingDirectory` field to `INSTALLDIR` so the app can read paths relatively (previously resolving to `C:\Windows\System32`).

--- a/cli/tauri-bundler/CHANGELOG.md
+++ b/cli/tauri-bundler/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## [0.9.4]
-
--   `dirs` crate is unmaintained, now using `dirs-next` instead.
-    -   [82cda98](https://www.github.com/tauri-apps/tauri/commit/82cda98532975c6d4b1c93bf2f326173f39e0964) chore(tauri) `dirs` crate is unmaintained, use `dirst-next` instead ([#1057](https://www.github.com/tauri-apps/tauri/pull/1057)) on 2020-10-17
--   Force IPv4 on `wget` so AppImage bundling doesn't hang.
-    -   [6f5667b](https://www.github.com/tauri-apps/tauri/commit/6f5667bf72d58972b8d05ee2e42a031c85f95ed4) fix: [#1018](https://www.github.com/tauri-apps/tauri/pull/1018) Force IPv4 on wget requests ([#1019](https://www.github.com/tauri-apps/tauri/pull/1019)) on 2020-10-11
--   Set the Windows installer (WiX) `WorkingDirectory` field to `INSTALLDIR` so the app can read paths relatively (previously resolving to `C:\Windows\System32`).
-    -   [5cf3402](https://www.github.com/tauri-apps/tauri/commit/5cf3402735ac2e88fc4aae5fe39fc0a41262b6fa) fix: add working directory to wix's shortcut ([#1021](https://www.github.com/tauri-apps/tauri/pull/1021)) on 2020-09-24
-
 ## [0.9.3]
 
 -   Improve checking for Xcode command line tools to allow builds on mac

--- a/cli/tauri-bundler/Cargo.toml
+++ b/cli/tauri-bundler/Cargo.toml
@@ -2,7 +2,7 @@ workspace = { }
 
 [package]
 name = "tauri-bundler"
-version = "0.9.4"
+version = "0.9.3"
 authors = [
   "George Burton <burtonageo@gmail.com>",
   "Lucas Fernandes Gonçalves Nogueira <lucas@tauri.studio>",

--- a/cli/tauri.js/CHANGELOG.md
+++ b/cli/tauri.js/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [0.13.0]
-
--   Fixes `Reflect.deleteProperty` on promisified API calls failing with `Unable to delete property` by making it configurable.
-    -   [c8b167a](https://www.github.com/tauri-apps/tauri/commit/c8b167adb3561db182bc8f6e4d8753ce1ae3f450) fix(tauri.js) promisified API fails on Reflect.deleteProperty, fix [#1038](https://www.github.com/tauri-apps/tauri/pull/1038) ([#1056](https://www.github.com/tauri-apps/tauri/pull/1056)) on 2020-10-17
--   Adds a path resolution API (e.g. getting the download directory or resolving a path to the home directory).
-    -   [771e401](https://www.github.com/tauri-apps/tauri/commit/771e4019b8cfd1973015ffa632c9d6c6b82c5657) feat: Port path api to js ([#1006](https://www.github.com/tauri-apps/tauri/pull/1006)) on 2020-09-24
-
 ## [0.12.0]
 
 -   Break out TauriBuildConfig interface from TauriConfig build property

--- a/cli/tauri.js/package.json
+++ b/cli/tauri.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri",
-  "version": "0.13.0",
+  "version": "0.12.0",
   "description": "Multi-binding collection of libraries and templates for building Tauri apps",
   "bin": {
     "tauri": "./bin/tauri.js"

--- a/tauri-api/CHANGELOG.md
+++ b/tauri-api/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [0.7.5]
-
--   `dirs` crate is unmaintained, now using `dirs-next` instead.
-    -   [82cda98](https://www.github.com/tauri-apps/tauri/commit/82cda98532975c6d4b1c93bf2f326173f39e0964) chore(tauri) `dirs` crate is unmaintained, use `dirst-next` instead ([#1057](https://www.github.com/tauri-apps/tauri/pull/1057)) on 2020-10-17
-
 ## [0.7.4]
 
 -   Bump all deps as noted in #975, #976, #977, #978, and #979.

--- a/tauri-api/Cargo.toml
+++ b/tauri-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-api"
-version = "0.7.5"
+version = "0.7.4"
 authors = [
   "Lucas Fernandes Gonçalves Nogueira <lucas@tauri.studio>",
   "Daniel Thompson-Yvetot <denjell@sfosc.org>",

--- a/tauri/CHANGELOG.md
+++ b/tauri/CHANGELOG.md
@@ -1,14 +1,5 @@
 # Changelog
 
-## [0.10.0]
-
--   Adds missing APIs features from `allowlist` to the tauri crate's manifest file.
-    -   [2c0f09c](https://www.github.com/tauri-apps/tauri/commit/2c0f09c85c8a60c2fa304fb25174d5020663f0d7) fix(tauri) add missing API features, closes [#1023](https://www.github.com/tauri-apps/tauri/pull/1023) ([#1052](https://www.github.com/tauri-apps/tauri/pull/1052)) on 2020-10-17
--   Adds a path resolution API (e.g. getting the download directory or resolving a path to the home directory).
-    -   [771e401](https://www.github.com/tauri-apps/tauri/commit/771e4019b8cfd1973015ffa632c9d6c6b82c5657) feat: Port path api to js ([#1006](https://www.github.com/tauri-apps/tauri/pull/1006)) on 2020-09-24
--   Update minimum Rust version to 1.42.0 due to a dependency update.
-    -   [d13dcd9](https://www.github.com/tauri-apps/tauri/commit/d13dcd9fd8d30b1db147a78cecb878e924382274) chore(deps) Update Tauri Bundler ([#1045](https://www.github.com/tauri-apps/tauri/pull/1045)) on 2020-10-17
-
 ## [0.9.2]
 
 -   Bump all deps as noted in #975, #976, #977, #978, and #979.

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri"
-version = "0.10.0"
+version = "0.9.2"
 authors = [
   "Lucas Fernandes Gonçalves Nogueira <lucas@tauri.studio>",
   "Daniel Thompson-Yvetot <denjell@sfosc.org>",
@@ -33,7 +33,7 @@ anyhow = "1.0.33"
 thiserror = "1.0.21"
 envmnt = "0.8.4"
 once_cell = "1.4.1"
-tauri-api = { version = "0.7.5", path = "../tauri-api" }
+tauri-api = { version = "0.7.4", path = "../tauri-api" }
 urlencoding = "1.1.1"
 
 [target."cfg(target_os = \"windows\")".dependencies]


### PR DESCRIPTION
This reverts commit 72996be1bd3eb878c4cf30bfec79058071c26d7a. It will let us merge and publish with existing changes on `dev` without another version bump for some packages.