### PR TITLE
refactor(core): make `zstd` optional enabled by default

### DIFF
--- a/core/tauri-codegen/Cargo.toml
+++ b/core/tauri-codegen/Cargo.toml
@@ -21,6 +21,10 @@ serde_json = "1"
 tauri-utils = { version = "1.0.0-beta.3", path = "../tauri-utils", features = [ "build" ] }
 thiserror = "1"
 walkdir = "2"
-zstd = "0.9"
+zstd = { version = "0.9", optional = true }
 kuchiki = "0.8"
 regex = "1"
+
+[features]
+default = [ "compression" ]
+compression = [ "zstd", "tauri-utils/compression" ]

--- a/core/tauri-macros/Cargo.toml
+++ b/core/tauri-macros/Cargo.toml
@@ -19,7 +19,8 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = [ "full" ] }
-tauri-codegen = { version = "1.0.0-beta.4", path = "../tauri-codegen" }
+tauri-codegen = { version = "1.0.0-beta.4", default-features = false, path = "../tauri-codegen" }
 
 [features]
 custom-protocol = [ ]
+compression = [ "tauri-codegen/compression" ]

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -28,10 +28,7 @@ use tauri_runtime::{SystemTray, SystemTrayEvent};
 #[cfg(windows)]
 use webview2_com::FocusChangedEventHandler;
 #[cfg(windows)]
-use windows::Win32::{
-    Foundation::HWND,
-    System::WinRT::EventRegistrationToken,
-};
+use windows::Win32::{Foundation::HWND, System::WinRT::EventRegistrationToken};
 #[cfg(all(feature = "system-tray", target_os = "macos"))]
 use wry::application::platform::macos::{SystemTrayBuilderExtMacOS, SystemTrayExtMacOS};
 #[cfg(target_os = "linux")]

--- a/core/tauri-utils/Cargo.toml
+++ b/core/tauri-utils/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 thiserror = "1.0.30"
 phf = { version = "0.10", features = [ "macros" ] }
-zstd = "0.9"
+zstd = { version = "0.9", optional = true }
 url = { version = "2.2", features = [ "serde" ] }
 kuchiki = "0.8"
 html5ever = "0.25"
@@ -28,3 +28,4 @@ heck = "0.4"
 
 [features]
 build = [ "proc-macro2", "quote" ]
+compression = [ "zstd" ]

--- a/core/tauri-utils/src/assets.rs
+++ b/core/tauri-utils/src/assets.rs
@@ -94,6 +94,7 @@ impl EmbeddedAssets {
 }
 
 impl Assets for EmbeddedAssets {
+  #[cfg(feature = "compression")]
   fn get(&self, key: &AssetKey) -> Option<Cow<'_, [u8]>> {
     self
       .0
@@ -102,5 +103,14 @@ impl Assets for EmbeddedAssets {
       .map(zstd::decode_all)
       .and_then(Result::ok)
       .map(Cow::Owned)
+  }
+
+  #[cfg(not(feature = "compression"))]
+  fn get(&self, key: &AssetKey) -> Option<Cow<'_, [u8]>> {
+    self
+      .0
+      .get(key.as_ref())
+      .copied()
+      .map(|a| Cow::Owned(a.to_vec()))
   }
 }

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -19,7 +19,8 @@ exclude = [
 readme = "README.md"
 
 [package.metadata.docs.rs]
-all-features = true
+default-features = false
+features = ["wry", "custom-protocol", "api-all", "cli", "updater", "system-tray", "dox"]
 rustdoc-args = [ "--cfg", "doc_cfg" ]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
@@ -95,7 +96,8 @@ tokio = { version = "1.15", features = [ "full" ] }
 mockito = "0.30"
 
 [features]
-default = [ "wry" ]
+default = [ "wry", "compression" ]
+compression = [ "tauri-macros/compression", "tauri-utils/compression" ]
 dox = [ "tauri-runtime-wry/dox" ]
 wry = [ "tauri-runtime-wry" ]
 cli = [ "clap" ]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

We're facing issues when cross compiling zstd on docs.rs. This change is an attempt to make the build work on Windows on macOS so we have documentation for all platforms.
