### PR TITLE
chore: enable covector prerelease beta

### DIFF
--- a/.changes/beta-rc.md
+++ b/.changes/beta-rc.md
@@ -1,0 +1,14 @@
+---
+"api": major
+"tauri-bundler": major
+"cli.rs": major
+"cli.js": major
+"tauri-utils": major
+"tauri-codegen": major
+"tauri-macros": major
+"tauri-build": major
+"tauri": major
+"create-tauri-app": major
+---
+
+The beta process has begun!

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -3,6 +3,7 @@
   "timeout": 3600000,
   "pkgManagers": {
     "rust": {
+      "errorOnVersionRange": "1.0.0-beta-rc.100 - 99.x || ^1.1.0-0 || ^2.0.0-0",
       "version": true,
       "getPublishedVersion": "cargo search ${ pkgFile.pkg.package.name } --limit 1 | sed -nE 's/^[^\"]*\"//; s/\".*//1p' -",
       "prepublish": [
@@ -76,6 +77,7 @@
       ]
     },
     "javascript": {
+      "errorOnVersionRange": "1.0.0-beta-rc.100 - 99.x || ^1.1.0-0 || ^2.0.0-0",
       "version": true,
       "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
       "prepublish": [

--- a/.changes/pre.json
+++ b/.changes/pre.json
@@ -1,0 +1,4 @@
+{
+  "tag": "beta-rc",
+  "changes": [".changes/beta-rc.md"]
+}

--- a/.github/workflows/change-status-on-PR.yml
+++ b/.github/workflows/change-status-on-PR.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: covector status
-        uses: jbolda/covector/packages/action@covector-v0
+        uses: jbolda/covector/packages/action@feat/enable-prereleases
         id: covector
         with:
-          command: 'status'
+          command: "status"

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: cargo login
         run: cargo login ${{ secrets.crate_token }}
       - name: git config
@@ -33,14 +33,14 @@ jobs:
           git config --global user.name "${{ github.event.pusher.name }}"
           git config --global user.email "${{ github.event.pusher.email }}"
       - name: covector version or publish (publish when no change files present)
-        uses: jbolda/covector/packages/action@covector-v0
+        uses: jbolda/covector/packages/action@feat/enable-prereleases
         id: covector
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           CARGO_AUDIT_OPTIONS: ${{ secrets.CARGO_AUDIT_OPTIONS }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          command: 'version-or-publish'
+          command: "version-or-publish"
           createRelease: true
       - name: Create Pull Request With Versions Bumped
         if: steps.covector.outputs.commandRan == 'version'


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
This adjusts the covector workflow to work off of a [PR branch that enables prereleases](https://github.com/jbolda/covector/pull/180). The workflow has been pretty well tested (and tested on what exists in Tauri right now). We will want to keep an eye on it, but it will be much better improvement over the 100% manual and error prone process we have without this functionality.

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
