### PR TITLE
fix(updater): Run elevated task only if server tell us

### DIFF
--- a/.changes/tauri-updater-windows.md
+++ b/.changes/tauri-updater-windows.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+---
+
+- Do not run the updater with UAC task if server don't tell us. (Allow toggling server-side)
+- The updater expect a field named `with_elevated_task` with a `boolean` and will not run if the task is not installed first. (windows only)

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -73,10 +73,11 @@ impl RemoteRelease {
     };
 
     // pub_date is required default is: `N/A` if not provided by the remote JSON
-    let date = match release.get("pub_date") {
-      Some(pub_date) => pub_date.as_str().unwrap_or("N/A").to_string(),
-      None => "N/A".to_string(),
-    };
+    let date = release
+      .get("pub_date")
+      .and_then(|v| v.as_str())
+      .unwrap_or("N/A")
+      .to_string();
 
     // body is optional to build our update
     let body = release
@@ -125,10 +126,10 @@ impl RemoteRelease {
             .to_string();
           #[cfg(target_os = "windows")]
           {
-            with_elevated_task = match current_target_data.get("with_elevated_task") {
-              Some(with_elevated_task) => with_elevated_task.as_bool().unwrap_or(false),
-              None => false,
-            };
+            with_elevated_task = current_target_data
+              .get("with_elevated_task")
+              .and_then(|v| v.as_bool())
+              .unwrap_or_default();
           }
         } else {
           // make sure we have an available platform from the static


### PR DESCRIPTION

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Fix https://github.com/tauri-apps/tauri/issues/2356

PS: It'll not run if the task is not installed, but it allows the customer to toggle if something appends.