### PR TITLE
feat(tauri): fetch window(s) from Manager

### DIFF
--- a/tauri/src/runtime/manager.rs
+++ b/tauri/src/runtime/manager.rs
@@ -559,8 +559,8 @@ where
     self.windows_lock().get(label).cloned()
   }
 
-  fn windows(&self) -> HashSet<Window<Self>> {
-    self.windows_lock().values().cloned().collect()
+  fn windows(&self) -> HashMap<L, Window<Self>> {
+    self.windows_lock().clone()
   }
 }
 

--- a/tauri/src/runtime/mod.rs
+++ b/tauri/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use crate::{
   },
 };
 use serde::Serialize;
-use std::convert::TryFrom;
+use std::{collections::HashSet, convert::TryFrom};
 
 pub(crate) mod app;
 pub mod flavor;
@@ -241,6 +241,12 @@ pub(crate) mod sealed {
 
     /// Verify that the passed salt is a valid salt in the manager.
     fn verify_salt(&self, salt: String) -> bool;
+
+    /// Get a single managed window.
+    fn get_window(&self, label: &M::Label) -> Option<Window<M>>;
+
+    /// Get all managed windows.
+    fn windows(&self) -> HashSet<Window<M>>;
   }
 
   /// Represents a managed handle to the application runner.
@@ -325,6 +331,16 @@ pub trait Manager<M: Params>: sealed::ManagerPrivate<M> {
   /// Remove an event listener.
   fn unlisten(&self, handler_id: EventHandler) {
     self.manager().unlisten(handler_id)
+  }
+
+  /// Fetch a single window from the manager.
+  fn get_window(&self, label: &M::Label) -> Option<Window<M>> {
+    self.manager().get_window(label)
+  }
+
+  /// Fetch all managed windows.
+  fn windows(&self) -> HashSet<Window<M>> {
+    self.manager().windows()
   }
 }
 

--- a/tauri/src/runtime/mod.rs
+++ b/tauri/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use crate::{
   },
 };
 use serde::Serialize;
-use std::{collections::HashSet, convert::TryFrom};
+use std::convert::TryFrom;
 
 pub(crate) mod app;
 pub mod flavor;
@@ -19,6 +19,7 @@ pub(crate) mod webview;
 pub(crate) mod window;
 
 pub use self::tag::Tag;
+use std::collections::HashMap;
 
 /// Important configurable items required by Tauri.
 pub struct Context<A: Assets> {
@@ -154,7 +155,7 @@ pub(crate) mod sealed {
     },
   };
   use serde::Serialize;
-  use std::collections::HashSet;
+  use std::collections::{HashMap, HashSet};
   use uuid::Uuid;
 
   /// private manager api
@@ -246,7 +247,7 @@ pub(crate) mod sealed {
     fn get_window(&self, label: &M::Label) -> Option<Window<M>>;
 
     /// Get all managed windows.
-    fn windows(&self) -> HashSet<Window<M>>;
+    fn windows(&self) -> HashMap<M::Label, Window<M>>;
   }
 
   /// Represents a managed handle to the application runner.
@@ -339,7 +340,7 @@ pub trait Manager<M: Params>: sealed::ManagerPrivate<M> {
   }
 
   /// Fetch all managed windows.
-  fn windows(&self) -> HashSet<Window<M>> {
+  fn windows(&self) -> HashMap<M::Label, Window<M>> {
     self.manager().windows()
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No (not released)


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Adds back previous functionality. Users can now use `Manager::get_window(&self, label: M::Label)` to fetch a single window with a specific label, or `Manager::windows(&sefl)` to fetch all managed windows.
