### PR TITLE
refactor(core/wry): use `is_menu_visible` instead of atomic bool

### DIFF
--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -1198,8 +1198,6 @@ struct WebviewWrapper {
   inner: WebView,
   #[cfg(feature = "menu")]
   menu_items: HashMap<u16, WryCustomMenuItem>,
-  #[cfg(feature = "menu")]
-  is_menu_visible: AtomicBool,
 }
 
 /// A Tauri [`Runtime`] wrapper around wry.
@@ -1699,9 +1697,7 @@ fn handle_event_loop(
             WindowMessage::IsResizable(tx) => tx.send(window.is_resizable()).unwrap(),
             WindowMessage::IsVisible(tx) => tx.send(window.is_visible()).unwrap(),
             #[cfg(feature = "menu")]
-            WindowMessage::IsMenuVisible(tx) => tx
-              .send(webview.is_menu_visible.load(Ordering::Relaxed))
-              .unwrap(),
+            WindowMessage::IsMenuVisible(tx) => tx.send(window.is_menu_visible()).unwrap(),
             WindowMessage::CurrentMonitor(tx) => tx.send(window.current_monitor()).unwrap(),
             WindowMessage::PrimaryMonitor(tx) => tx.send(window.primary_monitor()).unwrap(),
             WindowMessage::AvailableMonitors(tx) => {
@@ -1733,15 +1729,9 @@ fn handle_event_loop(
             WindowMessage::Minimize => window.set_minimized(true),
             WindowMessage::Unminimize => window.set_minimized(false),
             #[cfg(feature = "menu")]
-            WindowMessage::ShowMenu => {
-              window.show_menu();
-              webview.is_menu_visible.store(true, Ordering::Relaxed);
-            }
+            WindowMessage::ShowMenu => window.show_menu(),
             #[cfg(feature = "menu")]
-            WindowMessage::HideMenu => {
-              window.hide_menu();
-              webview.is_menu_visible.store(false, Ordering::Relaxed);
-            }
+            WindowMessage::HideMenu => window.hide_menu(),
             WindowMessage::Show => window.set_visible(true),
             WindowMessage::Hide => window.set_visible(false),
             WindowMessage::Close => {
@@ -2062,8 +2052,6 @@ fn create_webview(
     inner: webview,
     #[cfg(feature = "menu")]
     menu_items,
-    #[cfg(feature = "menu")]
-    is_menu_visible: AtomicBool::new(true),
   })
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
