### PR TITLE
fix(bundler): workspace detection, closes #1007

### DIFF
--- a/.changes/workspace-detection.md
+++ b/.changes/workspace-detection.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": minor
+---
+
+Fixes the bundler workspace detection.

--- a/cli/tauri-bundler/src/bundle/settings.rs
+++ b/cli/tauri-bundler/src/bundle/settings.rs
@@ -507,19 +507,18 @@ impl Settings {
   /// Otherwise returns the current directory.
   pub fn get_workspace_dir(current_dir: &PathBuf) -> PathBuf {
     let mut dir = current_dir.clone();
-    let project_name = CargoSettings::load(&dir).unwrap().package.unwrap().name;
+    let project_path = current_dir.clone();
 
     while dir.pop() {
       if let Ok(cargo_settings) = CargoSettings::load(&dir) {
         if let Some(workspace_settings) = cargo_settings.workspace {
-          if workspace_settings.members.is_some()
-            && workspace_settings
-              .members
-              .expect("Couldn't get members")
+          if let Some(members) = workspace_settings.members {
+            if members
               .iter()
-              .any(|member| member.as_str() == project_name)
-          {
-            return dir;
+              .any(|member| dir.join(member) == project_path)
+            {
+              return dir;
+            }
           }
         }
       }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The bundler workspace detection from the official cargo-bundle project assumes that the folder name and the project name are always the same. This is never the case for Tauri though, unless your app is named `src-tauri` :joy: This PR changes the algorithm to compare file paths instead of project names, which is the way Cargo workspaces work.