### PR TITLE
fix: Make CMD handle quotes `"` properly.

### DIFF
--- a/.changes/windows-modify-cmd-string-behaviour.md
+++ b/.changes/windows-modify-cmd-string-behaviour.md
@@ -2,4 +2,4 @@
 "cli.rs": patch
 ---
 
-Change `beforeDevCommand` and `beforeBuildCommand` to run with `CMD /S /C {command}` instead of `CMD /C {command}` on Windows.
+On Windows, Fix `beforeDevCommand` and `beforeBuildCommand` not executing the expected command if it contains quotes. This is done by executing them with `CMD /S /C {command}` instead of `CMD /C {command}` on Windows.

--- a/.changes/windows-modify-cmd-string-behaviour.md
+++ b/.changes/windows-modify-cmd-string-behaviour.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": patch
+---
+
+Change `beforeDevCommand` and `beforeBuildCommand` to run with `CMD /S /C {command}` instead of `CMD /C {command}` on Windows.

--- a/tooling/cli.rs/src/build.rs
+++ b/tooling/cli.rs/src/build.rs
@@ -75,6 +75,7 @@ pub fn command(options: Options) -> Result<()> {
       #[cfg(target_os = "windows")]
       execute_with_output(
         Command::new("cmd")
+          .arg("/S")
           .arg("/C")
           .arg(before_build)
           .current_dir(app_dir())

--- a/tooling/cli.rs/src/dev.rs
+++ b/tooling/cli.rs/src/dev.rs
@@ -108,6 +108,7 @@ pub fn command(options: Options) -> Result<()> {
       logger.log(format!("Running `{}`", before_dev));
       #[cfg(target_os = "windows")]
       let child = Command::new("cmd")
+        .arg("/S")
         .arg("/C")
         .arg(before_dev)
         .current_dir(app_dir())


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

Technically this is a breaking change, as any workarounds to this bug people have done may stop working. But this would just mean that they can remove those workarounds. But seeing as it hasn't been reported previously and only happens in complex commands I believe it's reasonably safe to make this bugfix. The presumably by far most common workaround, extracting the logic to a script, will likely work without issue.

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
Currently `beforeDevCommand` and `beforeBuildCommand` have an issue where they can't deal with quotes properly on windows. Simple example is setting `beforeBuildCommand` to `ECHO %CD% && mkdir \"src-tauri\\websrc\"` which will first echo out the expected project repository, then wrongly create the directory `C:\src-tauri\websrc`.

From `CMD /?`
```
If /C or /K is specified, then the remainder of the command line after
the switch is processed as a command line, where the following logic is
used to process quote (") characters:

    1.  If all of the following conditions are met, then quote characters
        on the command line are preserved:

        - no /S switch
        - exactly two quote characters
        - no special characters between the two quote characters,
          where special is one of: &<>()@^|
        - there are one or more whitespace characters between the
          two quote characters
        - the string between the two quote characters is the name
          of an executable file.

    2.  Otherwise, old behavior is to see if the first character is
        a quote character and if so, strip the leading character and
        remove the last quote character on the command line, preserving
        any text after the last quote character.
```

We just wish to run the command provided in the configuration without extra parsing. Without `/S` the user must escape certain characters for no benefit as we just wish to run whatever is entered in the configuration.

Sidenote: It is not clear to me by reading the contributing guidelines if bugfixes requires issues to be created. If so I will create one.