### PR TITLE
feat: add Log directory

### DIFF
--- a/.changes/add-log-dir.md
+++ b/.changes/add-log-dir.md
@@ -1,0 +1,6 @@
+---
+"tauri": minor
+"api": minor
+---
+
+Add `tauri::api::path::log_dir` and `path.logDir` functions to access sugested log directory.

--- a/.changes/add-log-dir.md
+++ b/.changes/add-log-dir.md
@@ -1,6 +1,0 @@
----
-"tauri": minor
-"api": minor
----
-
-Add `tauri::api::path::log_dir` and `path.logDir` functions to access sugested log directory.

--- a/.changes/api-add-log-dir.md
+++ b/.changes/api-add-log-dir.md
@@ -1,0 +1,6 @@
+---
+"api": minor
+---
+
+Add `logDir` function to the `path` module to access the sugested log directory.
+Add `BaseDirectory.Log` to the `fs` module.

--- a/.changes/core-add-log-dir.md
+++ b/.changes/core-add-log-dir.md
@@ -1,0 +1,5 @@
+---
+"tauri": minor
+---
+
+Add `tauri::api::path::log_dir` function to access the sugested log directory path.

--- a/core/tauri/src/api/path.rs
+++ b/core/tauri/src/api/path.rs
@@ -60,8 +60,12 @@ pub enum BaseDirectory {
   /// The default App config directory.
   /// Resolves to [`BaseDirectory::Config`].
   App,
+  /// The Log directory.
+  /// Resolves to [`BaseDirectory::Home/Library/Logs/{app identifies}`] on macos
+  /// and [`BaseDirectory::Config/{app identifier}/logs`] on linux and windows.
+  Log,
   /// The current working directory.
-  Current,
+  Current
 }
 
 /// Resolves the path with the optional base directory.
