### PR TITLE
refactor(macros): explicitly pass idents

### DIFF
--- a/.changes/command-macros-binding-refactor.md
+++ b/.changes/command-macros-binding-refactor.md
@@ -1,0 +1,5 @@
+---
+"tauri-macros": patch
+---
+
+internal: Refactor all macro code that expects specific bindings to be passed Idents

--- a/core/tauri-macros/src/command/handler.rs
+++ b/core/tauri-macros/src/command/handler.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use quote::format_ident;
 use syn::{
   parse::{Parse, ParseBuffer},
   Ident, Path, Token,
@@ -51,12 +52,14 @@ impl From<Handler> for proc_macro::TokenStream {
       wrappers,
     }: Handler,
   ) -> Self {
-    quote::quote!(move |__tauri_invoke__| {
-      let __tauri_cmd__ = __tauri_invoke__.message.command();
-      match __tauri_cmd__ {
-        #(stringify!(#commands) => #wrappers!(#paths, __tauri_invoke__),)*
+    let cmd = format_ident!("__tauri_cmd__");
+    let invoke = format_ident!("__tauri_invoke__");
+    quote::quote!(move |#invoke| {
+      let #cmd = #invoke.message.command();
+      match #cmd {
+        #(stringify!(#commands) => #wrappers!(#paths, #invoke),)*
         _ => {
-          __tauri_invoke__.resolver.reject(format!("command {} not found", __tauri_cmd__))
+          #invoke.resolver.reject(format!("command {} not found", #cmd))
         },
       }
     })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Cleans up the code a bit by removing all "expected to exist" items used inside command macro codegen to explicitly passed items. This should make it easier in the future to change the binding names if wanted, and to make related mistakes in new codegen code less likely.