### PR TITLE
fix(cli.rs): prefix the "before script" env vars with `TAURI_`

### DIFF
--- a/.changes/before-script-envs.md
+++ b/.changes/before-script-envs.md
@@ -2,4 +2,4 @@
 "cli.rs": patch
 ---
 
-Define `PLATFORM`, `ARCH`, `FAMILY`, `PLATFORM_TYPE` and `TAURI_DEBUG` environment variables for the `beforeDevCommand` and `beforeBuildCommand` scripts.
+Define `TAURI_PLATFORM`, `TAURI_ARCH`, `TAURI_FAMILY`, `TAURI_PLATFORM_TYPE`, `TAURI_PLATFORM_VERSION` and `TAURI_DEBUG` environment variables for the `beforeDevCommand` and `beforeBuildCommand` scripts.

--- a/tooling/cli.rs/config_definition.rs
+++ b/tooling/cli.rs/config_definition.rs
@@ -850,11 +850,11 @@ pub struct BuildConfig {
   pub dist_dir: AppUrl,
   /// A shell command to run before `tauri dev` kicks in.
   ///
-  /// The PLATFORM, ARCH, FAMILY, PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.
+  /// The TAURI_PLATFORM, TAURI_ARCH, TAURI_FAMILY, TAURI_PLATFORM_VERSION, TAURI_PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.
   pub before_dev_command: Option<String>,
   /// A shell command to run before `tauri build` kicks in.
   ///
-  /// The PLATFORM, ARCH, FAMILY, PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.
+  /// The TAURI_PLATFORM, TAURI_ARCH, TAURI_FAMILY, TAURI_PLATFORM_VERSION, TAURI_PLATFORM_TYPE and TAURI_DEBUG environment variables are set if you perform conditional compilation.
   pub before_build_command: Option<String>,
   /// Features passed to `cargo` commands.
   pub features: Option<Vec<String>>,

--- a/tooling/cli.rs/src/helpers/mod.rs
+++ b/tooling/cli.rs/src/helpers/mod.rs
@@ -44,17 +44,17 @@ pub fn execute_with_output(cmd: &mut Command) -> crate::Result<()> {
 pub fn command_env(debug: bool) -> HashMap<String, String> {
   let mut map = HashMap::new();
 
-  map.insert("PLATFORM".into(), std::env::consts::OS.into());
-  map.insert("ARCH".into(), std::env::consts::ARCH.into());
-  map.insert("FAMILY".into(), std::env::consts::FAMILY.into());
-  map.insert("VERSION".into(), os_info::get().version().to_string());
+  map.insert("TAURI_PLATFORM".into(), std::env::consts::OS.into());
+  map.insert("TAURI_ARCH".into(), std::env::consts::ARCH.into());
+  map.insert("TAURI_FAMILY".into(), std::env::consts::FAMILY.into());
+  map.insert("TAURI_PLATFORM_VERSION".into(), os_info::get().version().to_string());
 
   #[cfg(target_os = "linux")]
-  map.insert("PLATFORM_TYPE".into(), "Linux".into());
+  map.insert("TAURI_PLATFORM_TYPE".into(), "Linux".into());
   #[cfg(target_os = "windows")]
-  map.insert("PLATFORM_TYPE".into(), "Windows_NT".into());
+  map.insert("TAURI_PLATFORM_TYPE".into(), "Windows_NT".into());
   #[cfg(target_os = "macos")]
-  map.insert("PLATFORM_TYPE".into(), "Darwin".into());
+  map.insert("TAURI_PLATFORM_TYPE".into(), "Darwin".into());
 
   if debug {
     map.insert("TAURI_DEBUG".into(), "true".to_string());


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Before we exported env vars to the "before scripts" (`beforeDevCommand` and `beforeBuildCommand`) like this `ARCH`, `PLATFORM` and `VERSION` which is problematic for two reasons:
1. It can clash with env variables defined by the OS (`ARCH` is very generic for example)
2. It wasn't clear that the env vars above came from the tauri bundling process.
3. Tools like vite, have a whitelist by prefix for security reasons. So having everything prefixed with `TAURI_` will make life easier and more secure for our tauri+vite users.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
