### PR TITLE
fix(core): macOS crashing due to WebContext drop, closes #2622

### DIFF
--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2557,31 +2557,32 @@ fn create_webview(
     webview_builder = webview_builder.with_initialization_script(&script);
   }
 
-  let webview = if let Ok("true") = std::env::var("TAURI_AUTOMATION").as_deref() {
-    let mut web_context = web_context.lock().expect("poisoned WebContext store");
-    let is_first_context = web_context.is_empty();
-    let web_context = match web_context.entry(webview_attributes.data_directory) {
-      Occupied(occupied) => occupied.into_mut(),
-      Vacant(vacant) => {
-        let mut web_context = WebContext::new(vacant.key().clone());
-        web_context.set_allows_automation(match std::env::var("TAURI_AUTOMATION").as_deref() {
-          Ok("true") => is_first_context,
-          _ => false,
-        });
-        vacant.insert(web_context)
-      }
-    };
-    webview_builder
-      .with_web_context(web_context)
-      .build()
-      .map_err(|e| Error::CreateWebview(Box::new(e)))?
-  } else {
-    let mut context = WebContext::new(webview_attributes.data_directory);
-    webview_builder
-      .with_web_context(&mut context)
-      .build()
-      .map_err(|e| Error::CreateWebview(Box::new(e)))?
+  let mut web_context = web_context.lock().expect("poisoned WebContext store");
+  let is_first_context = web_context.is_empty();
+  let web_context = match web_context.entry(
+    // force a unique WebContext when automation is false;
+    // the context must be stored on the HashMap because it must outlive the WebView on macOS
+    if let Ok("true") = std::env::var("TAURI_AUTOMATION").as_deref() {
+      webview_attributes.data_directory.clone()
+    } else {
+      // random unique key
+      Some(Uuid::new_v4().to_hyphenated().to_string().into())
+    },
+  ) {
+    Occupied(occupied) => occupied.into_mut(),
+    Vacant(vacant) => {
+      let mut web_context = WebContext::new(webview_attributes.data_directory);
+      web_context.set_allows_automation(match std::env::var("TAURI_AUTOMATION").as_deref() {
+        Ok("true") => is_first_context,
+        _ => false,
+      });
+      vacant.insert(web_context)
+    }
   };
+  let webview = webview_builder
+    .with_web_context(web_context)
+    .build()
+    .map_err(|e| Error::CreateWebview(Box::new(e)))?;
 
   Ok(WindowWrapper {
     label,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This reflects an internal change on wry's next branch, so I won't add that to the changelog. Wry stores the custom protocol pointers on the WebContext, which gets cleared on drop. This PR changes the Tauri implementation to hold the WebContext on the static HashMap to prevent the Drop implementation from being called before the WebView instance is dropped.

https://github.com/tauri-apps/wry/blob/e056fb2a15e29de1b8ed85a548cfeb1f85031357/src/webview/wkwebview/mod.rs#L229
