### PR TITLE
feat(core): allow users to access the Assets instance

### DIFF
--- a/.changes/assets-refactor.md
+++ b/.changes/assets-refactor.md
@@ -4,4 +4,4 @@
 "tauri": patch
 ---
 
-The `assets` field on the `tauri::Context` struct is now a `Arc<impl Assets>`.
+**Breaking:** The `assets` field on the `tauri::Context` struct is now a `Arc<impl Assets>`.

--- a/.changes/assets-refactor.md
+++ b/.changes/assets-refactor.md
@@ -1,0 +1,7 @@
+---
+"tauri-codegen": patch
+"tauri-utils": patch
+"tauri": patch
+---
+
+The `assets` field on the `tauri::Context` struct is now a `Arc<impl Assets>`.

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -72,7 +72,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
   // double braces are purposeful to force the code into a block expression
   Ok(quote!(#root::Context {
     config: #config,
-    assets: #assets,
+    assets: ::std::sync::Arc::new(#assets),
     default_window_icon: #default_window_icon,
     package_info: #root::api::PackageInfo {
       name: #package_name,

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -39,7 +39,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub type SyncTask = Box<dyn FnOnce() + Send>;
 
 use crate::{
-  api::{assets::Assets, config::Config},
   event::{Event, EventHandler},
   runtime::{
     tag::{Tag, TagRef},
@@ -48,11 +47,14 @@ use crate::{
   },
 };
 use serde::Serialize;
-use std::{borrow::Borrow, collections::HashMap, path::PathBuf};
+use std::{borrow::Borrow, collections::HashMap, path::PathBuf, sync::Arc};
 
 // Export types likely to be used by the application.
 pub use {
-  self::api::config::WindowUrl,
+  self::api::{
+    assets::Assets,
+    config::{Config, WindowUrl},
+  },
   self::hooks::{
     Invoke, InvokeError, InvokeHandler, InvokeMessage, InvokeResolver, InvokeResponse, OnPageLoad,
     PageLoadPayload, SetupHook,
@@ -113,7 +115,7 @@ pub struct Context<A: Assets> {
   pub config: Config,
 
   /// The assets to be served directly by Tauri.
-  pub assets: A,
+  pub assets: Arc<A>,
 
   /// The default window icon Tauri should use when creating windows.
   pub default_window_icon: Option<Vec<u8>>,

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -134,7 +134,7 @@ impl<P: Params> WindowManager<P> {
         invoke_handler,
         on_page_load,
         config: context.config,
-        assets: Arc::new(context.assets),
+        assets: context.assets,
         default_window_icon: context.default_window_icon,
         salts: Mutex::default(),
         package_info: context.package_info,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Allows Tauri users to access the `assets` instance, e.g.

```rust
fn main() {
  use tauri::Assets;
  let context = tauri::generate_context!();
  let assets = context.assets.clone();
  // now you can read the embedded assets anywhere in the code
  let asset = assets.get("something");
  tauri::Builder::default()
    .run(context)
    .expect("error while running tauri application");
}
```
