### PR TITLE
use older symlink check function

### DIFF
--- a/.changes/rust-1.57-usage.md
+++ b/.changes/rust-1.57-usage.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch
+---
+
+Use `is_symlink` API compatible with Rust v1.57 instead of std/fs/struct.Metadata.html#method.is_symlink.

--- a/core/tauri-utils/src/platform/starting_binary.rs
+++ b/core/tauri-utils/src/platform/starting_binary.rs
@@ -69,6 +69,7 @@ impl StartingBinary {
           .symlink_metadata()
           .as_ref()
           .map(std::fs::Metadata::file_type)
+          .as_ref()
           .map(std::fs::FileType::is_symlink),
         Ok(true)
       )

--- a/core/tauri-utils/src/platform/starting_binary.rs
+++ b/core/tauri-utils/src/platform/starting_binary.rs
@@ -68,7 +68,8 @@ impl StartingBinary {
         ancestor
           .symlink_metadata()
           .as_ref()
-          .map(std::fs::Metadata::is_symlink),
+          .map(std::fs::Metadata::file_type)
+          .map(std::fs::FileType::is_symlink),
         Ok(true)
       )
     })


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
I meant to do this before finishing the restart PR, but I forgot. `std::fs::Metadata::is_symlink` was stabilized in Rust 1.58, but we don't want to bump our MSRV just for that since there is a very simple workaround (metadata -> filetype -> is_symlink). I didn't actually get to test/run this myself because I made this edit from my phone.