### PR TITLE
fix(api): http  `ResponseType` export type error

### DIFF
--- a/.changes/api-export-type-fix.md
+++ b/.changes/api-export-type-fix.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Export `Response` and `ResponseType` as value instead of type.

--- a/tooling/api/src/http.ts
+++ b/tooling/api/src/http.ts
@@ -352,8 +352,7 @@ export type {
   HttpVerb,
   HttpOptions,
   RequestOptions,
-  FetchOptions,
-  Response
+  FetchOptions
 }
 
-export { getClient, fetch, Body, Client, ResponseType }
+export { getClient, fetch, Body, Client, Response, ResponseType }

--- a/tooling/api/src/http.ts
+++ b/tooling/api/src/http.ts
@@ -348,7 +348,6 @@ async function fetch<T>(
 
 export type {
   ClientOptions,
-  ResponseType,
   Part,
   HttpVerb,
   HttpOptions,
@@ -357,4 +356,4 @@ export type {
   Response
 }
 
-export { getClient, fetch, Body, Client }
+export { getClient, fetch, Body, Client, ResponseType }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No

**Other information:**

`enum ResponseType` should be export as a value rather than `export type` when user need to config `responseType` of the request. If users want to import it as a type, maybe use  `import type { ResponseType } from '@tauri-apps/api/http'`?

`"@tauri-apps/api": "1.0.0-beta.1"` work fine, when I upgraded to `beta.2` occurred an error("ResponseType" cannot be used as a value, because i was exported using export type 1362) .
![image](https://user-images.githubusercontent.com/11495164/123200203-d8354800-d4e2-11eb-84b1-3244d653391c.png)

"@tauri-apps/api": "1.0.0-beta.2"
![image](https://user-images.githubusercontent.com/11495164/123200293-0155d880-d4e3-11eb-9d6a-d6e8013e14c5.png)

