### PR TITLE
wix installer is also signed

### DIFF
--- a/.changes/wix-signing.md
+++ b/.changes/wix-signing.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Sign WiX installer in addition to the executable file.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -389,7 +389,7 @@ pub fn build_wix_app_installer(
   let app_exe_source = settings.binary_path(main_binary);
   let try_sign = |file_path: &PathBuf| -> crate::Result<()> {
     if let Some(certificate_thumbprint) = &settings.windows().certificate_thumbprint {
-      common::print_info(&format!("signing {}", file_path.display()));
+      common::print_info(&format!("signing {}", file_path.display()))?;
       sign(
         &file_path,
         &SignParams {

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -389,7 +389,7 @@ pub fn build_wix_app_installer(
   let app_exe_source = settings.binary_path(main_binary);
   let try_sign = |file_path: &PathBuf| -> crate::Result<()> {
     if let Some(certificate_thumbprint) = &settings.windows().certificate_thumbprint {
-      common::print_info(format!("signing {}", file_path.display()));
+      common::print_info(&format!("signing {}", file_path.display()));
       sign(
         &file_path,
         &SignParams {
@@ -412,7 +412,7 @@ pub fn build_wix_app_installer(
   };
 
   common::print_info("trying to sign app")?;
-  try_sign(app_exe_source)?;
+  try_sign(&app_exe_source)?;
 
   // ensure that `target/{release, debug}/wix` folder exists
   std::fs::create_dir_all(settings.project_out_directory().join("wix"))?;

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -387,30 +387,32 @@ pub fn build_wix_app_installer(
     .find(|bin| bin.main())
     .ok_or_else(|| anyhow::anyhow!("Failed to get main binary"))?;
   let app_exe_source = settings.binary_path(main_binary);
-
-  let sign_params = SignParams {
-    digest_algorithm: settings
-      .windows()
-      .digest_algorithm
-      .as_ref()
-      .map(|algorithm| algorithm.to_string())
-      .unwrap_or_else(|| "sha256".to_string()),
-    certificate_thumbprint: certificate_thumbprint.to_string(),
-    timestamp_url: settings
-      .windows()
-      .timestamp_url
-      .as_ref()
-      .map(|url| url.to_string()),
-  };
-  let sign = |file_path: &PathBuf| -> crate::Result<()> {
-    sign(&file_path, &sign_params)?;
+  let try_sign = |file_path: &PathBuf| -> crate::Result<()> {
+    if let Some(certificate_thumbprint) = &settings.windows().certificate_thumbprint {
+      common::print_info(format!("signing {}", file_path.display()));
+      sign(
+        &file_path,
+        &SignParams {
+          digest_algorithm: settings
+            .windows()
+            .digest_algorithm
+            .as_ref()
+            .map(|algorithm| algorithm.to_string())
+            .unwrap_or_else(|| "sha256".to_string()),
+          certificate_thumbprint: certificate_thumbprint.to_string(),
+          timestamp_url: settings
+            .windows()
+            .timestamp_url
+            .as_ref()
+            .map(|url| url.to_string()),
+        },
+      )?;
+    }
     Ok(())
   };
 
-  if let Some(certificate_thumbprint) = &settings.windows().certificate_thumbprint {
-    common::print_info("signing app")?;
-    sign(app_exe_source)?;
-  }
+  common::print_info("trying to sign app")?;
+  try_sign(app_exe_source)?;
 
   // ensure that `target/{release, debug}/wix` folder exists
   std::fs::create_dir_all(settings.project_out_directory().join("wix"))?;
@@ -656,9 +658,7 @@ pub fn build_wix_app_installer(
     settings,
   )?;
   rename(&msi_output_path, &msi_path)?;
-  if let Some(certificate_thumbprint) = &settings.windows().certificate_thumbprint {
-    sign(&msi_path)?;
-  }
+  try_sign(&msi_path)?;
 
   Ok(msi_path)
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?
Signing a binary that goes into wix is great, but end user will still experience a malware warning unless the wix installer itself is also signed. 
- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
