### PR TITLE
chore(issue-template): make tauri info required [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,66 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+<!-- BEFORE YOU FILE A NEW ISSUE-->
+<!--
+
+0. Please search open issues before duplicating a new one.
+1. Make sure you are using the latest version of everything including: 
+  - rustc 
+  - ALL relevant Tauri Libs
+2. You must attach the results of cargo tauri info or yarn tauri info to your issue.
+3. Make sure it is an issue with Tauri, and not something to do with your side of the stack.
+4. Consider starting a discussion. Speaking of which, have you looked there? Maybe your question has been answered.
+5. Remember to follow our community guidelines and be friendly.
+6. Is this an issue or a feature request? If the latter, please use the other template.
+
+-->
+
+### **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### **To Reproduce**
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+### **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
+### **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Platform and Versions (please complete the following information):**
-<!-- You can use the `tauri info` command to get this information -->
-OS:
-Node:
-NPM:
-Yarn:
-Rustc:
+### **Platform and Versions (required):**
+<!-- Use `yarn tauri info` or `cargo tauri info` command to get this information, and paste it here: -->
+```
+Operating System
 
-**Additional context**
+Node.js environment
+Node.js 
+@tauri-apps/cli 
+@tauri-apps/api 
+
+Global packages
+npm 
+yarn 
+
+Rust environment
+rustc 
+cargo 
+
+App directory structure
+
+
+App
+tauri.rs 
+build-type 
+CSP 
+```
+
+### **Additional context**
 Add any other context about the problem here.
 
-**Stack Trace**
+### **Stack Trace**
 <!-- add if applicable -->


### PR DESCRIPTION
Make our expectations clear.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
