### PR TITLE
fix: updater signature fail if `TAURI_PRIVATE_KEY` is not set (#1791)

### DIFF
--- a/.changes/bundler-tauri-private-key.md
+++ b/.changes/bundler-tauri-private-key.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Fix bundler building when `TAURI_PRIVATE_KEY` was missing.

--- a/.changes/bundler-tauri-private-key.md
+++ b/.changes/bundler-tauri-private-key.md
@@ -1,5 +1,5 @@
 ---
-"tauri-bundler": patch
+"cli.rs": patch
 ---
 
 Fix bundler building when `TAURI_PRIVATE_KEY` was missing.

--- a/tooling/cli.rs/src/build.rs
+++ b/tooling/cli.rs/src/build.rs
@@ -199,8 +199,10 @@ impl Build {
           // another type of updater package who require multiple file signature
           for path in elem.bundle_paths.iter() {
             // sign our path from environment variables
-            let (signature_path, _signature) = sign_file_from_env_variables(path)?;
-            signed_paths.append(&mut vec![signature_path]);
+            match sign_file_from_env_variables(path) {
+              Ok((signature_path, _signature)) => signed_paths.append(&mut vec![signature_path]),
+              Err(err) => println!("Updater signature error: {}", err)
+            }            
           }
         }
         if !signed_paths.is_empty() {

--- a/tooling/cli.rs/src/build.rs
+++ b/tooling/cli.rs/src/build.rs
@@ -201,7 +201,7 @@ impl Build {
             // sign our path from environment variables
             match sign_file_from_env_variables(path) {
               Ok((signature_path, _signature)) => signed_paths.append(&mut vec![signature_path]),
-              Err(err) => println!("Updater signature error: {}", err)
+              Err(err) => println!("Updater signature error: {}", err),
             }
           }
         }

--- a/tooling/cli.rs/src/build.rs
+++ b/tooling/cli.rs/src/build.rs
@@ -202,7 +202,7 @@ impl Build {
             match sign_file_from_env_variables(path) {
               Ok((signature_path, _signature)) => signed_paths.append(&mut vec![signature_path]),
               Err(err) => println!("Updater signature error: {}", err)
-            }            
+            }
           }
         }
         if !signed_paths.is_empty() {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Fix: #1791
