### PR TITLE
Added Windows signing guide, renamed osx guide to macos

### DIFF
--- a/docs/guides/bundler/sign-macos.md
+++ b/docs/guides/bundler/sign-macos.md
@@ -1,6 +1,6 @@
 ---
-title: How to code-sign and notorize a OSX .dmg file with GitHub Actions
-sidebar_label: OSX Code-signing with GitHub Actions
+title: macOS - Code signing guide using Github Actions
+sidebar_label: macOS - Code signing
 ---
 
 import Alert from '@theme/Alert'

--- a/docs/guides/bundler/sign-windows.md
+++ b/docs/guides/bundler/sign-windows.md
@@ -9,12 +9,10 @@ import Alert from '@theme/Alert'
 
 Code-signing will add a level of authenticity to your application, while it is not required it can often improve the user experience for your users. 
 
-*Note: I will be keeping this CLI friendly, there are ways to do this via GUI if thats your flavor, but that will not be covered in this documentation*
-
 # Prerequisites 
 
-- Windows - you can likely use other platforms, but this tutorial is using Powershell native features (I know, i hate this as much as you do.)
-- Code signing certificate - you can aqquire one of these on services such as Digicert.com, Comodo.com, & Godaddy.com. In this guide I am using Comodo.com
+- Windows - you can likely use other platforms, but this tutorial is using Powershell native features.
+- Code signing certificate - you can aqquire one of these on services such as Digicert.com, Comodo.com, & Godaddy.com. In this guide we are using Comodo.com
 - A working tauri application
 
 

--- a/docs/guides/bundler/sign-windows.md
+++ b/docs/guides/bundler/sign-windows.md
@@ -1,0 +1,83 @@
+---
+title: Windows - Code signing guide locally & with Github Actions
+sidebar_label: Windows - Code signing
+---
+
+import Alert from '@theme/Alert'
+
+# Intro
+
+Code-signing will add a level of authenticity to your application, while it is not required it can often improve the user experience for your users. 
+
+*Note: I will be keeping this CLI friendly, there are ways to do this via GUI if thats your flavor, but that will not be covered in this documentation*
+
+# Prerequisites 
+
+- Windows - you can likely use other platforms, but this tutorial is using Powershell native features (I know, i hate this as much as you do.)
+- Code signing certificate - you can aqquire one of these on services such as Digicert.com, Comodo.com, & Godaddy.com. In this guide I am using Comodo.com
+- A working tauri application
+
+
+# Getting Started
+
+There are a few things we will have to do to get our windows installation prepared for code signing. This includes converting our certificate to a speific format, installing this certificate, & then decoding required information from certificate that is required by tauri.
+
+## A. Convert your `.cer` to `.pfx`
+
+1. You will need the following:
+	- certificate file (mine is `cert.cer`) 
+	- private key file (mine is `private-key.key`)
+
+2. Open up a command prompt and change to your current directory using `cd Documents/Certs`
+
+3. Convert your `.cer` to a `.pfx` using `openssl pkcs12 -export -in cert.cer -inkey private-key.key -out certificate.pfx`
+
+4. You will be prompted to enter an export password **DON'T FORGET IT!**
+
+## B. Import your `.pfx` file into the keystore. 
+
+We will now need to import our `.pfx` file.
+
+1. Assign your export password to a variable using `$WINDOWS_PFX_PASSWORD = 'MYPASSWORD'`
+
+2. Now Import the certificate using `Import-PfxCertificate -FilePath Certs/certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String $env:WINDOWS_PFX_PASSWORD -Force -AsPlainText)`
+
+## C. Prepare Variables
+
+1. We will need the SHA-1 thumbprint of the certificate, you can get this using `openssl pkcs12 -info -in certificate.pfx` and look under for following
+```
+Bag Attributes
+    localKeyID: A1 B1 A2 B2 A3 B3 A4 B4 A5 B5 A6 B6 A7 B7 A8 B8 A9 B9 A0 B0
+```
+
+2. You will capture the `localKeyID` but with no spaces, in this example it would be `A1B1A2B2A3B3A4B4A5B5A6B6A7B7A8B8A9B9A0B0`. This is our `certificateThumbprint`.
+
+3. We will need the SHA digest algorythm used for your certificate (Hint: this is likely `sha256`
+
+4. We will also need a timestamp url, this is a time server used to verify the time of the certificate signing. Im using `http://timestamp.comodoca.com` but whoever you got your certificate from likely has one aswell. 
+
+# Prepare `tauri.conf.json` file
+
+1. Now that we have our `certificateThumbprint`, `digestAlgorithm`, & `timestampUrl` we will open up the `tauri.conf.json`.
+
+2. In the `tauri.conf.json` you will look for the `tauri` -> `bundle` -> `windows` section. You will see there are three variable for the information we have captured. Fill it out like below. 
+```
+"windows": {
+        "certificateThumbprint": "A1B1A2B2A3B3A4B4A5B5A6B6A7B7A8B8A9B9A0B0",
+        "digestAlgorithm": "sha256",
+        "timestampUrl": "http://timestamp.comodoca.com"
+}
+```
+3. Save, and run `yarn | yarn build`
+
+4. In the console output you will see the following output.
+
+```
+info: signing app
+info: running signtool "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x64\\signtool.exe"
+info: "Done Adding Additional Store\r\nSuccessfully signed: APPLICATION FILE PATH HERE
+``` 
+
+which shows you have successfully signed the `.exe`. 
+
+And thats it! You have successfully signed your .exe file.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -49,7 +49,8 @@
           "guides/bundler/anti-bloat",
           "guides/bundler/sidecar",
           "guides/bundler/debian",
-          "guides/bundler/sign-osx"
+          "guides/bundler/sign-macos",
+          "guides/bundler/sign-windows"
         ]
       },
       "guides/cli",


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Added Windows code signing guide, added under the bundler section


In the OSX Code signing Docs, OSX has been renamed to macOS as this is the Apple official name