### PR TITLE
chore: sync cli.rs metadata.json file versions

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -208,22 +208,6 @@
       "path": "./tooling/bundler",
       "manager": "rust"
     },
-    "cli.rs": {
-      "path": "./tooling/cli.rs",
-      "manager": "rust",
-      "dependencies": ["api", "tauri-bundler", "tauri"]
-    },
-    "cli.js": {
-      "path": "./tooling/cli.js",
-      "manager": "javascript",
-      "dependencies": ["cli.rs"],
-      "assets": [
-        {
-          "path": "./tooling/cli.js/tauri-apps-cli-${ pkgFile.version }.tgz",
-          "name": "cli.js-${ pkgFile.version }.tgz"
-        }
-      ]
-    },
     "tauri-utils": {
       "path": "./core/tauri-utils",
       "manager": "rust"
@@ -241,12 +225,31 @@
     "tauri-build": {
       "path": "./core/tauri-build",
       "manager": "rust",
-      "dependencies": ["tauri-codegen"]
+      "dependencies": ["tauri-codegen"],
+      "postversion": "../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }"
     },
     "tauri": {
       "path": "./core/tauri",
       "manager": "rust",
-      "dependencies": ["api", "tauri-macros", "tauri-utils"]
+      "dependencies": ["api", "tauri-macros", "tauri-utils"],
+      "postversion": "../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }"
+    },
+    "cli.js": {
+      "path": "./tooling/cli.js",
+      "manager": "javascript",
+      "dependencies": ["cli.rs"],
+      "postversion": "../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }",
+      "assets": [
+        {
+          "path": "./tooling/cli.js/tauri-apps-cli-${ pkgFile.version }.tgz",
+          "name": "cli.js-${ pkgFile.version }.tgz"
+        }
+      ]
+    },
+    "cli.rs": {
+      "path": "./tooling/cli.rs",
+      "manager": "rust",
+      "dependencies": ["api", "tauri-bundler", "tauri", "tauri-build", "cli.js"]
     },
     "create-tauri-app": {
       "path": "./tooling/create-tauri-app",

--- a/.changes/sync-metadata.md
+++ b/.changes/sync-metadata.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Sync `metadata.json` via script to update version reference to cli.js, tauri (core) and tauri-build.

--- a/.scripts/sync-cli-metadata.js
+++ b/.scripts/sync-cli-metadata.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Copyright 2019-2021 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+/*
+This script is solely intended to be run as part of the `covector version` step to
+keep the `../tooling/cli.rs/metadata.json` up to date with other version bumps. Long term
+we should look to find a more "rusty way" to import / "pin" a version value in our cli.rs
+rust binaries.
+*/
+
+const { readFileSync, writeFileSync } = require("fs");
+
+const filePath = `../../tooling/cli.rs/metadata.json`;
+const packageNickname = process.argv[2];
+const bump = process.argv[3];
+if (bump !== "prerelease") {
+  throw new Error(
+    `We don't handle anything except prerelease right now. Exiting.`
+  );
+}
+
+const inc = (version) => {
+  const v = version.split("");
+  const n = v.pop();
+  return [...v, String(Number(n) + 1)].join("");
+};
+
+// read file into js object
+const metadata = JSON.parse(readFileSync(filePath, "utf-8"));
+
+// set field version
+let version;
+if (packageNickname === "cli.js") {
+  version = inc(metadata[packageNickname].version);
+  metadata[packageNickname].version = version;
+} else {
+  version = inc(metadata[packageNickname]);
+  metadata[packageNickname] = version;
+}
+
+writeFileSync(filePath, JSON.stringify(metadata, null, 2) + "\n");
+console.log(`wrote ${version} for ${packageNickname} into metadata.json`);
+console.dir(metadata);

--- a/tooling/cli.rs/metadata.json
+++ b/tooling/cli.rs/metadata.json
@@ -1,8 +1,8 @@
 {
   "cli.js": {
-    "version": "1.0.0-beta-rc.0",
+    "version": "1.0.0-beta-rc.1",
     "node": ">= 10.17.0"
   },
-  "tauri": "1.0.0-beta-rc.0",
+  "tauri": "1.0.0-beta-rc.1",
   "tauri-build": "1.0.0-beta-rc.0"
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

This syncs the `metadata.json` file and sets up covector to keep it in sync when we version our files. This only will work while we are in `-beta-rc.N` and then will likely be adjusted. Hopefully by then we figure out a more "rusty way" to handle this.

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
