### PR TITLE
allow event listeners to be nested

### DIFF
--- a/.changes/nested-events.md
+++ b/.changes/nested-events.md
@@ -1,0 +1,9 @@
+---
+"tauri": patch
+---
+
+Window and global events can now be nested inside event handlers. They will run as soon
+as the event handler closure is finished in the order they were called. Previously, calling
+events inside an event handler would produce a deadlock.
+
+Note: The order that event handlers are called when triggered is still non-deterministic.

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -130,8 +130,8 @@ impl<P: Params> Listeners<P> {
       std::mem::take(&mut *lock)
     };
 
-    for pending in pending.into_iter() {
-      match pending {
+    for action in pending {
+      match action {
         Pending::Unlisten(id) => self.unlisten(id),
         Pending::Listen(id, event, handler) => self.listen_(id, event, handler),
         Pending::Trigger(event, window, payload) => self.trigger(event, window, payload),

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -109,7 +109,7 @@ impl<P: Params> Listeners<P> {
     self.inner.queue_object_name.to_string()
   }
 
-  /// Insert an event handler to be inster
+  /// Insert a pending event action to the queue.
   fn insert_pending(&self, action: Pending<P>) {
     self
       .inner
@@ -119,7 +119,7 @@ impl<P: Params> Listeners<P> {
       .push(action)
   }
 
-  /// Finish all pending event actions
+  /// Finish all pending event actions.
   fn flush_pending(&self) {
     let pending = {
       let mut lock = self

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -31,19 +31,19 @@ use std::{
 };
 use uuid::Uuid;
 
-pub struct InnerWindowManager<M: Params> {
-  windows: Mutex<HashMap<M::Label, Window<M>>>,
-  plugins: Mutex<PluginStore<M>>,
-  listeners: Listeners<M::Event, M::Label>,
+pub struct InnerWindowManager<P: Params> {
+  windows: Mutex<HashMap<P::Label, Window<P>>>,
+  plugins: Mutex<PluginStore<P>>,
+  listeners: Listeners<P>,
 
   /// The JS message handler.
-  invoke_handler: Box<InvokeHandler<M>>,
+  invoke_handler: Box<InvokeHandler<P>>,
 
   /// The page load hook, invoked when the webview performs a navigation.
-  on_page_load: Box<OnPageLoad<M>>,
+  on_page_load: Box<OnPageLoad<P>>,
 
   config: Config,
-  assets: Arc<M::Assets>,
+  assets: Arc<P::Assets>,
   default_window_icon: Option<Vec<u8>>,
 
   /// A list of salts that are valid for the current application.

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 pub struct InnerWindowManager<P: Params> {
   windows: Mutex<HashMap<P::Label, Window<P>>>,
   plugins: Mutex<PluginStore<P>>,
-  listeners: Listeners<P>,
+  listeners: Listeners<P::Event, P::Label>,
 
   /// The JS message handler.
   invoke_handler: Box<InvokeHandler<P>>,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This builds upon #1446 and #1506. The core issue is that event handler closures are ran inside of `Listeners::trigger` while it has a lock on the handlers. There are 4 exposed event functions that `Mutex::lock()` the listeners:  `Listeners::listen`, `Listeners::once`, `Listeners::unlisten`, and `Listeners::trigger`. If any of those 4 are called from inside the event handler closure, then a deadlock will occur because the closure runner (`Listeners::trigger`) already locked it.

I saw a few non-breaking solutions to this:
1. Clone the handlers inside of `Listeners::trigger`, after getting them from the lock, and then use their closures.
2. Like #1446, spawn an async task to wait for the lock later. This downside is that when that will be executed is unknown, and can cause things like `Listeners::once` being able to be called multiple times if called soon enough.
3. (this PR) Use non-blocking `Mutex::try_lock()` locking inside those mentioned 4 functions, adding to a pending queue if the handlers are currently already locked. `Listeners::trigger`, has been modified so that if any event handler closure was executed, all pending events will be flushed in the order they were added.

A side-effect of the chosen solution is that nested event calls technically don't happen during the closure - but after it. This is something we should document so that users expect this behavior. In all cases I can think of right now, this side-effect doesn't matter much since the execution order of different closures was already non-deterministic (another thing we should document).

```rust
use tauri::{Builder, Manager};

fn main() {
  Builder::default()
    .on_page_load(|window, _| {
      let foo = window.listen("foo".into(), |event| {
        println!("foo: {:?}", event);
      });

      let window_ = window.clone();
      window.listen("bar".into(), move |event| {
        window_.unlisten(foo);
        println!("bar: {:?}", event);
      });

      window.trigger("foo".into(), None);
      window.trigger("bar".into(), None);
      window.trigger("foo".into(), None);
    })
    .run(tauri::generate_context!())
    .expect("error while running tauri application");
}

```

fix/nested-events:
```text
foo: Event { id: EventHandler(d9bc19f3-aea5-46bf-ad7f-5d7ea36a384f), data: None }
bar: Event { id: EventHandler(b762e118-e50c-4aa6-9b11-35c060be9b70), data: None }
```

dev:
```text
foo: Event { id: EventHandler(8ba87934-916a-437e-bb2f-fef106ade9e7), data: None }
```
[deadlocks]