### PR TITLE
refactor(tauri): remove private params trait methods

### DIFF
--- a/.changes/no-private-params-trait.md
+++ b/.changes/no-private-params-trait.md
@@ -1,0 +1,10 @@
+---
+"tauri": patch
+---
+
+internal refactoring of `Params` to allow for easier usage without a private trait with only 1 implementor.
+
+`ParamsPrivate` -> `ParamsBase`
+`ManagerPrivate` -> `ManagerBase`
+(new) `Args`, crate only. Now implements `Params`/`ParamsBase`.
+`App` and `Window` use `WindowManager` directly

--- a/core/tauri/src/endpoints/event.rs
+++ b/core/tauri/src/endpoints/event.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{endpoints::InvokeResponse, sealed::ManagerPrivate, Manager, Params, Window};
+use crate::{endpoints::InvokeResponse, sealed::ManagerBase, Manager, Params, Window};
 use serde::Deserialize;
 
 /// The API descriptor.

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -373,10 +373,7 @@ mod test {
     assert_eq!(manager.get_url(), "tauri://studio.tauri.example");
 
     #[cfg(dev)]
-    {
-      use crate::sealed::ParamsBase;
-      assert_eq!(manager.get_url(), manager.config().build.dev_path);
-    }
+    assert_eq!(manager.get_url(), manager.config().build.dev_path);
   }
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
No more large `ParamPrivate` trait with a bunch of methods that are only implemented for a single type.

`ParamsPrivate` -> `ParamsBase`
`ManagerPrivate` -> `ManagerBase`
(new) `Args` ZST marker type. This is the type now implements `Params` instead of `WindowManager`.
`App` and `Window` now use `WindowManager<P>` instead of `P`.