### PR TITLE
fix: webpack progress display options not valid

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -68,3 +68,8 @@ jobs:
           cd ./cli/tauri.js
           yarn
           yarn test
+      - name: run release build
+        timeout-minutes: 15
+        working-directory: cli/tauri.js
+        run: yarn build-release
+        

--- a/cli/tauri.js/package.json
+++ b/cli/tauri.js/package.json
@@ -14,7 +14,7 @@
     "build:webpack": "rimraf ./dist && yarn build:typevalidators && webpack --progress",
     "build:typevalidators": "node ./build/type-validators",
     "build:api": "rimraf ./api && rollup -c --silent",
-    "build-release": "yarn build --display none --progress false",
+    "build-release": "yarn build:api && rimraf ./dist && yarn build:typevalidators && webpack",
     "test": "jest --runInBand --no-cache --testPathIgnorePatterns=\"(build|dev)\"",
     "pretest": "yarn build",
     "prepublishOnly": "yarn build-release",


### PR DESCRIPTION
It seems something changed that the progress and display options we were using the hide the output are no longer valid. Remove them.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
