### PR TITLE
refactor(api): move event's `once` to its own function

### DIFF
--- a/.changes/js-event-once.md
+++ b/.changes/js-event-once.md
@@ -1,0 +1,5 @@
+---
+"tauri-api": minor
+---
+
+The event listener `once` kind was moved to a dedicated function.

--- a/api/src/event.ts
+++ b/api/src/event.ts
@@ -4,5 +4,5 @@ async function emit(event: string, payload?: string): Promise<void> {
   return emitEvent(event, undefined, payload)
 }
 
-export { listen } from './helpers/event'
+export { listen, once } from './helpers/event'
 export { emit }

--- a/api/src/helpers/event.ts
+++ b/api/src/helpers/event.ts
@@ -7,16 +7,10 @@ export interface Event<T> {
 
 export type EventCallback<T> = (event: Event<T>) => void
 
-/**
- * listen to an event from the backend
- *
- * @param event the event name
- * @param handler the event handler callback
- */
-async function listen<T>(
+async function _listen<T>(
   event: string,
   handler: EventCallback<T>,
-  once = false
+  once: boolean
 ): Promise<void> {
   await invoke({
     __tauriModule: 'Event',
@@ -27,6 +21,32 @@ async function listen<T>(
       once
     }
   })
+}
+
+/**
+ * listen to an event from the backend
+ *
+ * @param event the event name
+ * @param handler the event handler callback
+ */
+async function listen<T>(
+  event: string,
+  handler: EventCallback<T>
+): Promise<void> {
+  return _listen(event, handler, false)
+}
+
+/**
+ * listen to an one-off event from the backend
+ *
+ * @param event the event name
+ * @param handler the event handler callback
+ */
+async function once<T>(
+  event: string,
+  handler: EventCallback<T>
+): Promise<void> {
+  return _listen(event, handler, true)
 }
 
 /**
@@ -51,4 +71,4 @@ async function emit(
   })
 }
 
-export { listen, emit }
+export { listen, once, emit }

--- a/api/src/window.ts
+++ b/api/src/window.ts
@@ -1,5 +1,5 @@
 import { invoke } from './tauri'
-import { EventCallback, emit, listen } from './helpers/event'
+import { EventCallback, emit, listen, once } from './helpers/event'
 
 interface WindowDef {
   label: string
@@ -33,14 +33,25 @@ class TauriWindow {
    *
    * @param event the event name
    * @param handler the event handler callback
-   * @param once unlisten after the first trigger if true
    */
   async listen<T>(
     event: string,
-    handler: EventCallback<T>,
-    once = false
+    handler: EventCallback<T>
   ): Promise<void> {
-    return listen(event, handler, once)
+    return listen(event, handler)
+  }
+
+  /**
+   * Listen to an one-off event emitted by the webview
+   *
+   * @param event the event name
+   * @param handler the event handler callback
+   */
+  async once<T>(
+    event: string,
+    handler: EventCallback<T>
+  ): Promise<void> {
+    return once(event, handler)
   }
 
   /**


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Move `once` from a argument to its own function.