### PR TITLE
fix(core): allow !Sync futures to be used with #[command]

### DIFF
--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -100,8 +100,9 @@ fn body_async(function: &ItemFn) -> syn::Result<TokenStream2> {
     quote! {
       resolver.respond_async_serialized(async move {
         let result = $path(#(#args?),*);
-        (&result).async_kind().future(result).await
-      })
+        let kind = (&result).async_kind();
+        kind.future(result).await
+      });
     }
   })
 }
@@ -125,7 +126,8 @@ fn body_blocking(function: &ItemFn) -> syn::Result<TokenStream2> {
 
   Ok(quote! {
     let result = $path(#(match #args #match_body),*);
-    (&result).blocking_kind().block(result, resolver);
+    let kind = (&result).blocking_kind();
+    kind.block(result, resolver);
   })
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
This separates the autoref tag binding from executing the future so that rust can figure out that it doesn't need to stay borrowed. this allows `!Sync` futures again.