### PR TITLE
fix(cli): beforeDev/beforeBuild cmds on windows - find cmd with `which`

### DIFF
--- a/cli/core/Cargo.lock
+++ b/cli/core/Cargo.lock
@@ -1265,9 +1265,9 @@ checksum = "3ac73b1112776fc109b2e61909bc46c7e1bf0d7f690ffb1676553acce16d5cda"
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1299,7 +1299,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -1320,7 +1320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1340,9 +1340,9 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
@@ -1362,7 +1362,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1454,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1511,7 +1511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a620b0994a180cdfa25c0439e6d58c0628272571501880d626ffff58e96a0799"
 dependencies = [
  "cc",
- "which",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -1777,6 +1777,7 @@ dependencies = [
  "shared_child",
  "tauri-bundler",
  "toml_edit",
+ "which 4.0.2",
 ]
 
 [[package]]
@@ -2050,6 +2051,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "wildmatch"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2896475a242c41366941faa27264df2cb935185a92e059a004d0048feb2ac5"
+checksum = "5a8977234acab718eb2820494b2f96cbb16004c19dddf88b7445b27381450997"
 dependencies = [
  "byteorder",
  "bzip2",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -23,3 +23,6 @@ shared_child = "0.3"
 toml_edit = "0.2"
 convert_case = "0.4"
 json-patch = "0.2"
+
+[target."cfg(target_os = \"windows\")".dependencies]
+which = "4.0"

--- a/cli/core/src/build.rs
+++ b/cli/core/src/build.rs
@@ -8,7 +8,7 @@ use crate::helpers::{
   config::get as get_config,
   execute_with_output,
   manifest::rewrite_manifest,
-  TauriScript,
+  Logger, TauriScript,
 };
 use std::{
   env::{set_current_dir, set_var},
@@ -52,6 +52,7 @@ impl Build {
   }
 
   pub fn run(self) -> crate::Result<()> {
+    let logger = Logger::new("tauri:build");
     let config = get_config(self.config.as_deref())?;
     let config_guard = config.lock().unwrap();
     let config_ = config_guard.as_ref().unwrap();
@@ -117,6 +118,12 @@ impl Build {
       }
 
       if let Some(cmd) = cmd {
+        logger.log(format!("Running `{}`", before_build));
+        #[cfg(target_os = "windows")]
+        let mut command = Command::new(
+          which::which(&cmd).expect(&format!("failed to find `{}` in your $PATH", cmd)),
+        );
+        #[cfg(not(target_os = "windows"))]
         let mut command = Command::new(cmd);
         command.args(args).current_dir(app_dir());
         execute_with_output(&mut command)?;

--- a/cli/core/src/dev.rs
+++ b/cli/core/src/dev.rs
@@ -80,6 +80,11 @@ impl Dev {
 
       if let Some(cmd) = cmd {
         logger.log(format!("Running `{}`", before_dev));
+        #[cfg(target_os = "windows")]
+        let mut command = Command::new(
+          which::which(&cmd).expect(&format!("failed to find `{}` in your $PATH", cmd)),
+        );
+        #[cfg(not(target_os = "windows"))]
         let mut command = Command::new(cmd);
         let child = command.args(args).current_dir(app_dir()).spawn()?;
         BEFORE_DEV.set(Mutex::new(child)).unwrap();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

On Windows the command might need a `.cmd` appended to be found, so `which` fixes that.