### PR TITLE
Implement default runtime for plugin structs

### DIFF
--- a/.changes/fix-plugin-default-runtime.md
+++ b/.changes/fix-plugin-default-runtime.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Implement `default_runtime` for `plugin::Builder` and `plugin::TauriPlugin`

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -58,6 +58,7 @@ type OnWebviewReady<R> = dyn Fn(Window<R>) + Send + Sync;
 type OnEvent<R> = dyn Fn(&AppHandle<R>, &RunEvent) + Send + Sync;
 
 /// Builds a [`TauriPlugin`].
+#[default_runtime(crate::Wry, wry)]
 pub struct Builder<R: Runtime> {
   name: &'static str,
   invoke_handler: Box<InvokeHandler<R>>,
@@ -152,6 +153,7 @@ impl<R: Runtime> Builder<R> {
 }
 
 /// Plugin struct that is returned by the [`PluginBuilder`]. Should only be constructed through the builder.
+#[default_runtime(crate::Wry, wry)]
 pub struct TauriPlugin<R: Runtime> {
   name: &'static str,
   invoke_handler: Box<InvokeHandler<R>>,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

I overlooked this in the original PR, both structs should implement the default runtime. 
