### PR TITLE
Fix log_dir

### DIFF
--- a/core/tauri/src/api/path.rs
+++ b/core/tauri/src/api/path.rs
@@ -236,7 +236,7 @@ pub fn app_dir(config: &Config) -> Option<PathBuf> {
   dirs_next::config_dir().map(|dir| dir.join(&config.tauri.bundle.identifier))
 }
 
-/// Returns the path to the log directory.
+/// Returns the path to the suggested log directory.
 pub fn log_dir(config: &Config) -> Option<PathBuf> {
   #[cfg(target_os = "macos")]
   let path = dirs_next::home_dir().map(|dir| {

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -162,6 +162,11 @@ impl PathResolver {
   pub fn app_dir(&self) -> Option<PathBuf> {
     crate::api::path::app_dir(&self.config)
   }
+
+  /// Returns the path to the suggested log directory.
+  pub fn log_dir(&self) -> Option<PathBuf> {
+    crate::api::path::log_dir(&self.config)
+  }
 }
 
 /// A handle to the currently running application.

--- a/tooling/api/src/path.ts
+++ b/tooling/api/src/path.ts
@@ -429,7 +429,7 @@ async function currentDir(): Promise<string> {
 }
 
 /**
- * Returns the path to the log directory.
+ * Returns the path to the suggested log directory.
  *
  * ### Platform-specific
  *


### PR DESCRIPTION
In #2736 I forgot to add `log_dir` to the apps `PathResolver`, but it makes sense to be there as it requires access to the config.
This also updates inline descriptions of the functions.

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
