### PR TITLE
feat(bundler): add option to skip webview2 runtime installation, closes #1606

### DIFF
--- a/.changes/wix-skip-webview-install.md
+++ b/.changes/wix-skip-webview-install.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Adds `skip_webview_install` config under `windows > wix` to disable Webview2 runtime installation after the app install.

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -181,6 +181,8 @@ pub struct WixSettings {
   pub feature_refs: Vec<String>,
   #[serde(default)]
   pub merge_refs: Vec<String>,
+  #[serde(default)]
+  pub skip_webview_install: bool,
 }
 
 /// The Windows bundle settings.

--- a/tooling/bundler/src/bundle/templates/main.wxs
+++ b/tooling/bundler/src/bundle/templates/main.wxs
@@ -175,6 +175,7 @@
             {{/each~}}
         </Feature>
 
+        {{#if install_webview}}
         <!-- WebView2 -->
         <Property Id="WVRTINSTALLED">
             <RegistrySearch Id="WVRTInstalled" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" Win64="no"/>
@@ -185,6 +186,7 @@
                 <![CDATA[NOT(REMOVE OR WVRTINSTALLED)]]>
             </Custom>
         </InstallExecuteSequence>
+        {{/if}}
 
         <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>        
     </Product>

--- a/tooling/bundler/src/bundle/wix.rs
+++ b/tooling/bundler/src/bundle/wix.rs
@@ -478,6 +478,7 @@ pub fn build_wix_app_installer(
   data.insert("icon_path", to_json(icon_path));
 
   let mut fragment_paths = Vec::new();
+  let mut install_webview = true;
 
   if let Some(wix) = &settings.windows().wix {
     data.insert("component_group_refs", to_json(&wix.component_group_refs));
@@ -486,6 +487,11 @@ pub fn build_wix_app_installer(
     data.insert("feature_refs", to_json(&wix.feature_refs));
     data.insert("merge_refs", to_json(&wix.merge_refs));
     fragment_paths = wix.fragment_paths.clone();
+    install_webview = !wix.skip_webview_install;
+  }
+
+  if install_webview {
+    data.insert("install_webview", to_json(true));
   }
 
   let temp = HANDLEBARS.render("main.wxs", &data)?;

--- a/tooling/cli.rs/config_definition.rs
+++ b/tooling/cli.rs/config_definition.rs
@@ -56,6 +56,8 @@ pub struct WixConfig {
   pub feature_refs: Vec<String>,
   #[serde(default)]
   pub merge_refs: Vec<String>,
+  #[serde(default)]
+  pub skip_webview_install: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Deserialize, Serialize, JsonSchema)]

--- a/tooling/cli.rs/schema.json
+++ b/tooling/cli.rs/schema.json
@@ -1220,6 +1220,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "skipWebviewInstall": {
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/tooling/cli.rs/src/helpers/config.rs
+++ b/tooling/cli.rs/src/helpers/config.rs
@@ -22,6 +22,7 @@ impl From<WixConfig> for tauri_bundler::WixSettings {
       feature_group_refs: config.feature_group_refs,
       feature_refs: config.feature_refs,
       merge_refs: config.merge_refs,
+      skip_webview_install: config.skip_webview_install,
     }
   }
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This will be helpful when we add support to shipping the webview2 runtime with the app (so the webview version is fixed).
