### PR TITLE
feat(cli.rs): expose debug flag to beforeDev/beforeBuild commands

### DIFF
--- a/.changes/before-script-envs.md
+++ b/.changes/before-script-envs.md
@@ -2,4 +2,4 @@
 "cli.rs": patch
 ---
 
-Define `PLATFORM`, `ARCH`, `FAMILY` and `PLATFORM_TYPE` environment variables for the `beforeDevCommand` and `beforeBuildCommand` scripts.
+Define `PLATFORM`, `ARCH`, `FAMILY`, `PLATFORM_TYPE` and `TAURI_DEBUG` environment variables for the `beforeDevCommand` and `beforeBuildCommand` scripts.

--- a/.changes/cli.rs-tauri-debug-env.md
+++ b/.changes/cli.rs-tauri-debug-env.md
@@ -1,5 +1,0 @@
----
-"cli.rs": patch
----
-
-Define `TAURI_DEBUG` environment variable for the `beforeDevCommand` and `beforeBuildCommand` scripts.

--- a/.changes/cli.rs-tauri-debug-env.md
+++ b/.changes/cli.rs-tauri-debug-env.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Define `TAURI_DEBUG` environment variable for the `beforeDevCommand` and `beforeBuildCommand` scripts.

--- a/tooling/cli.rs/config_definition.rs
+++ b/tooling/cli.rs/config_definition.rs
@@ -820,11 +820,11 @@ pub struct BuildConfig {
   pub dist_dir: AppUrl,
   /// A shell command to run before `tauri dev` kicks in.
   ///
-  /// The PLATFORM, ARCH, FAMILY and PLATFORM_TYPE environment variables are set if you perform conditional compilation.
+  /// The PLATFORM, ARCH, FAMILY, PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.
   pub before_dev_command: Option<String>,
   /// A shell command to run before `tauri build` kicks in.
   ///
-  /// The PLATFORM, ARCH, FAMILY and PLATFORM_TYPE environment variables are set if you perform conditional compilation.
+  /// The PLATFORM, ARCH, FAMILY, PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.
   pub before_build_command: Option<String>,
   /// Features passed to `cargo` commands.
   pub features: Option<Vec<String>>,

--- a/tooling/cli.rs/schema.json
+++ b/tooling/cli.rs/schema.json
@@ -261,7 +261,7 @@
       "type": "object",
       "properties": {
         "beforeBuildCommand": {
-          "description": "A shell command to run before `tauri build` kicks in.\n\nThe PLATFORM, ARCH, FAMILY PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.",
+          "description": "A shell command to run before `tauri build` kicks in.\n\nThe PLATFORM, ARCH, FAMILY, PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.",
           "type": [
             "string",
             "null"

--- a/tooling/cli.rs/schema.json
+++ b/tooling/cli.rs/schema.json
@@ -261,14 +261,14 @@
       "type": "object",
       "properties": {
         "beforeBuildCommand": {
-          "description": "A shell command to run before `tauri build` kicks in.\n\nThe PLATFORM, ARCH, FAMILY and PLATFORM_TYPE environment variables are set if you perform conditional compilation.",
+          "description": "A shell command to run before `tauri build` kicks in.\n\nThe PLATFORM, ARCH, FAMILY PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.",
           "type": [
             "string",
             "null"
           ]
         },
         "beforeDevCommand": {
-          "description": "A shell command to run before `tauri dev` kicks in.\n\nThe PLATFORM, ARCH, FAMILY and PLATFORM_TYPE environment variables are set if you perform conditional compilation.",
+          "description": "A shell command to run before `tauri dev` kicks in.\n\nThe PLATFORM, ARCH, FAMILY, PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.",
           "type": [
             "string",
             "null"

--- a/tooling/cli.rs/src/build.rs
+++ b/tooling/cli.rs/src/build.rs
@@ -91,7 +91,7 @@ impl Build {
             .arg("/C")
             .arg(before_build)
             .current_dir(app_dir())
-            .envs(command_env()),
+            .envs(command_env(self.debug)),
         )
         .with_context(|| format!("failed to run `{}` with `cmd /C`", before_build))?;
         #[cfg(not(target_os = "windows"))]
@@ -100,7 +100,7 @@ impl Build {
             .arg("-c")
             .arg(before_build)
             .current_dir(app_dir())
-            .envs(command_env()),
+            .envs(command_env(self.debug)),
         )
         .with_context(|| format!("failed to run `{}` with `sh -c`", before_build))?;
       }

--- a/tooling/cli.rs/src/dev.rs
+++ b/tooling/cli.rs/src/dev.rs
@@ -142,7 +142,7 @@ impl Dev {
           .arg("/C")
           .arg(before_dev)
           .current_dir(app_dir())
-          .envs(command_env())
+          .envs(command_env(true)) // development build always includes debug information
           .spawn()
           .with_context(|| format!("failed to run `{}` with `cmd /C`", before_dev))?;
         #[cfg(not(target_os = "windows"))]
@@ -150,7 +150,7 @@ impl Dev {
           .arg("-c")
           .arg(before_dev)
           .current_dir(app_dir())
-          .envs(command_env())
+          .envs(command_env(true)) // development build always includes debug information
           .spawn()
           .with_context(|| format!("failed to run `{}` with `sh -c`", before_dev))?;
         BEFORE_DEV.set(Mutex::new(child)).unwrap();

--- a/tooling/cli.rs/src/helpers/mod.rs
+++ b/tooling/cli.rs/src/helpers/mod.rs
@@ -41,8 +41,9 @@ pub fn execute_with_output(cmd: &mut Command) -> crate::Result<()> {
   }
 }
 
-pub fn command_env() -> HashMap<String, String> {
+pub fn command_env(debug: bool) -> HashMap<String, String> {
   let mut map = HashMap::new();
+  map.insert("TAURI_DEBUG".into(), debug);
   map.insert("PLATFORM".into(), std::env::consts::OS.into());
   map.insert("ARCH".into(), std::env::consts::ARCH.into());
   map.insert("FAMILY".into(), std::env::consts::FAMILY.into());

--- a/tooling/cli.rs/src/helpers/mod.rs
+++ b/tooling/cli.rs/src/helpers/mod.rs
@@ -43,7 +43,7 @@ pub fn execute_with_output(cmd: &mut Command) -> crate::Result<()> {
 
 pub fn command_env(debug: bool) -> HashMap<String, String> {
   let mut map = HashMap::new();
-  map.insert("TAURI_DEBUG".into(), debug);
+
   map.insert("PLATFORM".into(), std::env::consts::OS.into());
   map.insert("ARCH".into(), std::env::consts::ARCH.into());
   map.insert("FAMILY".into(), std::env::consts::FAMILY.into());
@@ -55,6 +55,10 @@ pub fn command_env(debug: bool) -> HashMap<String, String> {
   map.insert("PLATFORM_TYPE".into(), "Windows_NT".into());
   #[cfg(target_os = "macos")]
   map.insert("PLATFORM_TYPE".into(), "Darwing".into());
+
+  if debug {
+    map.insert("TAURI_DEBUG".into(), "true".to_string());
+  }
 
   map
 }


### PR DESCRIPTION
Exposes the the `--debug` flag to `beforeBuildCommand` and `beforeDevCommand` through an environment variable called `TAURI_DEBUG`. This is useful for frontend bundlers to adjust their compilation based on the chosen build environment.
An example would be producing source maps for debug builds, but omitting them for release builds.
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
