### PR TITLE
refactor(tauri-api): remove unsafe usage in rpc callback generator

### DIFF
--- a/tauri-api/Cargo.toml
+++ b/tauri-api/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [ "test/fixture/**" ]
 
 [dependencies]
 serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = [ "raw_value" ]}
 serde_repr = "0.1"
 dirs-next = "2.0.0"
 zip = "0.5.11"

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -114,8 +114,8 @@ pub fn format_callback<T: Serialize, S: AsRef<str>>(
   // ensure that we won't be creating a literal string too big for a browser
   check_json_len(json.len())?;
 
-  // We should only use JSON.parse('{arg}') if it's an array or object.
-  // We likely won't get any performance benefit from other data types.
+  // only use JSON.parse('{arg}') for arrays and objects less than the limit
+  // smaller literals do not benefit from being parsed from json
   Ok(
     if json.len() > MIN_JSON_PARSE_LEN || first == b'{' || first == b'[' {
       let escaped = escape_json_parse(json);

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -50,26 +50,6 @@ fn escape_json_parse(json: &RawValue) -> String {
   s
 }
 
-#[test]
-fn test_escape_json_parse() {
-  let dangerous_json = RawValue::from_string(
-    r#"{"test":"don\\🚀🐱‍👤\\'t forget to escape me!🚀🐱‍👤","te🚀🐱‍👤st2":"don't forget to escape me!","test3":"\\🚀🐱‍👤\\\\'''\\\\🚀🐱‍👤\\\\🚀🐱‍👤\\'''''"}"#.into()
-  ).unwrap();
-
-  let definitely_escaped_dangerous_json = format!(
-    "JSON.parse('{}')",
-    dangerous_json
-      .get()
-      .replace('\\', "\\\\")
-      .replace('\'', "\\'")
-  );
-  let escape_single_quoted_json_test = escape_json_parse(&dangerous_json);
-
-  let result = r#"JSON.parse('{"test":"don\\\\🚀🐱‍👤\\\\\'t forget to escape me!🚀🐱‍👤","te🚀🐱‍👤st2":"don\'t forget to escape me!","test3":"\\\\🚀🐱‍👤\\\\\\\\\'\'\'\\\\\\\\🚀🐱‍👤\\\\\\\\🚀🐱‍👤\\\\\'\'\'\'\'"}')"#;
-  assert_eq!(definitely_escaped_dangerous_json, result);
-  assert_eq!(escape_single_quoted_json_test, result);
-}
-
 /// Formats a function name and argument to be evaluated as callback.
 ///
 /// This will serialize primitive JSON types (e.g. booleans, strings, numbers, etc.) as JavaScript literals,
@@ -190,6 +170,26 @@ pub fn format_callback_result<T: Serialize, E: Serialize>(
 mod test {
   use crate::rpc::*;
   use quickcheck_macros::quickcheck;
+
+  #[test]
+  fn test_escape_json_parse() {
+    let dangerous_json = RawValue::from_string(
+      r#"{"test":"don\\🚀🐱‍👤\\'t forget to escape me!🚀🐱‍👤","te🚀🐱‍👤st2":"don't forget to escape me!","test3":"\\🚀🐱‍👤\\\\'''\\\\🚀🐱‍👤\\\\🚀🐱‍👤\\'''''"}"#.into()
+    ).unwrap();
+
+    let definitely_escaped_dangerous_json = format!(
+      "JSON.parse('{}')",
+      dangerous_json
+        .get()
+        .replace('\\', "\\\\")
+        .replace('\'', "\\'")
+    );
+    let escape_single_quoted_json_test = escape_json_parse(&dangerous_json);
+
+    let result = r#"JSON.parse('{"test":"don\\\\🚀🐱‍👤\\\\\'t forget to escape me!🚀🐱‍👤","te🚀🐱‍👤st2":"don\'t forget to escape me!","test3":"\\\\🚀🐱‍👤\\\\\\\\\'\'\'\\\\\\\\🚀🐱‍👤\\\\\\\\🚀🐱‍👤\\\\\'\'\'\'\'"}')"#;
+    assert_eq!(definitely_escaped_dangerous_json, result);
+    assert_eq!(escape_single_quoted_json_test, result);
+  }
 
   // check abritrary strings in the format callback function
   #[quickcheck]

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -68,14 +68,17 @@ fn escape_json_parse(json: &RawValue) -> String {
 /// ```
 /// use tauri_api::rpc::format_callback;
 /// use serde::Serialize;
-/// // callback with JSON argument
+///
+/// // callback with large JSON argument
 /// #[derive(Serialize)]
 /// struct MyResponse {
 ///   value: String
 /// }
-/// let cb = format_callback("callback-function-name", &MyResponse { value: "some value".into()})
+///
+/// let cb = format_callback("callback-function-name", &MyResponse { value: String::from_utf8(vec![b'X'; 10_240]).unwrap()})
 ///   .expect("failed to serialize");
-/// assert!(cb.contains(r#"window["callback-function-name"](JSON.parse('{"value":"some value"}'))"#));
+///
+/// assert!(cb.contains(r#"window["callback-function-name"](JSON.parse('{"value":"XXXXXXXXX"#));
 /// ```
 pub fn format_callback<T: Serialize, S: AsRef<str>>(
   function_name: S,

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -116,7 +116,7 @@ pub fn format_callback<T: Serialize, S: AsRef<str>>(
   // only use JSON.parse('{arg}') for arrays and objects less than the limit
   // smaller literals do not benefit from being parsed from json
   Ok(
-    if json.len() > MIN_JSON_PARSE_LEN || first == b'{' || first == b'[' {
+    if json.len() > MIN_JSON_PARSE_LEN && (first == b'{' || first == b'[') {
       let escaped = escape_json_parse(&raw);
       if escaped.len() < MAX_JSON_STR_LEN {
         format_callback!(escaped)

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -111,7 +111,7 @@ pub fn format_callback<T: Serialize, S: AsRef<str>>(
   #[cfg(debug_assertions)]
   if first == b'"' {
     debug_assert!(
-      json.len() >= MAX_JSON_STR_LEN,
+      json.len() < MAX_JSON_STR_LEN,
       "passing a callback string larger than the max JavaScript literal string size"
     )
   }

--- a/tauri-api/src/rpc.rs
+++ b/tauri-api/src/rpc.rs
@@ -111,7 +111,7 @@ pub fn format_callback<T: Serialize, S: AsRef<str>>(
   #[cfg(debug_assertions)]
   if first == b'"' {
     debug_assert!(
-      json.len() < MAX_JSON_STR_LEN,
+      json.len() >= MAX_JSON_STR_LEN,
       "passing a callback string larger than the max JavaScript literal string size"
     )
   }

--- a/tauri/src/endpoints/global_shortcut.rs
+++ b/tauri/src/endpoints/global_shortcut.rs
@@ -43,10 +43,8 @@ fn register_shortcut<D: Dispatch>(
   handler: String,
 ) -> crate::Result<()> {
   manager.register(shortcut.clone(), move || {
-    let callback_string = crate::api::rpc::format_callback(
-      handler.to_string(),
-      serde_json::Value::String(shortcut.clone()),
-    );
+    let callback_string = crate::api::rpc::format_callback(handler.to_string(), &shortcut)
+      .expect("unable to serialize shortcut string to json");
     let _ = dispatcher.eval_script(callback_string.as_str());
   })?;
   Ok(())

--- a/tauri/src/endpoints/shell.rs
+++ b/tauri/src/endpoints/shell.rs
@@ -81,7 +81,9 @@ impl Cmd {
               if matches!(event, CommandEvent::Terminated(_)) {
                 command_childs().lock().unwrap().remove(&pid);
               }
-              let js = format_callback(on_event_fn.clone(), serde_json::to_value(event).unwrap());
+              let js = format_callback(on_event_fn.clone(), &event)
+                .expect("unable to serialize CommandEvent");
+
               let _ = window.eval(js.as_str());
             }
           });

--- a/tauri/src/hooks.rs
+++ b/tauri/src/hooks.rs
@@ -156,7 +156,8 @@ impl<M: Params> InvokeMessage<M> {
     let callback_string =
       match format_callback_result(result, success_callback, error_callback.clone()) {
         Ok(callback_string) => callback_string,
-        Err(e) => format_callback(error_callback, e.to_string()),
+        Err(e) => format_callback(error_callback, &e.to_string())
+          .expect("unable to serialize shortcut string to json"),
       };
 
     let _ = window.eval(&callback_string);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No (no release)


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Hi, sorry I didn't see #1370 before it was merged otherwise I would have brought the following points up (@WilliamVenner I'm tagging you so you can discuss this too).

1. Unsafe
     * #1370 introduces the first unsafe code to be directly used in `tauri`. Of course `wry` uses a lot of unsafe under the hood, but it's mostly self contained. We should probably be avoiding unsafe in `tauri` unless there is a good, measurable reason to use it.
    * IMO the introduced unsafe code seems relatively useless because the unsafely manipulated String (as a Vec) is then later used to concatenate into a new String allocation. I think effort is better spent to just build it normally and avoid `format!`.
    * I'm not against all unsafe code, but there should probably be a measurable benchmark against a safe alternative so that we can understand the benefits.
 
2. Minimum size to escape at
    * The gains of `JSON.parse` are only seen after a certain size, otherwise it's slower for small items. `10KiB` was just set arbitrarily from the [advice given in the blog post that introduced the practice.](https://v8.dev/blog/cost-of-javascript-2019#json).
    * Not only is it slower for small items on the JS side, but it introduces at a minimum 1 extra allocation if we decide to escape an item on the rust side. In the unsafe code it's two extra allocations minimum.
    * I think it could useful to make a benchmark to measure what this minimum threshold is if we wish to absolutely maximize performance of this function. Since we build for different targets, we might even be able to set different sizes for different `target_os`'s.
 
3. API exposure
    * I moved the constants and the escaping function out of the `pub` scope. I'm not sure if this was planned to expose, but I'm not sure of the use-case of calling either the constants or the escaping function outside of `fn format_callback`. If possible we should avoid putting it in pub scope so that we don't need to worry about backwards compatibility with them in the future.

Here's some notes of the specifics of this implementation change:
* `fn format_callback` now returns a `crate::Result<String>` instead of `String`. This is because constructing a `RawValue` is a bit of a pain, so the next easiest parameter to use is a `Serialize`.  We can just accept a `RawValue` if that's desired and leave it up to the caller. Also, it takes a reference of the serializable item now.
* `debug_assert!` for passing string literal too large to be represented as a JavaScript string literal
* I left 2 `todo` comments that I am interested to know your thoughts on

I tried to keep the spirit of minimizing allocations to allow this callback serialization to stay as fast as possible. It would be helpful to have benchmarks for this because I have no idea how much this specific serialization matters in the larger picture, and some data would be great.
