### PR TITLE
fix(core): notification permission check when !allowlisted, closes #1666

### DIFF
--- a/.changes/notification-permission.md
+++ b/.changes/notification-permission.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+---
+
+`Notification.requestPermission()` now returns `"denied"` when not allowlisted.
+`IsNotificationPermissionGranted` returns `false` when not allowlisted.

--- a/core/tauri/src/endpoints/notification.rs
+++ b/core/tauri/src/endpoints/notification.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use crate::api::notification::Notification;
 
 // `Granted` response from `request_permission`. Matches the Web API return value.
+#[cfg(notification_all)]
 const PERMISSION_GRANTED: &str = "granted";
 // `Denied` response from `request_permission`. Matches the Web API return value.
 const PERMISSION_DENIED: &str = "denied";


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Fixes a console error message when the notification API isn't allowlisted.
