### PR TITLE
replace lazy_static uses with once_cell

### DIFF
--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -21,7 +21,6 @@ features = [ "api-all" ]
 serde_json = "1.0"
 serde = { version = "1.0", features = [ "derive" ] }
 base64 = "0.13.0"
-lazy_static = "1.4.0"
 tokio = { version = "1.4", features = ["rt", "rt-multi-thread", "sync"] }
 futures = "0.3"
 async-trait = "0.1"

--- a/tauri/src/app/event.rs
+++ b/tauri/src/app/event.rs
@@ -5,10 +5,10 @@ use std::{
 };
 
 use crate::ApplicationDispatcherExt;
-use lazy_static::lazy_static;
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
+use uuid::Uuid;
 
 /// Event identifier.
 pub type EventId = u64;
@@ -25,11 +25,9 @@ struct EventHandler {
 
 type Listeners = Arc<Mutex<HashMap<String, Vec<EventHandler>>>>;
 
-lazy_static! {
-  static ref EMIT_FUNCTION_NAME: String = uuid::Uuid::new_v4().to_string();
-  static ref EVENT_LISTENERS_OBJECT_NAME: String = uuid::Uuid::new_v4().to_string();
-  static ref EVENT_QUEUE_OBJECT_NAME: String = uuid::Uuid::new_v4().to_string();
-}
+static EMIT_FUNCTION_NAME: Lazy<String> = Lazy::new(|| Uuid::new_v4().to_string());
+static EVENT_LISTENERS_OBJECT_NAME: Lazy<String> = Lazy::new(|| Uuid::new_v4().to_string());
+static EVENT_QUEUE_OBJECT_NAME: Lazy<String> = Lazy::new(|| Uuid::new_v4().to_string());
 
 /// Gets the listeners map.
 fn listeners() -> &'static Listeners {

--- a/tauri/src/salt.rs
+++ b/tauri/src/salt.rs
@@ -9,7 +9,7 @@ struct Salt {
   one_time: bool,
 }
 
-static SALTS: Lazy<Mutex<Vec<Salt>>> = Lazy::new(|| Default::default());
+static SALTS: Lazy<Mutex<Vec<Salt>>> = Lazy::new(Mutex::default);
 
 /// Generates a one time Salt and returns its string representation.
 pub fn generate() -> String {

--- a/tauri/src/salt.rs
+++ b/tauri/src/salt.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use uuid::Uuid;
 
 /// A salt definition.
@@ -9,9 +9,7 @@ struct Salt {
   one_time: bool,
 }
 
-lazy_static! {
-  static ref SALTS: Mutex<Vec<Salt>> = Mutex::new(vec![]);
-}
+static SALTS: Lazy<Mutex<Vec<Salt>>> = Lazy::new(|| Default::default());
 
 /// Generates a one time Salt and returns its string representation.
 pub fn generate() -> String {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
We explicitly depended on both, but they provide similar functionality. Preferred `once_cell` because there were already more uses of it, and it is currently exported (but hidden) in `tauri-api::private` mod.  Note that they both still exist as transitive dependencies.