### PR TITLE
fix: Monitor if --isolatedModules is enabled

### DIFF
--- a/.changes/api-export-type.md
+++ b/.changes/api-export-type.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Use `export type` to export TS types.

--- a/tooling/api/src/window.ts
+++ b/tooling/api/src/window.ts
@@ -741,7 +741,6 @@ export {
   getCurrent,
   getAll,
   appWindow,
-  Monitor,
   LogicalSize,
   PhysicalSize,
   LogicalPosition,
@@ -749,4 +748,8 @@ export {
   currentMonitor,
   primaryMonitor,
   availableMonitors
+}
+
+export type {
+  Monitor
 }


### PR DESCRIPTION
Re-exporting a type is not possible if the flag '--isolatedModules' is provided, it requires the use of 'export type'.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
