### PR TITLE
fix(core): streaming of small files using `asset://`, closes #2854

### DIFF
--- a/.changes/streaming-small-file-fix.md
+++ b/.changes/streaming-small-file-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fix streaming of small files using the `asset` protocol.

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -336,7 +336,7 @@ impl<R: Runtime> WindowManager<R> {
               if range.length > file_size / 3 {
                 // max size sent (400ko / request)
                 // as it's local file system we can afford to read more often
-                real_length = 1024 * 400;
+                real_length = std::cmp::min(file_size - range.start, 1024 * 400);
               }
 
               // last byte we are reading, the length of the range include the last byte

--- a/examples/streaming/src-tauri/src/main.rs
+++ b/examples/streaming/src-tauri/src/main.rs
@@ -9,6 +9,7 @@
 
 fn main() {
   use std::{
+    cmp::min,
     io::{Read, Seek, SeekFrom},
     path::PathBuf,
     process::{Command, Stdio},
@@ -74,7 +75,7 @@ fn main() {
           if range.length > file_size / 3 {
             // max size sent (400ko / request)
             // as it's local file system we can afford to read more often
-            real_length = 1024 * 400;
+            real_length = min(file_size - range.start, 1024 * 400);
           }
 
           // last byte we are reading, the length of the range include the last byte

--- a/tooling/api/src/tauri.ts
+++ b/tooling/api/src/tauri.ts
@@ -96,7 +96,7 @@ async function invoke<T>(cmd: string, args: InvokeArgs = {}): Promise<T> {
  * Convert a device file path to an URL that can be loaded by the webview.
  * Note that `asset:` must be allowed on the `csp` value configured on `tauri.conf.json`.
  *
- * @param  filePath the file path. On Windows, the drive name must be omitted, i.e. using `/Users/user/file.png` instead of `C:/Users/user/file.png`.
+ * @param  filePath the file path.
  *
  * @return the URL that can be used as source on the webview
  */


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
