### PR TITLE
Update wry rev. fixes build crash on webkit2gtk-sys compilation

### DIFF
--- a/core/tauri-runtime-wry/Cargo.toml
+++ b/core/tauri-runtime-wry/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 
 [dependencies]
 #wry = { version = "0.12", default-features = false, features = [ "file-drop", "protocol" ] }
-wry = { git = "https://github.com/tauri-apps/wry", rev = "11557f15cf759fcf3008598b684c009f03a8c645", default-features = false, features = [ "file-drop", "protocol", "transparent", "fullscreen" ] }
+wry = { git = "https://github.com/tauri-apps/wry", rev = "81e92bd2539a27cd2aa169adc6a52f4f78e00292", default-features = false, features = [ "file-drop", "protocol", "transparent", "fullscreen" ] }
 tauri-runtime = { version = "0.2.1", path = "../tauri-runtime" }
 tauri-utils = { version = "1.0.0-beta.3", path = "../tauri-utils" }
 uuid = { version = "0.8.2", features = [ "v4" ] }


### PR DESCRIPTION
The `next` branch and projects depending on it currently can't compile on linux. Using the latest wry commit, which only change is using the updated webkit2gtk(-sys) crates fixes this.
I'll probably gonna go ahead and merge this myself once the tests run through

### What kind of change does this PR introduce?**
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding Issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Dependency update

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
