### PR TITLE
fix(tauri-build): allow user to specify win sdk path (fix: #2871)

### DIFF
--- a/.changes/build-specify-win-sdk.md
+++ b/.changes/build-specify-win-sdk.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch
+---
+
+Allow user to specify windows sdk path in build.rs.

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -30,7 +30,7 @@ impl Default for WindowsAttributes {
   fn default() -> Self {
     Self {
       window_icon_path: PathBuf::from("icons/icon.ico"),
-      sdk_dir: None
+      sdk_dir: None,
     }
   }
 }
@@ -128,7 +128,9 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
         if let Some(sdk_dir_str) = sdk_dir.to_str() {
           res.set_toolkit_path(sdk_dir_str);
         } else {
-          return Err(anyhow!("sdk_dir path is not valid; only UTF-8 characters are allowed"));
+          return Err(anyhow!(
+            "sdk_dir path is not valid; only UTF-8 characters are allowed"
+          ));
         }
       }
       if let Some(version) = &config.package.version {


### PR DESCRIPTION
This fixes #2871 by allowing users to pass in the sdk_path (windows only) when it can otherwise not be found.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:
This is a fix because I need this to get the builds to work on my machine. Some may consider this a new feature that allows for greater flexibility.

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No
If the new parameter is not specified, the old methods of resolving the path are taken.

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
