### PR TITLE
fix: deb installation error

### DIFF
--- a/.changes/cli.rs-libwebkit2gtk-4.0-37.md
+++ b/.changes/cli.rs-libwebkit2gtk-4.0-37.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Fixes the libwebkit2gtk package name.

--- a/tooling/cli.rs/src/build/rust.rs
+++ b/tooling/cli.rs/src/build/rust.rs
@@ -380,7 +380,7 @@ fn tauri_config_to_bundle_settings(
       depends.push("libappindicator3-1".to_string());
     }
 
-    depends.push("libwebkit2gtk-4.0".to_string());
+    depends.push("libwebkit2gtk-4.0-37".to_string());
     depends.push("libgtk-3-0".to_string());
     if manifest.features.contains(&"menu".into()) || system_tray_config.is_some() {
       depends.push("libgtksourceview-3.0-1".to_string());


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

it will fix the installation error occured by this steps:

```sh
# /your/path/to/tauri/examples/helloworld
$ cargo tauri build
...
    Bundling helloworld_0.1.0_amd64.deb
    Bundling helloworld_0.1.0_amd64.AppImage
    Finished 2 bundles at:
        /your/path/to/tauri/target/release/bundle/deb/helloworld_0.1.0_amd64.deb
        /your/path/to/tauri/target/release/bundle/appimage/helloworld_0.1.0_amd64.AppImage
```

```sh
$ sudo apt-get install ../../target/release/bundle/deb/helloworld_0.1.0_amd64.deb
[sudo] password for <you>: 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'helloworld' instead of '../../target/release/bundle/deb/helloworld_0.1.0_amd64.deb'
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 helloworld : Depends: libwebkit2gtk-4.0 but it is not installable
E: Unable to correct problems, you have held broken packages.
```
