### PR TITLE
fix(core): dialog's `defaultPath` behavior on Linux, closes #2232

### DIFF
--- a/.changes/fix-dialog-save-default-path-linux.md
+++ b/.changes/fix-dialog-save-default-path-linux.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fixes `defaultPath` option on dialog API not setting the file name if it doesn't exist on Linux.

--- a/core/tauri/src/endpoints/dialog.rs
+++ b/core/tauri/src/endpoints/dialog.rs
@@ -114,35 +114,18 @@ impl Cmd {
   }
 }
 
-#[cfg(all(target_os = "linux", any(dialog_open, dialog_save)))]
+#[cfg(any(dialog_open, dialog_save))]
 fn set_default_path(
   mut dialog_builder: FileDialogBuilder,
   default_path: PathBuf,
 ) -> FileDialogBuilder {
   if default_path.is_file() || !default_path.exists() {
-    dialog_builder = dialog_builder.set_file_name(&default_path.to_string_lossy().to_string());
-    dialog_builder.set_directory(default_path.parent().unwrap())
-  } else {
-    dialog_builder.set_directory(default_path)
-  }
-}
-
-#[cfg(all(any(windows, target_os = "macos"), any(dialog_open, dialog_save)))]
-fn set_default_path(
-  mut dialog_builder: FileDialogBuilder,
-  default_path: PathBuf,
-) -> FileDialogBuilder {
-  if default_path.is_file() {
-    if let Some(parent) = default_path.parent() {
+    if let (Some(parent), Some(file_name)) = (default_path.parent(), default_path.file_name()) {
       dialog_builder = dialog_builder.set_directory(parent);
+      dialog_builder = dialog_builder.set_file_name(&file_name.to_string_lossy().to_string());
+    } else {
+      dialog_builder = dialog_builder.set_directory(default_path);
     }
-    dialog_builder = dialog_builder.set_file_name(
-      &default_path
-        .file_name()
-        .unwrap()
-        .to_string_lossy()
-        .to_string(),
-    );
     dialog_builder
   } else {
     dialog_builder.set_directory(default_path)

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -91,7 +91,7 @@ impl RemoteRelease {
 
     let download_url;
     #[cfg(target_os = "windows")]
-    let mut with_elevated_task = false;
+    let with_elevated_task;
 
     match release.get("platforms") {
       //

--- a/tooling/api/src/dialog.ts
+++ b/tooling/api/src/dialog.ts
@@ -57,7 +57,11 @@ interface OpenDialogOptions {
 interface SaveDialogOptions {
   /** The filters of the dialog. */
   filters?: DialogFilter[]
-  /** Initial directory or file path. It must exist. */
+  /**
+   * Initial directory or file path.
+   * If it's a directory path, the dialog interface will change to that folder.
+   * If it's not an existing directory, the file name will be set to the dialog's file name input and the dialog will be set to the parent folder.
+   */
   defaultPath?: string
 }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
