### PR TITLE
refactor: use own invoke return struct instead of serde_json::Value

### DIFF
--- a/cli/tauri.js/templates/src-tauri/src/main.rs
+++ b/cli/tauri.js/templates/src-tauri/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
               println!("{}", argument);
             }
           }
-          Ok(serde_json::Value::Null)
+          Ok(().into())
         }
       }
     })

--- a/tauri/examples/api/src-tauri/src/main.rs
+++ b/tauri/examples/api/src-tauri/src/main.rs
@@ -38,11 +38,11 @@ fn main() {
         Ok(command) => match command {
           LogOperation { event, payload } => {
             println!("{} {:?}", event, payload);
-            Ok(serde_json::Value::Null)
+            Ok(().into())
           }
           PerformRequest { endpoint, body } => {
             println!("{} {:?}", endpoint, body);
-            Ok(serde_json::Value::String("message response".to_string()))
+            Ok("message response".into())
           }
         },
       }

--- a/tauri/examples/communication/src-tauri/src/main.rs
+++ b/tauri/examples/communication/src-tauri/src/main.rs
@@ -39,11 +39,11 @@ fn main() {
         Ok(command) => match command {
           LogOperation { event, payload } => {
             println!("{} {:?}", event, payload);
-            Ok(serde_json::Value::Null)
+            Ok(().into())
           }
           PerformRequest { endpoint, body } => {
             println!("{} {:?}", endpoint, body);
-            Ok(serde_json::Value::String("message response".to_string()))
+            Ok("message response".into())
           }
         },
       }

--- a/tauri/src/endpoints/cli.rs
+++ b/tauri/src/endpoints/cli.rs
@@ -1,5 +1,5 @@
+use crate::app::InvokeResponse;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
 
 /// The API descriptor.
 #[derive(Deserialize)]
