### PR TITLE
feat(bundler): initialize msi install path with previous location

### DIFF
--- a/.changes/bundler-msi-init-installdir.md
+++ b/.changes/bundler-msi-init-installdir.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Initialize the preselected installation path with the location of the previous installation.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -465,8 +465,10 @@ pub fn build_wix_app_installer(
 
   data.insert("product_name", to_json(settings.product_name()));
   data.insert("version", to_json(settings.version_string()));
-  let manufacturer = settings.bundle_identifier().to_string();
-  data.insert("manufacturer", to_json(manufacturer.as_str()));
+  let bundle_id = settings.bundle_identifier();
+  let manufacturer = bundle_id.split('.').nth(1).unwrap_or(bundle_id);
+  data.insert("bundle_id", to_json(bundle_id));
+  data.insert("manufacturer", to_json(manufacturer));
   let upgrade_code = Uuid::new_v5(
     &Uuid::NAMESPACE_DNS,
     format!("{}.app.x64", &settings.main_binary_name()).as_bytes(),

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -46,6 +46,11 @@
         <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />      <!-- Remove repair -->
         <SetProperty Id="ARPNOMODIFY" Value="1" After="InstallValidate" Sequence="execute"/>
 
+        <!-- initialize with previous InstallDir -->
+        <Property Id="INSTALLDIR">
+            <RegistrySearch Id="PrevInstallDirReg" Root="HKCU" Key="Software\\{{{manufacturer}}}\\{{{product_name}}}" Name="InstallDir" Type="raw"/>
+        </Property>
+
         <!-- launch app checkbox -->
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Launch {{{product_name}}}" />
         <Property Id="WixShellExecTarget" Value="{{{app_exe_source}}}" />
@@ -79,7 +84,7 @@
                 <Component Id="ApplicationShortcutDesktop" Guid="*">
                     <Shortcut Id="ApplicationDesktopShortcut" Name="{{{product_name}}}" Description="Runs {{{product_name}}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
                     <RemoveFolder Id="DesktopFolder" On="uninstall" />
-                    <RegistryValue Root="HKCU" Key="Software\\{{{product_name}}}" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+                    <RegistryValue Root="HKCU" Key="Software\\{{{manufacturer}}}\\{{{product_name}}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
                 </Component>
             </Directory>
             <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
@@ -91,6 +96,11 @@
         </Directory>
 
         <DirectoryRef Id="INSTALLDIR">
+            <Component Id="RegistryEntries" Guid="*">
+                <RegistryKey Root="HKCU" Key="Software\\{{{manufacturer}}}\\{{{product_name}}}">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+                </RegistryKey>
+            </Component>
             <Component Id="Path" Guid="{{{path_component_guid}}}" Win64="$(var.Win64)">
                 <File Id="Path" Source="{{{app_exe_source}}}" KeyPath="yes" Checksum="yes"/>
             </Component>
@@ -122,9 +132,9 @@
 				<RemoveFolder Id="INSTALLDIR"
 							  On="uninstall" />
 
-				<RegistryValue Root="HKCR"
+				<RegistryValue Root="HKCU"
 							   Key="Software\\{{{manufacturer}}}\\{{{product_name}}}"
-							   Name="installed"
+							   Name="Uninstaller Shortcut"
 							   Type="integer"
 							   Value="1"
 							   KeyPath="yes" />
@@ -139,10 +149,10 @@
                     Target="[!Path]"
                     Icon="ProductIcon"
                     WorkingDirectory="INSTALLDIR">
-                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{{manufacturer}}}"/>
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{{bundle_id}}}"/>
                 </Shortcut>
                 <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
-                <RegistryValue Root="HKCU" Key="Software\\{{{manufacturer}}}\\{{{product_name}}}" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+                <RegistryValue Root="HKCU" Key="Software\\{{{manufacturer}}}\\{{{product_name}}}" Name="Start Menu Shortcut" Type="integer" Value="1" KeyPath="yes"/>
            </Component>
         </DirectoryRef>
 
@@ -165,6 +175,8 @@
                 AllowAdvertise="no"
                 Display="expand"
                 Absent="disallow">
+
+            <ComponentRef Id="RegistryEntries"/>
 
             {{#each resource_file_ids as |resource_file_id| ~}}
                 <ComponentRef Id="{{ resource_file_id }}"/>


### PR DESCRIPTION
With this PR we now save the installation directory to the registry and use that value to initialize the default install dir on following installations (upgrades).
This was requested a few times so that tauri's buit-in updater doesn't default to `C:\Program Files\app_name` (ofc useful for manual update-installations too).

The default path if the reg key doesn't exist is the same as before.

I intentionally added the reg value stuff in a separate `Component` (for clarity) and inside a `RegistryKey` object (for extensibility).

With this change i also changed `manufacturer` to be the middle part of the bundle identifier instead of the whole thing. This was imho just plain wrong.
The whole bundle identifier is still used as the `AppId`, mainly because notifications don't work without it.

Furthermore I changed the dummy registry values used as keyPaths for the shortcuts to be all in the same registry "folder".
Instead of having an `installed` key in 3 locations, we now have 3 different (dummy) keys in the same path, much cleaner imo.

Just to be extra clear, this is not a breaking change. New installers are still compatible with previous ones. Upgrading old installations with the new installer works normally (old reg keys will be removed by the old uninstaller).

### What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary