### PR TITLE
fix(bundler): sidecar on Windows, closes #3446

### DIFF
--- a/.changes/fix-windows-sidecar.md
+++ b/.changes/fix-windows-sidecar.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Fixes sidecar bundling on Windows.

--- a/examples/sidecar/src-tauri/Cargo.lock
+++ b/examples/sidecar/src-tauri/Cargo.lock
@@ -2569,6 +2569,7 @@ dependencies = [
 name = "tauri"
 version = "1.0.0-rc.2"
 dependencies = [
+ "anyhow",
  "bincode",
  "cfg_aliases",
  "dirs-next",
@@ -2610,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "anyhow",
  "cargo_toml",

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -495,6 +495,11 @@ impl Settings {
     &self.project_out_directory
   }
 
+  /// Returns the target triple.
+  pub fn target(&self) -> &str {
+    &self.target
+  }
+
   /// Returns the architecture for the binary being bundled (e.g. "arm", "x86" or "x86_64").
   pub fn binary_arch(&self) -> &str {
     if self.target.starts_with("x86_64") {
@@ -634,6 +639,7 @@ impl Settings {
           .to_string_lossy()
           .replace(&format!("-{}", self.target), ""),
       );
+      println!("{:?} {:?} {:?}", src, dest, self.target);
       common::copy_file(&src, &dest)?;
     }
     Ok(())

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -716,13 +716,21 @@ pub fn build_wix_app_installer(
 fn generate_binaries_data(settings: &Settings) -> crate::Result<Vec<Binary>> {
   let mut binaries = Vec::new();
   let cwd = std::env::current_dir()?;
+  let tmp_dir = std::env::temp_dir();
   for src in settings.external_binaries() {
     let src = src?;
+    let binary_path = cwd.join(&src);
+    let dest_filename = src
+      .file_name()
+      .expect("failed to extract external binary filename")
+      .to_string_lossy()
+      .replace(&format!("-{}", settings.target()), "");
+    let dest = tmp_dir.join(dest_filename);
+    std::fs::copy(binary_path, &dest)?;
 
     binaries.push(Binary {
       guid: Uuid::new_v4().to_string(),
-      path: cwd
-        .join(src)
+      path: dest
         .into_os_string()
         .into_string()
         .expect("failed to read external binary path"),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This is an extension of the #3356 work, we forgot to update the WiX bundler as it doesn't use the `copy_binaries` function.
