### PR TITLE
fix: use correct action path in update-docs workflow

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -83,7 +83,7 @@ jobs:
           linksRoot: /docs/api/rust/
           cratesToProcess: "tauri,tauri_utils"
       - name: run typedocusaurus
-        uses: tauri-apps/typedocusaurus/github-action@v1
+        uses: tauri-apps/typedocusaurus@v1
         with:
           originPath: ./tauri/tooling/api/
           sidebarFile: sidebars.json

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -8,13 +8,13 @@ on:
   workflow_dispatch:
     inputs:
       gitName:
-        description: 'git name for PR'
+        description: "git name for PR"
         required: false
-        default: 'tauri-bot'
+        default: "tauri-bot"
       gitEmail:
-        description: 'git email for PR'
+        description: "git email for PR"
         required: false
-        default: 'tauri-bot@tauri.studio'
+        default: "tauri-bot@tauri.studio"
 
 jobs:
   update-docs:
@@ -37,7 +37,7 @@ jobs:
         working-directory: ./tauri/core/tauri
         run: cargo doc --no-deps
       - name: run rustdocusaurus
-        uses: tauri-apps/rustdocusaurus/github-action@v1
+        uses: tauri-apps/typedocusaurus@v1
         with:
           originPath: ./tauri/target/doc/
           targetPath: ./tauri-docs/docs/en/api/rust/


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
