### PR TITLE
refactor(core): clear `uri_scheme_protocol` registration function names

### DIFF
--- a/.changes/multi-custom-protocols.md
+++ b/.changes/multi-custom-protocols.md
@@ -2,4 +2,4 @@
 "tauri": patch
 ---
 
-Adds APIs to determine global and window-specific custom protocol handlers.
+Adds APIs to determine global and webview-specific URI scheme handlers.

--- a/core/tauri/src/api/dir.rs
+++ b/core/tauri/src/api/dir.rs
@@ -120,22 +120,22 @@ mod test {
       if first.path.extension() == Some(OsStr::new("txt")) {
         // check the fields for the first DiskEntry
         assert_eq!(first.path, file_one);
-        assert_eq!(first.children.is_some(), false);
+        assert!(first.children.is_none());
         assert_eq!(first.name, name_from_path(file_one));
 
         // check the fields for the third DiskEntry
         assert_eq!(second.path, file_two);
-        assert_eq!(second.children.is_some(), false);
+        assert!(second.children.is_none());
         assert_eq!(second.name, name_from_path(file_two));
       } else {
         // check the fields for the second DiskEntry
         assert_eq!(first.path, file_two);
-        assert_eq!(first.children.is_some(), false);
+        assert!(first.children.is_none());
         assert_eq!(first.name, name_from_path(file_two));
 
         // check the fields for the third DiskEntry
         assert_eq!(second.path, file_one);
-        assert_eq!(second.children.is_some(), false);
+        assert!(second.children.is_none());
         assert_eq!(second.name, name_from_path(file_one));
       }
     }
@@ -165,22 +165,22 @@ mod test {
       if first.path.extension() == Some(OsStr::new("txt")) {
         // check the fields for the first DiskEntry
         assert_eq!(first.path, PathBuf::from("test/api/test.txt"));
-        assert_eq!(first.children.is_some(), false);
+        assert!(first.children.is_none());
         assert_eq!(first.name, Some("test.txt".to_string()));
 
         // check the fields for the second DiskEntry
         assert_eq!(second.path, PathBuf::from("test/api/test_binary"));
-        assert_eq!(second.children.is_some(), false);
+        assert!(second.children.is_none());
         assert_eq!(second.name, Some("test_binary".to_string()));
       } else {
         // check the fields for the first DiskEntry
         assert_eq!(second.path, PathBuf::from("test/api/test.txt"));
-        assert_eq!(second.children.is_some(), false);
+        assert!(second.children.is_none());
         assert_eq!(second.name, Some("test.txt".to_string()));
 
         // check the fields for the second DiskEntry
         assert_eq!(first.path, PathBuf::from("test/api/test_binary"));
-        assert_eq!(first.children.is_some(), false);
+        assert!(first.children.is_none());
         assert_eq!(first.name, Some("test_binary".to_string()));
       }
     }

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -242,7 +242,7 @@ mod test {
       let l = listeners.inner.handlers.lock().unwrap();
 
       // check if the generated key is in the map
-      assert_eq!(l.contains_key(&key), true);
+      assert!(l.contains_key(&key));
     }
 
     // check to see if listen inputs a handler function properly into the LISTENERS map.

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -49,7 +49,7 @@ use std::path::PathBuf;
 // Export types likely to be used by the application.
 pub use {
   api::config::WindowUrl,
-  hooks::{InvokeMessage, PageLoadPayload},
+  hooks::{InvokeHandler, InvokeMessage, OnPageLoad, PageLoadPayload, SetupHook},
   runtime::app::{App, Builder},
   runtime::webview::Attributes,
   runtime::window::export::Window,

--- a/core/tauri/src/runtime/app.rs
+++ b/core/tauri/src/runtime/app.rs
@@ -193,7 +193,7 @@ where
   }
 
   /// Registers a webview protocol available to all windows.
-  pub fn register_webview_protocol<
+  pub fn register_global_webview_protocol<
     N: Into<String>,
     H: Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync + 'static,
   >(

--- a/core/tauri/src/runtime/app.rs
+++ b/core/tauri/src/runtime/app.rs
@@ -192,17 +192,25 @@ where
     self
   }
 
