### PR TITLE
fix(bundler) wix template escape character

### DIFF
--- a/.changes/wix-registry-keys.md
+++ b/.changes/wix-registry-keys.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Fix registry keys on the WiX template.

--- a/tooling/bundler/src/bundle/path_utils.rs
+++ b/tooling/bundler/src/bundle/path_utils.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 /// Directory options.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub struct DirOpts {
   pub depth: u64,
 }
@@ -48,12 +48,6 @@ impl Default for Options {
       content_only: false,
       depth: 0,
     }
-  }
-}
-
-impl Default for DirOpts {
-  fn default() -> DirOpts {
-    DirOpts { depth: 0 }
   }
 }
 

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -71,7 +71,7 @@
                 <Component Id="ApplicationShortcutDesktop" Guid="*">
                     <Shortcut Id="ApplicationDesktopShortcut" Name="{{{product_name}}}" Description="Runs {{{product_name}}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
                     <RemoveFolder Id="DesktopFolder" On="uninstall" />
-                    <RegistryValue Root="HKCU" Key="Software\{{{product_name}}}" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                    <RegistryValue Root="HKCU" Key="Software\\{{{product_name}}}" Name="installed" Type="integer" Value="1" KeyPath="yes" />
                 </Component>
             </Directory>
             <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
@@ -115,7 +115,7 @@
 							  On="uninstall" />
 
 				<RegistryValue Root="HKCR"
-							   Key="Software\{{{manufacturer}}}\{{{product_name}}}"
+							   Key="Software\\{{{manufacturer}}}\\{{{product_name}}}"
 							   Name="installed"
 							   Type="integer"
 							   Value="1"
@@ -134,7 +134,7 @@
                     <ShortcutProperty Key="System.AppUserModel.ID" Value="{{{manufacturer}}}"/>
                 </Shortcut>
                 <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
-                <RegistryValue Root="HKCU" Key="Software\{{{manufacturer}}}\{{{product_name}}}" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+                <RegistryValue Root="HKCU" Key="Software\\{{{manufacturer}}}\\{{{product_name}}}" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
            </Component>
         </DirectoryRef>
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

**Other information:**

An escape character is being recognized instead of the replacement pattern for variables in the WIX template.

Given:

manufacturer = acme
product_name = anvil

Current Registry Result:
`Computer\HKEY_CURRENT_USER\Software{{{manufacturer}}}{{{product_name}}}`

Expected Registry Result
`Computer\HKEY_CURRENT_USER\Software\acme\anvil`
