### PR TITLE
refactor(cli.rs): rename `init plugin` subcommand to `plugin init`

### DIFF
--- a/.changes/plugin-command.md
+++ b/.changes/plugin-command.md
@@ -2,4 +2,4 @@
 "cli.rs": patch
 ---
 
-Added `$ tauri init plugin` command, which initializes a Tauri plugin.
+Added `$ tauri plugin init` command, which initializes a Tauri plugin.

--- a/tooling/cli.rs/src/cli.yml
+++ b/tooling/cli.rs/src/cli.yml
@@ -124,7 +124,6 @@ subcommands:
               long: force
               about: Overwrite private key even if it exists on the specified path
               requires: generate
-              
   - info:
       about: Shows information about Tauri dependencies
   - init:
@@ -171,35 +170,37 @@ subcommands:
               long: dev-path
               about: Url of your dev server
               takes_value: true
+  - plugin:
+      about: Manage Tauri plugins.
       subcommands:
-        - plugin:
-            about: Initializes a Tauri plugin project.
-            args:
-                - name:
-                    short: n
-                    long: name
-                    about: Name of your Tauri plugin
-                    takes_value: true
-                    required: true
-                - directory:
-                    short: d
-                    long: directory
-                    about: Set target directory for init
-                    takes_value: true
-                - tauri-path:
-                    short: t
-                    long: tauri-path
-                    about: Path of the Tauri project to use (relative to the cwd)
-                    takes_value: true
-                - api:
-                    short: a
-                    long: api
-                    about: Initializes a Tauri plugin with TypeScript API.
-                - author:
-                    long: author
-                    about: Author name.
-                    takes_value: true
-                - tauri:
-                    long: tauri
-                    about: Initializes a Tauri core plugin (internal usage).
-                    setting: Hidden
+          - init:
+              about: Initializes a Tauri plugin project.
+              args:
+                  - name:
+                      short: n
+                      long: name
+                      about: Name of your Tauri plugin
+                      takes_value: true
+                      required: true
+                  - directory:
+                      short: d
+                      long: directory
+                      about: Set target directory for init
+                      takes_value: true
+                  - tauri-path:
+                      short: t
+                      long: tauri-path
+                      about: Path of the Tauri project to use (relative to the cwd)
+                      takes_value: true
+                  - api:
+                      short: a
+                      long: api
+                      about: Initializes a Tauri plugin with TypeScript API.
+                  - author:
+                      long: author
+                      about: Author name.
+                      takes_value: true
+                  - tauri:
+                      long: tauri
+                      about: Initializes a Tauri core plugin (internal usage).
+                      setting: Hidden

--- a/tooling/cli.rs/src/main.rs
+++ b/tooling/cli.rs/src/main.rs
@@ -58,40 +58,44 @@ macro_rules! value_or_prompt {
 }
 
 fn plugin_command(matches: &ArgMatches) -> Result<()> {
-  let api = matches.is_present("api");
-  let plugin_name = matches.value_of("name").expect("name is required");
-  let directory = matches.value_of("directory");
-  let tauri_path = matches.value_of("tauri-path");
-  let tauri = matches.is_present("tauri");
-  let author = matches
-    .value_of("author")
-    .map(|p| p.to_string())
-    .unwrap_or_else(|| {
-      if tauri {
-        "Tauri Programme within The Commons Conservancy".into()
-      } else {
-        "You".into()
-      }
-    });
+  if let Some(matches) = matches.subcommand_matches("init") {
+    let api = matches.is_present("api");
+    let plugin_name = matches.value_of("name").expect("name is required");
+    let directory = matches.value_of("directory");
+    let tauri_path = matches.value_of("tauri-path");
+    let tauri = matches.is_present("tauri");
+    let author = matches
+      .value_of("author")
+      .map(|p| p.to_string())
+      .unwrap_or_else(|| {
+        if tauri {
+          "Tauri Programme within The Commons Conservancy".into()
+        } else {
+          "You".into()
+        }
+      });
 
-  let mut plugin_runner = plugin::Plugin::new()
-    .plugin_name(plugin_name.to_string())
-    .author(author);
+    let mut plugin_runner = plugin::Plugin::new()
+      .plugin_name(plugin_name.to_string())
+      .author(author);
 
-  if api {
-    plugin_runner = plugin_runner.api();
-  }
-  if tauri {
-    plugin_runner = plugin_runner.tauri();
-  }
-  if let Some(directory) = directory {
-    plugin_runner = plugin_runner.directory(directory);
-  }
-  if let Some(tauri_path) = tauri_path {
-    plugin_runner = plugin_runner.tauri_path(tauri_path);
-  }
+    if api {
+      plugin_runner = plugin_runner.api();
+    }
+    if tauri {
+      plugin_runner = plugin_runner.tauri();
+    }
+    if let Some(directory) = directory {
+      plugin_runner = plugin_runner.directory(directory);
+    }
+    if let Some(tauri_path) = tauri_path {
+      plugin_runner = plugin_runner.tauri_path(tauri_path);
+    }
 
-  plugin_runner.run()
+    plugin_runner.run()
+  } else {
+    Ok(())
+  }
 }
 
 fn init_command(matches: &ArgMatches) -> Result<()> {
@@ -308,11 +312,9 @@ fn main() -> Result<()> {
   let matches = app.get_matches();
 
   if let Some(matches) = matches.subcommand_matches("init") {
-    if let Some(matches) = matches.subcommand_matches("plugin") {
-      plugin_command(matches)?;
-    } else {
-      init_command(matches)?;
-    }
+    init_command(matches)?;
+  } else if let Some(matches) = matches.subcommand_matches("plugin") {
+    plugin_command(matches)?;
   } else if let Some(matches) = matches.subcommand_matches("dev") {
     dev_command(matches)?;
   } else if let Some(matches) = matches.subcommand_matches("build") {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
