### PR TITLE
Remove target triple from sidecar bin paths, closes #3355

### DIFF
--- a/.changes/sidecar-runtime-rename.md
+++ b/.changes/sidecar-runtime-rename.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+"tauri-bundler": patch
+---
+
+**Breaking change**: The sidecar's target triple suffix is now removed at build time.

--- a/.changes/universal-apple-target-sidecar.md
+++ b/.changes/universal-apple-target-sidecar.md
@@ -1,0 +1,9 @@
+---
+"tauri-bundler": patch
+"api": patch
+---
+
+When building Universal macOS Binaries through the virtual target `universal-apple-darwin`:
+
+- Expect a universal binary to be created by the user
+- Ensure that binary is bundled and accessed correctly at runtime

--- a/core/tauri/src/api/process/command.rs
+++ b/core/tauri/src/api/process/command.rs
@@ -177,12 +177,7 @@ impl Command {
   /// A sidecar program is a embedded external binary in order to make your application work
   /// or to prevent users having to install additional dependencies (e.g. Node.js, Python, etc).
   pub fn new_sidecar<S: Into<String>>(program: S) -> crate::Result<Self> {
-    let program = format!(
-      "{}-{}",
-      program.into(),
-      platform::target_triple().expect("unsupported platform")
-    );
-    Ok(Self::new(relative_command_path(program)?))
+    Ok(Self::new(relative_command_path(program.into())?))
   }
 
   /// Appends arguments to the command.


### PR DESCRIPTION
Consistent with the main executable, bundled sidecar binaries
now get the original name - `my-sidecar[.exe]`.

The previous target triple resulted in an path that could not be
reconstructed at runtime if the target
was a universal binary (MacOS)

Clarified documentation on external binaries.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
