### PR TITLE
Fix: writeBinaryFile to call the correct command (fix #1133)

### DIFF
--- a/.changes/writeBinaryFile.md
+++ b/.changes/writeBinaryFile.md
@@ -1,0 +1,13 @@
+---
+"tauri.js": patch
+"tauri": minor
+---
+
+fix writeBinaryFile in the js api to call the correct function
+on the rust side. Before, files were sent in base64 encoding, but
+the save-as-text `WriteFile` fs command was reused, without any 
+indication that the contents were base64 encoded. So the WriteFile
+command had no way of checking and decoding when necessary. 
+WriteBinaryFile on the rust side expects a base64 encoded string, then
+decodes it.
+

--- a/.changes/writeBinaryFile.md
+++ b/.changes/writeBinaryFile.md
@@ -3,11 +3,4 @@
 "tauri": minor
 ---
 
-fix writeBinaryFile in the js api to call the correct function
-on the rust side. Before, files were sent in base64 encoding, but
-the save-as-text `WriteFile` fs command was reused, without any 
-indication that the contents were base64 encoded. So the WriteFile
-command had no way of checking and decoding when necessary. 
-WriteBinaryFile on the rust side expects a base64 encoded string, then
-decodes it.
-
+Match writeBinaryFile command name between js and rust

--- a/cli/tauri.js/api-src/fs.ts
+++ b/cli/tauri.js/api-src/fs.ts
@@ -166,7 +166,7 @@ async function writeBinaryFile(
   }
 
   return await promisified({
-    cmd: 'writeFile',
+    cmd: 'writeBinaryFile',
     path: file.path,
     contents: arrayBufferToBase64(file.contents),
     options


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Fixes #1133.

Fix writeBinaryFile in the js api to call the correct function on the rust side. Before, files were sent in base64 encoding, but the save-as-text `WriteFile` fs command was reused, without any indication that the contents were base64 encoded. So the WriteFile command had no way of checking and decoding when necessary. WriteBinaryFile on the rust side expects a base64 encoded string, then decodes it.