### PR TITLE
feat: simplfy `Args`

### DIFF
--- a/.changes/simpler-args.md
+++ b/.changes/simpler-args.md
@@ -1,0 +1,5 @@
+---
+"create-tauri-app": minor
+---
+
+Simplify `Args` and many other types that based on it.

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -132,7 +132,7 @@ pub mod private {
 }
 
 /// Types associated with the running Tauri application.
-pub trait Params: private::ParamsBase + 'static {
+pub trait Params: 'static {
   /// The event type used to create and listen to events.
   type Event: Tag;
 

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -7,17 +7,15 @@
 pub(crate) mod tray;
 
 use crate::{
-  api::assets::Assets,
   api::config::{Config, WindowUrl},
   command::{CommandArg, CommandItem},
   hooks::{InvokeHandler, OnPageLoad, PageLoadPayload, SetupHook},
   manager::{Args, WindowManager},
   plugin::{Plugin, PluginStore},
   runtime::{
-    tag::Tag,
     webview::{CustomProtocol, WebviewAttributes, WindowBuilder},
     window::{PendingWindow, WindowEvent},
-    Dispatch, MenuId, Params, RunEvent, Runtime,
+    Dispatch, Params, RunEvent, Runtime,
   },
   sealed::{ManagerBase, RuntimeOrDispatch},
   Context, Invoke, InvokeError, Manager, StateManager, Window,

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -76,14 +76,12 @@ pub enum Event<P: Params> {
   WindowClosed(P::Label),
 }
 
-crate::manager::default_args! {
-  /// A menu event that was triggered on a window.
-  #[cfg(feature = "menu")]
-  #[cfg_attr(doc_cfg, doc(cfg(feature = "menu")))]
-  pub struct WindowMenuEvent<P: Params> {
-    pub(crate) menu_item_id: P::MenuId,
-    pub(crate) window: Window<P>,
-  }
+/// A menu event that was triggered on a window.
+#[cfg(feature = "menu")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "menu")))]
+pub struct WindowMenuEvent<P: Params> {
+  pub(crate) menu_item_id: P::MenuId,
+  pub(crate) window: Window<P>,
 }
 
 #[cfg(feature = "menu")]
@@ -99,12 +97,10 @@ impl<P: Params> WindowMenuEvent<P> {
   }
 }
 
-crate::manager::default_args! {
-  /// A window event that was triggered on the specified window.
-  pub struct GlobalWindowEvent<P: Params> {
-    pub(crate) event: WindowEvent,
-    pub(crate) window: Window<P>,
-  }
+/// A window event that was triggered on the specified window.
+pub struct GlobalWindowEvent<P: Params> {
+  pub(crate) event: WindowEvent,
+  pub(crate) window: Window<P>,
 }
 
 impl<P: Params> GlobalWindowEvent<P> {
@@ -138,18 +134,16 @@ impl PathResolver {
   }
 }
 
-crate::manager::default_args! {
-  /// A handle to the currently running application.
-  ///
-  /// This type implements [`Manager`] which allows for manipulation of global application items.
-  pub struct AppHandle<P: Params> {
-    runtime_handle: <P::Runtime as Runtime>::Handle,
-    manager: WindowManager<P>,
-    global_shortcut_manager: <P::Runtime as Runtime>::GlobalShortcutManager,
-    clipboard_manager: <P::Runtime as Runtime>::ClipboardManager,
-    #[cfg(feature = "system-tray")]
-    tray_handle: Option<tray::SystemTrayHandle<P>>,
-  }
+/// A handle to the currently running application.
+///
+/// This type implements [`Manager`] which allows for manipulation of global application items.
+pub struct AppHandle<P: Params> {
+  runtime_handle: <P::Runtime as Runtime>::Handle,
+  manager: WindowManager<P>,
+  global_shortcut_manager: <P::Runtime as Runtime>::GlobalShortcutManager,
+  clipboard_manager: <P::Runtime as Runtime>::ClipboardManager,
+  #[cfg(feature = "system-tray")]
+  tray_handle: Option<tray::SystemTrayHandle<P>>,
 }
 
 impl<P: Params> Clone for AppHandle<P> {
@@ -196,19 +190,17 @@ impl<P: Params> ManagerBase<P> for AppHandle<P> {
   }
 }
 
-crate::manager::default_args! {
-  /// The instance of the currently running application.
-  ///
-  /// This type implements [`Manager`] which allows for manipulation of global application items.
-  pub struct App<P: Params> {
-    runtime: Option<P::Runtime>,
-    manager: WindowManager<P>,
-    global_shortcut_manager: <P::Runtime as Runtime>::GlobalShortcutManager,
-    clipboard_manager: <P::Runtime as Runtime>::ClipboardManager,
-    #[cfg(feature = "system-tray")]
-    tray_handle: Option<tray::SystemTrayHandle<P>>,
-    handle: AppHandle<P>,
-  }
+/// The instance of the currently running application.
+///
+/// This type implements [`Manager`] which allows for manipulation of global application items.
+pub struct App<P: Params> {
+  runtime: Option<P::Runtime>,
+  manager: WindowManager<P>,
+  global_shortcut_manager: <P::Runtime as Runtime>::GlobalShortcutManager,
+  clipboard_manager: <P::Runtime as Runtime>::ClipboardManager,
+  #[cfg(feature = "system-tray")]
+  tray_handle: Option<tray::SystemTrayHandle<P>>,
+  handle: AppHandle<P>,
 }
 
 impl<P: Params> Manager<P> for App<P> {}
@@ -428,30 +420,21 @@ impl<P: Params> App<P> {
 }
 
 /// Builds a Tauri application.
-#[allow(clippy::type_complexity)]
-pub struct Builder<E, L, MID, TID, A, R>
-where
-  E: Tag,
-  L: Tag,
-  MID: MenuId,
-  TID: MenuId,
-  A: Assets,
-  R: Runtime,
-{
+pub struct Builder<P: Params = Args> {
   /// The JS message handler.
-  invoke_handler: Box<InvokeHandler<Args<E, L, MID, TID, A, R>>>,
+  invoke_handler: Box<InvokeHandler<P>>,
 
   /// The setup hook.
-  setup: SetupHook<Args<E, L, MID, TID, A, R>>,
+  setup: SetupHook<P>,
 
   /// Page load hook.
-  on_page_load: Box<OnPageLoad<Args<E, L, MID, TID, A, R>>>,
+  on_page_load: Box<OnPageLoad<P>>,
 
   /// windows to create when starting up.
-  pending_windows: Vec<PendingWindow<Args<E, L, MID, TID, A, R>>>,
+  pending_windows: Vec<PendingWindow<P>>,
 
   /// All passed plugins
-  plugins: PluginStore<Args<E, L, MID, TID, A, R>>,
+  plugins: PluginStore<P>,
 
   /// The webview protocols available to all windows.
   uri_scheme_protocols: HashMap<String, Arc<CustomProtocol>>,
@@ -461,33 +444,25 @@ where
 
   /// The menu set to all windows.
   #[cfg(feature = "menu")]
-  menu: Option<Menu<MID>>,
+  menu: Option<Menu<P::MenuId>>,
 
   /// Menu event handlers that listens to all windows.
   #[cfg(feature = "menu")]
-  menu_event_listeners: Vec<GlobalMenuEventListener<Args<E, L, MID, TID, A, R>>>,
+  menu_event_listeners: Vec<GlobalMenuEventListener<P>>,
 
   /// Window event handlers that listens to all windows.
-  window_event_listeners: Vec<GlobalWindowEventListener<Args<E, L, MID, TID, A, R>>>,
+  window_event_listeners: Vec<GlobalWindowEventListener<P>>,
 
   /// The app system tray.
   #[cfg(feature = "system-tray")]
-  system_tray: Option<tray::SystemTray<TID>>,
+  system_tray: Option<tray::SystemTray<P::SystemTrayMenuId>>,
 
   /// System tray event handlers.
   #[cfg(feature = "system-tray")]
-  system_tray_event_listeners: Vec<SystemTrayEventListener<Args<E, L, MID, TID, A, R>>>,
+  system_tray_event_listeners: Vec<SystemTrayEventListener<P>>,
 }
 
-impl<E, L, MID, TID, A, R> Builder<E, L, MID, TID, A, R>
-where
-  E: Tag,
-  L: Tag,
-  MID: MenuId,
-  TID: MenuId,
-  A: Assets,
-  R: Runtime,
-{
+impl<P: Params> Builder<P> {
   /// Creates a new App builder.
   pub fn new() -> Self {
     Self {
@@ -513,7 +488,7 @@ where
   /// Defines the JS message handler callback.
   pub fn invoke_handler<F>(mut self, invoke_handler: F) -> Self
   where
-    F: Fn(Invoke<Args<E, L, MID, TID, A, R>>) + Send + Sync + 'static,
+    F: Fn(Invoke<P>) + Send + Sync + 'static,
   {
     self.invoke_handler = Box::new(invoke_handler);
     self
@@ -522,9 +497,7 @@ where
   /// Defines the setup hook.
   pub fn setup<F>(mut self, setup: F) -> Self
   where
-    F: Fn(&mut App<Args<E, L, MID, TID, A, R>>) -> Result<(), Box<dyn std::error::Error + Send>>
-      + Send
-      + 'static,
+    F: Fn(&mut App<P>) -> Result<(), Box<dyn std::error::Error + Send>> + Send + 'static,
   {
     self.setup = Box::new(setup);
     self
@@ -533,14 +506,14 @@ where
   /// Defines the page load hook.
   pub fn on_page_load<F>(mut self, on_page_load: F) -> Self
   where
-    F: Fn(Window<Args<E, L, MID, TID, A, R>>, PageLoadPayload) + Send + Sync + 'static,
+    F: Fn(Window<P>, PageLoadPayload) + Send + Sync + 'static,
   {
     self.on_page_load = Box::new(on_page_load);
     self
   }
 
   /// Adds a plugin to the runtime.
-  pub fn plugin<P: Plugin<Args<E, L, MID, TID, A, R>> + 'static>(mut self, plugin: P) -> Self {
+  pub fn plugin<PL: Plugin<P> + 'static>(mut self, plugin: PL) -> Self {
     self.plugins.register(plugin);
     self
   }
@@ -633,18 +606,18 @@ where
   }
 
   /// Creates a new webview window.
-  pub fn create_window<F>(mut self, label: L, url: WindowUrl, setup: F) -> Self
+  pub fn create_window<F>(mut self, label: P::Label, url: WindowUrl, setup: F) -> Self
   where
     F: FnOnce(
-      <R::Dispatcher as Dispatch>::WindowBuilder,
+      <<P::Runtime as Runtime>::Dispatcher as Dispatch>::WindowBuilder,
       WebviewAttributes,
     ) -> (
-      <R::Dispatcher as Dispatch>::WindowBuilder,
+      <<P::Runtime as Runtime>::Dispatcher as Dispatch>::WindowBuilder,
       WebviewAttributes,
     ),
   {
     let (window_builder, webview_attributes) = setup(
-      <R::Dispatcher as Dispatch>::WindowBuilder::new(),
+      <<P::Runtime as Runtime>::Dispatcher as Dispatch>::WindowBuilder::new(),
       WebviewAttributes::new(url),
     );
     self.pending_windows.push(PendingWindow::new(
@@ -658,7 +631,7 @@ where
   /// Adds the icon configured on `tauri.conf.json` to the system tray with the specified menu items.
   #[cfg(feature = "system-tray")]
   #[cfg_attr(doc_cfg, doc(cfg(feature = "system-tray")))]
-  pub fn system_tray(mut self, system_tray: tray::SystemTray<TID>) -> Self {
+  pub fn system_tray(mut self, system_tray: tray::SystemTray<P::SystemTrayMenuId>) -> Self {
     self.system_tray.replace(system_tray);
     self
   }
@@ -666,7 +639,7 @@ where
   /// Sets the menu to use on all windows.
   #[cfg(feature = "menu")]
   #[cfg_attr(doc_cfg, doc(cfg(feature = "menu")))]
-  pub fn menu(mut self, menu: Menu<MID>) -> Self {
+  pub fn menu(mut self, menu: Menu<P::MenuId>) -> Self {
     self.menu.replace(menu);
     self
   }
@@ -674,9 +647,7 @@ where
   /// Registers a menu event handler for all windows.
   #[cfg(feature = "menu")]
   #[cfg_attr(doc_cfg, doc(cfg(feature = "menu")))]
-  pub fn on_menu_event<
-    F: Fn(WindowMenuEvent<Args<E, L, MID, TID, A, R>>) + Send + Sync + 'static,
-  >(
+  pub fn on_menu_event<F: Fn(WindowMenuEvent<P>) + Send + Sync + 'static>(
     mut self,
     handler: F,
   ) -> Self {
@@ -685,9 +656,7 @@ where
   }
 
   /// Registers a window event handler for all windows.
-  pub fn on_window_event<
-    F: Fn(GlobalWindowEvent<Args<E, L, MID, TID, A, R>>) + Send + Sync + 'static,
-  >(
+  pub fn on_window_event<F: Fn(GlobalWindowEvent<P>) + Send + Sync + 'static>(
     mut self,
     handler: F,
   ) -> Self {
@@ -699,7 +668,7 @@ where
   #[cfg(feature = "system-tray")]
   #[cfg_attr(doc_cfg, doc(cfg(feature = "system-tray")))]
   pub fn on_system_tray_event<
-    F: Fn(&AppHandle<Args<E, L, MID, TID, A, R>>, tray::SystemTrayEvent<TID>) + Send + Sync + 'static,
+    F: Fn(&AppHandle<P>, tray::SystemTrayEvent<P::SystemTrayMenuId>) + Send + Sync + 'static,
   >(
     mut self,
     handler: F,
@@ -736,7 +705,7 @@ where
 
   /// Builds the application.
   #[allow(clippy::type_complexity)]
-  pub fn build(mut self, context: Context<A>) -> crate::Result<App<Args<E, L, MID, TID, A, R>>> {
+  pub fn build(mut self, context: Context<P::Assets>) -> crate::Result<App<P>> {
     #[cfg(feature = "system-tray")]
     let system_tray_icon = {
       let icon = context.system_tray_icon.clone();
@@ -797,7 +766,7 @@ where
       ));
     }
 
-    let runtime = R::new()?;
+    let runtime = P::Runtime::new()?;
     let runtime_handle = runtime.handle();
     let global_shortcut_manager = runtime.global_shortcut_manager();
     let clipboard_manager = runtime.clipboard_manager();
@@ -921,7 +890,7 @@ where
   }
 
   /// Runs the configured Tauri application.
-  pub fn run(self, context: Context<A>) -> crate::Result<()> {
+  pub fn run(self, context: Context<P::Assets>) -> crate::Result<()> {
     self.build(context)?.run(|_, _| {});
     Ok(())
   }
@@ -935,14 +904,7 @@ fn on_event_loop_event<P: Params>(event: &RunEvent, manager: &WindowManager<P>) 
 
 /// Make `Wry` the default `Runtime` for `Builder`
 #[cfg(feature = "wry")]
-impl<A: Assets> Default for Builder<String, String, String, String, A, crate::Wry> {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
-#[cfg(not(feature = "wry"))]
-impl<A: Assets, R: Runtime> Default for Builder<String, String, String, String, A, R> {
+impl Default for Builder<Args> {
   fn default() -> Self {
     Self::new()
   }

--- a/core/tauri/src/app/tray.rs
+++ b/core/tauri/src/app/tray.rs
@@ -75,12 +75,10 @@ pub enum SystemTrayEvent<I: MenuId> {
   },
 }
 
-crate::manager::default_args! {
-  /// A handle to a system tray. Allows updating the context menu items.
-  pub struct SystemTrayHandle<P: Params> {
-    pub(crate) ids: Arc<HashMap<u16, P::SystemTrayMenuId>>,
-    pub(crate) inner: <P::Runtime as Runtime>::TrayHandler,
-  }
+/// A handle to a system tray. Allows updating the context menu items.
+pub struct SystemTrayHandle<P: Params> {
+  pub(crate) ids: Arc<HashMap<u16, P::SystemTrayMenuId>>,
+  pub(crate) inner: <P::Runtime as Runtime>::TrayHandler,
 }
 
 impl<P: Params> Clone for SystemTrayHandle<P> {
@@ -92,12 +90,10 @@ impl<P: Params> Clone for SystemTrayHandle<P> {
   }
 }
 
-crate::manager::default_args! {
-  /// A handle to a system tray menu item.
-  pub struct SystemTrayMenuItemHandle<P: Params> {
-    id: u16,
-    tray_handler: <P::Runtime as Runtime>::TrayHandler,
-  }
+/// A handle to a system tray menu item.
+pub struct SystemTrayMenuItemHandle<P: Params> {
+  id: u16,
+  tray_handler: <P::Runtime as Runtime>::TrayHandler,
 }
 
 impl<P: Params> Clone for SystemTrayMenuItemHandle<P> {

--- a/core/tauri/src/hooks.rs
+++ b/core/tauri/src/hooks.rs
@@ -34,15 +34,13 @@ impl PageLoadPayload {
   }
 }
 
-crate::manager::default_args! {
-  /// The message and resolver given to a custom command.
-  pub struct Invoke<P: Params> {
-    /// The message passed.
-    pub message: InvokeMessage<P>,
+/// The message and resolver given to a custom command.
+pub struct Invoke<P: Params> {
+  /// The message passed.
+  pub message: InvokeMessage<P>,
 
-    /// The resolver of the message.
-    pub resolver: InvokeResolver<P>,
-  }
+  /// The resolver of the message.
+  pub resolver: InvokeResolver<P>,
 }
 
 /// Error response from an [`InvokeMessage`].
@@ -112,13 +110,11 @@ impl From<InvokeError> for InvokeResponse {
   }
 }
 
-crate::manager::default_args! {
-  /// Resolver of a invoke message.
-  pub struct InvokeResolver<P: Params> {
-    window: Window<P>,
-    pub(crate) callback: String,
-    pub(crate) error: String,
-  }
+/// Resolver of a invoke message.
+pub struct InvokeResolver<P: Params> {
+  window: Window<P>,
+  pub(crate) callback: String,
+  pub(crate) error: String,
 }
 
 impl<P: Params> InvokeResolver<P> {
@@ -232,18 +228,16 @@ impl<P: Params> InvokeResolver<P> {
   }
 }
 
-crate::manager::default_args! {
-  /// An invoke message.
-  pub struct InvokeMessage<P: Params> {
-    /// The window that received the invoke message.
-    pub(crate) window: Window<P>,
-    /// Application managed state.
-    pub(crate) state: Arc<StateManager>,
-    /// The RPC command.
-    pub(crate) command: String,
-    /// The JSON argument passed on the invoke message.
-    pub(crate) payload: JsonValue,
-  }
+/// An invoke message.
+pub struct InvokeMessage<P: Params> {
+  /// The window that received the invoke message.
+  pub(crate) window: Window<P>,
+  /// Application managed state.
+  pub(crate) state: Arc<StateManager>,
+  /// The RPC command.
+  pub(crate) command: String,
+  /// The JSON argument passed on the invoke message.
+  pub(crate) payload: JsonValue,
 }
 
 impl<P: Params> InvokeMessage<P> {

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -529,23 +529,22 @@ impl<P: Params> WindowManager<P> {
 #[cfg(test)]
 mod test {
   use super::{Args, WindowManager};
-  use crate::{generate_context, plugin::PluginStore, StateManager, Wry};
+  use crate::{generate_context, plugin::PluginStore, StateManager};
 
   #[test]
   fn check_get_url() {
     let context = generate_context!("test/fixture/src-tauri/tauri.conf.json", crate);
-    let manager: WindowManager<Args<String, String, String, String, _, Wry>> =
-      WindowManager::with_handlers(
-        context,
-        PluginStore::default(),
-        Box::new(|_| ()),
-        Box::new(|_, _| ()),
-        Default::default(),
-        StateManager::new(),
-        Default::default(),
-        #[cfg(feature = "menu")]
-        Default::default(),
-      );
+    let manager: WindowManager<Args> = WindowManager::with_handlers(
+      context,
+      PluginStore::default(),
+      Box::new(|_| ()),
+      Box::new(|_, _| ()),
+      Default::default(),
+      StateManager::new(),
+      Default::default(),
+      #[cfg(feature = "menu")]
+      Default::default(),
+    );
 
     #[cfg(custom_protocol)]
     assert_eq!(manager.get_url(), "tauri://localhost");

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -21,7 +21,7 @@ use crate::{
       WindowBuilder,
     },
     window::{dpi::PhysicalSize, DetachedWindow, PendingWindow, WindowEvent},
-    Icon, MenuId, Params,
+    Icon, Params,
   },
   App, Context, Invoke, StateManager, Window,
 };
@@ -138,7 +138,7 @@ impl<P: Params> Clone for WindowManager<P> {
 }
 
 #[cfg(feature = "menu")]
-fn get_menu_ids<I: MenuId>(map: &mut HashMap<u16, I>, menu: &Menu<I>) {
+fn get_menu_ids<I: crate::MenuId>(map: &mut HashMap<u16, I>, menu: &Menu<I>) {
   for item in &menu.items {
     match item {
       MenuEntry::CustomItem(c) => {

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -21,7 +21,7 @@ use crate::{
       WindowBuilder,
     },
     window::{dpi::PhysicalSize, DetachedWindow, PendingWindow, WindowEvent},
-    Icon, MenuId, Params, Runtime,
+    Icon, MenuId, Params,
   },
   App, Context, Invoke, StateManager, Window,
 };

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -44,11 +44,9 @@ pub trait Plugin<P: Params>: Send {
   fn extend_api(&mut self, invoke: Invoke<P>) {}
 }
 
-crate::manager::default_args! {
-  /// Plugin collection type.
-  pub(crate) struct PluginStore<P: Params> {
-    store: HashMap<&'static str, Box<dyn Plugin<P>>>,
-  }
+/// Plugin collection type.
+pub(crate) struct PluginStore<P: Params> {
+  store: HashMap<&'static str, Box<dyn Plugin<P>>>,
 }
 
 impl<P: Params> Default for PluginStore<P> {

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -15,7 +15,7 @@ use crate::{
   app::AppHandle,
   command::{CommandArg, CommandItem},
   event::{Event, EventHandler},
-  manager::WindowManager,
+  manager::{Args, WindowManager},
   runtime::{
     monitor::Monitor as RuntimeMonitor,
     tag::{TagRef, ToJsString},
@@ -83,18 +83,16 @@ impl Monitor {
 }
 
 // TODO: expand these docs since this is a pretty important type
-crate::manager::default_args! {
-  /// A webview window managed by Tauri.
-  ///
-  /// This type also implements [`Manager`] which allows you to manage other windows attached to
-  /// the same application.
-  pub struct Window<P: Params> {
-    /// The webview window created by the runtime.
-    window: DetachedWindow<P>,
-    /// The manager to associate this webview window with.
-    manager: WindowManager<P>,
-    pub(crate) app_handle: AppHandle<P>,
-  }
+/// A webview window managed by Tauri.
+///
+/// This type also implements [`Manager`] which allows you to manage other windows attached to
+/// the same application.
+pub struct Window<P: Params = Args> {
+  /// The webview window created by the runtime.
+  window: DetachedWindow<P>,
+  /// The manager to associate this webview window with.
+  manager: WindowManager<P>,
+  pub(crate) app_handle: AppHandle<P>,
 }
 
 impl<P: Params> Clone for Window<P> {

--- a/core/tauri/src/window/menu.rs
+++ b/core/tauri/src/window/menu.rs
@@ -24,12 +24,10 @@ impl<I: MenuId> MenuEvent<I> {
   }
 }
 
-crate::manager::default_args! {
-  /// A handle to a system tray. Allows updating the context menu items.
-  pub struct MenuHandle<P: Params> {
-    pub(crate) ids: HashMap<u16, P::MenuId>,
-    pub(crate) dispatcher: <P::Runtime as Runtime>::Dispatcher,
-  }
+/// A handle to a system tray. Allows updating the context menu items.
+pub struct MenuHandle<P: Params> {
+  pub(crate) ids: HashMap<u16, P::MenuId>,
+  pub(crate) dispatcher: <P::Runtime as Runtime>::Dispatcher,
 }
 
 impl<P: Params> Clone for MenuHandle<P> {
@@ -41,12 +39,10 @@ impl<P: Params> Clone for MenuHandle<P> {
   }
 }
 
-crate::manager::default_args! {
-  /// A handle to a system tray menu item.
-  pub struct MenuItemHandle<P: Params> {
-    id: u16,
-    dispatcher: <P::Runtime as Runtime>::Dispatcher,
-  }
+/// A handle to a system tray menu item.
+pub struct MenuItemHandle<P: Params> {
+  id: u16,
+  dispatcher: <P::Runtime as Runtime>::Dispatcher,
 }
 
 impl<P: Params> Clone for MenuItemHandle<P> {

--- a/examples/api/src-tauri/src/main.rs
+++ b/examples/api/src-tauri/src/main.rs
@@ -16,8 +16,8 @@ mod menu;
 
 use serde::Serialize;
 use tauri::{
-  CustomMenuItem, Event, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, WindowBuilder,
-  WindowUrl,
+  CustomMenuItem, Event, Manager, Params, SystemTray, SystemTrayEvent, SystemTrayMenu,
+  WindowBuilder, WindowUrl,
 };
 
 #[derive(Serialize)]

--- a/examples/api/src-tauri/src/main.rs
+++ b/examples/api/src-tauri/src/main.rs
@@ -16,8 +16,8 @@ mod menu;
 
 use serde::Serialize;
 use tauri::{
-  CustomMenuItem, Event, Manager, Params, SystemTray, SystemTrayEvent, SystemTrayMenu,
-  WindowBuilder, WindowUrl,
+  CustomMenuItem, Event, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, WindowBuilder,
+  WindowUrl,
 };
 
 #[derive(Serialize)]

--- a/examples/params/src-tauri/src/main.rs
+++ b/examples/params/src-tauri/src/main.rs
@@ -14,16 +14,7 @@
 use serde::Serialize;
 use std::fmt;
 use std::str::FromStr;
-use tauri::{command, Wry};
-
-trait Params:
-  tauri::Params<Event = Event, Label = Window, MenuId = Menu, SystemTrayMenuId = SystemMenu>
-{
-}
-impl<P> Params for P where
-  P: tauri::Params<Event = Event, Label = Window, MenuId = Menu, SystemTrayMenuId = SystemMenu>
-{
-}
+use tauri::{api::assets::EmbeddedAssets, command, Params, Wry};
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum Event {
@@ -92,19 +83,30 @@ pub enum SystemMenu {
 }
 
 #[command]
-fn log_window_label(window: tauri::Window<impl Params>) {
+fn log_window_label(window: tauri::Window<CustomArgs>) {
   dbg!(window.label());
 }
 
 #[command]
-fn send_foo(window: tauri::Window<impl Params>) {
+fn send_foo(window: tauri::Window<CustomArgs>) {
   window
     .emit(&Event::Foo, ())
     .expect("couldn't send Event::Foo");
 }
 
+pub struct CustomArgs {}
+
+impl Params for CustomArgs {
+  type Event = Event;
+  type Label = Window;
+  type MenuId = Menu;
+  type SystemTrayMenuId = SystemMenu;
+  type Assets = EmbeddedAssets;
+  type Runtime = Wry;
+}
+
 fn main() {
-  tauri::Builder::<Event, Window, Menu, SystemMenu, _, Wry>::new()
+  tauri::Builder::<CustomArgs>::new()
     .invoke_handler(tauri::generate_handler![log_window_label, send_foo])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Remove all generics from `Args` and implement `Params` to it directly.
It also makes signatures of all types and functions based on it
simpler. The compiler time could be improved without the need for macro too.

This means `Arg` is also the default arg type and it requires `wry`
feature flag. If there's a new runtime in the future, all it needs to do
is add another `Arg` under its feature flag.

Custom command and params should still work, see `params` example to
learn how to define it now. Not much needs to change.