### PR TITLE
feat(api/invoke): separate cmd arg

### DIFF
--- a/.changes/separate-cmd-arg.md
+++ b/.changes/separate-cmd-arg.md
@@ -1,0 +1,5 @@
+---
+"api": minor
+---
+
+The invoke function can now be called with the cmd as the first parameter and the args as the second.

--- a/api/src/tauri.ts
+++ b/api/src/tauri.ts
@@ -1,7 +1,7 @@
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface Window {
-    __TAURI_INVOKE_HANDLER__: (command: string) => void
+    __TAURI_INVOKE_HANDLER__: (command: { [key: string]: unknown }) => void
   }
 }
 
@@ -56,7 +56,10 @@ function transformCallback(
  *
  * @return {Promise<T>} Promise resolving or rejecting to the backend response
  */
-async function invoke<T>(args: any): Promise<T> {
+async function invoke<T>(
+  cmd: string | { [key: string]: unknown },
+  args: { [key: string]: unknown } = {}
+): Promise<T> {
   return new Promise((resolve, reject) => {
     const callback = transformCallback((e) => {
       resolve(e)
@@ -66,6 +69,17 @@ async function invoke<T>(args: any): Promise<T> {
       reject(e)
       Reflect.deleteProperty(window, callback)
     }, true)
+
+    if (typeof cmd === 'string') {
+      args.cmd = cmd
+    } else if (typeof cmd === 'object') {
+      if (args !== {}) {
+        console.log(cmd, args)
+      }
+      args = cmd
+    } else {
+      return reject(new Error('Invalid argument type.'))
+    }
 
     window.__TAURI_INVOKE_HANDLER__({
       callback,

--- a/api/src/tauri.ts
+++ b/api/src/tauri.ts
@@ -73,9 +73,6 @@ async function invoke<T>(
     if (typeof cmd === 'string') {
       args.cmd = cmd
     } else if (typeof cmd === 'object') {
-      if (args !== {}) {
-        console.log(cmd, args)
-      }
       args = cmd
     } else {
       return reject(new Error('Invalid argument type.'))

--- a/cli/core/src/templates/tauri.js
+++ b/cli/core/src/templates/tauri.js
@@ -103,7 +103,7 @@ if (!String.prototype.startsWith) {
     return identifier;
   };
 
-  window.__TAURI__.invoke = function invoke(args) {
+  window.__TAURI__.invoke = function invoke(cmd, args = {}) {
     var _this = this;
 
     return new Promise(function (resolve, reject) {
@@ -115,6 +115,14 @@ if (!String.prototype.startsWith) {
         reject(e);
         delete window[callback];
       }, true);
+
+      if (typeof cmd === "string") {
+        args.cmd = cmd;
+      } else if (typeof cmd === "object") {
+        args = cmd;
+      } else {
+        return reject(new Error("Invalid argument type."));
+      }
 
       if (window.__TAURI_INVOKE_HANDLER__) {
         window.__TAURI_INVOKE_HANDLER__(
@@ -191,18 +199,18 @@ if (!String.prototype.startsWith) {
   }
 
   window.__TAURI__.invoke({
-    __tauriModule: 'Event',
+    __tauriModule: "Event",
     message: {
-      cmd: 'listen',
-      event: 'tauri://window-created',
+      cmd: "listen",
+      event: "tauri://window-created",
       handler: window.__TAURI__.transformCallback(function (event) {
         if (event.payload) {
-          var windowLabel = event.payload.label
-          window.__TAURI__.__windows.push({ label: windowLabel })
+          var windowLabel = event.payload.label;
+          window.__TAURI__.__windows.push({ label: windowLabel });
         }
-      })
-    }
-  })
+      }),
+    },
+  });
 
   let permissionSettable = false;
   let permissionValue = "default";

--- a/tauri/examples/api/src/components/Communication.svelte
+++ b/tauri/examples/api/src/components/Communication.svelte
@@ -2,26 +2,24 @@
   import { listen, emit } from "@tauri-apps/api/event";
   import { invoke } from "@tauri-apps/api/tauri";
 
-  export let onMessage
+  export let onMessage;
 
   listen("rust-event", onMessage);
 
   function log() {
-    invoke({
-      cmd: "log_operation",
+    invoke("log_operation", {
       event: "tauri-click",
-      payload: "this payload is optional because we used Option in Rust"
+      payload: "this payload is optional because we used Option in Rust",
     });
   }
 
   function performRequest() {
-    invoke({
-      cmd: "perform_request",
+    invoke("perform_request", {
       endpoint: "dummy endpoint arg",
       body: {
         id: 5,
-        name: "test"
-      }
+        name: "test",
+      },
     })
       .then(onMessage)
       .catch(onMessage);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Now, the invoke function can now be called with the cmd as the first parameter and the args as the second:

```js
invoke('my_command', {myArg: 'hi'})
```

The old syntax where everything is an object is still supported.