### PR TITLE
fix: move to separate config file and fix mocks docs

### DIFF
--- a/tooling/api/package.json
+++ b/tooling/api/package.json
@@ -19,7 +19,7 @@
     "lint:lockfile": "lockfile-lint --path yarn.lock --type yarn --validate-https --allowed-hosts npm yarn",
     "format": "prettier --write --end-of-line=auto \"./**/*.{cjs,js,jsx,ts,tsx,html,css,json}\" --ignore-path .gitignore",
     "format:check": "prettier --check --end-of-line=auto \"./**/*.{cjs,js,jsx,ts,tsx,html,css,json}\" --ignore-path .gitignore",
-    "generate-docs": "typedoc src --githubPages false --readme none --entryDocument index.md --hideInPageTOC true --out docs --json docs/js-api.json --pretty false"
+    "generate-docs": "typedoc src/* --githubPages false --readme none --hideInPageTOC true --out docs --json docs/js-api.json --pretty false"
   },
   "repository": {
     "type": "git",

--- a/tooling/api/package.json
+++ b/tooling/api/package.json
@@ -19,7 +19,7 @@
     "lint:lockfile": "lockfile-lint --path yarn.lock --type yarn --validate-https --allowed-hosts npm yarn",
     "format": "prettier --write --end-of-line=auto \"./**/*.{cjs,js,jsx,ts,tsx,html,css,json}\" --ignore-path .gitignore",
     "format:check": "prettier --check --end-of-line=auto \"./**/*.{cjs,js,jsx,ts,tsx,html,css,json}\" --ignore-path .gitignore",
-    "generate-docs": "typedoc src/* --githubPages false --readme none --hideInPageTOC true --out docs --json docs/js-api.json --pretty false"
+    "generate-docs": "typedoc"
   },
   "repository": {
     "type": "git",

--- a/tooling/api/typedoc.json
+++ b/tooling/api/typedoc.json
@@ -1,0 +1,27 @@
+{
+  "entryPoints": [
+    "src/app.ts",
+    "src/cli.ts",
+    "src/clipboard.ts",
+    "src/dialog.ts",
+    "src/event.ts",
+    "src/fs.ts",
+    "src/globalShortcut.ts",
+    "src/http.ts",
+    "src/mocks.ts",
+    "src/notification.ts",
+    "src/os.ts",
+    "src/path.ts",
+    "src/process.ts",
+    "src/shell.ts",
+    "src/tauri.ts",
+    "src/updater.ts",
+    "src/window.ts"
+  ],
+  "githubPages": false,
+  "readme": "none",
+  "hideInPageTOC": true,
+  "out": "docs",
+  "json": "docs/js-api.json",
+  "pretty": false
+}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Your typedoc config didn't pick up on the new `mocks.ts` module since it's not reexported through the `index.ts` file.
