### PR TITLE
Fix: #1394 Extremely slow dev builds caused by embedding + compressing assets at compile time

### DIFF
--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -24,12 +24,17 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
   let assets = EmbeddedAssets::new(&dist_dir)?;
 
   // handle default window icons for Windows targets
+  #[cfg(not(debug_assertions))]
   let default_window_icon = if cfg!(windows) {
     let icon_path = config_parent.join("icons/icon.ico").display().to_string();
     quote!(Some(include_bytes!(#icon_path)))
   } else {
     quote!(None)
   };
+
+  // in development builds, don't use an icon as it slows down cargo check
+  #[cfg(debug_assertions)]
+  let default_window_icon = quote!(None);
 
   // double braces are purposeful to force the code into a block expression
   Ok(quote! {{

--- a/core/tauri-codegen/src/embedded_assets.rs
+++ b/core/tauri-codegen/src/embedded_assets.rs
@@ -51,6 +51,7 @@ pub enum EmbeddedAssetsError {
 pub struct EmbeddedAssets(HashMap<AssetKey, (String, Vec<u8>)>);
 
 impl EmbeddedAssets {
+  #[cfg(not(debug_assertions))]
   /// Compress a directory of assets, ready to be generated into a [`tauri_api::assets::Assets`].
   pub fn new(path: &Path) -> Result<Self, EmbeddedAssetsError> {
     WalkDir::new(&path)
@@ -71,6 +72,14 @@ impl EmbeddedAssets {
       })
       .collect::<Result<_, _>>()
       .map(Self)
+  }
+
+  #[cfg(debug_assertions)]
+  /// A dummy EmbeddedAssets for use during development builds.
+  /// Compressing + including the bytes of assets during development takes a long time.
+  /// On development builds, assets will simply be resolved & fetched from the configured dist folder.
+  pub fn new(_: &Path) -> Result<Self, EmbeddedAssetsError> {
+    Ok(EmbeddedAssets(HashMap::new()))
   }
 
   /// Use highest compression level for release, the fastest one for everything else


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?**
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [X] Bugfix #1394

**Does this PR introduce a breaking change?**
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [X] No

**Other information:**

On development builds, Tauri will now directly serve files from the configured dist folder instead of embedding, recompiling and compressing every time.