### PR TITLE
fix: tauri init may failed with no error message. (fix #2079)

### DIFF
--- a/.changes/throw-error-on-cli-download-failure.md
+++ b/.changes/throw-error-on-cli-download-failure.md
@@ -1,0 +1,5 @@
+---
+"cli.js": patch
+---
+
+Throw error on `cli.rs` download failure instead of silent exit.

--- a/tooling/cli.js/src/helpers/download-binary.ts
+++ b/tooling/cli.js/src/helpers/download-binary.ts
@@ -43,9 +43,8 @@ async function downloadBinaryRelease(
     try {
       // eslint-disable-next-line security/detect-non-literal-fs-filename
       fs.unlinkSync(outPath)
-    } finally {
-      throw e
-    }
+    } catch {}
+    throw e
   })
   // eslint-disable-next-line security/detect-object-injection
   downloads[url] = true

--- a/tooling/cli.js/src/helpers/download-binary.ts
+++ b/tooling/cli.js/src/helpers/download-binary.ts
@@ -40,8 +40,12 @@ async function downloadBinaryRelease(
   // TODO: Check hash of download
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, security/detect-non-literal-fs-filename
   await pipeline(got.stream(url), fs.createWriteStream(outPath)).catch((e) => {
-    removeDownloadedCliIfNeeded()
-    throw e
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      fs.unlinkSync(outPath)
+    } finally {
+      throw e
+    }
   })
   // eslint-disable-next-line security/detect-object-injection
   downloads[url] = true


### PR DESCRIPTION
if pipeline failed, removeDownloadedCliIfNeeded() will exit process and error will never be thrown.
try unlinkSync here and finally throw error.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
