### PR TITLE
refactor(tauri): remove app runner, use builder

### DIFF
--- a/cli/core/Cargo.lock
+++ b/cli/core/Cargo.lock
@@ -50,9 +50,9 @@ checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "attohttpc"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
+checksum = "9a8bda305457262b339322106c776e3fd21df860018e566eb6a5b1aa4b6ae02d"
 dependencies = [
  "flate2",
  "http",

--- a/cli/core/templates/src-tauri/src/main.rs
+++ b/cli/core/templates/src-tauri/src/main.rs
@@ -4,8 +4,7 @@
 )]
 
 fn main() {
-  tauri::AppBuilder::default()
-    .build(tauri::generate_context!())
-    .run()
+  tauri::Builder::default()
+    .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/cli/tauri.js/test/jest/fixtures/app/src-tauri/src/main.rs
+++ b/cli/tauri.js/test/jest/fixtures/app/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 use tauri::ApplicationDispatcherExt;
 
 fn main() {
-  tauri::AppBuilder::default()
+  tauri::Build::default()
     .setup(|webview_manager| async move {
       let mut webview_manager_ = webview_manager.clone();
       tauri::event::listen(String::from("hello"), move |_| {
@@ -21,6 +21,6 @@ fn main() {
         webview_manager.close().unwrap();
       }
     })
-    .build(tauri::generate_context!())
-    .run();
+    .run(tauri::generate_context!())
+    .expect("error encountered while running tauri application");
 }

--- a/cli/tauri.js/test/jest/fixtures/app/src-tauri/src/main.rs
+++ b/cli/tauri.js/test/jest/fixtures/app/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 use tauri::ApplicationDispatcherExt;
 
 fn main() {
-  tauri::Build::default()
+  tauri::Builder::default()
     .setup(|webview_manager| async move {
       let mut webview_manager_ = webview_manager.clone();
       tauri::event::listen(String::from("hello"), move |_| {

--- a/examples/api/src-tauri/src/main.rs
+++ b/examples/api/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ struct Reply {
 }
 
 fn main() {
-  tauri::AppBuilder::default()
+  tauri::Builder::default()
     .on_page_load(|window, _| {
       let window_ = window.clone();
       window.listen("js-event".into(), move |event| {
@@ -31,7 +31,6 @@ fn main() {
       cmd::log_operation,
       cmd::perform_request
     ])
-    .build(tauri::generate_context!())
-    .run()
+    .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/examples/helloworld/src-tauri/src/main.rs
+++ b/examples/helloworld/src-tauri/src/main.rs
@@ -9,9 +9,8 @@ fn my_custom_command(argument: String) {
 }
 
 fn main() {
-  tauri::AppBuilder::default()
+  tauri::Builder::default()
     .invoke_handler(tauri::generate_handler![my_custom_command])
-    .build(tauri::generate_context!())
-    .run()
+    .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/examples/multiwindow/src-tauri/src/main.rs
+++ b/examples/multiwindow/src-tauri/src/main.rs
@@ -6,7 +6,7 @@
 use tauri::Attributes;
 
 fn main() {
-  tauri::AppBuilder::default()
+  tauri::Builder::default()
     .on_page_load(|window, _payload| {
       let label = window.label().to_string();
       window.listen("clicked".to_string(), move |_payload| {
@@ -16,7 +16,6 @@ fn main() {
     .create_window("Rust".to_string(), tauri::WindowUrl::App, |attributes| {
       attributes.title("Tauri - Rust")
     })
-    .build(tauri::generate_context!())
-    .run()
+    .run(tauri::generate_context!())
     .expect("failed to run tauri application");
 }

--- a/examples/updater/src-tauri/src/main.rs
+++ b/examples/updater/src-tauri/src/main.rs
@@ -9,9 +9,8 @@ fn my_custom_command(argument: String) {
 }
 
 fn main() {
-  tauri::AppBuilder::default()
+  tauri::Builder::default()
     .invoke_handler(tauri::generate_handler![my_custom_command])
-    .build(tauri::generate_context!())
-    .run()
+    .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/tauri/src/lib.rs
+++ b/tauri/src/lib.rs
@@ -35,7 +35,7 @@ pub type SyncTask = Box<dyn FnOnce() + Send>;
 pub use {
   api::config::WindowUrl,
   hooks::InvokeMessage,
-  runtime::app::AppBuilder,
+  runtime::app::Builder,
   runtime::webview::Attributes,
   runtime::{Context, Manager, Params},
 };

--- a/tauri/src/runtime/app.rs
+++ b/tauri/src/runtime/app.rs
@@ -181,7 +181,12 @@ where
 
   /// Runs the configured Tauri application.
   pub fn run(mut self, context: Context<A>) -> crate::Result<()> {
-    let manager = WindowManager::with_handlers(context, self.invoke_handler, self.on_page_load);
+    let manager = WindowManager::with_handlers(
+      context,
+      self.plugins,
+      self.invoke_handler,
+      self.on_page_load,
+    );
 
     // set up all the windows defined in the config
     for config in manager.config().tauri.windows.clone() {

--- a/tauri/src/runtime/manager.rs
+++ b/tauri/src/runtime/manager.rs
@@ -81,13 +81,14 @@ where
 {
   pub(crate) fn with_handlers(
     context: Context<A>,
+    plugins: PluginStore<Self>,
     invoke_handler: Box<InvokeHandler<Self>>,
     on_page_load: Box<OnPageLoad<Self>>,
   ) -> Self {
     Self {
       inner: Arc::new(InnerWindowManager {
         windows: Mutex::default(),
-        plugins: Mutex::default(),
+        plugins: Mutex::new(plugins),
         listeners: Listeners::default(),
         invoke_handler,
         on_page_load,
@@ -345,15 +346,18 @@ where
 
 #[cfg(test)]
 mod test {
-  use crate::{generate_context, runtime::flavor::wry::Wry};
-
   use super::WindowManager;
+  use crate::{generate_context, plugin::PluginStore, runtime::flavor::wry::Wry};
 
   #[test]
   fn check_get_url() {
     let context = generate_context!("test/fixture/src-tauri/tauri.conf.json", crate::Context);
-    let manager: WindowManager<String, String, _, Wry> =
-      WindowManager::with_handlers(context, Box::new(|_| ()), Box::new(|_, _| ()));
+    let manager: WindowManager<String, String, _, Wry> = WindowManager::with_handlers(
+      context,
+      PluginStore::default(),
+      Box::new(|_| ()),
+      Box::new(|_, _| ()),
+    );
 
     #[cfg(custom_protocol)]
     assert_eq!(manager.get_url(), "tauri://studio.tauri.example");


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
The "runner" was never really used.  Really the runner is the underlying runtime, wry by default. Instead of `AppBuilder::build(context).run().unwrap()` it's now just `tauri::Builder::run(context).unwrap()`.  all the builder setup/hooks/plugin methods are the same.

other projects use the same naming typically. e.g `hyper` which uses `Builder` struct as the builder to a `Server`, which is created with `Builder::run`. Similarly, we don't have any steps that can take place between `build()` and `run()`, so it's a bit redundant.