### PR TITLE
fix(tauri-api): remove `.exe` from `app_name` on windows

### DIFF
--- a/tauri-api/src/path.rs
+++ b/tauri-api/src/path.rs
@@ -193,7 +193,11 @@ fn app_name() -> crate::Result<String> {
     .expect("failed to get exe filename")
     .to_string_lossy();
 
-  Ok(app_name.to_string())
+  if cfg!(target_os = "windows") {
+    Ok(app_name.replace(".exe", ""))
+  } else {
+    Ok(app_name.to_string())
+  }
 }
 
 /// Returns the path to the suggested directory for your app config files.

--- a/tauri-api/src/path.rs
+++ b/tauri-api/src/path.rs
@@ -189,15 +189,11 @@ pub fn resource_dir() -> Option<PathBuf> {
 fn app_name() -> crate::Result<String> {
   let exe = std::env::current_exe()?;
   let app_name = exe
-    .file_name()
+    .file_stem()
     .expect("failed to get exe filename")
     .to_string_lossy();
 
-  if cfg!(target_os = "windows") {
-    Ok(app_name.replace(".exe", ""))
-  } else {
-    Ok(app_name.to_string())
-  }
+  Ok(app_name.to_string())
 }
 
 /// Returns the path to the suggested directory for your app config files.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [X] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Previously, On windows , the app_dir would be something like this `C:\Users\username\AppData\Roaming\app_name.exe\`