### PR TITLE
feat(core) Use rfd for message dialogs

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -51,7 +51,6 @@ ignore = "0.4"
 either = "1.6"
 tar = "0.4"
 flate2 = "1.0"
-tinyfiledialogs = "3.3"
 http = "0.2"
 state = "0.4"
 bincode = "1.3"
@@ -80,7 +79,7 @@ shared_child = { version = "0.3", optional = true }
 os_pipe = { version = "0.9", optional = true }
 
 # Dialogs
-rfd = { version = "0.3", optional = true }
+rfd = "0.4"
 
 # Updater
 minisign-verify = { version = "0.1", optional = true }
@@ -127,8 +126,8 @@ shell-all = [ "shell-open", "shell-execute" ]
 shell-execute = [ "shared_child", "os_pipe" ]
 shell-open = [ "open" ]
 dialog-all = [ "dialog-open", "dialog-save" ]
-dialog-open = [ "rfd" ]
-dialog-save = [ "rfd" ]
+dialog-open = [ ]
+dialog-save = [ ]
 http-all = [ ]
 http-request = [ ]
 notification-all = [ "notify-rust" ]

--- a/core/tauri/src/api/dialog.rs
+++ b/core/tauri/src/api/dialog.rs
@@ -5,8 +5,6 @@
 #[cfg(any(dialog_open, dialog_save))]
 use std::path::{Path, PathBuf};
 
-use tinyfiledialogs::{message_box_ok, message_box_yes_no, MessageBoxIcon, YesNo};
-
 /// The file dialog builder.
 /// Constructs file picker dialogs that can select single/multiple files or directories.
 #[cfg(any(dialog_open, dialog_save))]
@@ -69,18 +67,24 @@ pub enum AskResponse {
 
 /// Displays a dialog with a message and an optional title with a "yes" and a "no" button
 pub fn ask(title: impl AsRef<str>, message: impl AsRef<str>) -> AskResponse {
-  match message_box_yes_no(
-    title.as_ref(),
-    message.as_ref(),
-    MessageBoxIcon::Question,
-    YesNo::No,
-  ) {
-    YesNo::Yes => AskResponse::Yes,
-    YesNo::No => AskResponse::No,
+  match rfd::MessageDialog::new()
+    .set_title(title.as_ref())
+    .set_description(message.as_ref())
+    .set_buttons(rfd::MessageButtons::YesNo)
+    .set_level(rfd::MessageLevel::Info)
+    .show()
+  {
+    true => AskResponse::Yes,
+    false => AskResponse::No,
   }
 }
 
 /// Displays a message dialog
 pub fn message(title: impl AsRef<str>, message: impl AsRef<str>) {
-  message_box_ok(title.as_ref(), message.as_ref(), MessageBoxIcon::Info);
+  rfd::MessageDialog::new()
+    .set_title(title.as_ref())
+    .set_description(message.as_ref())
+    .set_buttons(rfd::MessageButtons::Ok)
+    .set_level(rfd::MessageLevel::Info)
+    .show();
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature:
- `rfd` is used for file dialogs anyway, so why not use it for messages too.
-  `rfd` can be easily modified to fit `tauri` needs, `tinyfiledialogs` is a lot more limiting 
- `rfd` will increase build time a little, so it's understandable if you'd like to stick to `tinyfiledialogs`
