### PR TITLE
Ease plugin hook restrictions

### DIFF
--- a/.changes/fix-ease-plugin-hook-requirements.md
+++ b/.changes/fix-ease-plugin-hook-requirements.md
@@ -2,4 +2,4 @@
 "tauri": patch
 ---
 
-Ease the requirements for plugin hooks. Hook callbacks can now be `FnOnce` and don't need to implement `Sync` anymore.
+Ease the requirements for plugin hooks. `setup` can now be `FnOnce` and no hooks need to implement `Sync` anymore.

--- a/.changes/fix-ease-plugin-hook-requirements.md
+++ b/.changes/fix-ease-plugin-hook-requirements.md
@@ -2,4 +2,4 @@
 "tauri": patch
 ---
 
-Ease the requirements for plugin hooks. `setup` can now be `FnOnce` and no hooks need to implement `Sync` anymore.
+Ease the requirements for plugin hooks. `setup` and `setup_with_config` can now be `FnOnce` and `on_webview_ready`, `on_event` and `on_page_load` can be `FnMut`.

--- a/.changes/fix-ease-plugin-hook-requirements.md
+++ b/.changes/fix-ease-plugin-hook-requirements.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Ease the requirements for plugin hooks. Hook callbacks can now be `FnOnce` and don't need to implement `Sync` anymore.

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -147,7 +147,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   ///     .build()
   /// }
   ///
-  /// tauri::Builder::default().plugin(init());
+  /// tauri::Builder::default().plugin(get_plugin());
   /// ```
   ///
   /// [setup]: struct.Builder.html#method.setup

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -5,8 +5,8 @@
 //! The Tauri plugin extension to expand Tauri functionality.
 
 use crate::{
-  runtime::Runtime, utils::config::PluginConfig, AppHandle, Invoke, InvokeHandler,
-  PageLoadPayload, RunEvent, Window,
+  runtime::Runtime, utils::config::PluginConfig, AppHandle, Invoke, InvokeHandler, PageLoadPayload,
+  RunEvent, Window,
 };
 use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -54,10 +54,10 @@ pub trait Plugin<R: Runtime>: Send {
   fn extend_api(&mut self, invoke: Invoke<R>) {}
 }
 
-type SetupHook<R> = dyn Fn(&AppHandle<R>) -> Result<()> + Send + Sync;
-type SetupWithConfigHook<R, T> = dyn Fn(&AppHandle<R>, T) -> Result<()> + Send + Sync;
-type OnWebviewReady<R> = dyn Fn(Window<R>) + Send + Sync;
-type OnEvent<R> = dyn Fn(&AppHandle<R>, &RunEvent) + Send + Sync;
+type SetupHook<R> = dyn Fn(&AppHandle<R>) -> Result<()> + Send;
+type SetupWithConfigHook<R, T> = dyn Fn(&AppHandle<R>, T) -> Result<()> + Send;
+type OnWebviewReady<R> = dyn Fn(Window<R>) + Send;
+type OnEvent<R> = dyn Fn(&AppHandle<R>, &RunEvent) + Send;
 
 /// Builds a [`TauriPlugin`].
 pub struct Builder<R: Runtime, C: DeserializeOwned = ()> {

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -5,7 +5,7 @@
 //! The Tauri plugin extension to expand Tauri functionality.
 
 use crate::{
-  runtime::Runtime, utils::config::PluginConfig, AppHandle, Invoke, InvokeHandler, OnPageLoad,
+  runtime::Runtime, utils::config::PluginConfig, AppHandle, Invoke, InvokeHandler,
   PageLoadPayload, RunEvent, Window,
 };
 use serde::de::DeserializeOwned;
@@ -56,8 +56,9 @@ pub trait Plugin<R: Runtime>: Send {
 
 type SetupHook<R> = dyn FnOnce(&AppHandle<R>) -> Result<()> + Send + Sync;
 type SetupWithConfigHook<R, T> = dyn FnOnce(&AppHandle<R>, T) -> Result<()> + Send + Sync;
-type OnWebviewReady<R> = dyn Fn(Window<R>) + Send + Sync;
-type OnEvent<R> = dyn Fn(&AppHandle<R>, &RunEvent) + Send + Sync;
+type OnWebviewReady<R> = dyn FnMut(Window<R>) + Send + Sync;
+type OnEvent<R> = dyn FnMut(&AppHandle<R>, &RunEvent) + Send + Sync;
+type OnPageLoad<R> = dyn FnMut(Window<R>, PageLoadPayload) + Send + Sync;
 
 /// Builds a [`TauriPlugin`].
 pub struct Builder<R: Runtime, C: DeserializeOwned = ()> {
@@ -146,7 +147,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   ///     .build()
   /// }
   ///
-  /// tauri::Builder::default().plugin(get_plugin());
+  /// tauri::Builder::default().plugin(init());
   /// ```
   ///
   /// [setup]: struct.Builder.html#method.setup
@@ -163,7 +164,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   #[must_use]
   pub fn on_page_load<F>(mut self, on_page_load: F) -> Self
   where
-    F: Fn(Window<R>, PageLoadPayload) + Send + Sync + 'static,
+    F: FnMut(Window<R>, PageLoadPayload) + Send + Sync + 'static,
   {
     self.on_page_load = Box::new(on_page_load);
     self
@@ -173,7 +174,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   #[must_use]
   pub fn on_webview_ready<F>(mut self, on_webview_ready: F) -> Self
   where
-    F: Fn(Window<R>) + Send + Sync + 'static,
+    F: FnMut(Window<R>) + Send + Sync + 'static,
   {
     self.on_webview_ready = Box::new(on_webview_ready);
     self
@@ -183,7 +184,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   #[must_use]
   pub fn on_event<F>(mut self, on_event: F) -> Self
   where
-    F: Fn(&AppHandle<R>, &RunEvent) + Send + Sync + 'static,
+    F: FnMut(&AppHandle<R>, &RunEvent) + Send + Sync + 'static,
   {
     self.on_event = Box::new(on_event);
     self

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -54,7 +54,7 @@ pub trait Plugin<R: Runtime>: Send {
   fn extend_api(&mut self, invoke: Invoke<R>) {}
 }
 
-type SetupHook<R> = dyn Fn(&AppHandle<R>) -> Result<()> + Send;
+type SetupHook<R> = dyn FnMut(&AppHandle<R>) -> Result<()> + Send;
 type SetupWithConfigHook<R, T> = dyn Fn(&AppHandle<R>, T) -> Result<()> + Send;
 type OnWebviewReady<R> = dyn Fn(Window<R>) + Send;
 type OnEvent<R> = dyn Fn(&AppHandle<R>, &RunEvent) + Send;
@@ -117,7 +117,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   #[must_use]
   pub fn setup<F>(mut self, setup: F) -> Self
   where
-    F: Fn(&AppHandle<R>) -> Result<()> + Send + Sync + 'static,
+    F: FnMut(&AppHandle<R>) -> Result<()> + Send + 'static,
   {
     self.setup = Box::new(setup);
     self


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Relaxes the `Sync` Requirement for plugin callbacks and allows FnMut callbacks as the `setup` hook. 
Ideally we should make this `FnOnce` as the setup hook must only ever be called once anyway, but I haven't found a nice way to do so yet (Can one take a value out of a trait object? Can we call the fn and replace it's memory somehow?)

