### PR TITLE
fix(cli.js): Fix package installation on yarn 2+

### DIFF
--- a/.changes/fix-yarn-pnp.md
+++ b/.changes/fix-yarn-pnp.md
@@ -1,0 +1,5 @@
+---
+"cli.js": patch
+---
+
+Automatically unplug `@tauri-apps/cli` in yarn 2+ installations to fix the download of the rust-cli.

--- a/tooling/cli.js/package.json
+++ b/tooling/cli.js/package.json
@@ -16,6 +16,7 @@
     "url": "https://opencollective.com/tauri"
   },
   "scripts": {
+    "postinstall": "",
     "build": "rimraf ./dist && rollup -c --silent",
     "build-release": "rimraf ./dist && cross-env NODE_ENV=production rollup -c",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand --forceExit --no-cache --testPathIgnorePatterns=\"(build|dev)\"",


### PR DESCRIPTION
Yarn 2+ uses pnp by default. This makes installed npm packages read-only by default. This will obviously break the rust-cli download. To fix this we need yarn to `unplug` our cli. We can either tell the user to do that after each installation (lol no) or tell yarn to do it automatically by specifying a "postinstall" script. This script can be empty too so we don't have to go through the hassle of rewriting our download script to actually happen at postinstall time. Who knows what new issues this will create 😅

In theory this would close some gh issues, but they are already closed lol.

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)