### PR TITLE
`App.create_window()` to accept any `Into<String>` type (fix #2290)

### DIFF
--- a/.changes/fix-create-window-str.md
+++ b/.changes/fix-create-window-str.md
@@ -2,4 +2,4 @@
 "tauri": major
 ---
 
-Fix `App.create_window()` to accept any `Into<String>` type instead of only `String` itself.
+Change `App.create_window()` and `AppHandle.create_window()` to accept an `Into<String>` type instead of `String`.

--- a/.changes/fix-create-window-str.md
+++ b/.changes/fix-create-window-str.md
@@ -1,5 +1,5 @@
 ---
-"tauri": major
+"tauri": patch
 ---
 
 Change `App.create_window()` and `AppHandle.create_window()` to accept an `Into<String>` type instead of `String`.

--- a/.changes/fix-create-window-str.md
+++ b/.changes/fix-create-window-str.md
@@ -1,0 +1,5 @@
+---
+"tauri": major
+---
+
+Fix `App.create_window()` to accept any `Into<String>` type instead of only `String` itself.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -225,7 +225,12 @@ macro_rules! shared_app_impl {
   ($app: ty) => {
     impl<R: Runtime> $app {
       /// Creates a new webview window.
-      pub fn create_window<F>(&self, label: String, url: WindowUrl, setup: F) -> crate::Result<()>
+      pub fn create_window<F>(
+        &self,
+        label: impl Into<String>,
+        url: WindowUrl,
+        setup: F,
+      ) -> crate::Result<()>
       where
         F: FnOnce(
           <R::Dispatcher as Dispatch>::WindowBuilder,

--- a/examples/api/src-tauri/src/main.rs
+++ b/examples/api/src-tauri/src/main.rs
@@ -82,7 +82,7 @@ fn main() {
           }
           "new" => app
             .create_window(
-              "new".into(),
+              "new",
               WindowUrl::App("index.html".into()),
               |window_builder, webview_attributes| {
                 (window_builder.title("Tauri"), webview_attributes)


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. Issue #2290 
- [ ] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
See #2290.