### PR TITLE
fix: cta templates dir missing

### DIFF
--- a/.changes/cta-templates-missing.md
+++ b/.changes/cta-templates-missing.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": patch
+---
+
+CTA also needs the template directory published as it doesn't get bundled into the `dist` directory.

--- a/tooling/create-tauri-app/package.json
+++ b/tooling/create-tauri-app/package.json
@@ -18,7 +18,8 @@
   "main": "bin/create-tauri-app.js",
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "src/templates"
   ],
   "scripts": {
     "create-tauri-app": "create-tauri-app",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
We were also missing the templates dir which doesn't get pulled into the `dist` dir.

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
