### PR TITLE
Removed tauri-hotkey-rs from External Crates list.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,9 +64,6 @@ Cross-platform application window creation library in Rust that supports all maj
 WRY is a cross-platform WebView rendering library in Rust that supports all major desktop platforms like Windows, macOS, and Linux.
 Tauri uses WRY as the abstract layer responsible to determine which webview is used (and how interactions are made).
 
-## [tauri-hotkey-rs](https://github.com/tauri-apps/tauri-hotkey-rs)
-We needed to fix hotkey to work on all platforms, because upstream was not being responsive.
-
 # Additional tooling
 
 ## [binary-releases](https://github.com/tauri-apps/binary-releases)


### PR DESCRIPTION
The tauri-hotkey-rs repo is archived, and no longer relevant
to the Architecture document.

Supersedes https://github.com/tauri-apps/tauri-docs/pull/419 — @lucasfernog said to make the PR here. Thanks. 