### PR TITLE
fix(tauri): run plugin::ready without webview.dispatch

### DIFF
--- a/.changes/plugin-ready-hook.md
+++ b/.changes/plugin-ready-hook.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch"
+---
+
+Fixes the event system usage on the plugin `ready` hook.

--- a/tauri/src/app/runner.rs
+++ b/tauri/src/app/runner.rs
@@ -312,9 +312,7 @@ fn build_webview(
       };
       application.run_setup(&mut w, source.to_string());
       if source == "window-1" {
-        w.dispatch(|w| {
-          crate::plugin::ready(w);
-        });
+        crate::plugin::ready(&mut w);
       }
     } else if arg == r#"{"cmd":"closeSplashscreen"}"# {
       let content_href = match content_clone {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Using `webview.dispatch` and sending the closure `webview` value doesn't work with the event system since the `webview` variable is dropped in that case, so `webview.as_mut` always errors out.