### PR TITLE
refactor(core): Context fields now private, Icon used on all platforms

### DIFF
--- a/.changes/private-context.md
+++ b/.changes/private-context.md
@@ -1,0 +1,8 @@
+---
+"tauri": patch
+"tauri-runtime": patch
+"tauri-wry-runtime": patch
+---
+
+**Breaking:** `Context` fields are now private, and is expected to be created through `Context::new(...)`.
+All fields previously available through `Context` are now public methods.

--- a/.changes/private-context.md
+++ b/.changes/private-context.md
@@ -1,7 +1,7 @@
 ---
 "tauri": patch
 "tauri-runtime": patch
-"tauri-wry-runtime": patch
+"tauri-runtime-wry": patch
 ---
 
 **Breaking:** `Context` fields are now private, and is expected to be created through `Context::new(...)`.

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -88,16 +88,18 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
         .join(system_tray_icon_path)
         .display()
         .to_string();
-      quote!(Some(::std::path::PathBuf::from(#system_tray_icon_path)))
+      quote!(Some(#root::Icon::File(::std::path::PathBuf::from(#system_tray_icon_path))))
     } else {
       let system_tray_icon_file_path = system_tray_icon_path.to_string_lossy().to_string();
       quote!(
         Some(
-          #root::api::path::resolve_path(
-            &#config, &#package_info,
-            #system_tray_icon_file_path,
-            Some(#root::api::path::BaseDirectory::Resource)
-          ).expect("failed to resolve resource dir")
+          #root::Icon::File(
+            #root::api::path::resolve_path(
+              &#config, &#package_info,
+             #system_tray_icon_file_path,
+             Some(#root::api::path::BaseDirectory::Resource)
+            ).expect("failed to resolve resource dir")
+          )
         )
       )
     }
@@ -113,17 +115,17 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
       .join(system_tray_icon_path)
       .display()
       .to_string();
-    quote!(Some(include_bytes!(#system_tray_icon_path).to_vec()))
+    quote!(Some(#root::Icon::Raw(include_bytes!(#system_tray_icon_path).to_vec())))
   } else {
     quote!(None)
   };
 
   // double braces are purposeful to force the code into a block expression
-  Ok(quote!(#root::Context {
-    system_tray_icon: #system_tray_icon,
-    config: #config,
-    assets: ::std::sync::Arc::new(#assets),
-    default_window_icon: #default_window_icon,
-    package_info: #package_info,
-  }))
+  Ok(quote!(#root::Context::new(
+    #config,
+    ::std::sync::Arc::new(#assets),
+    #default_window_icon,
+    #system_tray_icon,
+    #package_info,
+  )))
 }

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -842,7 +842,7 @@ impl Runtime for Wry {
       }
 
       #[cfg(not(target_os = "linux"))]
-      Icon::File(path) => {
+      Icon::File(_) => {
         panic!("non-linux system menu icons must be bytes, not a file path",)
       }
       _ => unreachable!(),

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -820,30 +820,34 @@ impl Runtime for Wry {
     Ok(DetachedWindow { label, dispatcher })
   }
 
-  #[cfg(all(feature = "system-tray", target_os = "linux"))]
+  #[cfg(feature = "system-tray")]
   fn system_tray<I: MenuId>(
     &self,
-    icon: std::path::PathBuf,
+    icon: Icon,
     menu_items: Vec<SystemTrayMenuItem<I>>,
   ) -> Result<()> {
-    SystemTrayBuilder::new(
-      icon,
-      menu_items
-        .into_iter()
-        .map(|m| MenuItemWrapper::from(m).0)
-        .collect(),
-    )
-    .build(&self.event_loop)
-    .map_err(|e| Error::SystemTray(Box::new(e)))?;
-    Ok(())
-  }
+    // todo: fix this interface in Tao to an enum similar to Icon
 
-  #[cfg(all(feature = "system-tray", not(target_os = "linux")))]
-  fn system_tray<I: MenuId>(
-    &self,
-    icon: Vec<u8>,
-    menu_items: Vec<SystemTrayMenuItem<I>>,
-  ) -> Result<()> {
+    // we expect the code that passes the Icon enum to have already checked the platform.
+    let icon = match icon {
+      #[cfg(target_os = "linux")]
+      Icon::File(path) => path,
+
+      #[cfg(not(target_os = "linux"))]
+      Icon::Raw(bytes) => bytes,
+
+      #[cfg(target_os = "linux")]
+      Icon::Raw(_) => {
+        panic!("linux requires the system menu icon to be a file path, not bytes.")
+      }
+
+      #[cfg(not(target_os = "linux"))]
+      Icon::File(path) => {
+        panic!("non-linux system menu icons must be bytes, not a file path",)
+      }
+      _ => unreachable!()
+    };
+
     SystemTrayBuilder::new(
       icon,
       menu_items

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -845,7 +845,7 @@ impl Runtime for Wry {
       Icon::File(path) => {
         panic!("non-linux system menu icons must be bytes, not a file path",)
       }
-      _ => unreachable!()
+      _ => unreachable!(),
     };
 
     SystemTrayBuilder::new(

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -119,23 +119,11 @@ pub trait Runtime: Sized + 'static {
   ) -> crate::Result<DetachedWindow<P>>;
 
   /// Adds the icon to the system tray with the specified menu items.
-  #[cfg(all(feature = "system-tray", target_os = "linux"))]
-  #[cfg_attr(doc_cfg, doc(cfg(all(feature = "system-tray", target_os = "linux"))))]
+  #[cfg(feature = "system-tray")]
+  #[cfg_attr(doc_cfg, doc(cfg(feature = "system-tray")))]
   fn system_tray<I: MenuId>(
     &self,
-    icon: std::path::PathBuf,
-    menu: Vec<menu::SystemTrayMenuItem<I>>,
-  ) -> crate::Result<()>;
-
-  /// Adds the icon to the system tray with the specified menu items.
-  #[cfg(all(feature = "system-tray", not(target_os = "linux")))]
-  #[cfg_attr(
-    doc_cfg,
-    doc(cfg(all(feature = "system-tray", not(target_os = "linux"))))
-  )]
-  fn system_tray<I: MenuId>(
-    &self,
-    icon: Vec<u8>,
+    icon: Icon,
     menu: Vec<menu::SystemTrayMenuItem<I>>,
   ) -> crate::Result<()>;
 

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -23,11 +23,10 @@ use std::{collections::HashMap, sync::Arc};
 #[cfg(feature = "menu")]
 use crate::runtime::menu::Menu;
 #[cfg(feature = "system-tray")]
-use crate::runtime::menu::SystemTrayMenuItem;
+use crate::runtime::{menu::SystemTrayMenuItem, Icon};
 
 #[cfg(feature = "updater")]
 use crate::updater;
-use tauri_runtime::Icon;
 
 #[cfg(feature = "menu")]
 pub(crate) type GlobalMenuEventListener<P> = Box<dyn Fn(WindowMenuEvent<P>) + Send + Sync>;

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -164,6 +164,7 @@ impl<A: Assets> Context<A> {
   }
 
   /// Create a new [`Context`] from the minimal required items.
+  #[inline(always)]
   pub fn new(
     config: Config,
     assets: Arc<A>,

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -72,11 +72,10 @@ pub use {
       dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Pixel, Position, Size},
       WindowEvent,
     },
-    MenuId, Params,
+    Icon, MenuId, Params,
   },
   self::state::{State, StateManager},
   self::window::{Monitor, Window},
-  tauri_runtime::Icon,
 };
 #[cfg(feature = "system-tray")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "system-tray")))]

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -76,6 +76,7 @@ pub use {
   },
   self::state::{State, StateManager},
   self::window::{Monitor, Window},
+  tauri_runtime::Icon,
 };
 #[cfg(feature = "system-tray")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "system-tray")))]
@@ -124,25 +125,60 @@ macro_rules! tauri_build_context {
 
 /// User supplied data required inside of a Tauri application.
 pub struct Context<A: Assets> {
+  pub(crate) config: Config,
+  pub(crate) assets: Arc<A>,
+  pub(crate) default_window_icon: Option<Vec<u8>>,
+  pub(crate) system_tray_icon: Option<Icon>,
+  pub(crate) package_info: crate::api::PackageInfo,
+}
+
+impl<A: Assets> Context<A> {
   /// The config the application was prepared with.
-  pub config: Config,
+  #[inline(always)]
+  pub fn config(&self) -> &Config {
+    &self.config
+  }
 
   /// The assets to be served directly by Tauri.
-  pub assets: Arc<A>,
+  #[inline(always)]
+  pub fn assets(&self) -> Arc<A> {
+    self.assets.clone()
+  }
 
   /// The default window icon Tauri should use when creating windows.
-  pub default_window_icon: Option<Vec<u8>>,
+  #[inline(always)]
+  pub fn default_window_icon(&self) -> Option<&[u8]> {
+    self.default_window_icon.as_deref()
+  }
 
   /// The icon to use use on the system tray UI.
-  #[cfg(target_os = "linux")]
-  pub system_tray_icon: Option<std::path::PathBuf>,
-
-  /// The icon to use use on the system tray UI.
-  #[cfg(not(target_os = "linux"))]
-  pub system_tray_icon: Option<Vec<u8>>,
+  #[inline(always)]
+  pub fn system_tray_icon(&self) -> Option<&Icon> {
+    self.system_tray_icon.as_ref()
+  }
 
   /// Package information.
-  pub package_info: crate::api::PackageInfo,
+  #[inline(always)]
+  pub fn package_info(&self) -> &crate::api::PackageInfo {
+    &self.package_info
+  }
+
+  /// Create a new [`Context`] from the minimal required items.
+  pub fn new(
+    config: Config,
+    assets: Arc<A>,
+    default_window_icon: Option<Vec<u8>>,
+    system_tray_icon: Option<Icon>,
+    package_info: crate::api::PackageInfo,
+  ) -> Self {
+    Self {
+      config,
+      assets,
+      default_window_icon,
+      system_tray_icon,
+      package_info,
+    }
+  }
 }
 
 /// Manages a running application.


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Previously used #[cfg] to change the platform specific icon type, we now re-use `tauri_runtime::Icon` instead.

This change sets us up in the future to expand `tauri::Context` without breaking changes. Technically this struct was not considered part of the public api so while it's a breaking change, we never guaranteed its stability. Hopefully this change allows it to be more stable in the future, but the guarantee has not changed.