### PR TITLE
refactor(core): merge invoke items into single struct, allow ?

### DIFF
--- a/.changes/plugin-refactor.md
+++ b/.changes/plugin-refactor.md
@@ -3,5 +3,5 @@
 ---
 
 Refactored the `Plugin` trait `initialize` and `extend_api` signatures.
-`initialize` now takes the `App` as first argument, and `extend_api` takes a `InvokeResolver` as last argument.
+`initialize` now takes the `App` as first argument, and `extend_api` takes an `Invoke` instead of `InvokeMessage`.
 This adds support to managed state on plugins.

--- a/.changes/remove-with-window.md
+++ b/.changes/remove-with-window.md
@@ -2,4 +2,4 @@
 "tauri": patch
 ---
 
-Removes the `with_window` attribute on the `command` macro. Tauri now infers it using the `FromCommand` trait.
+Removes the `with_window` attribute on the `command` macro. Tauri now infers it using the `CommandArg` trait.

--- a/core/tauri-macros/src/command.rs
+++ b/core/tauri-macros/src/command.rs
@@ -63,7 +63,7 @@ pub fn generate_command(function: ItemFn) -> TokenStream {
       }
     }
 
-    let arg_name_ = arg_name.clone().unwrap();
+    let arg_name_ = format_ident!("_{}", arg_name.unwrap());
     let arg_name_s = arg_name_.to_string();
 
     let arg_type = match arg_type {
@@ -76,12 +76,13 @@ pub fn generate_command(function: ItemFn) -> TokenStream {
       }
     };
 