@@ -109,6 +113,7 @@ pub fn resolve_path<P: AsRef<Path>>(
       BaseDirectory::Video => video_dir(),
       BaseDirectory::Resource => resource_dir(package_info),
       BaseDirectory::App => app_dir(config),
+      BaseDirectory::Log => log_dir(config),
       BaseDirectory::Current => Some(env::current_dir()?),
     };
     if let Some(mut base_dir_path_value) = base_dir_path {
@@ -229,4 +234,15 @@ pub fn resource_dir(package_info: &PackageInfo) -> Option<PathBuf> {
 /// Returns the path to the suggested directory for your app config files.
 pub fn app_dir(config: &Config) -> Option<PathBuf> {
   dirs_next::config_dir().map(|dir| dir.join(&config.tauri.bundle.identifier))
+}
+
+/// Returns the path to the log directory.
+pub fn log_dir(config: &Config) -> Option<PathBuf> {
+  #[cfg(target_os = "macos")]
+  let path = dirs_next::home_dir().map(|dir| dir.join("Library/Logs").join(&config.tauri.bundle.identifier));
+
+  #[cfg(not(target_os = "macos"))]
+  let path = dirs_next::config_dir().map(|dir| dir.join(&config.tauri.bundle.identifier).join("logs"));
+
+  path
 }

--- a/core/tauri/src/api/path.rs
+++ b/core/tauri/src/api/path.rs
@@ -63,7 +63,7 @@ pub enum BaseDirectory {
   /// The current working directory.
   Current,
   /// The Log directory.
-  /// Resolves to [`BaseDirectory::Home/Library/Logs/{bundle_identifier}`] on macos
+  /// Resolves to [`BaseDirectory::Home/Library/Logs/{bundle_identifier}`] on macOS
   /// and [`BaseDirectory::Config/{bundle_identifier}/logs`] on linux and windows.
   Log,
 }

--- a/core/tauri/src/api/path.rs
+++ b/core/tauri/src/api/path.rs
@@ -60,12 +60,12 @@ pub enum BaseDirectory {
   /// The default App config directory.
   /// Resolves to [`BaseDirectory::Config`].
   App,
-  /// The Log directory.
-  /// Resolves to [`BaseDirectory::Home/Library/Logs/{app identifies}`] on macos
-  /// and [`BaseDirectory::Config/{app identifier}/logs`] on linux and windows.
-  Log,
   /// The current working directory.
-  Current
+  Current,
+  /// The Log directory.
+  /// Resolves to [`BaseDirectory::Home/Library/Logs/{bundle_identifier}`] on macos
+  /// and [`BaseDirectory::Config/{bundle_identifier}/logs`] on linux and windows.
+  Log,
 }
 
 /// Resolves the path with the optional base directory.
@@ -113,8 +113,8 @@ pub fn resolve_path<P: AsRef<Path>>(
       BaseDirectory::Video => video_dir(),
       BaseDirectory::Resource => resource_dir(package_info),
       BaseDirectory::App => app_dir(config),
-      BaseDirectory::Log => log_dir(config),
       BaseDirectory::Current => Some(env::current_dir()?),
+      BaseDirectory::Log => log_dir(config),
     };
     if let Some(mut base_dir_path_value) = base_dir_path {
       // use the same path resolution mechanism as the bundler's resource injection algorithm

--- a/core/tauri/src/api/path.rs
+++ b/core/tauri/src/api/path.rs
@@ -239,10 +239,15 @@ pub fn app_dir(config: &Config) -> Option<PathBuf> {
 /// Returns the path to the log directory.
 pub fn log_dir(config: &Config) -> Option<PathBuf> {
   #[cfg(target_os = "macos")]
-  let path = dirs_next::home_dir().map(|dir| dir.join("Library/Logs").join(&config.tauri.bundle.identifier));
+  let path = dirs_next::home_dir().map(|dir| {
+    dir
+      .join("Library/Logs")
+      .join(&config.tauri.bundle.identifier)
+  });
 
   #[cfg(not(target_os = "macos"))]
-  let path = dirs_next::config_dir().map(|dir| dir.join(&config.tauri.bundle.identifier).join("logs"));
+  let path =
+    dirs_next::config_dir().map(|dir| dir.join(&config.tauri.bundle.identifier).join("logs"));
 
   path
 }

--- a/tooling/api/src/fs.ts
+++ b/tooling/api/src/fs.ts
@@ -54,7 +54,8 @@ export enum BaseDirectory {
   Video,
   Resource,
   App,
-  Current
+  Current,
+  Log
 }
 
 interface FsOptions {

--- a/tooling/api/src/path.ts
+++ b/tooling/api/src/path.ts
@@ -439,7 +439,7 @@ async function currentDir(): Promise<string> {
  *
  * @returns
  */
- async function logDir(): Promise<string> {
+async function logDir(): Promise<string> {
   return invokeTauriCommand<string>({
     __tauriModule: 'Path',
     message: {

--- a/tooling/api/src/path.ts
+++ b/tooling/api/src/path.ts
@@ -579,6 +579,7 @@ export {
   templateDir,
   videoDir,
   currentDir,
+  logDir,
   BaseDirectory,
   sep,
   delimiter,

--- a/tooling/api/src/path.ts
+++ b/tooling/api/src/path.ts
@@ -429,6 +429,28 @@ async function currentDir(): Promise<string> {
 }
 
 /**
+ * Returns the path to the log directory.
+ *
+ * ### Platform-specific
+ *
+ * - **Linux:** Resolves to `${configDir}/${bundleIdentifier}`.
+ * - **macOS:** Resolves to `${homeDir}//Library/Logs/{bundleIdentifier}`
+ * - **Windows:** Resolves to `${configDir}/${bundleIdentifier}`.
+ *
+ * @returns
+ */
+ async function logDir(): Promise<string> {
+  return invokeTauriCommand<string>({
+    __tauriModule: 'Path',
+    message: {
+      cmd: 'resolvePath',
+      path: '',
+      directory: BaseDirectory.Log
+    }
+  })
+}
+
+/**
  * Provides the platform-specific path segment separator:
  * - `\` on Windows
  * - `/` on POSIX


### PR DESCRIPTION
Adds api functions that provide access to the suggested log directory. Resolves to `BaseDirectory::Home/Library/Logs/{bundle_identifier}` on macOS and `BaseDirectory::Config/{bundle_identifier}/logs` on windows and linux.
It exposes this through `tauri::api::path::BaseDirectory::Log` and `tauri::api::path::log_dir` for rust and `path.logDir` for javascript.
Inspired by electrons [setAppLogsPath](https://www.electronjs.org/docs/latest/api/app#appsetapplogspathpath) method and the [electron-log](https://www.npmjs.com/package/electron-log) package.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
