### PR TITLE
fix(cli.rs): `info` version checks not striping `\r` on Windows

### DIFF
--- a/.changes/fix-windows-info-cmd.md
+++ b/.changes/fix-windows-info-cmd.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Fixes `info` command not striping `\r` from child process version output.

--- a/tooling/cli.rs/src/info.rs
+++ b/tooling/cli.rs/src/info.rs
@@ -206,7 +206,11 @@ fn get_version(command: &str, args: &[&str]) -> crate::Result<Option<String>> {
 
   let output = cmd.args(args).arg("--version").output()?;
   let version = if output.status.success() {
-    Some(String::from_utf8_lossy(&output.stdout).replace("\n", "").replace("\r", ""))
+    Some(
+      String::from_utf8_lossy(&output.stdout)
+        .replace("\n", "")
+        .replace("\r", ""),
+    )
   } else {
     None
   };

--- a/tooling/cli.rs/src/info.rs
+++ b/tooling/cli.rs/src/info.rs
@@ -206,7 +206,7 @@ fn get_version(command: &str, args: &[&str]) -> crate::Result<Option<String>> {
 
   let output = cmd.args(args).arg("--version").output()?;
   let version = if output.status.success() {
-    Some(String::from_utf8_lossy(&output.stdout).replace("\n", ""))
+    Some(String::from_utf8_lossy(&output.stdout).replace("\n", "").replace("\r", ""))
   } else {
     None
   };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
