### PR TITLE
fix: #2861 return platform type typo "Darwing"  instead of "Darwin"

### DIFF
--- a/tooling/cli.rs/src/helpers/mod.rs
+++ b/tooling/cli.rs/src/helpers/mod.rs
@@ -54,7 +54,7 @@ pub fn command_env(debug: bool) -> HashMap<String, String> {
   #[cfg(target_os = "windows")]
   map.insert("PLATFORM_TYPE".into(), "Windows_NT".into());
   #[cfg(target_os = "macos")]
-  map.insert("PLATFORM_TYPE".into(), "Darwing".into());
+  map.insert("PLATFORM_TYPE".into(), "Darwin".into());
 
   if debug {
     map.insert("TAURI_DEBUG".into(), "true".to_string());


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. Issue #2861
- [ ] No

Could potentially be breaking for some apps using the os.type() function and just check against the returned string "Darwing".

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
