### PR TITLE
Menu revamp, closes #2807

### DIFF
--- a/.changes/menu-revamp.md
+++ b/.changes/menu-revamp.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime": major
+"tauri": major
+---
+
+Revamp the menu / tray API.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -9,7 +9,7 @@ use tauri_runtime::{
     Request as HttpRequest, RequestParts as HttpRequestParts, Response as HttpResponse,
     ResponseParts as HttpResponseParts,
   },
-  menu::{CustomMenuItem, Menu, MenuEntry, MenuHash, MenuId, MenuItem, MenuUpdate},
+  menu::{CustomMenuItem, Menu, MenuHash, MenuId, MenuItem, MenuUpdate},
   monitor::Monitor,
   webview::{
     FileDropEvent, FileDropHandler, RpcRequest, WebviewRpcHandler, WindowBuilder, WindowBuilderBase,
@@ -2492,7 +2492,7 @@ fn to_wry_menu(
   let mut wry_menu = MenuBar::new();
   for item in menu.items {
     match item {
-      MenuEntry::CustomItem(c) => {
+      MenuItem::Custom(c) => {
         let mut attributes = MenuItemAttributesWrapper::from(&c).0;
         attributes = attributes.with_id(WryMenuId(c.id));
         #[allow(unused_mut)]
@@ -2503,15 +2503,15 @@ fn to_wry_menu(
         }
         custom_menu_items.insert(c.id, item);
       }
-      MenuEntry::NativeItem(i) => {
-        wry_menu.add_native_item(MenuItemWrapper::from(i).0);
-      }
-      MenuEntry::Submenu(submenu) => {
+      MenuItem::Submenu(submenu) => {
         wry_menu.add_submenu(
           &submenu.title,
           submenu.enabled,
           to_wry_menu(custom_menu_items, submenu.inner),
         );
+      }
+      i => {
+        wry_menu.add_native_item(MenuItemWrapper::from(i).0);
       }
     }
   }

--- a/core/tauri-runtime-wry/src/system_tray.rs
+++ b/core/tauri-runtime-wry/src/system_tray.rs
@@ -3,10 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 pub use tauri_runtime::{
-  menu::{
-    Menu, MenuEntry, MenuItem, MenuUpdate, Submenu, SystemTrayMenu, SystemTrayMenuEntry,
-    SystemTrayMenuItem, TrayHandle,
-  },
+  menu::{Menu, MenuItem, MenuUpdate, Submenu, SystemTrayMenu, SystemTrayMenuItem, TrayHandle},
   Icon, SystemTrayEvent,
 };
 pub use wry::application::{
@@ -86,7 +83,7 @@ pub fn to_wry_context_menu(
   let mut tray_menu = WryContextMenu::new();
   for item in menu.items {
     match item {
-      SystemTrayMenuEntry::CustomItem(c) => {
+      SystemTrayMenuItem::Custom(c) => {
         #[allow(unused_mut)]
         let mut item = tray_menu.add_item(crate::MenuItemAttributesWrapper::from(&c).0);
         #[cfg(target_os = "macos")]
@@ -95,15 +92,15 @@ pub fn to_wry_context_menu(
         }
         custom_menu_items.insert(c.id, item);
       }
-      SystemTrayMenuEntry::NativeItem(i) => {
-        tray_menu.add_native_item(crate::MenuItemWrapper::from(i).0);
-      }
-      SystemTrayMenuEntry::Submenu(submenu) => {
+      SystemTrayMenuItem::Submenu(submenu) => {
         tray_menu.add_submenu(
           &submenu.title,
           submenu.enabled,
           to_wry_context_menu(custom_menu_items, submenu.inner),
         );
+      }
+      i => {
+        tray_menu.add_native_item(crate::MenuItemWrapper::from(i).0);
       }
     }
   }

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -74,6 +74,27 @@ impl SystemTray {
     self.menu.replace(menu);
     self
   }
+
+  /// Create a new system tray with the given menu items
+  ///
+  /// # Example
+  /// ```
+  /// # use tauri_runtime::menu::{Menu, MenuItem, CustomMenuItem, Submenu};
+  /// SystemTray::with_menu_items([
+  ///   MenuItem::SelectAll,
+  ///   #[cfg(target_os = "macos")]
+  ///   MenuItem::Redo,
+  ///   CustomMenuItem::new("toggle", "Toggle visibility").into(),
+  ///   MenuItem::new_submenu("View", []),
+  /// ]);
+  /// ```
+  pub fn with_menu_items<I>(mut self, items: I) -> Self
+  where
+    I: IntoIterator<Item = menu::SystemTrayMenuItem>,
+  {
+    self.menu.replace(menu::SystemTrayMenu::with_items(items));
+    self
+  }
 }
 
 /// Type of user attention requested on a window.

--- a/core/tauri-runtime/src/menu.rs
+++ b/core/tauri-runtime/src/menu.rs
@@ -326,11 +326,23 @@ pub enum SystemTrayMenuItem {
   /// A custom item.
   Custom(CustomMenuItem),
 
-  /// An entry with submenu.
+  /// An item with a submenu.
   Submenu(SystemTraySubmenu),
 
   /// A separator.
   Separator,
+}
+
+impl From<CustomMenuItem> for SystemTrayMenuItem {
+  fn from(item: CustomMenuItem) -> Self {
+    Self::Custom(item)
+  }
+}
+
+impl From<SystemTraySubmenu> for SystemTrayMenuItem {
+  fn from(submenu: SystemTraySubmenu) -> Self {
+    Self::Submenu(submenu)
+  }
 }
 
 /// A menu item, bound to a pre-defined action or `Custom` emit an event. Note that status bar only
@@ -342,7 +354,7 @@ pub enum MenuItem {
   /// A custom item.
   Custom(CustomMenuItem),
 
-  /// An item with submenu.
+  /// An item with a submenu.
   Submenu(Submenu),
 
   /// Shows a standard "About" item
@@ -517,3 +529,14 @@ impl MenuItem {
   }
 }
 
+impl From<CustomMenuItem> for MenuItem {
+  fn from(item: CustomMenuItem) -> Self {
+    Self::Custom(item)
+  }
+}
+
+impl From<Submenu> for MenuItem {
+  fn from(submenu: Submenu) -> Self {
+    Self::Submenu(submenu)
+  }
+}

--- a/core/tauri-runtime/src/menu.rs
+++ b/core/tauri-runtime/src/menu.rs
@@ -371,6 +371,41 @@ pub enum SystemTrayMenuItem {
   Separator,
 }
 
+impl SystemTrayMenuItem {
+  /// Shorthand for creating a new `SystemTrayMenuItem::Submenu` that contains a submenu.
+  ///
+  /// The following are equivalent:
+  /// ```
+  /// # use tauri_runtime::menu::{Menu, SystemTrayMenuItem, Submenu};
+  /// SystemTrayMenuItem::new_submenu("File", [MenuItem::Separator]);
+  /// SystemTrayMenuItem::Submenu(Submenu::new("File", Menu::new([SystemTrayMenuItem::Separator])));
+  /// ```
+  ///
+  /// # Example
+  /// ```
+  /// # use tauri_runtime::menu::{Menu, SystemTrayMenuItem, CustomMenuItem, Submenu};
+  /// SystemTrayMenuItem::new_submenu(
+  ///   "File",
+  ///   [
+  ///     CustomMenuItem::new("toggle", "Toggle visibility").into(),
+  ///     #[cfg(target_os = "macos")]
+  ///     MenuItem::Separator,
+  ///     MenuItem::new_submenu("View", []),
+  ///   ]
+  /// );
+  /// ```
+  pub fn new_submenu<S, I>(title: S, items: I) -> Self
+  where
+    S: Into<String>,
+    I: IntoIterator<Item = SystemTrayMenuItem>,
+  {
+    Self::Submenu(SystemTraySubmenu::new(
+      title,
+      SystemTrayMenu::with_items(items),
+    ))
+  }
+}
+
 impl From<CustomMenuItem> for SystemTrayMenuItem {
   fn from(item: CustomMenuItem) -> Self {
     Self::Custom(item)

--- a/core/tauri-runtime/src/menu.rs
+++ b/core/tauri-runtime/src/menu.rs
@@ -186,6 +186,25 @@ impl Menu {
     Default::default()
   }
 
+  /// Creates a new window menu with the given menu items.
+  ///
+  /// # Example
+  /// ```
+  /// # use tauri_runtime::menu::{Menu, MenuItem, CustomMenuItem, Submenu};
+  /// Menu::new([
+  ///   MenuItem::SelectAll,
+  ///   #[cfg(target_os = "macos")]
+  ///   MenuItem::Redo,
+  ///   CustomMenuItem::new("toggle", "Toggle visibility").into(),
+  ///   MenuItem::new_submenu("View", []),
+  /// ]);
+  /// ```
+  pub fn with_items<I: IntoIterator<Item = MenuItem>>(items: I) -> Self {
+    Self {
+      items: items.into_iter().collect(),
+    }
+  }
+
   /// Adds the custom menu item to the menu.
   pub fn add_item(mut self, item: CustomMenuItem) -> Self {
     self.items.push(MenuItem::Custom(item));
@@ -298,6 +317,25 @@ impl SystemTrayMenu {
   /// Creates a new system tray menu.
   pub fn new() -> Self {
     Default::default()
+  }
+
+  /// Creates a new system tray menu with the given menu items.
+  ///
+  /// # Example
+  /// ```
+  /// # use tauri_runtime::menu::{Menu, MenuItem, CustomMenuItem, Submenu};
+  /// Menu::new([
+  ///   MenuItem::SelectAll.into(),
+  ///   #[cfg(target_os = "macos")]
+  ///   MenuItem::Redo,
+  ///   CustomMenuItem::new("toggle", "Toggle visibility").into(),
+  ///   Submenu::new("View", Menu::new([])).into(),
+  /// ]);
+  /// ```
+  pub fn with_items<I: IntoIterator<Item = SystemTrayMenuItem>>(items: I) -> Self {
+    Self {
+      items: items.into_iter().collect(),
+    }
   }
 
   /// Adds the custom menu item to the system tray menu.
@@ -514,7 +552,7 @@ impl MenuItem {
   ///   [
   ///     MenuItem::SelectAll,
   ///     #[cfg(target_os = "macos")]
-  ///     MenuItem::Redo.into(),
+  ///     MenuItem::Redo,
   ///     CustomMenuItem::new("toggle", "Toggle visibility").into(),
   ///     MenuItem::new_submenu("View", []),
   ///   ]
@@ -525,7 +563,7 @@ impl MenuItem {
     S: Into<String>,
     I: IntoIterator<Item = MenuItem>,
   {
-    Self::Submenu(Submenu::new(title, Menu::new(items)))
+    Self::Submenu(Submenu::new(title, Menu::with_items(items)))
   }
 }
 

--- a/core/tauri-runtime/src/menu.rs
+++ b/core/tauri-runtime/src/menu.rs
@@ -483,3 +483,37 @@ pub enum MenuItem {
   ///
   Separator,
 }
+
+impl MenuItem {
+  /// Shorthand for creating a new `MenuItem::Submenu` that contains a submenu.
+  ///
+  /// The following are equivalent:
+  /// ```
+  /// # use tauri_runtime::menu::{Menu, MenuItem, Submenu};
+  /// MenuItem::new_submenu("File", [MenuItem::Undo]);
+  /// MenuItem::Submenu(Submenu::new("File", Menu::new([MenuItem::Undo])));
+  /// ```
+  ///
+  /// # Example
+  /// ```
+  /// # use tauri_runtime::menu::{Menu, MenuItem, CustomMenuItem, Submenu};
+  /// MenuItem::new_submenu(
+  ///   "File",
+  ///   [
+  ///     MenuItem::SelectAll,
+  ///     #[cfg(target_os = "macos")]
+  ///     MenuItem::Redo.into(),
+  ///     CustomMenuItem::new("toggle", "Toggle visibility").into(),
+  ///     MenuItem::new_submenu("View", []),
+  ///   ]
+  /// );
+  /// ```
+  pub fn new_submenu<S, I>(title: S, items: I) -> Self
+  where
+    S: Into<String>,
+    I: IntoIterator<Item = MenuItem>,
+  {
+    Self::Submenu(Submenu::new(title, Menu::new(items)))
+  }
+}
+

--- a/core/tauri-runtime/src/menu.rs
+++ b/core/tauri-runtime/src/menu.rs
@@ -158,7 +158,7 @@ pub trait TrayHandle: fmt::Debug {
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct Menu {
-  pub items: Vec<MenuEntry>,
+  pub items: Vec<MenuItem>,
 }
 
 #[derive(Debug, Clone)]
@@ -188,19 +188,19 @@ impl Menu {
 
   /// Adds the custom menu item to the menu.
   pub fn add_item(mut self, item: CustomMenuItem) -> Self {
-    self.items.push(MenuEntry::CustomItem(item));
+    self.items.push(MenuItem::Custom(item));
     self
   }
 
   /// Adds a native item to the menu.
   pub fn add_native_item(mut self, item: MenuItem) -> Self {
-    self.items.push(MenuEntry::NativeItem(item));
+    self.items.push(item);
     self
   }
 
   /// Adds an entry with submenu.
   pub fn add_submenu(mut self, submenu: Submenu) -> Self {
-    self.items.push(MenuEntry::Submenu(submenu));
+    self.items.push(MenuItem::Submenu(submenu));
     self
   }
 }
@@ -272,7 +272,7 @@ impl CustomMenuItem {
 #[derive(Debug, Default, Clone)]
 #[non_exhaustive]
 pub struct SystemTrayMenu {
-  pub items: Vec<SystemTrayMenuEntry>,
+  pub items: Vec<SystemTrayMenuItem>,
 }
 
 #[derive(Debug, Clone)]
@@ -302,51 +302,35 @@ impl SystemTrayMenu {
 
   /// Adds the custom menu item to the system tray menu.
   pub fn add_item(mut self, item: CustomMenuItem) -> Self {
-    self.items.push(SystemTrayMenuEntry::CustomItem(item));
+    self.items.push(SystemTrayMenuItem::Custom(item));
     self
   }
 
   /// Adds a native item to the system tray menu.
   pub fn add_native_item(mut self, item: SystemTrayMenuItem) -> Self {
-    self.items.push(SystemTrayMenuEntry::NativeItem(item));
+    self.items.push(item);
     self
   }
 
   /// Adds an entry with submenu.
   pub fn add_submenu(mut self, submenu: SystemTraySubmenu) -> Self {
-    self.items.push(SystemTrayMenuEntry::Submenu(submenu));
+    self.items.push(SystemTrayMenuItem::Submenu(submenu));
     self
   }
-}
-
-/// An entry on the system tray menu.
-#[derive(Debug, Clone)]
-pub enum SystemTrayMenuEntry {
-  /// A custom item.
-  CustomItem(CustomMenuItem),
-  /// A native item.
-  NativeItem(SystemTrayMenuItem),
-  /// An entry with submenu.
-  Submenu(SystemTraySubmenu),
 }
 
 /// System tray menu item.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum SystemTrayMenuItem {
+  /// A custom item.
+  Custom(CustomMenuItem),
+
+  /// An entry with submenu.
+  Submenu(SystemTraySubmenu),
+
   /// A separator.
   Separator,
-}
-
-/// An entry on the system tray menu.
-#[derive(Debug, Clone)]
-pub enum MenuEntry {
-  /// A custom item.
-  CustomItem(CustomMenuItem),
-  /// A native item.
-  NativeItem(MenuItem),
-  /// An entry with submenu.
-  Submenu(Submenu),
 }
 
 /// A menu item, bound to a pre-defined action or `Custom` emit an event. Note that status bar only
@@ -355,6 +339,12 @@ pub enum MenuEntry {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MenuItem {
+  /// A custom item.
+  Custom(CustomMenuItem),
+
+  /// An item with submenu.
+  Submenu(Submenu),
+
   /// Shows a standard "About" item
   ///
   /// ## Platform-specific

--- a/core/tauri-runtime/src/window.rs
+++ b/core/tauri-runtime/src/window.rs
@@ -6,7 +6,7 @@
 
 use crate::{
   http::{Request as HttpRequest, Response as HttpResponse},
-  menu::{Menu, MenuEntry, MenuHash, MenuId},
+  menu::{Menu, MenuHash, MenuId, MenuItem},
   webview::{FileDropHandler, WebviewAttributes, WebviewRpcHandler},
   Dispatch, Runtime, WindowBuilder,
 };
@@ -66,10 +66,10 @@ pub struct MenuEvent {
 fn get_menu_ids(map: &mut HashMap<MenuHash, MenuId>, menu: &Menu) {
   for item in &menu.items {
     match item {
-      MenuEntry::CustomItem(c) => {
+      MenuItem::Custom(c) => {
         map.insert(c.id, c.id_str.clone());
       }
-      MenuEntry::Submenu(s) => get_menu_ids(map, &s.inner),
+      MenuItem::Submenu(s) => get_menu_ids(map, &s.inner),
       _ => {}
     }
   }

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -147,6 +147,10 @@ name = "helloworld"
 path = "../../examples/helloworld/src-tauri/src/main.rs"
 
 [[example]]
+name = "api"
+path = "../../examples/api/src-tauri/src/main.rs"
+
+[[example]]
 name = "multiwindow"
 path = "../../examples/multiwindow/src-tauri/src/main.rs"
 

--- a/core/tauri/src/app/tray.rs
+++ b/core/tauri/src/app/tray.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 pub use crate::runtime::{
-  menu::{
-    MenuHash, MenuId, MenuIdRef, MenuUpdate, SystemTrayMenu, SystemTrayMenuEntry, TrayHandle,
-  },
+  menu::{MenuHash, MenuId, MenuIdRef, MenuUpdate, SystemTrayMenu, SystemTrayMenuItem, TrayHandle},
   window::dpi::{PhysicalPosition, PhysicalSize},
   Icon, Runtime, SystemTray,
 };
@@ -17,10 +15,10 @@ use std::{collections::HashMap, sync::Arc};
 pub(crate) fn get_menu_ids(map: &mut HashMap<MenuHash, MenuId>, menu: &SystemTrayMenu) {
   for item in &menu.items {
     match item {
-      SystemTrayMenuEntry::CustomItem(c) => {
+      SystemTrayMenuItem::Custom(c) => {
         map.insert(c.id, c.id_str.clone());
       }
-      SystemTrayMenuEntry::Submenu(s) => get_menu_ids(map, &s.inner),
+      SystemTrayMenuItem::Submenu(s) => get_menu_ids(map, &s.inner),
       _ => {}
     }
   }

--- a/docs/usage/guides/visual/menu.md
+++ b/docs/usage/guides/visual/menu.md
@@ -15,16 +15,32 @@ use tauri::{CustomMenuItem, Menu, MenuItem, Submenu};
 ```
 
 Create a `Menu` instance:
-
 ```rust
-// here `"quit".to_string()` defines the menu item id, and the second parameter is the menu item label.
-let quit = CustomMenuItem::new("quit".to_string(), "Quit");
-let close = CustomMenuItem::new("close".to_string(), "Close");
-let submenu = Submenu::new("File", Menu::new().add_item(quit).add_item(close));
-let menu = Menu::new()
-  .add_native_item(MenuItem::Copy)
-  .add_item(CustomMenuItem::new("hide", "Hide"))
-  .add_submenu(submenu);
+// here `"quit"` defines the menu item id, and `"Quit"` is the label.
+let quit = CustomMenuItem::new("quit", "Quit");
+let close = CustomMenuItem::new("close", "Close");
+let menu = Menu::with_items([
+  MenuItem::Copy,
+  MenuItem::Custom(CustomMenuItem::new("hide", "Hide")),
+  MenuItem::Submenu(Submenu::new("File", Menu::with_items([
+    MenuItem::Custom(quit),
+    MenuItem::Custom(close),
+  ])))
+])
+```
+
+The above is a bit much, so you can create the `Menu` more conveniently like this:
+```rust
+let menu = Menu::with_items([
+  MenuItem::Copy,
+  // `.into()` converts into `MenuItem`
+  CustomMenuItem::new("hide", "Hide").into(),
+  // `new_submenu()` returns `MenuItem`
+  MenuItem::new_submenu("File", [
+    quit.into(),
+    close.into(),
+  ]),
+])
 ```
 
 ### Adding the menu to all windows

--- a/docs/usage/guides/visual/system-tray.md
+++ b/docs/usage/guides/visual/system-tray.md
@@ -40,7 +40,7 @@ let tray = SystemTray::new();
 
 ### Configuring a system tray context menu
 
-Optionally you can add a context menu that is visible when the tray icon is right clicked. Import the `SystemTrayMenu`, `SystemTrayMenuItem` and `CustomMenuItem` types:
+Optionally you can add a context menu to the tray icon. On Windows/Linux, the menu is shown when the tray icon is right clicked, and on macOS when it's left clicked. Import the `SystemTrayMenu`, `SystemTrayMenuItem` and `CustomMenuItem` types:
 
 ```rust
 use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem};
@@ -49,13 +49,15 @@ use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem};
 Create the `SystemTrayMenu`:
 
 ```rust
-// here `"quit".to_string()` defines the menu item id, and the second parameter is the menu item label.
-let quit = CustomMenuItem::new("quit".to_string(), "Quit");
-let hide = CustomMenuItem::new("hide".to_string(), "Hide");
-let tray_menu = SystemTrayMenu::new()
-  .add_item(quit)
-  .add_native_item(SystemTrayMenuItem::Separator)
-  .add_item(hide);
+// here `"quit"` defines the menu item id, and `"Quit"` is the label.
+let quit = CustomMenuItem::new("quit", "Quit");
+let hide = CustomMenuItem::new("hide", "Hide");
+let tray_menu = SystemTrayMenu::with_items([
+  // `quit.into()` is an alternative to `SystemTrayMenuItem::Custom(quit)`
+  quit.into(),
+  SystemTrayMenuItem::Separator,
+  hide.into(),
+])
 ```
 
 Add the tray menu to the `SystemTray` instance:
@@ -72,9 +74,8 @@ The created `SystemTray` instance can be set using the `system_tray` API on the 
 use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu};
 
 fn main() {
-  let tray_menu = SystemTrayMenu::new(); // insert the menu items here
-  let system_tray = SystemTray::new()
-    .with_menu(tray_menu);
+  let tray_menu = SystemTrayMenu::with_items([/* menu items here */]);
+  let system_tray = SystemTray::new().with_menu(tray_menu);
   tauri::Builder::default()
     .system_tray(system_tray)
     .run(tauri::generate_context!())
@@ -93,7 +94,7 @@ use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu};
 use tauri::Manager;
 
 fn main() {
-  let tray_menu = SystemTrayMenu::new(); // insert the menu items here
+  let tray_menu = SystemTrayMenu::with_items([/* menu items here */]);
   tauri::Builder::default()
     .system_tray(SystemTray::new().with_menu(tray_menu))
     .on_system_tray_event(|app, event| match event {
@@ -148,7 +149,7 @@ use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu};
 use tauri::Manager;
 
 fn main() {
-  let tray_menu = SystemTrayMenu::new(); // insert the menu items here
+  let tray_menu = SystemTrayMenu::with_items([/* menu items here */]);
   tauri::Builder::default()
     .system_tray(SystemTray::new().with_menu(tray_menu))
     .on_system_tray_event(|app, event| match event {

--- a/examples/api/src-tauri/src/menu.rs
+++ b/examples/api/src-tauri/src/menu.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use tauri::{CustomMenuItem, Menu, MenuItem, Submenu};
+use tauri::{CustomMenuItem, Menu, MenuItem};
 
 pub fn get_menu() -> Menu {
   #[allow(unused_mut)]
@@ -17,22 +17,20 @@ pub fn get_menu() -> Menu {
   }
 
   // create a submenu
-  let my_sub_menu = Menu::new().add_item(disable_item);
+  let my_app_menu = [
+    MenuItem::Copy,
+    MenuItem::new_submenu("Sub menu", [disable_item.into()]),
+  ];
 
-  let my_app_menu = Menu::new()
-    .add_native_item(MenuItem::Copy)
-    .add_submenu(Submenu::new("Sub menu", my_sub_menu));
-
-  let test_menu = Menu::new()
-    .add_item(CustomMenuItem::new(
-      "selected/disabled",
-      "Selected and disabled",
-    ))
-    .add_native_item(MenuItem::Separator)
-    .add_item(test_item);
+  let test_menu = [
+    CustomMenuItem::new("selected/disabled", "Selected and disabled").into(),
+    MenuItem::Separator,
+    test_item.into(),
+  ];
 
   // add all our childs to the menu (order is how they'll appear)
-  Menu::new()
-    .add_submenu(Submenu::new("My app", my_app_menu))
-    .add_submenu(Submenu::new("Other menu", test_menu))
+  Menu::with_items([
+    MenuItem::new_submenu("My app", my_app_menu),
+    MenuItem::new_submenu("Other menu", test_menu),
+  ])
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?**
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary


### Other information

⚠️ **Breaking change that needs to be decided on**:
Merges `MenuEntry` into `MenuItem`, and `SystemTrayMenuEntry` into `SystemTrayMenuItem`.
- `MenuEntry::CustomItem(CustomMenuItem)` -> `MenuItem::Custom(CustomMenuItem)`
- `MenuEntry::Submenu(Submenu)` -> `MenuItem::Submenu(Submenu)`
- `MenuEntry::NativeItem(MenuItem::Copy)` -> `MenuItem::Copy` (etc)
- Same stuff for `SystemTrayMenuItem`

New way to define menus:
```rust
let menu = Menu::with_items([
  MenuItem::Copy,
  CustomMenuItem::new("hide", "Hide").into(),
  MenuItem::new_submenu("File", [
    quit.into(),
    close.into(),
  ]),
])
```

And for tray menus:
```rust
let tray_menu = SystemTrayMenu::with_items([
  CustomMenuItem::new("hide", "Hide").into(),
  SystemTrayMenuItem::Separator,
  SystemTrayMenuItem::new_submenu(
    "Sub",
    [
      CustomMenuItem::new("hide", "Hide").into(),
    ],
  ),
])
```