### PR TITLE
fix(deps): update webview2-com to 0.13.0 to fix compilation on windows

### DIFF
--- a/core/tauri-runtime-wry/Cargo.toml
+++ b/core/tauri-runtime-wry/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [ ".license_template", "CHANGELOG.md", "/target" ]
 readme = "README.md"
 
 [dependencies]
-wry = { version = "0.13.1", default-features = false, features = [ "file-drop", "protocol" ] }
+wry = { version = "0.13.2", default-features = false, features = [ "file-drop", "protocol" ] }
 tauri-runtime = { version = "0.3.1", path = "../tauri-runtime" }
 tauri-utils = { version = "1.0.0-rc.1", path = "../tauri-utils" }
 uuid = { version = "0.8.2", features = [ "v4" ] }
@@ -21,7 +21,7 @@ infer = "0.4"
 
 [target."cfg(windows)".dependencies]
 ico = "0.1"
-webview2-com = "0.11.0"
+webview2-com = "0.13.0"
 
   [target."cfg(windows)".dependencies.windows]
   version = "0.30.0"

--- a/core/tauri-runtime/Cargo.toml
+++ b/core/tauri-runtime/Cargo.toml
@@ -33,7 +33,7 @@ http-range = "0.1.4"
 infer = "0.4"
 
 [target."cfg(windows)".dependencies]
-webview2-com = "0.11.0"
+webview2-com = "0.13.0"
 
   [target."cfg(windows)".dependencies.windows]
   version = "0.30.0"


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
This one's kinda urgent because currently released versions are broken on windows because of this (we didn't pin the version of wry so we have 2 conflicting webview2-com versions)