### PR TITLE
Add Tauri API bindings via wasm-bindgen

### DIFF
--- a/tooling/api.rs/Cargo.toml
+++ b/tooling/api.rs/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tauri_bench"
+version = "0.1.0"
+authors = [ "Tauri Programme within The Commons Conservancy" ]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+description = "Cross-platform WebView rendering library"
+repository = "https://github.com/tauri-apps/tauri"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+js-sys = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen-futures = "0.4"

--- a/tooling/api.rs/src/lib.rs
+++ b/tooling/api.rs/src/lib.rs
@@ -1,0 +1,68 @@
+use js_sys;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(
+    inline_js = "export function invoke_tauri(cmd, args = {}) { return window.__TAURI__._invoke(cmd, args, window.__TAURI_INVOKE_KEY__) }"
+)]
+extern "C" {
+    async fn invoke_tauri(cmd: &str, args: JsValue) -> JsValue;
+}
+
+pub async fn invoke<M: Serialize + Deserialize<'static>>(args: InvokeCommand<M>) -> JsValue {
+    invoke_tauri("tauri".into(), JsValue::from_serde(&args).unwrap()).await
+}
+
+pub trait TauriMessage<M>
+where
+    M: Serialize + Deserialize<'static>,
+{
+    fn cmd(&self) -> M;
+    fn module(&self) -> String;
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct InvokeCommand<M> {
+    #[serde(rename = "__tauriModule")]
+    pub tauri_module: String,
+    pub message: M,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum App {
+    GetAppVersion,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct AppMessage {
+    pub cmd: App,
+}
+
+impl TauriMessage<App> for AppMessage {
+    fn cmd(&self) -> App {
+        self.cmd.clone()
+    }
+    fn module(&self) -> String {
+        "App".into()
+    }
+}
+
+impl From<App> for InvokeCommand<AppMessage> {
+    fn from(cmd: App) -> Self {
+        let msg = AppMessage { cmd };
+        InvokeCommand {
+            tauri_module: msg.module().into(),
+            message: msg,
+        }
+    }
+}
+
+#[test]
+fn tauri_cmd() -> () {
+    let args = InvokeCommand::from(App::GetAppVersion);
+    wasm_bindgen_futures::spawn_local( async move {
+        let result = invoke(args).await;
+        log::info!("{}", result.as_string().unwrap())
+    })
+}


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [X] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [X] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

This introduces some boilerplate that manages calls to the Tauri API by leveraging the existing JS bootstrap `window.__TAURI__._invoke` function.

**Other information:**
