### PR TITLE
feat(core): finish mutable getters for `Context`

### DIFF
--- a/.changes/context-mutable-methods.md
+++ b/.changes/context-mutable-methods.md
@@ -1,0 +1,9 @@
+---
+"tauri": patch
+---
+
+Expose mutable getters for the rest of the public `Context` getters.
+* `pub fn assets_mut(&mut self) -> &mut Arc<A>`
+* `pub fn default_window_icon_mut(&mut self) -> &mut Option<Vec<u8>>`
+* `pub fn system_tray_icon_mut(&mut self) -> &mut Option<Icon>`
+* `pub fn package_info_mut(&mut self) -> &mut tauri::api::PackageInfo`

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -154,22 +154,46 @@ impl<A: Assets> Context<A> {
     self.assets.clone()
   }
 
+  /// A mutable reference to the assets to be served directly by Tauri.
+  #[inline(always)]
+  pub fn assets_mut(&mut self) -> &mut Arc<A> {
+    &mut self.assets
+  }
+
   /// The default window icon Tauri should use when creating windows.
   #[inline(always)]
   pub fn default_window_icon(&self) -> Option<&[u8]> {
     self.default_window_icon.as_deref()
   }
 
-  /// The icon to use use on the system tray UI.
+  /// A mutable reference to the default window icon Tauri should use when creating windows.
+  #[inline(always)]
+  pub fn default_window_icon_mut(&mut self) -> &mut Option<Vec<u8>> {
+    &mut self.default_window_icon
+  }
+
+  /// The icon to use on the system tray UI.
   #[inline(always)]
   pub fn system_tray_icon(&self) -> Option<&Icon> {
     self.system_tray_icon.as_ref()
+  }
+
+  /// A mutable reference to the icon to use on the system tray UI.
+  #[inline(always)]
+  pub fn system_tray_icon_mut(&mut self) -> &mut Option<Icon> {
+    &mut self.system_tray_icon
   }
 
   /// Package information.
   #[inline(always)]
   pub fn package_info(&self) -> &crate::api::PackageInfo {
     &self.package_info
+  }
+
+  /// A mutable reference to the package information.
+  #[inline(always)]
+  pub fn package_info_mut(&mut self) -> &mut crate::api::PackageInfo {
+    &mut self.package_info
   }
 
   /// Create a new [`Context`] from the minimal required items.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
this finishes what #1803 started, bringing mutation support back up to what it was before #1774 