### PR TITLE
fix(core): `run_on_main_thread` now wakes the event loop

### DIFF
--- a/.changes/run-on-main-thread-refactor.md
+++ b/.changes/run-on-main-thread-refactor.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime-wry": patch
+"tauri": patch
+---
+
+The `run_on_main_thread` API now uses WRY's UserEvent, so it wakes the event loop.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -52,7 +52,7 @@ use std::{
   convert::TryFrom,
   fs::read,
   sync::{
-    mpsc::{channel, Receiver, Sender},
+    mpsc::{channel, Sender},
     Arc, Mutex, MutexGuard,
   },
 };
@@ -64,7 +64,6 @@ use menu::*;
 
 type CreateWebviewHandler =
   Box<dyn FnOnce(&EventLoopWindowTarget<Message>) -> Result<WebviewWrapper> + Send>;
-type MainThreadTask = Box<dyn FnOnce() + Send>;
 type WindowEventHandler = Box<dyn Fn(&WindowEvent) + Send>;
 type WindowEventListeners = Arc<Mutex<HashMap<Uuid, WindowEventHandler>>>;
 
@@ -494,6 +493,7 @@ pub(crate) enum TrayMessage {
 
 #[derive(Clone)]
 pub(crate) enum Message {
+  Task(Arc<Mutex<Option<Box<dyn FnOnce() + Send>>>>),
   Window(WindowId, WindowMessage),
   Webview(WindowId, WebviewMessage),
   #[cfg(feature = "system-tray")]
@@ -504,7 +504,6 @@ pub(crate) enum Message {
 #[derive(Clone)]
 struct DispatcherContext {
   proxy: EventLoopProxy<Message>,
-  task_tx: Sender<MainThreadTask>,
   window_event_listeners: WindowEventListeners,
   #[cfg(feature = "menu")]
   menu_event_listeners: MenuEventListeners,
@@ -536,8 +535,8 @@ impl Dispatch for WryDispatcher {
   fn run_on_main_thread<F: FnOnce() + Send + 'static>(&self, f: F) -> Result<()> {
     self
       .context
-      .task_tx
-      .send(Box::new(f))
+      .proxy
+      .send_event(Message::Task(Arc::new(Mutex::new(Some(Box::new(f))))))
       .map_err(|_| Error::FailedToSendMessage)
   }
 
@@ -908,11 +907,9 @@ struct WebviewWrapper {
 pub struct Wry {
   event_loop: EventLoop<Message>,
   webviews: Arc<Mutex<HashMap<WindowId, WebviewWrapper>>>,
-  task_tx: Sender<MainThreadTask>,
   window_event_listeners: WindowEventListeners,
   #[cfg(feature = "menu")]
   menu_event_listeners: MenuEventListeners,
-  task_rx: Arc<Receiver<MainThreadTask>>,
   #[cfg(feature = "system-tray")]
   tray_context: TrayContext,
 }
@@ -971,12 +968,9 @@ impl Runtime for Wry {
 
   fn new() -> Result<Self> {
     let event_loop = EventLoop::<Message>::with_user_event();
-    let (task_tx, task_rx) = channel();
     Ok(Self {
       event_loop,
       webviews: Default::default(),
-      task_tx,
-      task_rx: Arc::new(task_rx),
       window_event_listeners: Default::default(),
       #[cfg(feature = "menu")]
       menu_event_listeners: Default::default(),
@@ -989,7 +983,6 @@ impl Runtime for Wry {
     WryHandle {
       dispatcher_context: DispatcherContext {
         proxy: self.event_loop.create_proxy(),
-        task_tx: self.task_tx.clone(),
         window_event_listeners: self.window_event_listeners.clone(),
         #[cfg(feature = "menu")]
         menu_event_listeners: self.menu_event_listeners.clone(),
@@ -1007,7 +1000,6 @@ impl Runtime for Wry {
       &self.event_loop,
       DispatcherContext {
         proxy: proxy.clone(),
-        task_tx: self.task_tx.clone(),
         window_event_listeners: self.window_event_listeners.clone(),
         #[cfg(feature = "menu")]
         menu_event_listeners: self.menu_event_listeners.clone(),
@@ -1019,7 +1011,6 @@ impl Runtime for Wry {
       window_id: webview.inner.window().id(),
       context: DispatcherContext {
         proxy,
-        task_tx: self.task_tx.clone(),
         window_event_listeners: self.window_event_listeners.clone(),
         #[cfg(feature = "menu")]
         menu_event_listeners: self.menu_event_listeners.clone(),
@@ -1077,7 +1068,6 @@ impl Runtime for Wry {
   fn run_iteration(&mut self) -> RunIteration {
     use wry::application::platform::run_return::EventLoopExtRunReturn;
     let webviews = self.webviews.clone();
-    let task_rx = self.task_rx.clone();
     let window_event_listeners = self.window_event_listeners.clone();
     #[cfg(feature = "menu")]
     let menu_event_listeners = self.menu_event_listeners.clone();
@@ -1099,7 +1089,6 @@ impl Runtime for Wry {
           EventLoopIterationContext {
             callback: None,
             webviews: webviews.lock().expect("poisoned webview collection"),
-            task_rx: task_rx.clone(),
             window_event_listeners: window_event_listeners.clone(),
             #[cfg(feature = "menu")]
             menu_event_listeners: menu_event_listeners.clone(),
@@ -1114,7 +1103,6 @@ impl Runtime for Wry {
 
   fn run<F: Fn() + 'static>(self, callback: F) {
     let webviews = self.webviews.clone();
-    let task_rx = self.task_rx;
     let window_event_listeners = self.window_event_listeners.clone();
     #[cfg(feature = "menu")]
     let menu_event_listeners = self.menu_event_listeners.clone();
@@ -1129,7 +1117,6 @@ impl Runtime for Wry {
         EventLoopIterationContext {
           callback: Some(&callback),
           webviews: webviews.lock().expect("poisoned webview collection"),
-          task_rx: task_rx.clone(),
           window_event_listeners: window_event_listeners.clone(),
           #[cfg(feature = "menu")]
           menu_event_listeners: menu_event_listeners.clone(),
@@ -1144,7 +1131,6 @@ impl Runtime for Wry {
 struct EventLoopIterationContext<'a> {
   callback: Option<&'a (dyn Fn() + 'static)>,
   webviews: MutexGuard<'a, HashMap<WindowId, WebviewWrapper>>,
-  task_rx: Arc<Receiver<MainThreadTask>>,
   window_event_listeners: WindowEventListeners,
   #[cfg(feature = "menu")]
   menu_event_listeners: MenuEventListeners,
@@ -1161,7 +1147,6 @@ fn handle_event_loop(
   let EventLoopIterationContext {
     callback,
     mut webviews,
-    task_rx,
     window_event_listeners,
     #[cfg(feature = "menu")]
     menu_event_listeners,
@@ -1174,10 +1159,6 @@ fn handle_event_loop(
     if let Err(e) = w.inner.evaluate_script() {
       eprintln!("{}", e);
     }
-  }
-
-  while let Ok(task) = task_rx.try_recv() {
-    task();
   }
 
   match event {
@@ -1247,6 +1228,13 @@ fn handle_event_loop(
       }
     }
     Event::UserEvent(message) => match message {
+      Message::Task(task) => {
+        let task = {
+          let mut lock = task.lock().expect("poisoned pending event queue");
+          std::mem::take(&mut *lock)
+        }.expect("task already taken");
+        task();
+      }
       Message::Window(id, window_message) => {
         if let Some(webview) = webviews.get_mut(&id) {
           let window = webview.inner.window();


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

Related to #1942 (report that the dialog API is hang without moving the mouse).
