### PR TITLE
refactor(maskfile): enforce command name consistency

### DIFF
--- a/maskfile.md
+++ b/maskfile.md
@@ -1,6 +1,6 @@
 # Shorthand Commands
 
-<!-- 
+<!--
 // Copyright 2019-2021 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
@@ -128,7 +128,7 @@ switch ($smoke_test_path.parent) {
 
 ## list
 
-### list smoke tests
+### list smoke-tests
 
 > List all available smoke tests
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
In the move from the `examples` repository to `smoke-tests`, a typo may have been introduced:
For now, the command `mask list smoke tests` won't work, and requires to be written `mask list 'smoke tests'`.
As the `run` command is `mask run smoke-test (name)`, I suppose this is a simple typo with the initial intention being `mask list smoke-tests`.

The readme file in https://github.com/tauri-apps/smoke-tests could use a little update as well (as it uses the old command names), which I would be happy to write if needed.