### PR TITLE
refactor(core): drop `Option` payload type on `event::emit`

### DIFF
--- a/.changes/event-refactor.md
+++ b/.changes/event-refactor.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+The event `emit` function payload type is now `impl Serialize` instead of `Option<impl Serialize>`. 

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -143,7 +143,7 @@ pub trait Manager<P: Params>: sealed::ManagerBase<P> {
   }
 
   /// Emits a event to all windows.
-  fn emit_all<E: ?Sized, S>(&self, event: &E, payload: Option<S>) -> Result<()>
+  fn emit_all<E: ?Sized, S>(&self, event: &E, payload: S) -> Result<()>
   where
     P::Event: Borrow<E>,
     E: TagRef<P::Event>,
@@ -157,7 +157,7 @@ pub trait Manager<P: Params>: sealed::ManagerBase<P> {
     &self,
     label: &L,
     event: &E,
-    payload: Option<S>,
+    payload: S,
   ) -> Result<()>
   where
     P::Label: Borrow<L>,

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -364,13 +364,13 @@ impl<P: Params> WindowManager<P> {
         let window = Window::new(manager.clone(), window);
         let _ = match event {
           FileDropEvent::Hovered(paths) => {
-            window.emit_internal(&tauri_event::<P::Event>("tauri://file-drop"), Some(paths))
+            window.emit(&tauri_event::<P::Event>("tauri://file-drop"), Some(paths))
           }
-          FileDropEvent::Dropped(paths) => window.emit_internal(
+          FileDropEvent::Dropped(paths) => window.emit(
             &tauri_event::<P::Event>("tauri://file-drop-hover"),
             Some(paths),
           ),
-          FileDropEvent::Cancelled => window.emit_internal(
+          FileDropEvent::Cancelled => window.emit(
             &tauri_event::<P::Event>("tauri://file-drop-cancelled"),
             Some(()),
           ),
@@ -584,12 +584,7 @@ impl<P: Params> WindowManager<P> {
     window
   }
 
-  pub fn emit_filter<E: ?Sized, S, F>(
-    &self,
-    event: &E,
-    payload: Option<S>,
-    filter: F,
-  ) -> crate::Result<()>
+  pub fn emit_filter<E: ?Sized, S, F>(&self, event: &E, payload: S, filter: F) -> crate::Result<()>
   where
     P::Event: Borrow<E>,
     E: TagRef<P::Event>,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
