### PR TITLE
fix(macros): collision when command is named `cmd`

### DIFF
--- a/.changes/fix-command-named-cmd.md
+++ b/.changes/fix-command-named-cmd.md
@@ -1,0 +1,5 @@
+---
+"tauri-macros": patch
+---
+
+Fixes a name collision when the command function is named `cmd`.

--- a/core/tauri-macros/src/command/handler.rs
+++ b/core/tauri-macros/src/command/handler.rs
@@ -52,11 +52,11 @@ impl From<Handler> for proc_macro::TokenStream {
     }: Handler,
   ) -> Self {
     quote::quote!(move |invoke| {
-      let cmd = invoke.message.command();
-      match cmd {
+      let __tauri_cmd__ = invoke.message.command();
+      match __tauri_cmd__ {
         #(stringify!(#commands) => #wrappers!(#paths, invoke),)*
         _ => {
-          invoke.resolver.reject(format!("command {} not found", cmd))
+          invoke.resolver.reject(format!("command {} not found", __tauri_cmd__))
         },
       }
     })

--- a/examples/commands/src-tauri/src/commands.rs
+++ b/examples/commands/src-tauri/src/commands.rs
@@ -5,6 +5,9 @@
 use tauri::{command, State};
 
 #[command]
+pub fn cmd(_argument: String) {}
+
+#[command]
 pub fn simple_command(argument: String) {
   println!("{}", argument);
 }

--- a/examples/commands/src-tauri/src/main.rs
+++ b/examples/commands/src-tauri/src/main.rs
@@ -9,6 +9,7 @@
 
 // we move some basic commands to a separate module just to show it works
 mod commands;
+use commands::cmd;
 
 use serde::Deserialize;
 use tauri::{command, Params, State, Window};
@@ -167,6 +168,7 @@ fn main() {
       force_async_with_result,
       commands::simple_command,
       commands::stateful_command,
+      cmd,
       async_simple_command,
       future_simple_command,
       async_stateful_command,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
