### PR TITLE
feat(cli): use default macOS minimum system version when it is empty

### DIFF
--- a/.changes/cli-template-minimum-mac-system-version.md
+++ b/.changes/cli-template-minimum-mac-system-version.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Remove `minimumSystemVersion: null` from the application template configuration.

--- a/.changes/enhance-minimum-system-version-deserialization.md
+++ b/.changes/enhance-minimum-system-version-deserialization.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch
+---
+
+Use the default value for `MacConfig.minimumSystemVersion` if the value is set to an empty string.

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -99,6 +99,17 @@ pub struct DebConfig {
   pub files: HashMap<PathBuf, PathBuf>,
 }
 
+fn de_minimum_system_version<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let version = Option::<String>::deserialize(deserializer)?;
+    match version {
+      Some(v) if v.is_empty() => Ok(minimum_system_version()),
+      e => Ok(e),
+    }
+}
+
 /// Configuration for the macOS bundles.
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
@@ -110,9 +121,12 @@ pub struct MacConfig {
   /// If a name is used, ".framework" must be omitted and it will look for standard install locations. You may also use a path to a specific framework.
   pub frameworks: Option<Vec<String>>,
   /// A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.
+  /// 
   /// Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`
   /// and the `MACOSX_DEPLOYMENT_TARGET` environment variable.
-  #[serde(default = "minimum_system_version")]
+  /// 
+  /// An empty string is considered an invalid value so the default value is used.
+  #[serde(deserialize_with = "de_minimum_system_version", default = "minimum_system_version")]
   pub minimum_system_version: Option<String>,
   /// Allows your application to communicate with the outside world.
   /// It should be a lowercase, without port and protocol domain name.

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -101,13 +101,13 @@ pub struct DebConfig {
 
 fn de_minimum_system_version<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
-    D: Deserializer<'de>,
+  D: Deserializer<'de>,
 {
-    let version = Option::<String>::deserialize(deserializer)?;
-    match version {
-      Some(v) if v.is_empty() => Ok(minimum_system_version()),
-      e => Ok(e),
-    }
+  let version = Option::<String>::deserialize(deserializer)?;
+  match version {
+    Some(v) if v.is_empty() => Ok(minimum_system_version()),
+    e => Ok(e),
+  }
 }
 
 /// Configuration for the macOS bundles.
@@ -121,12 +121,15 @@ pub struct MacConfig {
   /// If a name is used, ".framework" must be omitted and it will look for standard install locations. You may also use a path to a specific framework.
   pub frameworks: Option<Vec<String>>,
   /// A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.
-  /// 
+  ///
   /// Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`
   /// and the `MACOSX_DEPLOYMENT_TARGET` environment variable.
-  /// 
+  ///
   /// An empty string is considered an invalid value so the default value is used.
-  #[serde(deserialize_with = "de_minimum_system_version", default = "minimum_system_version")]
+  #[serde(
+    deserialize_with = "de_minimum_system_version",
+    default = "minimum_system_version"
+  )]
   pub minimum_system_version: Option<String>,
   /// Allows your application to communicate with the outside world.
   /// It should be a lowercase, without port and protocol domain name.

--- a/examples/commands/src-tauri/tauri.conf.json
+++ b/examples/commands/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/helloworld/src-tauri/tauri.conf.json
+++ b/examples/helloworld/src-tauri/tauri.conf.json
@@ -29,7 +29,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/isolation/src-tauri/tauri.conf.json
+++ b/examples/isolation/src-tauri/tauri.conf.json
@@ -40,7 +40,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": "",
         "signingIdentity": null,

--- a/examples/navigation/src-tauri/tauri.conf.json
+++ b/examples/navigation/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/resources/src-tauri/tauri.conf.json
+++ b/examples/resources/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/sidecar/src-tauri/tauri.conf.json
+++ b/examples/sidecar/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/state/src-tauri/tauri.conf.json
+++ b/examples/state/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/streaming/src-tauri/tauri.conf.json
+++ b/examples/streaming/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/tauri-dynamic-lib/src-tauri/tauri.conf.json
+++ b/examples/tauri-dynamic-lib/src-tauri/tauri.conf.json
@@ -29,7 +29,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/examples/updater/src-tauri/tauri.conf.json
+++ b/examples/updater/src-tauri/tauri.conf.json
@@ -31,7 +31,6 @@
         "signingIdentity": null,
         "entitlements": "../entitlements.plist",
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       },

--- a/tooling/bench/tests/cpu_intensive/src-tauri/tauri.conf.json
+++ b/tooling/bench/tests/cpu_intensive/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/tooling/bench/tests/files_transfer/src-tauri/tauri.conf.json
+++ b/tooling/bench/tests/files_transfer/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/tooling/bench/tests/helloworld/src-tauri/tauri.conf.json
+++ b/tooling/bench/tests/helloworld/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1145,7 +1145,7 @@
           ]
         },
         "minimumSystemVersion": {
-          "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`. Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist` and the `MACOSX_DEPLOYMENT_TARGET` environment variable.",
+          "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.\n\nSetting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist` and the `MACOSX_DEPLOYMENT_TARGET` environment variable.\n\nAn empty string is considered an invalid value so the default value is used.",
           "default": "10.13",
           "type": [
             "string",

--- a/tooling/cli/templates/app/src-tauri/tauri.conf.json
+++ b/tooling/cli/templates/app/src-tauri/tauri.conf.json
@@ -33,7 +33,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": "",
         "signingIdentity": null,

--- a/tooling/cli/templates/plugin/backend/examples/vanilla/src-tauri/tauri.conf.json
+++ b/tooling/cli/templates/plugin/backend/examples/vanilla/src-tauri/tauri.conf.json
@@ -31,7 +31,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": "",
         "signingIdentity": null,

--- a/tooling/cli/templates/plugin/with-api/examples/svelte-app/src-tauri/tauri.conf.json
+++ b/tooling/cli/templates/plugin/with-api/examples/svelte-app/src-tauri/tauri.conf.json
@@ -29,7 +29,6 @@
       },
       "macOS": {
         "frameworks": [],
-        "minimumSystemVersion": "",
         "useBootstrapper": false,
         "exceptionDomain": ""
       }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This is an extension to #3497 (the default value is not applied to the default template, so users needed to manually change it).
