### PR TITLE
fix: read Command output ending with a carriage return, closes #3508

### DIFF
--- a/.changes/command-output-carriage-return.md
+++ b/.changes/command-output-carriage-return.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+The `tauri::api::process::Command` API now properly reads stdout and stderr messages that ends with a carriage return (`\r`) instead of just a newline (`\n`).

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -80,6 +80,7 @@ attohttpc = { version = "0.18", features = [ "json", "form" ], optional = true }
 open = { version = "2.0", optional = true }
 shared_child = { version = "1.0", optional = true }
 os_pipe = { version = "1.0", optional = true }
+memchr = { version = "2.4", optional = true }
 rfd = { version = "0.7.0", features = [ "parent" ], optional = true }
 raw-window-handle = "0.4.2"
 minisign-verify = { version = "0.2", optional = true }
@@ -125,7 +126,7 @@ updater = [ "minisign-verify", "base64", "http-api", "dialog-ask" ]
 http-api = [ "attohttpc" ]
 shell-open-api = [ "open", "regex", "tauri-macros/shell-scope" ]
 reqwest-client = [ "reqwest", "bytes" ]
-command = [ "shared_child", "os_pipe" ]
+command = [ "shared_child", "os_pipe", "memchr" ]
 dialog = [ "rfd" ]
 notification = [ "notify-rust" ]
 cli = [ "clap" ]

--- a/core/tauri/src/api/process/command.rs
+++ b/core/tauri/src/api/process/command.rs
@@ -421,13 +421,15 @@ fn read_command_output<R: BufRead + ?Sized>(
       };
       match memchr::memchr(b'\n', available) {
         Some(i) => {
-          buf.extend_from_slice(&available[..=i]);
-          (true, i + 1)
+          let end = i + 1;
+          buf.extend_from_slice(&available[..end]);
+          (true, end)
         }
         None => match memchr::memchr(b'\r', available) {
           Some(i) => {
-            buf.extend_from_slice(&available[..=i]);
-            (true, i + 1)
+            let end = i + 1;
+            buf.extend_from_slice(&available[..end]);
+            (true, end)
           }
           None => {
             buf.extend_from_slice(available);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

The `process::Command` API will now read lines until a `\n` or a `\r` is found.
