### PR TITLE
fix(cli.js): skip installing deps when `--ci` is passed on `tauri init`

### DIFF
--- a/.changes/tauri-init-ci-fix.md
+++ b/.changes/tauri-init-ci-fix.md
@@ -1,0 +1,5 @@
+---
+"cli.js": patch
+---
+
+Do not prompt to install dependencies on `tauri init` when the `--ci` argument is passed.

--- a/tooling/cli.js/bin/tauri.js
+++ b/tooling/cli.js/bin/tauri.js
@@ -19,7 +19,7 @@ const cmd = process.argv[2]
  */
 const tauri = async function (command) {
   // notifying updates.
-  if (!(process.argv || []).some((arg) => arg === '--no-update-notifier')) {
+  if (!process.argv.some((arg) => arg === '--no-update-notifier')) {
     updateNotifier({
       pkg,
       updateCheckInterval: 0
@@ -42,7 +42,7 @@ const tauri = async function (command) {
         (process.argv || []).filter((v) => v !== '--no-update-notifier')
       )
     ).promise.then(() => {
-      if (command === 'init') {
+      if (command === 'init' && !process.argv.some((arg) => arg === '--ci')) {
         const {
           installDependencies
         } = require('../dist/api/dependency-manager')


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
