### PR TITLE
refactor(core): use bundle identifier on app dir, closes #1693

### DIFF
--- a/.changes/app-dir-refactor.md
+++ b/.changes/app-dir-refactor.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+---
+
+**Breaking:** `api::path::resolve_path()` and `api::path::app_dir()` now takes the config as first argument.
+**Breaking:** `api::path::app_dir()` now resolves to `${configDir}/${config.tauri.bundle.identifier}`.

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -397,7 +397,7 @@ pub struct PackageConfig {
 }
 
 /// The tauri.conf.json mapper.
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Default, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Config {
   /// Package settings.

--- a/core/tauri/src/api/path.rs
+++ b/core/tauri/src/api/path.rs
@@ -65,7 +65,8 @@ pub enum BaseDirectory {
 /// # Example
 /// ```
 /// use tauri::api::path::{resolve_path, BaseDirectory};
-/// let path = resolve_path("path/to/something", Some(BaseDirectory::Config))
+/// // we use the default config, but in an actual app you should get the Config created from tauri.conf.json
+/// let path = resolve_path(&Default::default(), "path/to/something", Some(BaseDirectory::Config))
 ///   .expect("failed to resolve path");
 /// // path is equal to "/home/${whoami}/.config/path/to/something" on Linux
 /// ```

--- a/core/tauri/src/endpoints.rs
+++ b/core/tauri/src/endpoints.rs
@@ -73,8 +73,12 @@ impl Module {
       }),
       Self::Process(cmd) => resolver
         .respond_async(async move { cmd.run().and_then(|r| r.json).map_err(InvokeError::from) }),
-      Self::Fs(cmd) => resolver
-        .respond_async(async move { cmd.run(config).and_then(|r| r.json).map_err(InvokeError::from) }),
+      Self::Fs(cmd) => resolver.respond_async(async move {
+        cmd
+          .run(config)
+          .and_then(|r| r.json)
+          .map_err(InvokeError::from)
+      }),
       Self::Window(cmd) => resolver.respond_async(async move {
         cmd
           .run(window)

--- a/core/tauri/src/endpoints/file_system.rs
+++ b/core/tauri/src/endpoints/file_system.rs
@@ -104,14 +104,18 @@ impl Cmd {
   pub fn run(self, config: Arc<Config>) -> crate::Result<InvokeResponse> {
     match self {
       #[cfg(fs_read_text_file)]
-      Self::ReadTextFile { path, options } => read_text_file(&config, path, options).map(Into::into),
+      Self::ReadTextFile { path, options } => {
+        read_text_file(&config, path, options).map(Into::into)
+      }
       #[cfg(not(fs_read_text_file))]
       Self::ReadTextFile { .. } => Err(crate::Error::ApiNotAllowlisted(
         "fs > readTextFile".to_string(),
       )),
 
       #[cfg(fs_read_binary_file)]
-      Self::ReadBinaryFile { path, options } => read_binary_file(&config, path, options).map(Into::into),
+      Self::ReadBinaryFile { path, options } => {
+        read_binary_file(&config, path, options).map(Into::into)
+      }
       #[cfg(not(fs_read_binary_file))]
       Self::ReadBinaryFile { .. } => Err(crate::Error::ApiNotAllowlisted(
         "readBinaryFile".to_string(),

--- a/core/tauri/src/endpoints/file_system.rs
+++ b/core/tauri/src/endpoints/file_system.rs
@@ -101,6 +101,7 @@ pub enum Cmd {
 }
 
 impl Cmd {
+  #[allow(unused_variables)]
   pub fn run(self, config: Arc<Config>) -> crate::Result<InvokeResponse> {
     match self {
       #[cfg(fs_read_text_file)]

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -144,7 +144,7 @@ pub trait Params: sealed::ParamsBase {
 /// TODO: expand these docs
 pub trait Manager<P: Params>: sealed::ManagerBase<P> {
   /// The [`Config`] the manager was created with.
-  fn config(&self) -> &Config {
+  fn config(&self) -> Arc<Config> {
     self.manager().config()
   }
 

--- a/core/tauri/src/runtime/manager.rs
+++ b/core/tauri/src/runtime/manager.rs
@@ -62,7 +62,7 @@ pub struct InnerWindowManager<P: Params> {
   /// The page load hook, invoked when the webview performs a navigation.
   on_page_load: Box<OnPageLoad<P>>,
 
-  config: Config,
+  config: Arc<Config>,
   assets: Arc<P::Assets>,
   default_window_icon: Option<Vec<u8>>,
 
@@ -133,7 +133,7 @@ impl<P: Params> WindowManager<P> {
         state: Arc::new(state),
         invoke_handler,
         on_page_load,
-        config: context.config,
+        config: Arc::new(context.config),
         assets: context.assets,
         default_window_icon: context.default_window_icon,
         salts: Mutex::default(),
@@ -215,6 +215,7 @@ impl<P: Params> WindowManager<P> {
     }
 
     let local_app_data = resolve_path(
+      &self.inner.config,
       &self.inner.config.tauri.bundle.identifier,
       Some(BaseDirectory::LocalData),
     );
@@ -525,12 +526,15 @@ impl<P: Params> WindowManager<P> {
   pub fn labels(&self) -> HashSet<P::Label> {
     self.windows_lock().keys().cloned().collect()
   }
-  pub fn config(&self) -> &Config {
-    &self.inner.config
+
+  pub fn config(&self) -> Arc<Config> {
+    self.inner.config.clone()
   }
+
   pub fn package_info(&self) -> &PackageInfo {
     &self.inner.package_info
   }
+
   pub fn unlisten(&self, handler_id: EventHandler) {
     self.inner.listeners.unlisten(handler_id)
   }

--- a/core/tauri/src/settings.rs
+++ b/core/tauri/src/settings.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::api::{
-  file::read_string,
-  path::{resolve_path, BaseDirectory},
+use crate::{
+  api::{
+    file::read_string,
+    path::{resolve_path, BaseDirectory},
+  },
+  Config,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -22,14 +25,14 @@ pub struct Settings {
 }
 
 /// Gets the path to the settings file
-fn get_settings_path() -> crate::api::Result<PathBuf> {
-  resolve_path(".tauri-settings.json", Some(BaseDirectory::App))
+fn get_settings_path(config: &Config) -> crate::api::Result<PathBuf> {
+  resolve_path(config, ".tauri-settings.json", Some(BaseDirectory::App))
 }
 
 /// Write the settings to the file system.
 #[allow(dead_code)]
-pub(crate) fn write_settings(settings: Settings) -> crate::Result<()> {
-  let settings_path = get_settings_path()?;
+pub(crate) fn write_settings(config: &Config, settings: Settings) -> crate::Result<()> {
+  let settings_path = get_settings_path(config)?;
   let settings_folder = Path::new(&settings_path).parent().unwrap();
   if !settings_folder.exists() {
     std::fs::create_dir(settings_folder)?;
@@ -43,8 +46,8 @@ pub(crate) fn write_settings(settings: Settings) -> crate::Result<()> {
 }
 
 /// Reads the settings from the file system.
-pub fn read_settings() -> crate::Result<Settings> {
-  let settings_path = get_settings_path()?;
+pub fn read_settings(config: &Config) -> crate::Result<Settings> {
+  let settings_path = get_settings_path(config)?;
   if settings_path.exists() {
     read_string(settings_path)
       .and_then(|settings| serde_json::from_str(settings.as_str()).map_err(Into::into))


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

The bundle identifier is the true unique app id, so we should use that when resolving the suggested appDir path (also used on tauri settings storage).
