### PR TITLE
temporarily pin clap version

### DIFF
--- a/tooling/cli.rs/Cargo.toml
+++ b/tooling/cli.rs/Cargo.toml
@@ -18,7 +18,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "3.0.0-beta.5", features = [ "yaml" ] }
+clap = { version = "=3.0.0-beta.5", features = [ "yaml" ] }
 anyhow = "1.0"
 tauri-bundler = { version = "1.0.0-beta.4", path = "../bundler" }
 colored = "2.0"


### PR DESCRIPTION
For whatever reason, cargo resolves beta.5 to rc.0 (it didn't do that between beta releases). This breaks both the released cli and the `next` version ~~mainly because they completely removed the yaml api~~.
~~So if we rewrite the cli to use the builder or derive api soon enough, then~~ i don't expect this to be merged, but at least i can tell users with this problem to install the cli from this branch instead.

Edit: Nevermind they only deprecated the yaml feature for now. I'll take a look on what they changed that breaks our cli.

Edit2 (from discord): "tbf the fixes are pretty easy (another feature flag for macros, App::from -> App::from_yaml, arg.hidden -> arg.hide), but i don't know if it's worth it if the yaml api is supposedly so bad (<https://github.com/clap-rs/clap/issues/3087>)"

####

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)