### PR TITLE
Docs: change command to cmd

### DIFF
--- a/tooling/api/src/shell.ts
+++ b/tooling/api/src/shell.ts
@@ -42,7 +42,7 @@
  *
  * - `name`: the unique identifier of the command, passed to the [[Command.constructor | Command constructor]].
  * If it's a sidecar, this must be the value defined on `tauri.conf.json > tauri > bundle > externalBin`.
- * - `command`: the program that is executed on this configuration. If it's a sidecar, it must be the same as `name`.
+ * - `cmd`: the program that is executed on this configuration. If it's a sidecar, it must be the same as `name`.
  * - `sidecar`: whether the object configures a sidecar or a system program.
  * - `args`: the arguments that can be passed to the program. By default no arguments are allowed.
  *   - `true` means that any argument list is allowed.
@@ -59,7 +59,7 @@
  * {
  *   "scope": {
  *     "name": "run-git-commit",
- *     "command": "git",
+ *     "cmd": "git",
  *     "args": ["commit", "-m", { "validator": "\\S+" }]
  *   }
  * }

--- a/tooling/api/src/shell.ts
+++ b/tooling/api/src/shell.ts
@@ -38,7 +38,7 @@
  * ### Restricting access to the [[`Command`]] APIs
  *
  * The `shell` allowlist object has a `scope` field that defines an array of CLIs that can be used.
- * Each CLI is a configuration object `{ name: string, command: string, sidecar?: bool, args?: boolean | Arg[] }`.
+ * Each CLI is a configuration object `{ name: string, cmd: string, sidecar?: bool, args?: boolean | Arg[] }`.
  *
  * - `name`: the unique identifier of the command, passed to the [[Command.constructor | Command constructor]].
  * If it's a sidecar, this must be the value defined on `tauri.conf.json > tauri > bundle > externalBin`.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

To set a command inside of `tauri.conf.json` you now use `cmd` instead of `command`. This PR updated the docs to reflect that.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [X] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
