### PR TITLE
fix(tauri.js): init command properly building with manifests

### DIFF
--- a/cli/tauri.js/jest.config.js
+++ b/cli/tauri.js/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
   },
   transform: {
     'templates[\\\\/]tauri.js': './test/jest/raw-loader-transformer.js',
+    '\\.toml$': 'jest-transform-toml',
     '\\.(js|ts)$': 'babel-jest'
   }
 }

--- a/cli/tauri.js/package.json
+++ b/cli/tauri.js/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-security": "1.4.0",
     "is-running": "2.1.0",
     "jest": "26.6.3",
+    "jest-transform-toml": "^1.0.0",
     "lint-staged": "10.5.4",
     "lockfile-lint": "4.6.2",
     "prettier": "2.2.1",

--- a/cli/tauri.js/src/template/index.ts
+++ b/cli/tauri.js/src/template/index.ts
@@ -84,20 +84,21 @@ Run \`tauri init --force template\` to overwrite.`)
     return resolvedPath.replace(/\\/g, '/')
   }
 
-  const resolveCurrentTauriVersion = (crate: string): string => {
-    const manifestPath = `../../../../${crate}/Cargo.toml`
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access, security/detect-non-literal-require
-    const tauriManifest = require(manifestPath) as CargoManifest
-    const version = tauriManifest.package.version
+  const resolveCurrentTauriVersion = (manifest: CargoManifest): string => {
+    const version = manifest.package.version
     return version.substring(0, version.lastIndexOf('.'))
   }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const tauriManifest = require('../../../../tauri/Cargo.toml') as CargoManifest
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const tauriBuildManifest = require('../../../../core/tauri-build/Cargo.toml') as CargoManifest
 
   const tauriDep = tauriPath
     ? `{ path = "${resolveTauriPath(tauriPath, 'tauri')}" }`
-    : `{ version = "${resolveCurrentTauriVersion('tauri')}" }`
+    : `{ version = "${resolveCurrentTauriVersion(tauriManifest)}" }`
   const tauriBuildDep = tauriPath
     ? `{ path = "${resolveTauriPath(tauriPath, 'core/tauri-build')}" }`
-    : `{ version = "${resolveCurrentTauriVersion('core/tauri-build')}" }`
+    : `{ version = "${resolveCurrentTauriVersion(tauriBuildManifest)}" }`
 
   removeSync(dir)
   copyTemplates({

--- a/cli/tauri.js/yarn.lock
+++ b/cli/tauri.js/yarn.lock
@@ -4891,6 +4891,13 @@ jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
+jest-transform-toml@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-toml/-/jest-transform-toml-1.0.0.tgz#0a255066d4e59620ec3c3cc5a555321bb05f153d"
+  integrity sha1-CiVQZtTlliDsPDzFpVUyG7BfFT0=
+  dependencies:
+    toml-loader "^1.0.0"
+
 jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
@@ -7392,7 +7399,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toml-loader@1.0.0:
+toml-loader@1.0.0, toml-loader@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toml-loader/-/toml-loader-1.0.0.tgz#05249b9294b623601148260caa480b22a653a19a"
   integrity sha1-BSSbkpS2I2ARSCYMqkgLIqZToZo=


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fixes `init` command regression on the current unreleased code.
