### PR TITLE
feat(cli.rs): add release argument to the dev command

### DIFF
--- a/.changes/cli.rs-release-arg.md
+++ b/.changes/cli.rs-release-arg.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Adds `release` argument to the `dev` command. Allowing to run the backend in release mode during development.

--- a/tooling/cli.rs/src/cli.yml
+++ b/tooling/cli.rs/src/cli.yml
@@ -38,6 +38,9 @@ subcommands:
                     about: Args passed to the binary
                     index: 1
                     multiple: true
+                - release:
+                    long: release
+                    about: Run the code in release mode
         - build:
             about: Tauri build.
             args:

--- a/tooling/cli.rs/src/dev.rs
+++ b/tooling/cli.rs/src/dev.rs
@@ -53,6 +53,7 @@ pub struct Dev {
   exit_on_panic: bool,
   config: Option<String>,
   args: Vec<String>,
+  release_mode: bool,
 }
 
 impl Dev {
@@ -87,6 +88,11 @@ impl Dev {
 
   pub fn args(mut self, args: Vec<String>) -> Self {
     self.args = args;
+    self
+  }
+
+  pub fn release_mode(mut self, release_mode: bool) -> Self {
+    self.release_mode = release_mode;
     self
   }
 
@@ -248,6 +254,10 @@ impl Dev {
   ) -> Arc<SharedChild> {
     let mut command = Command::new(runner);
     command.args(&["run", "--no-default-features"]);
+
+    if self.release_mode {
+      command.args(&["--release"]);
+    }
 
     if let Some(target) = &self.target {
       command.args(&["--target", target]);

--- a/tooling/cli.rs/src/main.rs
+++ b/tooling/cli.rs/src/main.rs
@@ -147,11 +147,13 @@ fn dev_command(matches: &ArgMatches) -> Result<()> {
     .values_of("args")
     .map(|a| a.into_iter().map(|v| v.to_string()).collect())
     .unwrap_or_default();
+  let release_mode = matches.is_present("release");
 
   let mut dev_runner = dev::Dev::new()
     .exit_on_panic(exit_on_panic)
     .args(args)
-    .features(features);
+    .features(features)
+    .release_mode(release_mode);
 
   if let Some(runner) = runner {
     dev_runner = dev_runner.runner(runner.to_string());


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes. Issue #___
- [x] No

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

When developing using `cli.rs` I have a large amount of backend code that needs to run, is quite painful to have running in debug mode. This PR adds the ability to execute all this code in release mode during development.
