### PR TITLE
Re-order instructions for success

### DIFF
--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -18,6 +18,7 @@ Windows:
 ```
 ./.scripts/setup.ps1
 ```
+When prompted to install Node.js CLI, press `Y` (default `N`)
 
 - Install dependencies (Run inside of this folder tauri/examples/api/)
 ```bash

--- a/examples/api/README.md
+++ b/examples/api/README.md
@@ -5,14 +5,6 @@ In the future, this app will be used on Tauri's integration tests.
 ![App screenshot](./screenshot.png?raw=true)
 
 ## Running the example
-- Install dependencies (Run inside of this folder tauri/examples/api/)
-```bash
-# with yarn
-$ yarn
-# with npm
-$ npm install
-```
-
 - Compile tauri
 go to root of the tauri repo and run
 
@@ -25,6 +17,14 @@ sh .scripts/setup.sh
 Windows:
 ```
 ./.scripts/setup.ps1
+```
+
+- Install dependencies (Run inside of this folder tauri/examples/api/)
+```bash
+# with yarn
+$ yarn
+# with npm
+$ npm install
 ```
 
 - Compile the app (Run inside of this folder tauri/examples/api/)


### PR DESCRIPTION
It was my experience on Windows that I needed to run the setup script before `yarn` in the example.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
