### PR TITLE
fix text file busy on linux CI

### DIFF
--- a/core/tauri/tests/restart.rs
+++ b/core/tauri/tests/restart.rs
@@ -138,18 +138,20 @@ fn create_symlink(original: &Path, link: PathBuf) -> io::Result<Symlink> {
   };
 }
 
+/// Only use 1 test to prevent cargo from waiting on itself.
+///
+/// While not ideal, this is fine because they use the same solution for both cases.
 #[test]
-fn symlink() -> Result {
+fn restart_symlinks() -> Result {
+  // single symlink
   symlink_runner(|bin| {
     let mut link = bin.to_owned();
     link.set_file_name("symlink");
     link.set_extension("exe");
     create_symlink(bin, link)
-  })
-}
+  })?;
 
-#[test]
-fn nested_symlinks() -> Result {
+  // nested symlinks
   symlink_runner(|bin| {
     let mut link1 = bin.to_owned();
     link1.set_file_name("symlink1");


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: inconsistently failing test

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
I don't know if this actually works because I cannot get it to reproduce locally. In theory, I believe it is the `Command::status` result that is giving us the `ExecutableFileBusy`/"Text file busy" error, so this makes it so that the cargo project should only be fully built once, and only called sequentially