### PR TITLE
fix: InvalidArgs error message should include the command name

### DIFF
--- a/core/tauri/src/command.rs
+++ b/core/tauri/src/command.rs
@@ -50,8 +50,9 @@ pub trait CommandArg<'de, R: Runtime>: Sized {
 /// Automatically implement [`CommandArg`] for any type that can be deserialized.
 impl<'de, D: Deserialize<'de>, R: Runtime> CommandArg<'de, R> for D {
   fn from_command(command: CommandItem<'de, R>) -> Result<Self, InvokeError> {
+    let name = command.name;
     let arg = command.key;
-    Self::deserialize(command).map_err(|e| crate::Error::InvalidArgs(arg, e).into())
+    Self::deserialize(command).map_err(|e| crate::Error::InvalidArgs(name, arg, e).into())
   }
 }
 

--- a/core/tauri/src/error.rs
+++ b/core/tauri/src/error.rs
@@ -58,8 +58,8 @@ pub enum Error {
   #[error("'{0}' not on the allowlist (https://tauri.studio/docs/api/config#tauri.allowlist)")]
   ApiNotAllowlisted(String),
   /// Invalid args when running a command.
-  #[error("invalid args for command `{0}`: {1}")]
-  InvalidArgs(&'static str, serde_json::Error),
+  #[error("invalid args `{1}` for command `{0}`: {2}")]
+  InvalidArgs(&'static str, &'static str, serde_json::Error),
   /// Encountered an error in the setup hook,
   #[error("error encountered during setup hook: {0}")]
   Setup(Box<dyn std::error::Error + Send>),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

It's a breaking change because `Error::InvalidArgs` gains a new field. It's possible to keep the original definition by keeping only the `name` field, but the error message will become less accurate.

- [x] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Currently the error message of a `invoke('setGraph', { 'graph': {} })` command with wrong argument types looks like

```
Unhandled Promise Rejection: invalid args for command `graph`: invalid type: map, expected a string
```

It's confusing because the `graph` is the name of the argument. The proposed fix will render the error as

```
Unhandled Promise Rejection: invalid args `graph` for command `setGraph`: invalid type: map, expected a string
```

TODO: Add a change file after deciding the change level.