-    invoke_args.append_all(quote! {
-      let #arg_name_ = match <#arg_type>::from_command(#fn_name_str, #arg_name_s, &message) {
-        Ok(value) => value,
-        Err(e) => return tauri::InvokeResponse::error(::tauri::Error::InvalidArgs(#fn_name_str, e).to_string())
-      };
+    let item = quote!(::tauri::command::CommandItem {
+      name: #fn_name_str,
+      key: #arg_name_s,
+      message: &message,
     });
+
+    invoke_args.append_all(quote!(let #arg_name_ = <#arg_type>::from_command(#item)?;));
     invoke_arg_names.push(arg_name_.clone());
     invoke_arg_types.push(arg_type);
   }
@@ -97,20 +98,17 @@ pub fn generate_command(function: ItemFn) -> TokenStream {
   // otherwise we wrap it with an `Ok()`, converting the return value to tauri::InvokeResponse
   // note that all types must implement `serde::Serialize`.
   let return_value = if returns_result {
-    quote! {
-      match #fn_name(#(#invoke_arg_names),*)#await_maybe {
-        Ok(value) => ::core::result::Result::<_, ()>::Ok(value).into(),
-        Err(e) => ::core::result::Result::<(), _>::Err(e).into(),
-      }
-    }
+    quote!(::core::result::Result::Ok(#fn_name(#(#invoke_arg_names),*)#await_maybe?))
   } else {
-    quote! { ::core::result::Result::<_, ()>::Ok(#fn_name(#(#invoke_arg_names),*)#await_maybe).into() }
+    quote! { ::core::result::Result::<_, ::tauri::InvokeError>::Ok(#fn_name(#(#invoke_arg_names),*)#await_maybe) }
   };
 
   quote! {
     #function
-    #vis fn #fn_wrapper<P: ::tauri::Params>(message: ::tauri::InvokeMessage<P>, resolver: ::tauri::InvokeResolver<P>) {
-      use ::tauri::command::FromCommand;
+
+    #vis fn #fn_wrapper<P: ::tauri::Params>(invoke: ::tauri::Invoke<P>) {
+      use ::tauri::command::CommandArg;
+      let ::tauri::Invoke { message, resolver } = invoke;
       resolver.respond_async(async move {
         #invoke_args
         #return_value
@@ -139,12 +137,12 @@ pub fn generate_handler(item: proc_macro::TokenStream) -> TokenStream {
   });
 
   quote! {
-    move |message, resolver| {
-      let cmd = message.command().to_string();
-      match cmd.as_str() {
-        #(stringify!(#fn_names) => #fn_wrappers(message, resolver),)*
+    move |invoke| {
+      let cmd = invoke.message.command();
+      match cmd {
+        #(stringify!(#fn_names) => #fn_wrappers(invoke),)*
         _ => {
-          resolver.reject(format!("command {} not found", cmd))
+          invoke.resolver.reject(format!("command {} not found", cmd))
         },
       }
     }

--- a/core/tauri/src/endpoints/shell.rs
+++ b/core/tauri/src/endpoints/shell.rs
@@ -27,8 +27,9 @@ pub enum Buffer {
   Raw(Vec<u8>),
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn default_env() -> Option<HashMap<String, String>> {
-  Some(Default::default())
+  Some(HashMap::default())
 }
 
 #[allow(dead_code)]

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -54,8 +54,8 @@ use std::{borrow::Borrow, collections::HashMap, path::PathBuf};
 pub use {
   self::api::config::WindowUrl,
   self::hooks::{
-    InvokeHandler, InvokeMessage, InvokeResolver, InvokeResponse, OnPageLoad, PageLoadPayload,
-    SetupHook,
+    Invoke, InvokeError, InvokeHandler, InvokeMessage, InvokeResolver, InvokeResponse, OnPageLoad,
+    PageLoadPayload, SetupHook,
   },
   self::runtime::app::{App, Builder},
   self::runtime::flavors::wry::Wry,

--- a/core/tauri/src/runtime/app.rs
+++ b/core/tauri/src/runtime/app.rs
@@ -4,7 +4,7 @@
 
 use crate::{
   api::{assets::Assets, config::WindowUrl},
-  hooks::{InvokeHandler, InvokeMessage, InvokeResolver, OnPageLoad, PageLoadPayload, SetupHook},
+  hooks::{InvokeHandler, OnPageLoad, PageLoadPayload, SetupHook},
   plugin::{Plugin, PluginStore},
   runtime::{
     flavors::wry::Wry,
@@ -15,7 +15,7 @@ use crate::{
     Dispatch, Runtime,
   },
   sealed::{ManagerBase, RuntimeOrDispatch},
-  Context, Manager, Params, StateManager, Window,
+  Context, Invoke, Manager, Params, StateManager, Window,
 };
 
 use std::{collections::HashMap, sync::Arc};
@@ -142,7 +142,7 @@ where
   pub fn new() -> Self {
     Self {
       setup: Box::new(|_| Ok(())),
-      invoke_handler: Box::new(|_, _| ()),
+      invoke_handler: Box::new(|_| ()),
       on_page_load: Box::new(|_, _| ()),
       pending_windows: Default::default(),
       plugins: PluginStore::default(),
@@ -154,8 +154,7 @@ where
   /// Defines the JS message handler callback.
   pub fn invoke_handler<F>(mut self, invoke_handler: F) -> Self
   where
-    F:
-      Fn(InvokeMessage<Args<E, L, A, R>>, InvokeResolver<Args<E, L, A, R>>) + Send + Sync + 'static,
+    F: Fn(Invoke<Args<E, L, A, R>>) + Send + Sync + 'static,
   {
     self.invoke_handler = Box::new(invoke_handler);
     self

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -10,7 +10,7 @@ use crate::{
     PackageInfo,
   },
   event::{Event, EventHandler, Listeners},
-  hooks::{InvokeHandler, InvokeMessage, InvokeResolver, OnPageLoad, PageLoadPayload},
+  hooks::{InvokeHandler, OnPageLoad, PageLoadPayload},
   plugin::PluginStore,
   runtime::{
     tag::{tags_to_javascript_array, Tag, TagRef, ToJsString},
@@ -22,7 +22,7 @@ use crate::{
     Icon, Runtime,
   },
   sealed::ParamsBase,
-  App, Context, Params, StateManager, Window,
+  App, Context, Invoke, Params, StateManager, Window,
 };
 use serde::Serialize;
 use serde_json::Value as JsonValue;
@@ -401,7 +401,7 @@ mod test {
     let manager: WindowManager<Args<String, String, _, Wry>> = WindowManager::with_handlers(
       context,
       PluginStore::default(),
-      Box::new(|_, _| ()),
+      Box::new(|_| ()),
       Box::new(|_, _| ()),
       Default::default(),
       StateManager::new(),
@@ -416,8 +416,8 @@ mod test {
 }
 
 impl<P: Params> WindowManager<P> {
-  pub fn run_invoke_handler(&self, message: InvokeMessage<P>, resolver: InvokeResolver<P>) {
-    (self.inner.invoke_handler)(message, resolver);
+  pub fn run_invoke_handler(&self, invoke: Invoke<P>) {
+    (self.inner.invoke_handler)(invoke);
   }
 
   pub fn run_on_page_load(&self, window: Window<P>, payload: PageLoadPayload) {
@@ -430,13 +430,13 @@ impl<P: Params> WindowManager<P> {
       .on_page_load(window, payload);
   }
 
-  pub fn extend_api(&self, message: InvokeMessage<P>, resolver: InvokeResolver<P>) {
+  pub fn extend_api(&self, invoke: Invoke<P>) {
     self
       .inner
       .plugins
       .lock()
       .expect("poisoned plugin store")
-      .extend_api(message, resolver);
+      .extend_api(invoke);
   }
 
   pub fn initialize_plugins(&self, app: &App<P>) -> crate::Result<()> {

--- a/core/tauri/src/state.rs
+++ b/core/tauri/src/state.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::command::FromCommand;
-use crate::{InvokeMessage, Params};
+use crate::command::{CommandArg, CommandItem};
+use crate::{InvokeError, Params};
 use state::Container;
 
 /// A guard for a state value.
@@ -34,13 +34,10 @@ impl<T: Send + Sync + 'static> Clone for State<'_, T> {
   }
 }
 
-impl<'r, 'de: 'r, T: Send + Sync + 'static, P: Params> FromCommand<'de, P> for State<'r, T> {
-  fn from_command(
-    _: &'de str,
-    _: &'de str,
-    message: &'de InvokeMessage<P>,
-  ) -> Result<Self, serde_json::Error> {
-    Ok(message.state.get())
+impl<'r, 'de: 'r, T: Send + Sync + 'static, P: Params> CommandArg<'de, P> for State<'r, T> {
+  /// Grabs the [`State`] from the [`CommandItem`]. This will never fail.
+  fn from_command(command: CommandItem<'de, P>) -> Result<Self, InvokeError> {
+    Ok(command.message.state_ref().get())
   }
 }
 

--- a/examples/commands/src-tauri/src/main.rs
+++ b/examples/commands/src-tauri/src/main.rs
@@ -42,7 +42,7 @@ type Result<T> = std::result::Result<T, ()>;
 #[tauri::command]
 fn simple_command_with_result(argument: String) -> Result<String> {
   println!("{}", argument);
-  Ok(argument)
+  (!argument.is_empty()).then(|| argument).ok_or(())
 }
 
 #[tauri::command]
@@ -51,7 +51,7 @@ fn stateful_command_with_result(
   state: tauri::State<'_, MyState>,
 ) -> Result<String> {
   println!("{:?} {:?}", argument, state.inner());
-  Ok(argument.unwrap_or_else(|| "".to_string()))
+  argument.ok_or(())
 }
 
 // Async commands


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No (no release since the breaking change that this refactors)


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Not sure if `InvokeError` and `InvokeResponse` is the final abstraction to use - but we can finalize that after we get command returns using a trait. I undid most of the `InvokeResponse` interface changes so that we can use `?` inside of the closures. I added `InvokeError` to have an easy to use error type for it and `CommandArg`.  We still convert to an `InvokeResponse` before formatting the callback so that we can parse the value into a json error instead of failing parsing altogether