### PR TITLE
Consistent event name usage

### DIFF
--- a/.changes/consistent-event-name-usage.md
+++ b/.changes/consistent-event-name-usage.md
@@ -1,0 +1,5 @@
+---
+"api": minor
+---
+
+Change the `event` field of the `Event` interface to type `EventName` instead of `string`.

--- a/tooling/api/src/event.ts
+++ b/tooling/api/src/event.ts
@@ -16,7 +16,7 @@ import { LiteralUnion } from 'type-fest'
 
 interface Event<T> {
   /** Event name */
-  event: string
+  event: EventName
   /** Event identifier used to unlisten */
   id: number
   /** Event payload */


### PR DESCRIPTION
Makes the `Event` interface use the `EventName` type for the `event` field instea of `string`

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
https://discord.com/channels/616186924390023171/731495028677148753/931986520871690331