### PR TITLE
fix: #3137 - remove querystring when using asset protocol

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -73,6 +73,7 @@ raw-window-handle = "0.4.2"
 minisign-verify = { version = "0.2", optional = true }
 os_info = { version = "3.0.9", optional = true }
 futures-lite = "1.12"
+regex = "1"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = { version = "0.14", features = [ "v3_20" ] }

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -73,7 +73,6 @@ raw-window-handle = "0.4.2"
 minisign-verify = { version = "0.2", optional = true }
 os_info = { version = "3.0.9", optional = true }
 futures-lite = "1.12"
-regex = "1"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = { version = "0.14", features = [ "v3_20" ] }

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -43,7 +43,7 @@ use std::{
 };
 use tauri_macros::default_runtime;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
-use url::Url;
+use url::{Position, Url};
 
 const WINDOW_RESIZED_EVENT: &str = "tauri://resize";
 const WINDOW_MOVED_EVENT: &str = "tauri://move";
@@ -320,16 +320,12 @@ impl<R: Runtime> WindowManager<R> {
           )
         };
       pending.register_uri_scheme_protocol("asset", move |request| {
+        let parsed_path = Url::parse(&request.uri())?;
+        let filtered_path = &parsed_path[..Position::AfterPath];
         #[cfg(target_os = "windows")]
-        let path = request.uri().replace("asset://localhost/", "");
+        let path = filtered_path.replace("asset://localhost/", "");
         #[cfg(not(target_os = "windows"))]
-        let path = request.uri().replace("asset://", "");
-        let path = path
-          .split(&['?', '#'][..])
-          // ignore query string and fragment
-          .next()
-          .unwrap()
-          .to_string();
+        let path = filtered_path.replace("asset://", "");
         let path = percent_encoding::percent_decode(path.as_bytes())
           .decode_utf8_lossy()
           .to_string();

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -44,7 +44,6 @@ use std::{
 use tauri_macros::default_runtime;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use url::Url;
-use regex::Regex;
 
 const WINDOW_RESIZED_EVENT: &str = "tauri://resize";
 const WINDOW_MOVED_EVENT: &str = "tauri://move";
@@ -325,8 +324,12 @@ impl<R: Runtime> WindowManager<R> {
         let path = request.uri().replace("asset://localhost/", "");
         #[cfg(not(target_os = "windows"))]
         let path = request.uri().replace("asset://", "");
-        let re = Regex::new(r"\?.*").unwrap();
-        let path = re.replace_all(&path, "");
+        let path = path
+          .split(&['?', '#'][..])
+          // ignore query string and fragment
+          .next()
+          .unwrap()
+          .to_string();
         let path = percent_encoding::percent_decode(path.as_bytes())
           .decode_utf8_lossy()
           .to_string();
@@ -502,7 +505,7 @@ impl<R: Runtime> WindowManager<R> {
       let path = request
         .uri()
         .split(&['?', '#'][..])
-        // ignore query string
+        // ignore query string and fragment
         .next()
         .unwrap()
         .to_string()

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -44,6 +44,7 @@ use std::{
 use tauri_macros::default_runtime;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use url::Url;
+use regex::Regex;
 
 const WINDOW_RESIZED_EVENT: &str = "tauri://resize";
 const WINDOW_MOVED_EVENT: &str = "tauri://move";
@@ -324,6 +325,8 @@ impl<R: Runtime> WindowManager<R> {
         let path = request.uri().replace("asset://localhost/", "");
         #[cfg(not(target_os = "windows"))]
         let path = request.uri().replace("asset://", "");
+        let re = Regex::new(r"\?.*").unwrap();
+        let path = re.replace_all(&path, "");
         let path = percent_encoding::percent_decode(path.as_bytes())
           .decode_utf8_lossy()
           .to_string();


### PR DESCRIPTION
### What kind of change does this PR introduce?

issue: #3137

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This resolves an issue where the asset protocol loader would treat url querystrings as part of the literal file path. A scenario where this is an issue is when loading a local html file into an iframe, and that iframe contains script tags which include query strings in the src attributes.

attention @amrbashir 