### PR TITLE
feat(core): #[command] return with autoref specialization workaround fix #1672 

### DIFF
--- a/.changes/async-commands.md
+++ b/.changes/async-commands.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+"tauri-macros": patch
+---
+
+Only commands with a `async fn` are executed on a separate task. `#[command] fn command_name` runs on the main thread.

--- a/.changes/command-return.md
+++ b/.changes/command-return.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+"tauri-macros": patch
+---
+
+Improves support for commands returning `Result`.

--- a/core/tauri-macros/src/command/mod.rs
+++ b/core/tauri-macros/src/command/mod.rs
@@ -5,7 +5,7 @@
 use proc_macro2::Ident;
 use syn::{Path, PathSegment};
 
-pub use self::{handler::Handler, wrapper::Wrapper};
+pub use self::{handler::Handler, wrapper::wrapper};
 
 mod handler;
 mod wrapper;

--- a/core/tauri-macros/src/command/mod.rs
+++ b/core/tauri-macros/src/command/mod.rs
@@ -5,10 +5,7 @@
 use proc_macro2::Ident;
 use syn::{Path, PathSegment};
 
-pub use self::{
-  handler::Handler,
-  wrapper::{Wrapper, WrapperBody},
-};
+pub use self::{handler::Handler, wrapper::Wrapper};
 
 mod handler;
 mod wrapper;

--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -81,6 +81,7 @@ pub fn wrapper(attributes: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     // allow the macro to be resolved with the same path as the command function
+    #[allow(unused_imports)]
     #visibility use #wrapper;
   )
   .into()

--- a/core/tauri-macros/src/lib.rs
+++ b/core/tauri-macros/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate proc_macro;
 use crate::context::ContextItems;
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, AttributeArgs, ItemFn};
+use syn::parse_macro_input;
 
 mod command;
 
@@ -14,12 +14,7 @@ mod context;
 
 #[proc_macro_attribute]
 pub fn command(attributes: TokenStream, item: TokenStream) -> TokenStream {
-  let attributes = parse_macro_input!(attributes as AttributeArgs);
-  let function = parse_macro_input!(item as ItemFn);
-  match command::Wrapper::new(function, attributes) {
-    Ok(wrapper) => wrapper.into(),
-    Err(error) => error.into_compile_error().into(),
-  }
+  command::wrapper(attributes, item)
 }
 
 #[proc_macro]

--- a/core/tauri-macros/src/lib.rs
+++ b/core/tauri-macros/src/lib.rs
@@ -5,7 +5,6 @@
 extern crate proc_macro;
 use crate::context::ContextItems;
 use proc_macro::TokenStream;
-use std::convert::TryFrom;
 use syn::{parse_macro_input, ItemFn};
 
 mod command;
@@ -16,8 +15,7 @@ mod context;
 #[proc_macro_attribute]
 pub fn command(_attrs: TokenStream, item: TokenStream) -> TokenStream {
   let function = parse_macro_input!(item as ItemFn);
-  let body = command::WrapperBody::try_from(&function);
-  command::Wrapper::new(function, body).into()
+  command::Wrapper::new(function).into()
 }
 
 #[proc_macro]

--- a/core/tauri-macros/src/lib.rs
+++ b/core/tauri-macros/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate proc_macro;
 use crate::context::ContextItems;
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, ItemFn};
+use syn::{parse_macro_input, AttributeArgs, ItemFn};
 
 mod command;
 
@@ -13,9 +13,13 @@ mod command;
 mod context;
 
 #[proc_macro_attribute]
