### PR TITLE
feat(core): allow CSP configuration to be an object, ref #3533

### DIFF
--- a/.changes/object-csp.md
+++ b/.changes/object-csp.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Allows the configuration CSP to be an object mapping a directive name to its source list.

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -22,7 +22,12 @@ use serde_json::Value as JsonValue;
 use serde_with::skip_serializing_none;
 use url::Url;
 
-use std::{collections::HashMap, fmt, fs::read_to_string, path::PathBuf};
+use std::{
+  collections::HashMap,
+  fmt::{self, Display},
+  fs::read_to_string,
+  path::PathBuf,
+};
 
 /// Items to help with parsing content into a [`Config`].
 pub mod parse;
@@ -593,6 +598,121 @@ fn default_file_drop_enabled() -> bool {
   true
 }
 
+/// A Content-Security-Policy directive source list.
+/// See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources>.
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum CspDirectiveSources {
+  /// An inline list of CSP sources. Same as [`Self::List`], but concatenated with a space separator.
+  Inline(String),
+  /// A list of CSP sources. The collection will be concatenated with a space separator for the CSP string.
+  List(Vec<String>),
+}
+
+impl Default for CspDirectiveSources {
+  fn default() -> Self {
+    Self::List(Vec::new())
+  }
+}
+
+impl From<CspDirectiveSources> for Vec<String> {
+  fn from(sources: CspDirectiveSources) -> Self {
+    match sources {
+      CspDirectiveSources::Inline(source) => source.split(' ').map(|s| s.to_string()).collect(),
+      CspDirectiveSources::List(l) => l,
+    }
+  }
+}
+
+impl CspDirectiveSources {
+  /// Whether the given source is configured on this directive or not.
+  pub fn contains(&self, source: &str) -> bool {
+    match self {
+      Self::Inline(s) => s.contains(&format!("{} ", source)) || s.contains(&format!(" {}", source)),
+      Self::List(l) => l.contains(&source.into()),
+    }
+  }
+
+  /// Appends the given source to this directive.
+  pub fn push<S: AsRef<str>>(&mut self, source: S) {
+    match self {
+      Self::Inline(s) => {
+        s.push(' ');
+        s.push_str(source.as_ref());
+      }
+      Self::List(l) => {
+        l.push(source.as_ref().to_string());
+      }
+    }
+  }
+
+  /// Extends this CSP directive source list with the given array of sources.
+  pub fn extend(&mut self, sources: Vec<String>) {
+    for s in sources {
+      self.push(s);
+    }
+  }
+}
+
+/// A Content-Security-Policy definition.
+/// See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>.
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase", untagged)]
+pub enum Csp {
+  /// The entire CSP policy in a single text string.
+  Policy(String),
+  /// An object mapping a directive with its sources values as a list of strings.
+  DirectiveMap(HashMap<String, CspDirectiveSources>),
+}
+
+impl From<HashMap<String, CspDirectiveSources>> for Csp {
+  fn from(map: HashMap<String, CspDirectiveSources>) -> Self {
+    Self::DirectiveMap(map)
+  }
+}
+
+impl From<Csp> for HashMap<String, CspDirectiveSources> {
+  fn from(csp: Csp) -> Self {
+    match csp {
+      Csp::Policy(policy) => {
+        let mut map = HashMap::new();
+        for directive in policy.split(';') {
+          let mut tokens = directive.trim().split(' ');
+          if let Some(directive) = tokens.next() {
+            let sources = tokens.map(|s| s.to_string()).collect::<Vec<String>>();
+            map.insert(directive.to_string(), CspDirectiveSources::List(sources));
+          }
+        }
+        map
+      }
+      Csp::DirectiveMap(m) => m,
+    }
+  }
+}
+
+impl Display for Csp {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Self::Policy(s) => write!(f, "{}", s),
+      Self::DirectiveMap(m) => {
+        let len = m.len();
+        let mut i = 0;
+        for (directive, sources) in m {
+          let sources: Vec<String> = sources.clone().into();
+          write!(f, "{} {}", directive, sources.join(" "))?;
+          i += 1;
+          if i != len {
+            write!(f, "; ")?;
+          }
+        }
+        Ok(())
+      }
+    }
+  }
+}
+
 /// Security configuration.
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Clone, Deserialize, Serialize)]
@@ -604,12 +724,12 @@ pub struct SecurityConfig {
   ///
   /// This is a really important part of the configuration since it helps you ensure your WebView is secured.
   /// See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>.
-  pub csp: Option<String>,
+  pub csp: Option<Csp>,
   /// The Content Security Policy that will be injected on all HTML files on development.
   ///
   /// This is a really important part of the configuration since it helps you ensure your WebView is secured.
   /// See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>.
-  pub dev_csp: Option<String>,
+  pub dev_csp: Option<Csp>,
   /// Freeze the `Object.prototype` when using the custom protocol.
   #[serde(default)]
   pub freeze_prototype: bool,
@@ -2361,10 +2481,49 @@ mod build {
     }
   }
 
