### PR TITLE
fix(cli): unable to access match struct fields in rust

### DIFF
--- a/tauri-api/src/cli.rs
+++ b/tauri-api/src/cli.rs
@@ -16,28 +16,28 @@ pub struct ArgData {
   /// - Value::Array if it's multiple,
   /// - Value::String if it has value,
   /// - Value::Null otherwise.
-  value: Value,
+  pub value: Value,
   /// The number of occurrences of the arg.
   /// e.g. `./app --arg 1 --arg 2 --arg 2 3 4` results in three occurrences.
-  occurrences: u64,
+  pub occurrences: u64,
 }
 
 /// The matched subcommand.
 #[derive(Default, Debug, Serialize)]
 pub struct SubcommandMatches {
   /// The subcommand name.
-  name: String,
+  pub name: String,
   /// The subcommand arg matches.
-  matches: Matches,
+  pub matches: Matches,
 }
 
 /// The arg matches of a command.
 #[derive(Default, Debug, Serialize)]
 pub struct Matches {
   /// Data structure mapping each found arg with its resolution.
-  args: HashMap<String, ArgData>,
+  pub args: HashMap<String, ArgData>,
   /// The matched subcommand if found.
-  subcommand: Option<Box<SubcommandMatches>>,
+  pub subcommand: Option<Box<SubcommandMatches>>,
 }
 
 impl Matches {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The `Matches`, `SubcommandMatches` and `ArgData` struct fields were previously private and not accessible, meaning the data returned from `get_matches` was useless. This marks all the relevant fields as public.

Example:
```rust
use tauri::cli::get_matches;

fn main() {
  let matches = get_matches();
  if let Some(matches) = matches {
    println!("{:?}", matches.args) // currently causes compilation error as field is private
  }
}
```