-pub fn command(_attrs: TokenStream, item: TokenStream) -> TokenStream {
+pub fn command(attributes: TokenStream, item: TokenStream) -> TokenStream {
+  let attributes = parse_macro_input!(attributes as AttributeArgs);
   let function = parse_macro_input!(item as ItemFn);
-  command::Wrapper::new(function).into()
+  match command::Wrapper::new(function, attributes) {
+    Ok(wrapper) => wrapper.into(),
+    Err(error) => error.into_compile_error().into(),
+  }
 }
 
 #[proc_macro]

--- a/core/tauri/src/command.rs
+++ b/core/tauri/src/command.rs
@@ -138,6 +138,7 @@ impl<'de, P: Params> Deserializer<'de> for CommandItem<'de, P> {
   pass!(deserialize_ignored_any, visitor: V);
 }
 
+/// [Autoref-based stable specialization](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md)
 #[doc(hidden)]
 pub mod private {
   use crate::InvokeError;

--- a/core/tauri/src/hooks.rs
+++ b/core/tauri/src/hooks.rs
@@ -157,7 +157,12 @@ impl<P: Params> InvokeResolver<P> {
 
   /// Reject the invoke promise with an [`InvokeError`].
   pub fn invoke_error(self, value: InvokeError) {
-    Self::return_result(self.window, Result::<(), _>::Err(value), self.callback, self.error)
+    Self::return_result(
+      self.window,
+      Result::<(), _>::Err(value),
+      self.callback,
+      self.error,
+    )
   }
 
   /// Asynchronously executes the given task

--- a/core/tauri/src/hooks.rs
+++ b/core/tauri/src/hooks.rs
@@ -49,12 +49,14 @@ pub struct InvokeError(JsonValue);
 
 impl InvokeError {
   /// Create an [`InvokeError`] as a string of the [`serde_json::Error`] message.
+  #[inline(always)]
   pub fn from_serde_json(error: serde_json::Error) -> Self {
     Self(JsonValue::String(error.to_string()))
   }
 }
 
 impl<T: Serialize> From<T> for InvokeError {
+  #[inline]
   fn from(value: T) -> Self {
     serde_json::to_value(value)
       .map(Self)
@@ -63,6 +65,7 @@ impl<T: Serialize> From<T> for InvokeError {
 }
 
 impl From<crate::Error> for InvokeError {
+  #[inline(always)]
   fn from(error: crate::Error) -> Self {
     Self(JsonValue::String(error.to_string()))
   }
@@ -79,6 +82,7 @@ pub enum InvokeResponse {
 
 impl InvokeResponse {
   /// Turn a [`InvokeResponse`] back into a serializable result.
+  #[inline(always)]
   pub fn into_result(self) -> Result<JsonValue, JsonValue> {
     match self {
       Self::Ok(v) => Ok(v),
@@ -88,6 +92,7 @@ impl InvokeResponse {
 }
 
 impl<T: Serialize> From<Result<T, InvokeError>> for InvokeResponse {
+  #[inline]
   fn from(result: Result<T, InvokeError>) -> Self {
     match result {
       Ok(ok) => match serde_json::to_value(ok) {
@@ -99,9 +104,15 @@ impl<T: Serialize> From<Result<T, InvokeError>> for InvokeResponse {
   }
 }
 
+impl From<InvokeError> for InvokeResponse {
+  fn from(error: InvokeError) -> Self {
+    Self::Err(error)
+  }
+}
+
 /// Resolver of a invoke message.
-pub struct InvokeResolver<M: Params> {
-  window: Window<M>,
+pub struct InvokeResolver<P: Params> {
+  window: Window<P>,
   pub(crate) callback: String,
   pub(crate) error: String,
 }
@@ -126,6 +137,21 @@ impl<P: Params> InvokeResolver<P> {
     });
   }
 
+  /// Reply to the invoke promise with an async task which is already serialized.
+  pub fn respond_async_serialized<F>(self, task: F)
+  where
+    F: Future<Output = Result<JsonValue, InvokeError>> + Send + 'static,
+  {
+    crate::async_runtime::spawn(async move {
+      Self::return_result(self.window, task.await.into(), self.callback, self.error);
+    });
+  }
+
+  /// Reply to the invoke promise with a serializable value.
+  pub fn respond<T: Serialize>(self, value: Result<T, InvokeError>) {
+    Self::return_result(self.window, value.into(), self.callback, self.error)
+  }
+
   /// Reply to the invoke promise running the given closure.
   pub fn respond_closure<T, F>(self, f: F)
   where
@@ -135,34 +161,24 @@ impl<P: Params> InvokeResolver<P> {
     Self::return_closure(self.window, f, self.callback, self.error)
   }
 
-  /// Reply to the invoke promise running the given closure.
-  pub fn respond<T: Serialize>(self, value: Result<T, InvokeError>) {
-    Self::return_result(self.window, value, self.callback, self.error);
-  }
-
   /// Resolve the invoke promise with a value.
-  pub fn resolve<S: Serialize>(self, value: S) {
-    Self::return_result(self.window, Ok(value), self.callback, self.error)
+  pub fn resolve<T: Serialize>(self, value: T) {
+    Self::return_result(self.window, Ok(value).into(), self.callback, self.error)
   }
 
   /// Reject the invoke promise with a value.
-  pub fn reject<S: Serialize>(self, value: S) {
+  pub fn reject<T: Serialize>(self, value: T) {
     Self::return_result(
       self.window,
-      Result::<(), _>::Err(value.into()),
+      Result::<(), _>::Err(value.into()).into(),
       self.callback,
       self.error,
     )
   }
 
   /// Reject the invoke promise with an [`InvokeError`].
-  pub fn invoke_error(self, value: InvokeError) {
-    Self::return_result(
-      self.window,
-      Result::<(), _>::Err(value),
-      self.callback,
-      self.error,
-    )
+  pub fn invoke_error(self, error: InvokeError) {
+    Self::return_result(self.window, error.into(), self.callback, self.error)
   }
 
   /// Asynchronously executes the given task
@@ -189,17 +205,17 @@ impl<P: Params> InvokeResolver<P> {
     success_callback: String,
     error_callback: String,
   ) {
-    Self::return_result(window, f(), success_callback, error_callback)
+    Self::return_result(window, f().into(), success_callback, error_callback)
   }
 
-  pub(crate) fn return_result<T: Serialize>(
+  pub(crate) fn return_result(
     window: Window<P>,
-    response: Result<T, InvokeError>,
+    response: InvokeResponse,
     success_callback: String,
     error_callback: String,
   ) {
     let callback_string = match format_callback_result(
-      InvokeResponse::from(response).into_result(),
+      response.into_result(),
       success_callback,
       error_callback.clone(),
     ) {

--- a/core/tauri/src/hooks.rs
+++ b/core/tauri/src/hooks.rs
@@ -135,6 +135,11 @@ impl<P: Params> InvokeResolver<P> {
     Self::return_closure(self.window, f, self.callback, self.error)
   }
 
+  /// Reply to the invoke promise running the given closure.
+  pub fn respond<T: Serialize>(self, value: Result<T, InvokeError>) {
+    Self::return_result(self.window, value, self.callback, self.error);
+  }
+
   /// Resolve the invoke promise with a value.
   pub fn resolve<S: Serialize>(self, value: S) {
     Self::return_result(self.window, Ok(value), self.callback, self.error)
@@ -148,6 +153,11 @@ impl<P: Params> InvokeResolver<P> {
       self.callback,
       self.error,
     )
+  }
+
+  /// Reject the invoke promise with an [`InvokeError`].
+  pub fn invoke_error(self, value: InvokeError) {
+    Self::return_result(self.window, Result::<(), _>::Err(value), self.callback, self.error)
   }
 
   /// Asynchronously executes the given task

--- a/examples/commands/public/index.html
+++ b/examples/commands/public/index.html
@@ -26,6 +26,7 @@
 
     const container = document.querySelector('#container')
     const commands = [
+      { name: 'borrow_cmd' },
       { name: 'window_label' },
       { name: 'simple_command' },
       { name: 'stateful_command' },

--- a/examples/commands/public/index.html
+++ b/examples/commands/public/index.html
@@ -10,46 +10,47 @@
 
 <body>
   <h1>Tauri Commands</h1>
-  <div id="response">Response:</div>
+  <div>Response: <span id="response"></span></div>
+  <div >Without Args: <span id="response-optional"></span></div>
   <div id="container"></div>
   <script>
-    const responseDiv = document.querySelector('#response')
-    function runCommand(commandName, args) {
+    function runCommand(commandName, args, optional) {
+      const id = optional ? "#response-optional" : "#response";
+      const result = document.querySelector(id)
       window.__TAURI__.invoke(commandName, args).then(response => {
-        responseDiv.innerHTML = `Response: Ok(${response})`
+        result.innerText = `Ok(${response})`
       }).catch(error => {
-        responseDiv.innerHTML = `Response: Err(${error})`
+        result.innerText = `Err(${error})`
       })
     }
 
     const container = document.querySelector('#container')
     const commands = [
-      { name: 'window_label', required: true },
-      { name: 'simple_command', required: true },
-      { name: 'stateful_command', required: false },
-      { name: 'async_simple_command', required: true },
-      { name: 'async_stateful_command', required: false },
-      { name: 'simple_command_with_result', required: true },
-      { name: 'stateful_command_with_result', required: false },
-      { name: 'async_simple_command_with_result', required: true },
-      { name: 'async_stateful_command_with_result', required: false },
-      { name: 'command_arguments_wild', required: true },
-      { name: 'command_arguments_struct', required: true, args: { "Person": { "name": "ferris", age: 6 } } },
-      { name: 'command_arguments_tuple_struct', required: true, args: { "InlinePerson": [ "ferris", 6 ] } },
+      { name: 'window_label' },
+      { name: 'simple_command' },
+      { name: 'stateful_command' },
+      { name: 'async_simple_command' },
+      { name: 'future_simple_command'},
+      { name: 'async_stateful_command' },
+      { name: 'simple_command_with_result' },
+      { name: 'stateful_command_with_result' },
+      { name: 'async_simple_command_with_result' },
+      { name: 'future_simple_command_with_return' },
+      { name: 'future_simple_command_with_result' },
+      { name: 'async_stateful_command_with_result' },
+      { name: 'command_arguments_wild' },
+      { name: 'command_arguments_struct', args: { "Person": { "name": "ferris", age: 6 } } },
+      { name: 'command_arguments_tuple_struct', args: { "InlinePerson": [ "ferris", 6 ] } },
     ]
 
     for (const command of commands) {
-      const { name, required } = command
+      const { name } = command
       const args = command.args ?? { argument: 'value' }
       const button = document.createElement('button')
       button.innerHTML = `Run ${name}`;
       button.addEventListener("click", function () {
-        runCommand(name, args)
-        if (!required) {
-          setTimeout(() => {
-            runCommand(name, {})
-          }, 1000)
-        }
+        runCommand(name, args, false)
+        runCommand(name, Object.create(null), true)
       });
       container.appendChild(button);
     }

--- a/examples/commands/src-tauri/src/commands.rs
+++ b/examples/commands/src-tauri/src/commands.rs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-#[tauri::command]
+use tauri::{command, State};
+
+#[command]
 pub fn simple_command(argument: String) {
   println!("{}", argument);
 }
 
-#[tauri::command]
-pub fn stateful_command(argument: Option<String>, state: tauri::State<'_, super::MyState>) {
+#[command]
+pub fn stateful_command(argument: Option<String>, state: State<'_, super::MyState>) {
   println!("{:?} {:?}", argument, state.inner());
 }

--- a/examples/commands/src-tauri/src/main.rs
+++ b/examples/commands/src-tauri/src/main.rs
@@ -38,7 +38,6 @@ async fn async_simple_command(argument: String) {
 }
 
 #[command]
-#[allow(unused)] // temporarily disabled until I solve the lifetime issue
 async fn async_stateful_command(
   argument: Option<String>,
   state: State<'_, MyState>,
@@ -170,8 +169,7 @@ fn main() {
       commands::stateful_command,
       async_simple_command,
       future_simple_command,
-      // Because `async` appends '_ onto the generated future, the state thinks it needs live for 'static
-      //async_stateful_command,
+      async_stateful_command,
       command_arguments_wild,
       command_arguments_struct,
       simple_command_with_result,

--- a/examples/commands/src-tauri/src/main.rs
+++ b/examples/commands/src-tauri/src/main.rs
@@ -32,8 +32,8 @@ async fn async_simple_command(argument: String) {
   println!("{}", argument);
 }
 
-/// todo: even with #[allow(unused)], the macro generates an unused warning
-#[allow(unused)]
+// todo: even with #[allow(unused)], the macro generates an unused warning - commented out to prevent clippy from yelling at me
+/*#[allow(unused)]
 #[command]
 async fn async_stateful_command(
   argument: Option<String>,
@@ -41,7 +41,7 @@ async fn async_stateful_command(
 ) -> Result<(), ()> {
   println!("{:?} {:?}", argument, state.inner());
   Ok(())
-}
+}*/
 
 // Raw future commands
 #[command(future)]

--- a/examples/commands/src-tauri/src/main.rs
+++ b/examples/commands/src-tauri/src/main.rs
@@ -35,7 +35,10 @@ async fn async_simple_command(argument: String) {
 /// todo: even with #[allow(unused)], the macro generates an unused warning
 #[allow(unused)]
 #[command]
-async fn async_stateful_command(argument: Option<String>, state: State<'_, MyState>) -> Result<(),()> {
+async fn async_stateful_command(
+  argument: Option<String>,
+  state: State<'_, MyState>,
+) -> Result<(), ()> {
   println!("{:?} {:?}", argument, state.inner());
   Ok(())
 }

--- a/examples/commands/src-tauri/src/main.rs
+++ b/examples/commands/src-tauri/src/main.rs
@@ -44,13 +44,13 @@ async fn async_stateful_command(
 }*/
 
 // Raw future commands
-#[command(future)]
+#[command(async)]
 fn future_simple_command(argument: String) -> impl std::future::Future<Output = ()> {
   println!("{}", argument);
   std::future::ready(())
 }
 
-#[command(future)]
+#[command(async)]
 fn future_simple_command_with_return(
   argument: String,
 ) -> impl std::future::Future<Output = String> {
@@ -58,12 +58,22 @@ fn future_simple_command_with_return(
   std::future::ready(argument)
 }
 
-#[command(future)]
+#[command(async)]
 fn future_simple_command_with_result(
   argument: String,
 ) -> impl std::future::Future<Output = Result<String, ()>> {
   println!("{}", argument);
   std::future::ready(Ok(argument))
+}
+
+#[command(async)]
+fn force_async(argument: String) -> String {
+  argument
+}
+
+#[command(async)]
+fn force_async_with_result(argument: &str) -> Result<&str, ()> {
+  Ok(argument)
 }
 
 // ------------------------ Commands returning Result ------------------------
@@ -146,6 +156,8 @@ fn main() {
     .invoke_handler(tauri::generate_handler![
       borrow_cmd,
       window_label,
+      force_async,
+      force_async_with_result,
       commands::simple_command,
       commands::stateful_command,
       async_simple_command,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
So we can't really return a trait while also having a default implementation for `Serialize` because `Result` is also `Serialize` if the contents are.  Since the contents need to be `Serialize` to be useful as a command result, the implementations would conflict if we tried to have a specific implementation for `Result`. If we don't have a specific implementation for result, the value would be sent as `Result<Result<T, E>, InvokeError>`.

This is not the only solution, but is the one with the least user-land code needed. An alternative would be to manually `impl` every type that `Serialize` does for a `CommandResult` trait, and also require the user to implement it for any types they have that are serializable that they wish to return from commands. Not ideal, but possible.