### PR TITLE
feat(cli): add tao and wry version to the `info` output

### DIFF
--- a/.changes/info-extend-crates.md
+++ b/.changes/info-extend-crates.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Added `tauri-build`, `tao` and `wry` version to the `info` command output.

--- a/.changes/info-tao-wry.md
+++ b/.changes/info-tao-wry.md
@@ -1,6 +1,0 @@
----
-"cli.rs": patch
-"cli.js": patch
----
-
-Added `tao` and `wry` version to the `info` command output.

--- a/.changes/info-tao-wry.md
+++ b/.changes/info-tao-wry.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Added `tao` and `wry` version to the `info` command output.

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -688,7 +688,12 @@ pub fn command(_options: Options) -> Result<()> {
       None
     };
 
-  for (dep, label) in [("tauri", "  tauri"), ("tao", "  tao"), ("wry", "  wry")] {
+  for (dep, label) in [
+    ("tauri", "  tauri"),
+    ("tauri-build", "  tauri-build"),
+    ("tao", "  tao"),
+    ("wry", "  wry"),
+  ] {
     let (version_string, version_suffix) =
       crate_version(&tauri_dir, manifest.as_ref(), lock.as_ref(), dep);
     InfoBlock::new(label)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
