### PR TITLE
refactor(core): clearer case conversion + docs

### DIFF
--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -154,10 +154,10 @@ fn parse_arg(command: &Ident, arg: &FnArg) -> syn::Result<TokenStream2> {
     }
   };
 
-  // we only support patterns that allow us to extract some sort of keyed identifier.
+  // we only support patterns that allow us to extract some sort of keyed identifier
   let mut key = match &mut arg {
     Pat::Ident(arg) => arg.ident.to_string(),
-    Pat::Wild(_) => "_".into(), // we always convert to camelCase, so this will end up empty
+    Pat::Wild(_) => "".into(), // we always convert to camelCase, so "_" will end up empty anyways
     Pat::Struct(s) => super::path_to_command(&mut s.path).ident.to_string(),
     Pat::TupleStruct(s) => super::path_to_command(&mut s.path).ident.to_string(),
     err => {

--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -195,8 +195,8 @@ fn snake_case_to_camel_case(key: &str) -> String {
   let mut camel = String::with_capacity(key.len());
   let mut to_upper = false;
 
-  for char in key.chars() {
-    match char {
+  for c in key.chars() {
+    match c {
       '_' => to_upper = true,
       c if std::mem::take(&mut to_upper) => camel.push(c.to_ascii_uppercase()),
       c => camel.push(c),

--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -155,9 +155,9 @@ fn parse_arg(command: &Ident, arg: &FnArg) -> syn::Result<TokenStream2> {
   };
 
   // we only support patterns that allow us to extract some sort of keyed identifier.
-  let key = match &mut arg {
+  let mut key = match &mut arg {
     Pat::Ident(arg) => arg.ident.to_string(),
-    Pat::Wild(_) => "_".into(),
+    Pat::Wild(_) => "_".into(), // we always convert to camelCase, so this will end up empty
     Pat::Struct(s) => super::path_to_command(&mut s.path).ident.to_string(),
     Pat::TupleStruct(s) => super::path_to_command(&mut s.path).ident.to_string(),
     err => {
@@ -176,7 +176,10 @@ fn parse_arg(command: &Ident, arg: &FnArg) -> syn::Result<TokenStream2> {
     ));
   }
 
-  let key = snake_case_to_camel_case(key);
+  // snake_case -> camelCase
+  if key.as_str().contains('_') {
+    key = snake_case_to_camel_case(key.as_str());
+  }
 
   Ok(quote!(::tauri::command::CommandArg::from_command(
     ::tauri::command::CommandItem {
@@ -187,23 +190,18 @@ fn parse_arg(command: &Ident, arg: &FnArg) -> syn::Result<TokenStream2> {
   )))
 }
 
-fn snake_case_to_camel_case(s: String) -> String {
-  if s.as_str().contains('_') {
-    let mut camel = String::with_capacity(s.len());
-    let mut to_upper = false;
-    for c in s.chars() {
-      match c {
-        '_' => to_upper = true,
-        c if to_upper => {
-          camel.push(c.to_ascii_uppercase());
-          to_upper = false;
-        }
-        c => camel.push(c),
-      }
-    }
+/// Convert a snake_case string into camelCase, no underscores will be left.
+fn snake_case_to_camel_case(key: &str) -> String {
+  let mut camel = String::with_capacity(key.len());
+  let mut to_upper = false;
 
-    camel
-  } else {
-    s
+  for char in key.chars() {
+    match char {
+      '_' => to_upper = true,
+      c if std::mem::take(&mut to_upper) => camel.push(c.to_ascii_uppercase()),
+      c => camel.push(c),
+    }
   }
+
+  camel
 }

--- a/core/tauri/src/command.rs
+++ b/core/tauri/src/command.rs
@@ -59,6 +59,13 @@ macro_rules! pass {
     fn $fn<V: Visitor<'de>>(self, $($arg: $argt),*) -> Result<V::Value, Self::Error> {
       use serde::de::Error;
 
+      if self.key.is_empty() {
+        return Err(serde_json::Error::custom(format!(
+            "command {} has an argument with no name with a non-optional value",
+            self.name
+          )))
+      }
+
       match self.message.payload.get(self.key) {
         Some(value) => value.$fn($($arg),*),
         None => {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
the docs were a lacking for the quick case conversion i just wrote.

empty command keys (like if used with a wildcard `_: String`) for an `impl Serialize` type that are non-optional will now have a specific error message related to that.

if a new string was going to be allocated was a bit hidden, so I moved the underscore check to outside the conversion function.