### PR TITLE
fix(bundler): bundle additional webkit files. patch absolute paths in libwebkit*.so files. fixes #2805,#2689

### DIFF
--- a/.changes/bundler-fix-appimage.md
+++ b/.changes/bundler-fix-appimage.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': patch
+---
+
+Fixes AppImage crashes caused by missing WebKit runtime files.

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -12,10 +12,10 @@ cp -r ../appimage_deb/data/usr "{{app_name}}.AppDir"
 
 cd "{{app_name}}.AppDir"
 
-# Copy WebKit files
-find /usr/lib* -name WebKitNetworkProcess -exec cp --parents '{}' "." \;
-find /usr/lib* -name WebKitWebProcess -exec cp --parents '{}' "." \;
-find /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec cp --parents '{}' "." \;
+# Copy WebKit files. We need to pipe errors to dev/null, so that the find
+find /usr/lib* -name WebKitNetworkProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
+find /usr/lib* -name WebKitWebProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
+find /usr/lib* -name libwebkit2gtkinjectedbundle -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
 
 wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-aarch64
 chmod +x AppRun

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -12,7 +12,7 @@ cp -r ../appimage_deb/data/usr "{{app_name}}.AppDir"
 
 cd "{{app_name}}.AppDir"
 
-# Copy WebKit files. We need to pipe errors to dev/null, so that the find
+# Copy WebKit files.
 find /usr/lib* -name WebKitNetworkProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
 find /usr/lib* -name WebKitWebProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
 find /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -12,6 +12,11 @@ cp -r ../appimage_deb/data/usr "{{app_name}}.AppDir"
 
 cd "{{app_name}}.AppDir"
 
+# Copy WebKit files
+find /usr/lib* -name WebKitNetworkProcess -exec cp --parents '{}' "." \;
+find /usr/lib* -name WebKitWebProcess -exec cp --parents '{}' "." \;
+find /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec cp --parents '{}' "." \;
+
 wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-aarch64
 chmod +x AppRun
 
@@ -22,7 +27,7 @@ ln -s "usr/share/applications/{{app_name}}.desktop" "{{app_name}}.desktop"
 
 cd ..
 
-wget -q -4 -O linuxdeploy-plugin-gtk.sh "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
+wget -q -4 -O linuxdeploy-plugin-gtk.sh "https://raw.githubusercontent.com/FabianLars/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
 wget -q -4 -O linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
 
 chmod +x linuxdeploy-plugin-gtk.sh

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -15,7 +15,7 @@ cd "{{app_name}}.AppDir"
 # Copy WebKit files. We need to pipe errors to dev/null, so that the find
 find /usr/lib* -name WebKitNetworkProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
 find /usr/lib* -name WebKitWebProcess -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
-find /usr/lib* -name libwebkit2gtkinjectedbundle -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
+find /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec mkdir -p $(dirname '{}') \; -exec cp --parents '{}' "." \; || true
 
 wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64 || wget -q -4 -O AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-aarch64
 chmod +x AppRun

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -27,7 +27,7 @@ ln -s "usr/share/applications/{{app_name}}.desktop" "{{app_name}}.desktop"
 
 cd ..
 
-wget -q -4 -O linuxdeploy-plugin-gtk.sh "https://raw.githubusercontent.com/FabianLars/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
+wget -q -4 -O linuxdeploy-plugin-gtk.sh "https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
 wget -q -4 -O linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
 
 chmod +x linuxdeploy-plugin-gtk.sh


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)
- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

### ~~This needs to be tested on different distros before being merged!~~ :white_check_mark: 
~~Speaking of testing, fedora still won't work because of those `permission denied` errors (unrelated to this PR).~~
^Fixed this in the linuxdeploy plugin linked below.

I'm not sure if it actually fixes #2689, but it _should_ because it looks like a version mismatch between the bundled webkit and the system's one.

This is a really ugly fix imo, but i don't really think much can be improved concept wise, but who knows 🤷 

Anyway, here goes the explanation and stuff.
Basically we had 2 problems:
1) we didn't include files that webkit needs at runtime
2) the paths of those files are hardcoded into the libwebkit*.so file (hardcoded paths are a big no-no in AppImages).

The first issue's fix is pretty easy but also somewhat risky as we have to _search_ for those files as each distro stores them somewhere else. That's the main reason why we need more testing, who knows what absurd paths are out there in the wild...
- for example:
  - ubuntu: `WebKitNetworkProcess`, `WebKitWebProcess` and `injected-bundle/libwebkit2gtkinjectedbundle.so` in `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.0/` 
  - fedora: `WebKitNetworkProcess` and `WebKitWebProcess` in `usr/libexec/webkit2gtk-4.0/` and `libwebkit2gtkinjectedbundle.so` in `/usr/lib64/webkit2gtk-4.0/injected-bundle/`
The injectedbundle file doesn't seem to be needed as far as i can see, but it will log an error at launch (without crashing) so probably better to just include it.

The fork of linuxdeploy-plugin-gtk is needed because this plugin will overwrite the libwebkit*.so files and therefore we can't patch those files in `template/appimage.sh`. -> This one took me too long to notice...

Link to the change: https://github.com/FabianLars/linuxdeploy-plugin-gtk/blob/master/linuxdeploy-plugin-gtk.sh#L330
And yes we have to glob pattern match the file and folder names again because they seem to differ between distros too 😒 

We can also move the fork to the tauri org, i don't really care, but i don't expect such a change to make it into upstream at all.
Furthermore i won't even try to get something like this into webkit itself, that's no bueno for my mental health lol.

## Update 1
1. We now use mkdir to create the folders before copying to make them writable. Otherwise only the first file will be copied.
2. The `find` command can throw "permission denied" errors on protected folders. Normally, this would be fine as it just continues after throwing them. In this case we need to add `|| true` to not trigger the `set -euxo pipefail` guard. Unfortunately this will skip the exit on other errors from these commands too, so we can still end up with broken AppImages after a "successful" script execution, but at least they will be logged when invoked with `--verbose`.

## Update 2
Fixed the `os error 13` in the gtk plugin which crashed the appimage script on fedora (and probably on other distros too).
This also fixes the appimage folder being undeletable on the following runs which also crashed the bundler but even earlier.

## Update 3
Test results are coming in, check comment down below.

## How to test
0. (Optional) Clone the fork and run the examples instead of step 1&2
1. Install the rust based cli from the fork: `cargo install tauri-cli --force --git https://github.com/FabianLars/tauri --branch fix/appimage` -> remember to revert/remove this afterwards :)
2. Use `cargo tauri build` to build your project, the npm/yarn command won't work. (You may need to use tauri's next branch)
3. Copy the AppImage to another system (needs to be another distro or at least another version). Alternatively you could temporarily rename the above mentioned files if you find them.