### PR TITLE
feat: Add `on_app_ready` to `Builder`

### DIFF
--- a/.changes/on-ready-callback.md
+++ b/.changes/on-ready-callback.md
@@ -1,0 +1,8 @@
+---
+"tauri": patch
+"tauri-runtime": patch
+"tauri-runtime-wry": patch
+---
+
+Add `on_app_ready` to the `Builder` with access to the `AppHandle`.
+The callback is called once the event loop is ready.

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -304,6 +304,9 @@ pub trait Runtime: Sized + 'static {
   #[cfg_attr(doc_cfg, doc(cfg(feature = "system-tray")))]
   fn on_system_tray_event<F: Fn(&SystemTrayEvent) + Send + 'static>(&mut self, f: F) -> Uuid;
 
+  /// Registers a event loop ready handler.
+  fn on_app_ready<F: Fn() + Send + 'static>(&self, f: F) -> Uuid;
+
   /// Runs the one step of the webview runtime event loop and returns control flow to the caller.
   #[cfg(any(target_os = "windows", target_os = "macos"))]
   fn run_iteration<F: Fn(RunEvent) + 'static>(&mut self, callback: F) -> RunIteration;

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -520,7 +520,8 @@ impl<R: Runtime> Builder<R> {
   /// Defines a callback emitted once the event loop is ready.
   pub fn on_app_ready<F>(mut self, handler: F) -> Self
   where
-    F: Fn(&AppHandle<R>) + Send + Sync + 'static  {
+    F: Fn(&AppHandle<R>) + Send + Sync + 'static,
+  {
     self.app_ready_listeners.push(Box::new(handler));
     self
   }

--- a/examples/api/src-tauri/src/main.rs
+++ b/examples/api/src-tauri/src/main.rs
@@ -16,8 +16,8 @@ mod menu;
 
 use serde::Serialize;
 use tauri::{
-  CustomMenuItem, Event, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, WindowBuilder,
-  WindowUrl,
+  CustomMenuItem, Event, GlobalShortcutManager, Manager, SystemTray, SystemTrayEvent,
+  SystemTrayMenu, WindowBuilder, WindowUrl,
 };
 
 #[derive(Serialize)]
@@ -32,6 +32,17 @@ async fn menu_toggle(window: tauri::Window) {
 
 fn main() {
   tauri::Builder::default()
+    .on_app_ready(|handler| {
+      let handler = handler.clone();
+      handler
+        .global_shortcut_manager()
+        .register("Ctrl+1", move || {
+          let handler = handler.clone();
+          let window = handler.get_window("main").unwrap();
+          window.set_title("New title!").unwrap();
+        })
+        .unwrap();
+    })
     .on_page_load(|window, _| {
       let window_ = window.clone();
       window.listen("js-event", move |event| {

--- a/examples/updater/src-tauri/src/main.rs
+++ b/examples/updater/src-tauri/src/main.rs
@@ -18,6 +18,9 @@ fn my_custom_command(argument: String) {
 
 fn main() {
   tauri::Builder::default()
+    .on_app_ready( |handler| {
+      println!("app ready!");
+    })
     .invoke_handler(tauri::generate_handler![my_custom_command])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/examples/updater/src-tauri/src/main.rs
+++ b/examples/updater/src-tauri/src/main.rs
@@ -18,9 +18,6 @@ fn my_custom_command(argument: String) {
 
 fn main() {
   tauri::Builder::default()
-    .on_app_ready( |handler| {
-      println!("app ready!");
-    })
     .invoke_handler(tauri::generate_handler![my_custom_command])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