+  impl ToTokens for CspDirectiveSources {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+      let prefix = quote! { ::tauri::utils::config::CspDirectiveSources };
+
+      tokens.append_all(match self {
+        Self::Inline(sources) => {
+          let sources = sources.as_str();
+          quote!(#prefix::Inline(#sources.into()))
+        }
+        Self::List(list) => {
+          let list = vec_lit(list, str_lit);
+          quote!(#prefix::List(#list))
+        }
+      })
+    }
+  }
+
+  impl ToTokens for Csp {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+      let prefix = quote! { ::tauri::utils::config::Csp };
+
+      tokens.append_all(match self {
+        Self::Policy(policy) => {
+          let policy = policy.as_str();
+          quote!(#prefix::Policy(#policy.into()))
+        }
+        Self::DirectiveMap(list) => {
+          let map = map_lit(
+            quote! { ::std::collections::HashMap },
+            list,
+            str_lit,
+            identity,
+          );
+          quote!(#prefix::DirectiveMap(#map))
+        }
+      })
+    }
+  }
+
   impl ToTokens for SecurityConfig {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-      let csp = opt_str_lit(self.csp.as_ref());
-      let dev_csp = opt_str_lit(self.dev_csp.as_ref());
+      let csp = opt_lit(self.csp.as_ref());
+      let dev_csp = opt_lit(self.dev_csp.as_ref());
       let freeze_prototype = self.freeze_prototype;
 
       literal_struct!(tokens, SecurityConfig, csp, dev_csp, freeze_prototype);

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -1021,7 +1021,7 @@ impl<R: Runtime> WindowManager<R> {
           // naive way to check if it's an html
           if html.contains('<') && html.contains('>') {
             let mut document = tauri_utils::html::parse(html);
-            tauri_utils::html::inject_csp(&mut document, &csp);
+            tauri_utils::html::inject_csp(&mut document, &csp.to_string());
             url.set_path(&format!("text/html,{}", document.to_string()));
           }
         }

--- a/examples/api/src-tauri/tauri.conf.json
+++ b/examples/api/src-tauri/tauri.conf.json
@@ -116,7 +116,12 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' customprotocol: img-src: 'self'; style-src 'unsafe-inline' 'self' https://fonts.googleapis.com; img-src 'self' asset: https://asset.localhost blob: data:; font-src https://fonts.gstatic.com",
+      "csp": {
+        "default-src": ["'self'", "customprotocol:"],
+        "font-src": ["https://fonts.gstatic.com"],
+        "img-src": "'self' asset: https://asset.localhost blob: data:",
+        "style-src": "'unsafe-inline' 'self' https://fonts.googleapis.com"
+      },
       "freezePrototype": true
     },
     "systemTray": {

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -867,6 +867,38 @@
       },
       "additionalProperties": false
     },
+    "Csp": {
+      "description": "A Content-Security-Policy definition. See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>.",
+      "anyOf": [
+        {
+          "description": "The entire CSP policy in a single text string.",
+          "type": "string"
+        },
+        {
+          "description": "An object mapping a directive with its sources values as a list of strings.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/CspDirectiveSources"
+          }
+        }
+      ]
+    },
+    "CspDirectiveSources": {
+      "description": "A Content-Security-Policy directive source list. See <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources>.",
+      "anyOf": [
+        {
+          "description": "An inline list of CSP sources. Same as [`Self::List`], but concatenated with a space separator.",
+          "type": "string"
+        },
+        {
+          "description": "A list of CSP sources. The collection will be concatenated with a space separator for the CSP string.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "DebConfig": {
       "description": "Configuration for Debian (.deb) bundles.",
       "type": "object",
@@ -1283,16 +1315,24 @@
       "properties": {
         "csp": {
           "description": "The Content Security Policy that will be injected on all HTML files on the built application. If [`dev_csp`](SecurityConfig.dev_csp) is not specified, this value is also injected on dev.\n\nThis is a really important part of the configuration since it helps you ensure your WebView is secured. See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Csp"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "devCsp": {
           "description": "The Content Security Policy that will be injected on all HTML files on development.\n\nThis is a really important part of the configuration since it helps you ensure your WebView is secured. See <https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP>.",
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Csp"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "freezePrototype": {

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -729,7 +729,8 @@ pub fn command(_options: Options) -> Result<()> {
               .tauri
               .security
               .csp
-              .clone()
+              .as_ref()
+              .map(|c| c.to_string())
               .unwrap_or_else(|| "unset".to_string()),
           )
           .display();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
