### PR TITLE
`once_global` and `once` accept FnOnce callbacks

### DIFF
--- a/.changes/fix-once-fnonce.md
+++ b/.changes/fix-once-fnonce.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+`Manager::once_global` and `Window::once` allow `FnOnce` callbacks.

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -7,7 +7,7 @@ use std::{
   collections::HashMap,
   fmt,
   hash::Hash,
-  sync::{Arc, Mutex},
+  sync::{Arc, Mutex}, cell::Cell,
 };
 use uuid::Uuid;
 
@@ -170,16 +170,19 @@ impl Listeners {
   }
 
   /// Listen to a JS event and immediately unlisten.
-  pub(crate) fn once<F: Fn(Event) + Send + 'static>(
+  pub(crate) fn once<F: FnOnce(Event) + Send + 'static>(
     &self,
     event: String,
     window: Option<String>,
     handler: F,
   ) -> EventHandler {
     let self_ = self.clone();
+    let handler = Cell::new(Some(handler));
+
     self.listen(event, window, move |event| {
       self_.unlisten(event.id);
-      handler(event);
+      let handler = handler.take().expect("attempted to call handler more than once");
+      handler(event)
     })
   }
 

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -4,10 +4,11 @@
 
 use std::{
   boxed::Box,
+  cell::Cell,
   collections::HashMap,
   fmt,
   hash::Hash,
-  sync::{Arc, Mutex}, cell::Cell,
+  sync::{Arc, Mutex},
 };
 use uuid::Uuid;
 
@@ -181,7 +182,9 @@ impl Listeners {
 
     self.listen(event, window, move |event| {
       self_.unlisten(event.id);
-      let handler = handler.take().expect("attempted to call handler more than once");
+      let handler = handler
+        .take()
+        .expect("attempted to call handler more than once");
       handler(event)
     })
   }

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -427,7 +427,7 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
   /// Listen to a global event only once.
   fn once_global<F>(&self, event: impl Into<String>, handler: F) -> EventHandler
   where
-    F: Fn(Event) + Send + 'static,
+    F: FnOnce(Event) + Send + 'static,
   {
     self.manager().once(event.into(), None, handler)
   }

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -1176,7 +1176,7 @@ impl<R: Runtime> WindowManager<R> {
     self.inner.listeners.listen(event, window, handler)
   }
 
-  pub fn once<F: Fn(Event) + Send + 'static>(
+  pub fn once<F: FnOnce(Event) + Send + 'static>(
     &self,
     event: String,
     window: Option<String>,

--- a/core/tauri/src/updater/mod.rs
+++ b/core/tauri/src/updater/mod.rs
@@ -480,7 +480,6 @@ pub(crate) fn listener<R: Runtime>(
             window.once(EVENT_INSTALL_UPDATE, move |_msg| {
               let window = window_isolation.clone();
               let updater = updater.clone();
-              let pubkey = pubkey.clone();
 
               // Start installation
               crate::async_runtime::spawn(async move {

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -321,7 +321,7 @@ impl<R: Runtime> Window<R> {
   /// Listen to an event on this window a single time.
   pub fn once<F>(&self, event: impl Into<String>, handler: F) -> EventHandler
   where
-    F: Fn(Event) + Send + 'static,
+    F: FnOnce(Event) + Send + 'static,
   {
     let label = self.window.label.clone();
     self.manager.once(event.into(), Some(label), handler)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

I had to use `Cell` to get the interior mutability to work, if you guys have a better idea let me know.