### PR TITLE
feat: Add JoinHandle::abort()

### DIFF
--- a/.changes/join-handle-abort.md
+++ b/.changes/join-handle-abort.md
@@ -1,0 +1,5 @@
+---
+"core": patch
+---
+
+Added `abort` method to `tauri::async_runtime::JoinHandle`.

--- a/.changes/join-handle-abort.md
+++ b/.changes/join-handle-abort.md
@@ -1,5 +1,5 @@
 ---
-"core": patch
+"tauri": patch
 ---
 
 Added `abort` method to `tauri::async_runtime::JoinHandle`.

--- a/core/tauri/src/async_runtime.rs
+++ b/core/tauri/src/async_runtime.rs
@@ -40,7 +40,7 @@ impl<T> JoinHandle<T> {
   ///
   /// Awaiting a cancelled task might complete as usual if the task was
   /// already completed at the time it was cancelled, but most likely it
-  /// will fail with a [cancelled] `JoinError`.
+  /// will fail with a cancelled `JoinError`.
   pub fn abort(&self) {
     self.0.abort();
   }
@@ -129,7 +129,7 @@ mod tests {
       let raw_error = raw_box.downcast::<tokio::task::JoinError>().unwrap();
       assert!(raw_error.is_cancelled());
     } else {
-      panic!("Should never goes here!");
+      panic!("Abort did not result in the expected `JoinError`");
     }
   }
 }

--- a/core/tauri/src/async_runtime.rs
+++ b/core/tauri/src/async_runtime.rs
@@ -35,6 +35,17 @@ static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 #[derive(Debug)]
 pub struct JoinHandle<T>(TokioJoinHandle<T>);
 
+impl<T> JoinHandle<T> {
+  /// Abort the task associated with the handle.
+  ///
+  /// Awaiting a cancelled task might complete as usual if the task was
+  /// already completed at the time it was cancelled, but most likely it
+  /// will fail with a [cancelled] `JoinError`.
+  pub fn abort(&self) {
+    self.0.abort();
+  }
+}
+
 impl<T> Future for JoinHandle<T> {
   type Output = crate::Result<T>;
   fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -107,5 +118,18 @@ mod tests {
   fn handle_block_on() {
     let handle = handle();
     assert_eq!(handle.block_on(async { 0 }), 0);
+  }
+
+  #[tokio::test]
+  async fn handle_abort() {
+    let handle = handle();
+    let join = handle.spawn(async { 5 });
+    join.abort();
+    if let crate::Error::JoinError(raw_box) = join.await.unwrap_err() {
+      let raw_error = raw_box.downcast::<tokio::task::JoinError>().unwrap();
+      assert!(raw_error.is_cancelled());
+    } else {
+      panic!("Should never goes here!");
+    }
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [x] No

**The PR fulfills these requirements:**
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Just invokes the tokio JoinHandle::abort():  [https://docs.rs/tokio/1.13.0/tokio/task/struct.JoinHandle.html#method.abort](https://docs.rs/tokio/1.13.0/tokio/task/struct.JoinHandle.html#method.abort)
