### PR TITLE
feat(cli.rs): add context to errors

### DIFF
--- a/.changes/cli-error-logging.md
+++ b/.changes/cli-error-logging.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Improve error logging.

--- a/tooling/cli.rs/src/helpers/config.rs
+++ b/tooling/cli.rs/src/helpers/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use anyhow::Context;
 #[cfg(target_os = "linux")]
 use heck::KebabCase;
 use json_patch::merge;
@@ -52,7 +53,8 @@ fn get_internal(merge_config: Option<&str>, reload: bool) -> crate::Result<Confi
   let path = super::app_paths::tauri_dir().join("tauri.conf.json");
   let file = File::open(path)?;
   let buf = BufReader::new(file);
-  let mut config: JsonValue = serde_json::from_reader(buf)?;
+  let mut config: JsonValue =
+    serde_json::from_reader(buf).with_context(|| "failed to parse `tauri.conf.json`")?;
 
   let schema: JsonValue = serde_json::from_str(include_str!("../../schema.json"))?;
   let mut scope = valico::json_schema::Scope::new();
@@ -75,7 +77,8 @@ fn get_internal(merge_config: Option<&str>, reload: bool) -> crate::Result<Confi
   }
 
   if let Some(merge_config) = merge_config {
-    let merge_config: JsonValue = serde_json::from_str(&merge_config)?;
+    let merge_config: JsonValue =
+      serde_json::from_str(&merge_config).with_context(|| "failed to parse config to merge")?;
     merge(&mut config, &merge_config);
   }
 

--- a/tooling/cli.rs/src/init.rs
+++ b/tooling/cli.rs/src/init.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use crate::helpers::Logger;
+use anyhow::Context;
 use handlebars::{to_json, Handlebars};
 use include_dir::{include_dir, Dir};
 use serde::Deserialize;
@@ -142,7 +143,8 @@ impl Init {
         to_json(self.window_title.unwrap_or_else(|| "Tauri".to_string())),
       );
 
-      render_template(&handlebars, &data, &TEMPLATE_DIR, &self.directory)?;
+      render_template(&handlebars, &data, &TEMPLATE_DIR, &self.directory)
+        .with_context(|| "failed to render Tauri template")?;
     }
 
     Ok(())

--- a/tooling/cli.rs/src/sign.rs
+++ b/tooling/cli.rs/src/sign.rs
@@ -7,6 +7,8 @@ use crate::helpers::updater_signature::{
 };
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
+
 #[derive(Default)]
 pub struct Signer {
   private_key: Option<String>,
@@ -63,7 +65,8 @@ impl Signer {
       self.password.unwrap(),
       self.file.unwrap(),
       false,
-    )?;
+    )
+    .with_context(|| "failed to sign file")?;
 
     println!(
          "\nYour file was signed successfully, You can find the signature here:\n{}\n\nPublic signature:\n{}\n\nMake sure to include this into the signature field of your update server.",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Currently it's super hard to track CLI errors (specially IO errors, since it only outputs `No such file or directory`). This PR uses anyhow::Context to improve the error message.
