### PR TITLE
fix: run metadata sync script explicitly with node

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -226,19 +226,19 @@
       "path": "./core/tauri-build",
       "manager": "rust",
       "dependencies": ["tauri-codegen"],
-      "postversion": "../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }"
+      "postversion": "node ../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }"
     },
     "tauri": {
       "path": "./core/tauri",
       "manager": "rust",
       "dependencies": ["api", "tauri-macros", "tauri-utils"],
-      "postversion": "../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }"
+      "postversion": "node ../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }"
     },
     "cli.js": {
       "path": "./tooling/cli.js",
       "manager": "javascript",
       "dependencies": ["cli.rs"],
-      "postversion": "../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }",
+      "postversion": "node ../../.scripts/sync-cli-metadata.js ${ pkg.pkg } ${ release.type }",
       "assets": [
         {
           "path": "./tooling/cli.js/tauri-apps-cli-${ pkgFile.version }.tgz",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
Seems that we can't spawn a script that is located in another folder (only run things from PATH?).

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
