### PR TITLE
feat(core): add default Args to all types exposing Params

### DIFF
--- a/.changes/default-params-type.md
+++ b/.changes/default-params-type.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+---
+
+Adds the default types used with `Builder::default()` to items that expose `Params` in their type. This allows you to
+skip specifying a generic parameter to types like `Window<P>` if you use the default type.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -25,6 +25,7 @@ use crate::runtime::menu::Menu;
 #[cfg(feature = "system-tray")]
 use crate::runtime::menu::SystemTrayMenuItem;
 
+use crate::manager::DefaultArgs;
 #[cfg(feature = "updater")]
 use crate::updater;
 
@@ -53,7 +54,7 @@ impl<I: MenuId> SystemTrayEvent<I> {
 /// A menu event that was triggered on a window.
 #[cfg(feature = "menu")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "menu")))]
-pub struct WindowMenuEvent<P: Params> {
+pub struct WindowMenuEvent<P: Params = DefaultArgs> {
   pub(crate) menu_item_id: P::MenuId,
   pub(crate) window: Window<P>,
 }
@@ -72,7 +73,7 @@ impl<P: Params> WindowMenuEvent<P> {
 }
 
 /// A window event that was triggered on the specified window.
-pub struct GlobalWindowEvent<P: Params> {
+pub struct GlobalWindowEvent<P: Params = DefaultArgs> {
   pub(crate) event: WindowEvent,
   pub(crate) window: Window<P>,
 }
@@ -90,7 +91,7 @@ impl<P: Params> GlobalWindowEvent<P> {
 }
 
 /// A handle to the currently running application.
-pub struct AppHandle<P: Params> {
+pub struct AppHandle<P: Params = DefaultArgs> {
   manager: WindowManager<P>,
 }
 
@@ -104,7 +105,7 @@ impl<P: Params> ManagerBase<P> for AppHandle<P> {
 /// The instance of the currently running application.
 ///
 /// This type implements [`Manager`] which allows for manipulation of global application items.
-pub struct App<P: Params> {
+pub struct App<P: Params = DefaultArgs> {
   runtime: P::Runtime,
   manager: WindowManager<P>,
 }

--- a/core/tauri/src/hooks.rs
+++ b/core/tauri/src/hooks.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use crate::manager::DefaultArgs;
 use crate::{
   api::rpc::{format_callback, format_callback_result},
   app::App,
@@ -35,7 +36,7 @@ impl PageLoadPayload {
 }
 
 /// The message and resolver given to a custom command.
-pub struct Invoke<P: Params> {
+pub struct Invoke<P: Params = DefaultArgs> {
   /// The message passed.
   pub message: InvokeMessage<P>,
 
@@ -111,7 +112,7 @@ impl From<InvokeError> for InvokeResponse {
 }
 
 /// Resolver of a invoke message.
-pub struct InvokeResolver<P: Params> {
+pub struct InvokeResolver<P: Params = DefaultArgs> {
   window: Window<P>,
   pub(crate) callback: String,
   pub(crate) error: String,
@@ -229,7 +230,7 @@ impl<P: Params> InvokeResolver<P> {
 }
 
 /// An invoke message.
-pub struct InvokeMessage<P: Params> {
+pub struct InvokeMessage<P: Params = DefaultArgs> {
   /// The window that received the invoke message.
   pub(crate) window: Window<P>,
   /// Application managed state.

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -71,7 +71,7 @@ pub(crate) fn tauri_event<Event: Tag>(tauri_event: &str) -> Event {
   })
 }
 
-pub struct InnerWindowManager<P: Params> {
+pub struct InnerWindowManager<P: Params = DefaultArgs> {
   windows: Mutex<HashMap<P::Label, Window<P>>>,
   plugins: Mutex<PluginStore<P>>,
   listeners: Listeners<P::Event, P::Label>,
@@ -104,6 +104,9 @@ pub struct InnerWindowManager<P: Params> {
   /// Window event listeners to all windows.
   window_event_listeners: Arc<Vec<GlobalWindowEventListener<P>>>,
 }
+
+pub(crate) type DefaultArgs =
+  Args<String, String, String, String, crate::api::assets::EmbeddedAssets, crate::Wry>;
 
 /// A [Zero Sized Type] marker representing a full [`Params`].
 ///
@@ -147,7 +150,7 @@ impl<E: Tag, L: Tag, MID: MenuId, TID: MenuId, A: Assets, R: Runtime> Params
   type Runtime = R;
 }
 
-pub struct WindowManager<P: Params> {
+pub struct WindowManager<P: Params = DefaultArgs> {
   pub inner: Arc<InnerWindowManager<P>>,
   #[allow(clippy::type_complexity)]
   _marker: Args<P::Event, P::Label, P::MenuId, P::SystemTrayMenuId, P::Assets, P::Runtime>,

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -105,6 +105,7 @@ pub struct InnerWindowManager<P: Params = DefaultArgs> {
   window_event_listeners: Arc<Vec<GlobalWindowEventListener<P>>>,
 }
 
+/// This type should always match `Builder::default()`, otherwise the default type is useless.
 pub(crate) type DefaultArgs =
   Args<String, String, String, String, crate::api::assets::EmbeddedAssets, crate::Wry>;
 

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -4,6 +4,7 @@
 
 //! Extend Tauri functionality.
 
+use crate::manager::DefaultArgs;
 use crate::{api::config::PluginConfig, App, Invoke, PageLoadPayload, Params, Window};
 use serde_json::Value as JsonValue;
 use std::collections::HashMap;
@@ -45,7 +46,7 @@ pub trait Plugin<P: Params>: Send {
 }
 
 /// Plugin collection type.
-pub(crate) struct PluginStore<P: Params> {
+pub(crate) struct PluginStore<P: Params = DefaultArgs> {
   store: HashMap<&'static str, Box<dyn Plugin<P>>>,
 }
 

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -8,7 +8,7 @@ use crate::{
   api::config::WindowUrl,
   command::{CommandArg, CommandItem},
   event::{Event, EventHandler},
-  manager::WindowManager,
+  manager::{DefaultArgs, WindowManager},
   runtime::{
     monitor::Monitor as RuntimeMonitor,
     tag::{TagRef, ToJsString},
@@ -96,7 +96,7 @@ impl Monitor {
 ///
 /// This type also implements [`Manager`] which allows you to manage other windows attached to
 /// the same application.
-pub struct Window<P: Params> {
+pub struct Window<P: Params = DefaultArgs> {
   /// The webview window created by the runtime.
   window: DetachedWindow<P>,
 

--- a/examples/commands/src-tauri/src/main.rs
+++ b/examples/commands/src-tauri/src/main.rs
@@ -26,7 +26,7 @@ enum MyError {
 
 // ------------------------ Commands using Window ------------------------
 #[command]
-fn window_label(window: Window<impl Params<Label = String>>) {
+fn window_label(window: Window) {
   println!("window label: {}", window.label());
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
allows using no generic parameters when the user is using `Builder::default()`.

e.g. from
```rust
#[command]
fn window_label(window: Window<impl Params<Label = String>>) {
  println!("window label: {}", window.label());
}
```
to
```rust
#[command]
fn window_label(window: Window) {
  println!("window label: {}", window.label());
}
```

Marked as draft because it's late and I haven't tested it in the slightest. The command system extensively uses type inference, so we want to make sure that this doesn't break anything. It's not a breaking change to add this PR, so we are free to do so at any time in the future. Removing it after adding it would be a breaking change, so I want to be sure that it doesn't affect command inference first.