### PR TITLE
fix(create-tauri-app): correct dev port for svelte, closes #3210

### DIFF
--- a/tooling/create-tauri-app/src/recipes/svelte.ts
+++ b/tooling/create-tauri-app/src/recipes/svelte.ts
@@ -29,7 +29,7 @@ const svelte: Recipe = {
   configUpdate: ({ cfg, packageManager }) => ({
     ...cfg,
     distDir: `../public`,
-    devPath: 'http://localhost:5000',
+    devPath: 'http://localhost:8080',
     beforeDevCommand: `${
       packageManager === 'npm' ? 'npm run' : packageManager
     } dev`,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

- I validated the correct behavior by creating a svelte app with the local create-tauri-app.
- The new port is mentioned in the [README of the template repository](https://github.com/sveltejs/template/blob/master/README.md#get-started).