### PR TITLE
drop Sync req from `setup` and `setup_with_config`

### DIFF
--- a/.changes/fix-drop-sync.md
+++ b/.changes/fix-drop-sync.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Callbacks passed to `tauri::plugin::Builder::setup` or `tauri::plugin::Builder::setup_with_config` are no longer required to implement `Sync`.

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -251,7 +251,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   #[must_use]
   pub fn setup<F>(mut self, setup: F) -> Self
   where
-    F: FnOnce(&AppHandle<R>) -> Result<()> + Send + Sync + 'static,
+    F: FnOnce(&AppHandle<R>) -> Result<()> + Send + 'static,
   {
     self.setup.replace(Box::new(setup));
     self
@@ -287,7 +287,7 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   #[must_use]
   pub fn setup_with_config<F>(mut self, setup_with_config: F) -> Self
   where
-    F: FnOnce(&AppHandle<R>, C) -> Result<()> + Send + Sync + 'static,
+    F: FnOnce(&AppHandle<R>, C) -> Result<()> + Send + 'static,
   {
     self.setup_with_config.replace(Box::new(setup_with_config));
     self

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -54,8 +54,8 @@ pub trait Plugin<R: Runtime>: Send {
   fn extend_api(&mut self, invoke: Invoke<R>) {}
 }
 
-type SetupHook<R> = dyn FnOnce(&AppHandle<R>) -> Result<()> + Send + Sync;
-type SetupWithConfigHook<R, T> = dyn FnOnce(&AppHandle<R>, T) -> Result<()> + Send + Sync;
+type SetupHook<R> = dyn FnOnce(&AppHandle<R>) -> Result<()> + Send;
+type SetupWithConfigHook<R, T> = dyn FnOnce(&AppHandle<R>, T) -> Result<()> + Send;
 type OnWebviewReady<R> = dyn FnMut(Window<R>) + Send + Sync;
 type OnEvent<R> = dyn FnMut(&AppHandle<R>, &RunEvent) + Send + Sync;
 type OnPageLoad<R> = dyn FnMut(Window<R>, PageLoadPayload) + Send + Sync;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Somehow this got lost during the previous PR. There is really no reason for `SetupHook` and `SetupWithConfigHook`.
1. The function gets called during `App::plugin` on the same Thread.
2. Even if we call it from a different thread, if the closure consumes owned references, those will not live past that closure and can't be shared between threads anyway. So the `Sync` requirement is redundant if I'm correct.

