### PR TITLE
doc(api) XDG user dirs are not env vars, fix: #3090

### DIFF
--- a/tooling/api/src/path.ts
+++ b/tooling/api/src/path.ts
@@ -49,7 +49,7 @@ async function appDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux:** Resolves to `$XDG_MUSIC_DIR`.
+ * - **Linux:** Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_MUSIC_DIR`.
  * - **macOS:** Resolves to `$HOME/Music`.
  * - **Windows:** Resolves to `{FOLDERID_Music}`.
  *
@@ -137,7 +137,7 @@ async function dataDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux:** Resolves to `$XDG_DESKTOP_DIR`.
+ * - **Linux:** Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_DESKTOP_DIR`.
  * - **macOS:** Resolves to `$HOME/Library/Desktop`.
  * - **Windows:** Resolves to `{FOLDERID_Desktop}`.
 
@@ -159,7 +159,7 @@ async function desktopDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux:** Resolves to `$XDG_DOCUMENTS_DIR`.
+ * - **Linux:** Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_DOCUMENTS_DIR`.
  * - **macOS:** Resolves to `$HOME/Documents`.
  * - **Windows:** Resolves to `{FOLDERID_Documents}`.
  *
@@ -181,7 +181,7 @@ async function documentDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux**: Resolves to `$XDG_DOWNLOAD_DIR`.
+ * - **Linux**: Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_DOWNLOAD_DIR`.
  * - **macOS**: Resolves to `$HOME/Downloads`.
  * - **Windows**: Resolves to `{FOLDERID_Downloads}`.
  *
@@ -291,7 +291,7 @@ async function localDataDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux:** Resolves to `$XDG_PICTURES_DIR`.
+ * - **Linux:** Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_PICTURES_DIR`.
  * - **macOS:** Resolves to `$HOME/Pictures`.
  * - **Windows:** Resolves to `{FOLDERID_Pictures}`.
  *
@@ -313,7 +313,7 @@ async function pictureDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux:** Resolves to `$XDG_PUBLICSHARE_DIR`.
+ * - **Linux:** Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_PUBLICSHARE_DIR`.
  * - **macOS:** Resolves to `$HOME/Public`.
  * - **Windows:** Resolves to `{FOLDERID_Public}`.
  *
@@ -373,7 +373,7 @@ async function runtimeDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux:** Resolves to `$XDG_TEMPLATES_DIR`.
+ * - **Linux:** Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_TEMPLATES_DIR`.
  * - **macOS:** Not supported.
  * - **Windows:** Resolves to `{FOLDERID_Templates}`.
  *
@@ -395,7 +395,7 @@ async function templateDir(): Promise<string> {
  *
  * #### Platform-specific
  *
- * - **Linux:** Resolves to `$XDG_VIDEOS_DIR`.
+ * - **Linux:** Resolves to [`xdg-user-dirs`](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)' `XDG_VIDEOS_DIR`.
  * - **macOS:** Resolves to `$HOME/Movies`.
  * - **Windows:** Resolves to `{FOLDERID_Videos}`.
  *


### PR DESCRIPTION
This commit points the docs on `path.downloadDir` for XDG_DOWNLOAD_DIR
on Linux, and similar XDG user dirs, at the `xdg-user-dirs` program for
more information, and fixes that they currently imply these are
environment variables; which they a) are unfortunately not by any sort
of standard; b) such env vars are ignored by `dirs-next` which tauri
uses for resolving them.

This does not address the issue of
`${XDG_CONFIG_HOME:-$HOME/.config}/user-dirs.dir` needing to already
exist and contain the appropriate key for this to work (i.e. they do not
default to `$HOME` as the output of `xdg-user-dir` does) - because that
IMO is a shortcoming of `dirs-next` and is better addressed there.

Closes #3090

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)
<!--
If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.
-->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [x] No


**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