@@ -11,14 +11,14 @@ pub enum Cmd {
 
 impl Cmd {
   #[allow(unused_variables)]
-  pub async fn run(self, context: &crate::app::Context) -> crate::Result<JsonValue> {
+  pub async fn run(self, context: &crate::app::Context) -> crate::Result<InvokeResponse> {
     match self {
       #[allow(unused_variables)]
       Self::CliMatches => {
         #[cfg(cli)]
         return tauri_api::cli::get_matches(&context.config)
           .map_err(Into::into)
-          .and_then(super::to_value);
+          .map(Into::into);
         #[cfg(not(cli))]
           Err(crate::Error::ApiNotEnabled(
             "CLI definition not set under tauri.conf.json > tauri > cli (https://tauri.studio/docs/api/config#tauri.cli)".to_string(),

--- a/tauri/src/endpoints/event.rs
+++ b/tauri/src/endpoints/event.rs
@@ -1,5 +1,5 @@
+use crate::app::InvokeResponse;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
 
 /// The API descriptor.
 #[derive(Deserialize)]
@@ -26,7 +26,7 @@ impl Cmd {
   pub async fn run<A: crate::ApplicationExt + 'static>(
     self,
     webview_manager: &crate::WebviewManager<A>,
-  ) -> crate::Result<JsonValue> {
+  ) -> crate::Result<InvokeResponse> {
     match self {
       Self::Listen {
         event,
@@ -35,7 +35,6 @@ impl Cmd {
       } => {
         let js_string = listen_fn(event, handler, once)?;
         webview_manager.current_webview().await?.eval(&js_string)?;
-        Ok(JsonValue::Null)
       }
       Self::Emit {
         event,
@@ -54,9 +53,9 @@ impl Cmd {
           // dispatch the event to JS listeners
           webview_manager.emit(event, payload).await?;
         }
-        Ok(JsonValue::Null)
       }
     }
+    Ok(().into())
   }
 }
 

--- a/tauri/src/endpoints/global_shortcut.rs
+++ b/tauri/src/endpoints/global_shortcut.rs
@@ -1,7 +1,6 @@
-use crate::{api::shortcuts::ShortcutManager, async_runtime::Mutex};
+use crate::{api::shortcuts::ShortcutManager, app::InvokeResponse, async_runtime::Mutex};
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
 
 use std::sync::Arc;
 
@@ -26,7 +25,7 @@ impl Cmd {
   pub async fn run<A: crate::ApplicationExt + 'static>(
     self,
     webview_manager: &crate::WebviewManager<A>,
-  ) -> crate::Result<JsonValue> {
+  ) -> crate::Result<InvokeResponse> {
     #[cfg(not(global_shortcut))]
     return Err(crate::Error::ApiNotAllowlisted(
       "globalShortcut".to_string(),
@@ -41,13 +40,12 @@ impl Cmd {
             crate::api::rpc::format_callback(handler.to_string(), serde_json::Value::Null);
           let _ = dispatcher.eval(callback_string.as_str());
         })?;
-        Ok(JsonValue::Null)
       }
       Self::Unregister { shortcut } => {
         let mut manager = manager_handle().lock().await;
         manager.unregister_shortcut(shortcut)?;
-        Ok(JsonValue::Null)
       }
     }
+    Ok(().into())
   }
 }

--- a/tauri/src/endpoints/internal.rs
+++ b/tauri/src/endpoints/internal.rs
@@ -1,5 +1,5 @@
+use crate::app::InvokeResponse;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
 
 /// The API descriptor.
 #[derive(Deserialize)]
@@ -9,7 +9,7 @@ pub enum Cmd {
 }
 
 impl Cmd {
-  pub async fn run(self) -> crate::Result<JsonValue> {
+  pub async fn run(self) -> crate::Result<InvokeResponse> {
     match self {
       Self::ValidateSalt { salt } => validate_salt(salt),
     }
@@ -17,6 +17,6 @@ impl Cmd {
 }
 
 /// Validates a salt.
-pub fn validate_salt(salt: String) -> crate::Result<JsonValue> {
-  Ok(JsonValue::Bool(crate::salt::is_valid(salt)))
+pub fn validate_salt(salt: String) -> crate::Result<InvokeResponse> {
+  Ok(crate::salt::is_valid(salt).into())
 }

--- a/tauri/src/endpoints/shell.rs
+++ b/tauri/src/endpoints/shell.rs
@@ -1,5 +1,5 @@
+use crate::app::InvokeResponse;
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
 
 /// The API descriptor.
 #[derive(Deserialize)]
@@ -12,7 +12,7 @@ pub enum Cmd {
 }
 
 impl Cmd {
-  pub async fn run(self) -> crate::Result<JsonValue> {
+  pub async fn run(self) -> crate::Result<InvokeResponse> {
     match self {
       Self::Execute {
         command: _,
@@ -21,7 +21,7 @@ impl Cmd {
         #[cfg(execute)]
         {
           //TODO
-          Ok(JsonValue::Null)
+          Ok(().into())
         }
         #[cfg(not(execute))]
         Err(crate::Error::ApiNotAllowlisted("execute".to_string()))
@@ -30,7 +30,7 @@ impl Cmd {
         #[cfg(open)]
         {
           open_browser(uri);
-          Ok(JsonValue::Null)
+          Ok(().into())
         }
         #[cfg(not(open))]
         Err(crate::Error::ApiNotAllowlisted("open".to_string()))

--- a/tauri/src/endpoints/window.rs
+++ b/tauri/src/endpoints/window.rs
@@ -1,6 +1,5 @@
-use crate::app::{ApplicationExt, Icon};
+use crate::app::{ApplicationExt, Icon, InvokeResponse};
 use serde::Deserialize;
-use serde_json::Value as JsonValue;
 
 #[derive(Deserialize)]
 #[serde(untagged)]
@@ -95,7 +94,7 @@ impl Cmd {
   pub async fn run<A: ApplicationExt + 'static>(
     self,
     webview_manager: &crate::WebviewManager<A>,
-  ) -> crate::Result<JsonValue> {
+  ) -> crate::Result<InvokeResponse> {
     if cfg!(not(window)) {
       Err(crate::Error::ApiNotAllowlisted("setTitle".to_string()))
     } else {
@@ -151,7 +150,7 @@ impl Cmd {
         Self::SetFullscreen { fullscreen } => current_webview.set_fullscreen(fullscreen)?,
         Self::SetIcon { icon } => current_webview.set_icon(icon.into())?,
       }
-      Ok(JsonValue::Null)
+      Ok(().into())
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Using our own type allows flexibility in the future regarding breaking changes.