-  /// Registers a webview protocol available to all windows.
+  /// Registers a webview protocol available to all webviews.
+  /// Leverages [setURLSchemeHandler](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2875766-seturlschemehandler) on macOS,
+  /// [AddWebResourceRequestedFilter](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.addwebresourcerequestedfilter?view=webview2-dotnet-1.0.774.44) on Windows
+  /// and [webkit-web-context-register-uri-scheme](https://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#webkit-web-context-register-uri-scheme) on Linux.
+  ///
+  /// # Arguments
+  ///
+  /// * `uri_scheme` The URI scheme to register, such as `example`.
+  /// * `handler` the asset resolver for the given protocol. It's a function that takes the webview URL, such as `example://localhost/asset.css`.
   pub fn register_global_webview_protocol<
     N: Into<String>,
     H: Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync + 'static,
   >(
     mut self,
-    name: N,
+    uri_scheme: N,
     handler: H,
   ) -> Self {
     self.webview_protocols.insert(
-      name.into(),
+      uri_scheme.into(),
       Arc::new(CustomProtocol {
         handler: Box::new(handler),
       }),

--- a/core/tauri/src/runtime/app.rs
+++ b/core/tauri/src/runtime/app.rs
@@ -124,8 +124,8 @@ where
   /// All passed plugins
   plugins: PluginStore<Args<E, L, A, R>>,
 
-  /// The custom protocols available to all windows.
-  custom_protocols: HashMap<String, Arc<CustomProtocol>>,
+  /// The webview protocols available to all windows.
+  webview_protocols: HashMap<String, Arc<CustomProtocol>>,
 }
 
 impl<E, L, A, R> Builder<E, L, A, R>
@@ -143,7 +143,7 @@ where
       on_page_load: Box::new(|_, _| ()),
       pending_windows: Default::default(),
       plugins: PluginStore::default(),
-      custom_protocols: Default::default(),
+      webview_protocols: Default::default(),
     }
   }
 
@@ -192,8 +192,8 @@ where
     self
   }
 
