### PR TITLE
fix(tauri): don't remove once listener inside async task

### DIFF
--- a/.changes/event-once.md
+++ b/.changes/event-once.md
@@ -1,0 +1,9 @@
+---
+"tauri": patch
+---
+
+Prevent "once" events from being able to be called multiple times.
+* `Window::trigger(/*...*/)` is now properly `pub` instead of `pub(crate)`.
+* `Manager::once_global(/*...*/)` now returns an `EventHandler`.
+* `Window::once(/*...*/)` now returns an `EventHandler`.
+* (internal) `event::Listeners::trigger(/*...*/)` now handles removing "once" events.

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -173,7 +173,7 @@ pub trait Manager<M: Params>: sealed::ManagerBase<M> {
   }
 
   /// Listen to a global event only once.
-  fn once_global<F>(&self, event: M::Event, handler: F)
+  fn once_global<F>(&self, event: M::Event, handler: F) -> EventHandler
   where
     F: Fn(Event) + Send + 'static,
   {

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -516,7 +516,7 @@ impl<P: Params> WindowManager<P> {
     event: P::Event,
     window: Option<P::Label>,
     handler: F,
-  ) {
+  ) -> EventHandler {
     self.inner.listeners.once(event, window, handler)
   }
   pub fn event_listeners_object_name(&self) -> String {

--- a/core/tauri/src/runtime/window.rs
+++ b/core/tauri/src/runtime/window.rs
@@ -256,7 +256,7 @@ pub(crate) mod export {
     }
 
     /// Listen to a an event on this window a single time.
-    pub fn once<F>(&self, event: P::Event, handler: F)
+    pub fn once<F>(&self, event: P::Event, handler: F) -> EventHandler
     where
       F: Fn(Event) + Send + 'static,
     {
@@ -265,7 +265,7 @@ pub(crate) mod export {
     }
 
     /// Triggers an event on this window.
-    pub(crate) fn trigger(&self, event: P::Event, data: Option<String>) {
+    pub fn trigger(&self, event: P::Event, data: Option<String>) {
       let label = self.window.label.clone();
       self.manager.trigger(event, Some(label), data)
     }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Spawning an async task to remove the once listener caused it to be able to be called multiple times before being removed. This design choice was previously made due to deadlock happening when removing the event from inside `event::Listeners::once(/*...*/)`. That was because the listeners were already locked inside `trigger` when asked to be removed. `trigger` now handles removing once handlers, preventing a second lock attempt.

* `Window::trigger` is now `pub` not `pub(crate)`.
* Adding `EventHandler` return to `once` and `once_global` could be considered breaking if the result of the expression (previously `()`) was used directly instead of adding a semicolon. The fix in downstream code affected by it is adding a semicolon.

IIRC, the `fn once` deadlock fix was happening when calling `trigger`. If there are more cases in which it was happening that this doesn't fix, let me know.