### PR TITLE
use Wry as default ApplicationExt

### DIFF
--- a/cli/tauri.js/templates/src-tauri/src/main.rs
+++ b/cli/tauri.js/templates/src-tauri/src/main.rs
@@ -9,7 +9,7 @@ mod cmd;
 struct Context;
 
 fn main() {
-  tauri::AppBuilder::<tauri::flavors::Wry, Context>::new()
+  tauri::AppBuilder::<Context>::new()
     .invoke_handler(|_webview, arg| async move {
       use cmd::Cmd::*;
       match serde_json::from_str(&arg) {

--- a/tauri/examples/api/src-tauri/src/main.rs
+++ b/tauri/examples/api/src-tauri/src/main.rs
@@ -16,7 +16,7 @@ struct Reply {
 struct Context;
 
 fn main() {
-  tauri::AppBuilder::<tauri::flavors::Wry, Context>::new()
+  tauri::AppBuilder::<Context>::new()
     .setup(|webview_manager| async move {
       let dispatcher = webview_manager.current_webview().await.unwrap();
       let dispatcher_ = dispatcher.clone();

--- a/tauri/examples/helloworld/src-tauri/src/main.rs
+++ b/tauri/examples/helloworld/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ mod cmd;
 struct Context;
 
 fn main() {
-  tauri::AppBuilder::<tauri::flavors::Wry, Context>::new()
+  tauri::AppBuilder::<Context>::new()
     .invoke_handler(|_webview, arg| async move {
       use cmd::Cmd::*;
       match serde_json::from_str(&arg) {

--- a/tauri/examples/multiwindow/src-tauri/src/main.rs
+++ b/tauri/examples/multiwindow/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ struct Context;
 use tauri::WebviewBuilderExt;
 
 fn main() {
-  tauri::AppBuilder::<tauri::flavors::Wry, Context>::new()
+  tauri::AppBuilder::<Context>::new()
     .setup(|webview_manager| async move {
       if webview_manager.current_window_label() == "Main" {
         webview_manager.listen("clicked", move |_| {

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -13,6 +13,7 @@ pub(crate) mod webview;
 mod webview_manager;
 
 pub use crate::api::config::WindowUrl;
+use crate::flavors::Wry;
 pub use webview::{
   wry::WryApplication, ApplicationDispatcherExt, ApplicationExt, Callback, Icon, Message,
   WebviewBuilderExt,
@@ -187,7 +188,10 @@ impl<A: ApplicationExt + 'static> WebviewInitializer<A> for Arc<App<A>> {
 
 /// The App builder.
 #[derive(Default)]
-pub struct AppBuilder<A: ApplicationExt, C: AsTauriContext> {
+pub struct AppBuilder<C: AsTauriContext, A = Wry>
+where
+  A: ApplicationExt,
+{
   /// The JS message handler.
   invoke_handler: Option<Box<InvokeHandler<A>>>,
   /// The setup callback, invoked when the webview is ready.
@@ -199,7 +203,7 @@ pub struct AppBuilder<A: ApplicationExt, C: AsTauriContext> {
   webviews: Vec<Webview<A>>,
 }
 
-impl<A: ApplicationExt + 'static, C: AsTauriContext> AppBuilder<A, C> {
+impl<A: ApplicationExt + 'static, C: AsTauriContext> AppBuilder<C, A> {
   /// Creates a new App builder.
   pub fn new() -> Self {
     Self {

--- a/tauri/src/app/webview_manager.rs
+++ b/tauri/src/app/webview_manager.rs
@@ -4,6 +4,7 @@ use super::{
   App, ApplicationDispatcherExt, ApplicationExt, Icon, Webview, WebviewBuilderExt,
   WebviewInitializer,
 };
+use crate::flavors::Wry;
 use crate::{api::config::WindowUrl, async_runtime::Mutex};
 
 use serde::Serialize;
@@ -175,7 +176,10 @@ impl<A: ApplicationDispatcherExt> WebviewDispatcher<A> {
 }
 
 /// The webview manager.
-pub struct WebviewManager<A: ApplicationExt> {
+pub struct WebviewManager<A = Wry>
+where
+  A: ApplicationExt,
+{
   application: Arc<App<A>>,
   dispatchers: Arc<Mutex<HashMap<String, WebviewDispatcher<A::Dispatcher>>>>,
   current_webview_window_label: String,

--- a/tauri/src/app/webview_manager.rs
+++ b/tauri/src/app/webview_manager.rs
@@ -4,8 +4,7 @@ use super::{
   App, ApplicationDispatcherExt, ApplicationExt, Icon, Webview, WebviewBuilderExt,
   WebviewInitializer,
 };
-use crate::flavors::Wry;
-use crate::{api::config::WindowUrl, async_runtime::Mutex};
+use crate::{api::config::WindowUrl, async_runtime::Mutex, flavors::Wry};
 
 use serde::Serialize;
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. Context now needs to be first during `AppBuilder` (no releases with Context yet and it will change later anyways)
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When using `::tauri::WebviewManager` without generic arguments, it now defaults to using `WryApplication`