-  /// Adds a custom protocol available to all windows.
-  pub fn custom_protocol<
+  /// Registers a webview protocol available to all windows.
+  pub fn register_webview_protocol<
     N: Into<String>,
     H: Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync + 'static,
   >(
@@ -201,7 +201,7 @@ where
     name: N,
     handler: H,
   ) -> Self {
-    self.custom_protocols.insert(
+    self.webview_protocols.insert(
       name.into(),
       Arc::new(CustomProtocol {
         handler: Box::new(handler),
@@ -217,7 +217,7 @@ where
       self.plugins,
       self.invoke_handler,
       self.on_page_load,
-      self.custom_protocols,
+      self.webview_protocols,
     );
 
     // set up all the windows defined in the config

--- a/core/tauri/src/runtime/flavors/wry.rs
+++ b/core/tauri/src/runtime/flavors/wry.rs
@@ -206,14 +206,14 @@ impl Attributes for WryAttributes {
     H: Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync + 'static,
   >(
     self,
-    name: N,
+    uri_scheme: N,
     handler: H,
   ) -> Self {
-    let name = name.into();
+    let uri_scheme = uri_scheme.into();
     self.webview_protocols.lock().unwrap().insert(
-      name.clone(),
+      uri_scheme.clone(),
       wry::CustomProtocol {
-        name,
+        name: uri_scheme,
         handler: Box::new(move |data| (handler)(data).map_err(|_| wry::Error::InitScriptError)),
       },
     );

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -187,7 +187,7 @@ impl<P: Params> WindowManager<P> {
       }
     }
 
-    if !attributes.has_webviewprotocol("tauri") {
+    if !attributes.has_webview_protocol("tauri") {
       attributes =
         attributes.register_webview_protocol("tauri", self.prepare_webview_protocol().handler);
     }

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -52,7 +52,7 @@ pub struct InnerWindowManager<P: Params> {
   salts: Mutex<HashSet<Uuid>>,
   package_info: PackageInfo,
   /// The webview protocols protocols available to all windows.
-  webview_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
+  uri_scheme_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
 }
 
 /// A [Zero Sized Type] marker representing a full [`Params`].
@@ -104,7 +104,7 @@ impl<P: Params> WindowManager<P> {
     plugins: PluginStore<P>,
     invoke_handler: Box<InvokeHandler<P>>,
     on_page_load: Box<OnPageLoad<P>>,
-    webview_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
+    uri_scheme_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
   ) -> Self {
     Self {
       inner: Arc::new(InnerWindowManager {
@@ -118,7 +118,7 @@ impl<P: Params> WindowManager<P> {
         default_window_icon: context.default_window_icon,
         salts: Mutex::default(),
         package_info: context.package_info,
-        webview_protocols,
+        uri_scheme_protocols,
       }),
       _marker: Args::default(),
     }
@@ -179,17 +179,17 @@ impl<P: Params> WindowManager<P> {
       }
     }
 
-    for (name, protocol) in &self.inner.webview_protocols {
-      if !attributes.has_webview_protocol(name) {
+    for (uri_scheme, protocol) in &self.inner.uri_scheme_protocols {
+      if !attributes.has_uri_scheme_protocol(uri_scheme) {
         let protocol = protocol.clone();
-        attributes =
-          attributes.register_webview_protocol(name.clone(), move |p| (protocol.handler)(p));
+        attributes = attributes
+          .register_uri_scheme_protocol(uri_scheme.clone(), move |p| (protocol.protocol)(p));
       }
     }
 
-    if !attributes.has_webview_protocol("tauri") {
-      attributes =
-        attributes.register_webview_protocol("tauri", self.prepare_webview_protocol().handler);
+    if !attributes.has_uri_scheme_protocol("tauri") {
+      attributes = attributes
+        .register_uri_scheme_protocol("tauri", self.prepare_uri_scheme_protocol().protocol);
     }
 
     let local_app_data = resolve_path(
@@ -235,10 +235,10 @@ impl<P: Params> WindowManager<P> {
     })
   }
 
-  fn prepare_webview_protocol(&self) -> CustomProtocol {
+  fn prepare_uri_scheme_protocol(&self) -> CustomProtocol {
     let assets = self.inner.assets.clone();
     CustomProtocol {
-      handler: Box::new(move |path| {
+      protocol: Box::new(move |path| {
         let mut path = path
           .split('?')
           // ignore query string

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -51,8 +51,8 @@ pub struct InnerWindowManager<P: Params> {
   /// A list of salts that are valid for the current application.
   salts: Mutex<HashSet<Uuid>>,
   package_info: PackageInfo,
-  /// The custom protocols available to all windows.
-  custom_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
+  /// The webview protocols protocols available to all windows.
+  webview_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
 }
 
 /// A [Zero Sized Type] marker representing a full [`Params`].
@@ -104,7 +104,7 @@ impl<P: Params> WindowManager<P> {
     plugins: PluginStore<P>,
     invoke_handler: Box<InvokeHandler<P>>,
     on_page_load: Box<OnPageLoad<P>>,
-    custom_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
+    webview_protocols: HashMap<String, std::sync::Arc<CustomProtocol>>,
   ) -> Self {
     Self {
       inner: Arc::new(InnerWindowManager {
@@ -118,7 +118,7 @@ impl<P: Params> WindowManager<P> {
         default_window_icon: context.default_window_icon,
         salts: Mutex::default(),
         package_info: context.package_info,
-        custom_protocols,
+        webview_protocols,
       }),
       _marker: Args::default(),
     }
@@ -179,15 +179,17 @@ impl<P: Params> WindowManager<P> {
       }
     }
 
-    for (name, protocol) in &self.inner.custom_protocols {
-      if !attributes.has_custom_protocol(name) {
+    for (name, protocol) in &self.inner.webview_protocols {
+      if !attributes.has_webview_protocol(name) {
         let protocol = protocol.clone();
-        attributes = attributes.custom_protocol(name.clone(), move |p| (protocol.handler)(p));
+        attributes =
+          attributes.register_webview_protocol(name.clone(), move |p| (protocol.handler)(p));
       }
     }
 
-    if !attributes.has_custom_protocol("tauri") {
-      attributes = attributes.custom_protocol("tauri", self.prepare_custom_protocol().handler);
+    if !attributes.has_webviewprotocol("tauri") {
+      attributes =
+        attributes.register_webview_protocol("tauri", self.prepare_webview_protocol().handler);
     }
 
     let local_app_data = resolve_path(
@@ -233,7 +235,7 @@ impl<P: Params> WindowManager<P> {
     })
   }
 
-  fn prepare_custom_protocol(&self) -> CustomProtocol {
+  fn prepare_webview_protocol(&self) -> CustomProtocol {
     let assets = self.inner.assets.clone();
     CustomProtocol {
       handler: Box::new(move |path| {

--- a/core/tauri/src/runtime/webview.rs
+++ b/core/tauri/src/runtime/webview.rs
@@ -92,8 +92,8 @@ pub trait Attributes: AttributesBase {
   /// Sets the webview url.
   fn url(self, url: String) -> Self;
 
-  /// Whether the webview protocol handler is defined or not.
-  fn has_webview_protocol(&self, name: &str) -> bool;
+  /// Whether the webview URI scheme protocol is defined or not.
+  fn has_uri_scheme_protocol(&self, name: &str) -> bool;
 
   /// Registers a webview protocol handler.
   /// Leverages [setURLSchemeHandler](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2875766-seturlschemehandler) on macOS,
@@ -103,14 +103,14 @@ pub trait Attributes: AttributesBase {
   /// # Arguments
   ///
   /// * `uri_scheme` The URI scheme to register, such as `example`.
-  /// * `handler` the asset resolver for the given protocol. It's a function that takes the webview URL, such as `example://localhost/asset.css`.
-  fn register_webview_protocol<
+  /// * `protocol` the protocol associated with the given URI scheme. It's a function that takes an URL such as `example://localhost/asset.css`.
+  fn register_uri_scheme_protocol<
     N: Into<String>,
     H: Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync + 'static,
   >(
     self,
     uri_scheme: N,
-    handler: H,
+    protocol: H,
   ) -> Self;
 
   /// The full attributes.
@@ -125,10 +125,10 @@ pub struct RpcRequest {
   pub params: Option<JsonValue>,
 }
 
-/// Uses a custom handler to resolve file requests
+/// Uses a custom URI scheme handler to resolve file requests
 pub struct CustomProtocol {
   /// Handler for protocol
-  pub handler: Box<dyn Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync>,
+  pub protocol: Box<dyn Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync>,
 }
 
 /// The file drop event payload.

--- a/core/tauri/src/runtime/webview.rs
+++ b/core/tauri/src/runtime/webview.rs
@@ -92,11 +92,11 @@ pub trait Attributes: AttributesBase {
   /// Sets the webview url.
   fn url(self, url: String) -> Self;
 
-  /// Whether the custom protocol handler is defined or not.
-  fn has_custom_protocol(&self, name: &str) -> bool;
+  /// Whether the webview protocol handler is defined or not.
+  fn has_webview_protocol(&self, name: &str) -> bool;
 
-  /// Adds a custom protocol handler.
-  fn custom_protocol<
+  /// Registers a webview protocol handler.
+  fn register_webview_protocol<
     N: Into<String>,
     H: Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync + 'static,
   >(

--- a/core/tauri/src/runtime/webview.rs
+++ b/core/tauri/src/runtime/webview.rs
@@ -96,12 +96,20 @@ pub trait Attributes: AttributesBase {
   fn has_webview_protocol(&self, name: &str) -> bool;
 
   /// Registers a webview protocol handler.
+  /// Leverages [setURLSchemeHandler](https://developer.apple.com/documentation/webkit/wkwebviewconfiguration/2875766-seturlschemehandler) on macOS,
+  /// [AddWebResourceRequestedFilter](https://docs.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.addwebresourcerequestedfilter?view=webview2-dotnet-1.0.774.44) on Windows
+  /// and [webkit-web-context-register-uri-scheme](https://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#webkit-web-context-register-uri-scheme) on Linux.
+  ///
+  /// # Arguments
+  ///
+  /// * `uri_scheme` The URI scheme to register, such as `example`.
+  /// * `handler` the asset resolver for the given protocol. It's a function that takes the webview URL, such as `example://localhost/asset.css`.
   fn register_webview_protocol<
     N: Into<String>,
     H: Fn(&str) -> crate::Result<Vec<u8>> + Send + Sync + 'static,
   >(
     self,
-    name: N,
+    uri_scheme: N,
     handler: H,
   ) -> Self;
 

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -790,10 +790,10 @@ mod test {
       .url(mockito::server_url())
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check update");
 
-    assert_eq!(updater.should_update, true);
+    assert!(updater.should_update);
   }
 
   #[test]
@@ -809,10 +809,10 @@ mod test {
       .url(mockito::server_url())
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check update");
 
-    assert_eq!(updater.should_update, true);
+    assert!(updater.should_update);
   }
 
   #[test]
@@ -829,10 +829,10 @@ mod test {
       .url(mockito::server_url())
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check update");
 
-    assert_eq!(updater.should_update, true);
+    assert!(updater.should_update);
     assert_eq!(updater.version, "2.0.0");
     assert_eq!(updater.signature, Some("dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUldUTE5QWWxkQnlZOVJHMWlvTzRUSlQzTHJOMm5waWpic0p0VVI2R0hUNGxhQVMxdzBPRndlbGpXQXJJakpTN0toRURtVzBkcm15R0VaNTJuS1lZRWdzMzZsWlNKUVAzZGdJPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNTkyOTE1NTIzCWZpbGU6RDpcYVx0YXVyaVx0YXVyaVx0YXVyaVxleGFtcGxlc1xjb21tdW5pY2F0aW9uXHNyYy10YXVyaVx0YXJnZXRcZGVidWdcYXBwLng2NC5tc2kuemlwCitXa1lQc3A2MCs1KzEwZnVhOGxyZ2dGMlZqbjBaVUplWEltYUdyZ255eUF6eVF1dldWZzFObStaVEQ3QU1RS1lzcjhDVU4wWFovQ1p1QjJXbW1YZUJ3PT0K".into()));
     assert_eq!(
@@ -854,10 +854,10 @@ mod test {
       .url(mockito::server_url())
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check update");
 
-    assert_eq!(updater.should_update, false);
+    assert!(!updater.should_update);
   }
 
   #[test]
@@ -880,10 +880,10 @@ mod test {
       ))
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check update");
 
-    assert_eq!(updater.should_update, true);
+    assert!(updater.should_update);
   }
 
   #[test]
@@ -906,10 +906,10 @@ mod test {
       ))
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check update");
 
-    assert_eq!(updater.should_update, false);
+    assert!(!updater.should_update);
   }
 
   #[test]
@@ -926,10 +926,10 @@ mod test {
       .current_version("0.0.1")
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check remote update");
 
-    assert_eq!(updater.should_update, true);
+    assert!(updater.should_update);
   }
 
   #[test]
@@ -945,10 +945,10 @@ mod test {
       .current_version("0.0.1")
       .build());
 
-    assert_eq!(check_update.is_ok(), true);
+    assert!(check_update.is_ok());
     let updater = check_update.expect("Can't check remote update");
 
-    assert_eq!(updater.should_update, true);
+    assert!(updater.should_update);
   }
 
   #[test]
@@ -964,7 +964,7 @@ mod test {
       .current_version("0.0.1")
       .build());
 
-    assert_eq!(check_update.is_err(), true);
+    assert!(check_update.is_err());
   }
 
   // run complete process on mac only for now as we don't have


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The current `custom_protocol` registration functions names will be confusing when we add deeeplink supports. This PR renames it to `register_webview_protocol` to be explicit. Related to #1553