### PR TITLE
fix: getNpmLatestVersion, getNpmPackageVersion without npm

### DIFF
--- a/.changes/updater-issue-without-npm
+++ b/.changes/updater-issue-without-npm
@@ -1,0 +1,5 @@
+---
+"tauri.js": patch
+---
+
+Fixes an issue with the dependency updater when NPM isn't installed.

--- a/cli/tauri.js/src/api/dependency-manager/util.ts
+++ b/cli/tauri.js/src/api/dependency-manager/util.ts
@@ -23,7 +23,12 @@ async function getCrateLatestVersion(crateName: string): Promise<string> {
 }
 
 function getNpmLatestVersion(packageName: string): string {
-  const child = crossSpawnSync('npm', ['show', packageName, 'version'], {
+  const usesYarn = existsSync(appResolve.app('yarn.lock'))
+  const cmd = usesYarn ? 'yarn' : 'npm'
+  const args = usesYarn
+    ? ['--silent', 'info', packageName, 'version']
+    : ['show', packageName, 'version']
+  const child = crossSpawnSync(cmd, args, {
     cwd: appDir
   })
   return String(child.output[1]).replace('\n', '')
@@ -32,12 +37,13 @@ function getNpmLatestVersion(packageName: string): string {
 async function getNpmPackageVersion(
   packageName: string
 ): Promise<string | null> {
+  const usesYarn = existsSync(appResolve.app('yarn.lock'))
+  const cmd = usesYarn ? 'yarn' : 'npm'
+  const args = usesYarn
+    ? ['--silent', 'list', packageName, 'version', '--depth', '0']
+    : ['list', packageName, 'version', '--depth', '0']
   return await new Promise((resolve) => {
-    const child = crossSpawnSync(
-      'npm',
-      ['list', packageName, 'version', '--depth', '0'],
-      { cwd: appDir }
-    )
+    const child = crossSpawnSync(cmd, args, { cwd: appDir })
     const output = String(child.output[1])
     // eslint-disable-next-line security/detect-non-literal-regexp
     const matches = new RegExp(packageName + '@(\\S+)', 'g').exec(output)


### PR DESCRIPTION
Optionally use yarn commands to get package versions info instead of npm.
This allows the `tauri` CLI to run without `npm` available (only `yarn` is used).

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes. Issue #___
- [x] No

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

If `yarn` is used and the `npm` command is not available the package version commands in 
`getNpmLatestVersion()` and `getNpmPackageVersion()` will fail.

Equivalent commands for `yarn` are available:
- `npm show packageName version` : `yarn --silent info packageName version`
- `npm list packageName version --depth 0` : `yarn --silent list packageName version --depth 0`

Example error log for the curious:

```
yarn tauri init
yarn run v1.22.10
$ tauri init
[tauri]: running init
? What is your app name? Example
? What should the window title be? Example
? What is the url of your dev server? http://localhost:4000
? Where are your web assets (HTML/CSS/JS) located, relative to the "<current dir>/src-tauri" folder that will be created? ../dist
 dependency:manager Installing missing dependencies... +0ms
 dependency:cargo-commands "tauri-bundler" is already installed +206ms
 app:spawn [sync] Running "cargo generate-lockfile" +2ms

    Updating crates.io index
 dependency:crates "tauri" is already installed +2s
(node:3980) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '1' of null
    at example/node_modules/tauri/dist/api/dependency-manager.js:926:57
    at new Promise (<anonymous>)
    at Object.<anonymous> (example/node_modules/tauri/dist/api/dependency-manager.js:924:46)
    at step (example/node_modules/tauri/dist/api/dependency-manager.js:874:23)
    at Object.next (example/node_modules/tauri/dist/api/dependency-manager.js:855:53)
    at example/node_modules/tauri/dist/api/dependency-manager.js:849:71
    at new Promise (<anonymous>)
    at __webpack_modules__../src/api/dependency-manager/util.ts.__awaiter (example/node_modules/tauri/dist/api/dependency-manager.js:845:12)
    at Object.getNpmPackageVersion (example/node_modules/tauri/dist/api/dependency-manager.js:921:12)
    at example/node_modules/tauri/dist/api/dependency-manager.js:587:49
(Use `node --trace-warnings ...` to show where the warning was created)
(node:3980) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:3980) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Done in 15.92s.
```