### PR TITLE
Fix #3288: Add provider_short_name for macOS

### DIFF
--- a/.changes/bundler-add-provider-short-name.md
+++ b/.changes/bundler-add-provider-short-name.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Provide a provider short name for macOS app notarization if your Apple developer account is connected to more than one team.

--- a/tooling/bundler/README.md
+++ b/tooling/bundler/README.md
@@ -76,6 +76,7 @@ These settings are used only when bundling `app` and `dmg` packages.
 * `license`: Path to the license file for the DMG bundle.
 * `exception_domain`: The exception domain to use on the macOS .app bundle. Allows communication to the outside world e.g. a web server you're shipping.
 * `use_bootstrapper`: Enables the bootstrapper script, which allows access to the environment variables.
+* `provider_short_name`: If your Apple ID is connected to multiple teams, you have to specify the provider short name of the team you want to use to notarize your app. See [Customizing the notarization workflow](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow) and search for `--list-providers` for more information how to obtain your provider short name.
 
 ### Example `tauri.conf.json`:
 

--- a/tooling/bundler/src/bundle/macos/sign.rs
+++ b/tooling/bundler/src/bundle/macos/sign.rs
@@ -258,7 +258,7 @@ pub fn notarize(
     sign(zip_path.clone(), identity, &settings, false)?;
   };
 
-  let notarize_args = vec![
+  let mut notarize_args = vec![
     "altool",
     "--notarize-app",
     "-f",
@@ -268,6 +268,12 @@ pub fn notarize(
     "--primary-bundle-id",
     identifier,
   ];
+
+  if let Some(provider_short_name) = &settings.macos().provider_short_name {
+    notarize_args.push("--asc-provider");
+    notarize_args.push(provider_short_name);
+  }
+
   common::print_info("notarizing app")?;
   let output = Command::new("xcrun")
     .args(notarize_args)

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -168,6 +168,8 @@ pub struct MacOsSettings {
   pub exception_domain: Option<String>,
   /// Code signing identity.
   pub signing_identity: Option<String>,
+  /// Provider short name for notarization.
+  pub provider_short_name: Option<String>,
   /// Path to the entitlements.plist file.
   pub entitlements: Option<String>,
   /// Path to the Info.plist file for the bundle.

--- a/tooling/cli.rs/config_definition.rs
+++ b/tooling/cli.rs/config_definition.rs
@@ -65,6 +65,8 @@ pub struct MacConfig {
   pub use_bootstrapper: bool,
   /// Identity to use for code signing.
   pub signing_identity: Option<String>,
+  /// Provider short name for notarization.
+  pub provider_short_name: Option<String>,
   /// Path to the entitlements file.
   pub entitlements: Option<String>,
 }

--- a/tooling/cli.rs/schema.json
+++ b/tooling/cli.rs/schema.json
@@ -897,6 +897,13 @@
             "null"
           ]
         },
+        "providerShortName": {
+          "description": "Provider short name for notarization.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "useBootstrapper": {
           "description": "Enable the boostrapper script.",
           "default": false,

--- a/tooling/cli.rs/src/interface/rust.rs
+++ b/tooling/cli.rs/src/interface/rust.rs
@@ -420,6 +420,16 @@ fn tauri_config_to_bundle_settings(
     None => config.macos.signing_identity,
   };
 
+  let provider_short_name = match std::env::var_os("APPLE_PROVIDER_SHORT_NAME") {
+    Some(provider_short_name) => Some(
+      provider_short_name
+        .to_str()
+        .expect("failed to convert APPLE_PROVIDER_SHORT_NAME to string")
+        .to_string(),
+    ),
+    None => config.macos.provider_short_name,
+  };
+
   Ok(BundleSettings {
     identifier: config.identifier,
     icon: config.icon,
@@ -455,6 +465,7 @@ fn tauri_config_to_bundle_settings(
       use_bootstrapper: Some(config.macos.use_bootstrapper),
       exception_domain: config.macos.exception_domain,
       signing_identity,
+      provider_short_name,
       entitlements: config.macos.entitlements,
       info_plist_path: {
         let path = tauri_dir().join("Info.plist");

--- a/tooling/cli.rs/templates/app/src-tauri/tauri.conf.json
+++ b/tooling/cli.rs/templates/app/src-tauri/tauri.conf.json
@@ -37,6 +37,7 @@
         "useBootstrapper": false,
         "exceptionDomain": "",
         "signingIdentity": null,
+        "providerShortName": null,
         "entitlements": null
       },
       "windows": {


### PR DESCRIPTION
Fixes #3288

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
Allow to provide a provider short name, so macOS apps can be notarized using developer accounts connected to multiple teams.

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
