### PR TITLE
added support for cargo workspaces for `dev` command

### DIFF
--- a/.changes/cli.rs-dev-workspaces.md
+++ b/.changes/cli.rs-dev-workspaces.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Watch workspace crates on `dev` command.

--- a/tooling/cli.rs/src/dev.rs
+++ b/tooling/cli.rs/src/dev.rs
@@ -5,7 +5,7 @@
 use crate::helpers::{
   app_paths::{app_dir, tauri_dir},
   config::{get as get_config, reload as reload_config},
-  manifest::rewrite_manifest,
+  manifest::{get_workspace_members, rewrite_manifest},
   Logger,
 };
 
@@ -156,6 +156,12 @@ impl Dev {
     watcher.watch(tauri_path.join("src"), RecursiveMode::Recursive)?;
     watcher.watch(tauri_path.join("Cargo.toml"), RecursiveMode::Recursive)?;
     watcher.watch(tauri_path.join("tauri.conf.json"), RecursiveMode::Recursive)?;
+
+    for member in get_workspace_members()? {
+      let workspace_path = tauri_path.join(member);
+      watcher.watch(workspace_path.join("src"), RecursiveMode::Recursive)?;
+      watcher.watch(workspace_path.join("Cargo.toml"), RecursiveMode::Recursive)?;
+    }
 
     loop {
       if let Ok(event) = rx.recv() {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No

**Other information:**

With this PR you can use the hot-reload feature in cargo workspaces.

closes #1826 
