### PR TITLE
chore: publish codegen before macros and build

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -156,18 +156,12 @@
     "cli.rs": {
       "path": "./tooling/cli.rs",
       "manager": "rust",
-      "dependencies": [
-        "api",
-        "tauri-bundler",
-        "tauri"
-      ]
+      "dependencies": ["api", "tauri-bundler", "tauri"]
     },
     "cli.js": {
       "path": "./tooling/cli.js",
       "manager": "javascript",
-      "dependencies": [
-        "cli.rs"
-      ],
+      "dependencies": ["cli.rs"],
       "assets": [
         {
           "path": "./tooling/cli.js/tauri-apps-cli-${ pkgFile.version }.tgz",
@@ -179,28 +173,25 @@
       "path": "./core/tauri-utils",
       "manager": "rust"
     },
+    "tauri-codegen": {
+      "path": "./core/tauri-codegen",
+      "manager": "rust",
+      "dependencies": ["tauri-utils"]
+    },
     "tauri-macros": {
       "path": "./core/tauri-macros",
       "manager": "rust",
-      "dependencies": [
-        "tauri-utils"
-      ]
+      "dependencies": ["tauri-codegen"]
     },
     "tauri-build": {
       "path": "./core/tauri-build",
-      "manager": "rust"
-    },
-    "tauri-codegen": {
-      "path": "./core/tauri-codegen",
-      "manager": "rust"
+      "manager": "rust",
+      "dependencies": ["tauri-codegen"]
     },
     "tauri": {
       "path": "./core/tauri",
       "manager": "rust",
-      "dependencies": [
-        "api",
-        "tauri-macros"
-      ]
+      "dependencies": ["api", "tauri-macros", "tauri-utils"]
     },
     "create-tauri-app": {
       "path": "./tooling/create-tauri-app",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
Reorders publishing that codegen is published before the other crates that depend on it.

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
