### PR TITLE
chore: reintroduce option to access window APIs on command fn

### DIFF
--- a/cli/core/Cargo.lock
+++ b/cli/core/Cargo.lock
@@ -50,9 +50,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "attohttpc"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
+checksum = "9a8bda305457262b339322106c776e3fd21df860018e566eb6a5b1aa4b6ae02d"
 dependencies = [
  "flate2",
  "http",

--- a/examples/api/src-tauri/src/cmd.rs
+++ b/examples/api/src-tauri/src/cmd.rs
@@ -7,8 +7,8 @@ pub struct RequestBody {
   name: String,
 }
 
-#[command]
-pub fn log_operation(event: String, payload: Option<String>) {
+#[command(with_window)]
+pub fn log_operation<M: tauri::Params>(_window: tauri::Window<M>, event: String, payload: Option<String>) {
   println!("{} {:?}", event, payload);
 }
 

--- a/examples/api/src-tauri/src/cmd.rs
+++ b/examples/api/src-tauri/src/cmd.rs
@@ -8,7 +8,11 @@ pub struct RequestBody {
 }
 
 #[command(with_window)]
-pub fn log_operation<M: tauri::Params>(_window: tauri::Window<M>, event: String, payload: Option<String>) {
+pub fn log_operation<M: tauri::Params>(
+  _window: tauri::Window<M>,
+  event: String,
+  payload: Option<String>,
+) {
   println!("{} {:?}", event, payload);
 }
 

--- a/tauri-macros/src/lib.rs
+++ b/tauri-macros/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate proc_macro;
 use crate::context::ContextItems;
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, ItemFn};
+use syn::{parse_macro_input, AttributeArgs, ItemFn};
 
 mod command;
 
@@ -9,9 +9,10 @@ mod command;
 mod context;
 
 #[proc_macro_attribute]
-pub fn command(_: TokenStream, item: TokenStream) -> TokenStream {
+pub fn command(attrs: TokenStream, item: TokenStream) -> TokenStream {
   let function = parse_macro_input!(item as ItemFn);
-  let gen = command::generate_command(function);
+  let attrs = parse_macro_input!(attrs as AttributeArgs);
+  let gen = command::generate_command(attrs, function);
   gen.into()
 }
 

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub use {
   hooks::InvokeMessage,
   runtime::app::AppBuilder,
   runtime::webview::Attributes,
+  runtime::window::Window,
   runtime::{Context, Manager, Params},
 };
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
