### PR TITLE
fix(tauri/asset): escape octal sequences in css

### DIFF
--- a/.changes/css-inliner-octal.md
+++ b/.changes/css-inliner-octal.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Replace `\` with `\\` in css assets that are lazy loaded. Since these are injected in a template literal, backslashes must be escaped. Backslashes are sometimes used for octal sequences in CSS.

--- a/tauri/src/endpoints/asset.rs
+++ b/tauri/src/endpoints/asset.rs
@@ -76,7 +76,8 @@ pub fn load(
                   document.getElementsByTagName("head")[0].appendChild(css);
                 }})(`{css}`)
               "#,
-              css = asset_str
+              // Escape octal sequences, which aren't allowed in template literals
+              css = asset_str.replace("\\", "\\\\").as_str()
             ));
           } else {
             webview_ref.eval(asset_str);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Octal escape sequences, sometimes used for special unicode characters, are not allowed in template literals. Since Tauri's asset loader for no-server injects css into a template literal, it will throw an error if the css contains an octal sequence. This PR will replace `\` with `\\` in css assets which will allow the octal sequence to pass through to the css without triggering a JS error.