### PR TITLE
Disable version check with semver for now

### DIFF
--- a/.changes/cli.js-package-check.md
+++ b/.changes/cli.js-package-check.md
@@ -1,0 +1,5 @@
+---
+"cli.js": patch
+---
+
+Packages are checked with `!=` instead of `semver` for beta releases.

--- a/tooling/cli.js/src/api/dependency-manager/managers/yarn-manager.ts
+++ b/tooling/cli.js/src/api/dependency-manager/managers/yarn-manager.ts
@@ -38,11 +38,11 @@ export class YarnManager implements IManager {
   getLatestVersion(packageName: string): string {
     const child = crossSpawnSync(
       'yarn',
-      ['info', packageName, 'versions', '--json'],
+      ['info', packageName, 'version', '--json'],
       { cwd: appDir }
     )
     const output = String(child.output[1])
-    const packageJson = JSON.parse(output) as { data: string[] }
-    return packageJson.data[packageJson.data.length - 1]
+    const packageJson = JSON.parse(output) as { data: string }
+    return packageJson.data
   }
 }

--- a/tooling/cli.js/src/api/dependency-manager/util.ts
+++ b/tooling/cli.js/src/api/dependency-manager/util.ts
@@ -5,7 +5,7 @@
 import { sync as crossSpawnSync } from 'cross-spawn'
 import { resolve as appResolve } from '../../helpers/app-paths'
 import { existsSync } from 'fs'
-import semver from 'semver'
+// import semver from 'semver'
 import { IManager, NpmManager, YarnManager, PnpmManager } from './managers'
 
 const getManager = (): IManager => {

--- a/tooling/cli.js/src/api/dependency-manager/util.ts
+++ b/tooling/cli.js/src/api/dependency-manager/util.ts
@@ -61,7 +61,7 @@ function padVersion(version: string): string {
 
 function semverLt(first: string, second: string): boolean {
   return first !== second
-  // When version 1.0.0 is released this code should work again
+  // TODO: When version 1.0.0 is released this code should work again
   // return semver.lt(padVersion(first), padVersion(second))
 }
 

--- a/tooling/cli.js/src/api/dependency-manager/util.ts
+++ b/tooling/cli.js/src/api/dependency-manager/util.ts
@@ -60,7 +60,9 @@ function padVersion(version: string): string {
 }
 
 function semverLt(first: string, second: string): boolean {
-  return semver.lt(padVersion(first), padVersion(second))
+  return first !== second
+  // When version 1.0.0 is released this code should work again
+  // return semver.lt(padVersion(first), padVersion(second))
 }
 
 export {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Semver does not work correctly when comparing prereleases.
Therefore the package check is currently with != instead of semver.

As soon version 1.0.0 is released semver should work again