### PR TITLE
feat(core): use AppHandle instead of Window on the updater logic

### DIFF
--- a/.changes/updater-no-window.md
+++ b/.changes/updater-no-window.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Run the updater on startup even if no window was created.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -545,54 +545,54 @@ impl<R: Runtime> App<R> {
 #[cfg(feature = "updater")]
 impl<R: Runtime> App<R> {
   /// Runs the updater hook with built-in dialog.
-  fn run_updater_dialog(&self, window: Window<R>) {
+  fn run_updater_dialog(&self) {
     let updater_config = self.manager.config().tauri.updater.clone();
     let package_info = self.manager.package_info().clone();
+    let handle = self.handle();
 
     crate::async_runtime::spawn(async move {
-      updater::check_update_with_dialog(updater_config, package_info, window).await
+      updater::check_update_with_dialog(updater_config, package_info, handle).await
     });
   }
 
   /// Listen updater events when dialog are disabled.
-  fn listen_updater_events(&self, window: Window<R>) {
+  fn listen_updater_events(&self, handle: AppHandle<R>) {
     let updater_config = self.manager.config().tauri.updater.clone();
-    updater::listener(updater_config, self.manager.package_info().clone(), &window);
+    updater::listener(updater_config, self.manager.package_info().clone(), &handle);
   }
 
-  fn run_updater(&self, main_window: Option<Window<R>>) {
-    if let Some(main_window) = main_window {
-      let event_window = main_window.clone();
-      let updater_config = self.manager.config().tauri.updater.clone();
-      // check if updater is active or not
-      if updater_config.dialog && updater_config.active {
-        // if updater dialog is enabled spawn a new task
-        self.run_updater_dialog(main_window.clone());
-        let config = self.manager.config().tauri.updater.clone();
-        let package_info = self.manager.package_info().clone();
-        // When dialog is enabled, if user want to recheck
-        // if an update is available after first start
-        // invoke the Event `tauri://update` from JS or rust side.
-        main_window.listen(updater::EVENT_CHECK_UPDATE, move |_msg| {
-          let window = event_window.clone();
-          let package_info = package_info.clone();
-          let config = config.clone();
-          // re-spawn task inside tokyo to launch the download
-          // we don't need to emit anything as everything is handled
-          // by the process (user is asked to restart at the end)
-          // and it's handled by the updater
-          crate::async_runtime::spawn(async move {
-            updater::check_update_with_dialog(config, package_info, window).await
-          });
+  fn run_updater(&self) {
+    let handle = self.handle();
+    let handle_ = handle.clone();
+    let updater_config = self.manager.config().tauri.updater.clone();
+    // check if updater is active or not
+    if updater_config.dialog && updater_config.active {
+      // if updater dialog is enabled spawn a new task
+      self.run_updater_dialog();
+      let config = self.manager.config().tauri.updater.clone();
+      let package_info = self.manager.package_info().clone();
+      // When dialog is enabled, if user want to recheck
+      // if an update is available after first start
+      // invoke the Event `tauri://update` from JS or rust side.
+      handle.listen_global(updater::EVENT_CHECK_UPDATE, move |_msg| {
+        let handle = handle_.clone();
+        let package_info = package_info.clone();
+        let config = config.clone();
+        // re-spawn task inside tokyo to launch the download
+        // we don't need to emit anything as everything is handled
+        // by the process (user is asked to restart at the end)
+        // and it's handled by the updater
+        crate::async_runtime::spawn(async move {
+          updater::check_update_with_dialog(config, package_info, handle).await
         });
-      } else if updater_config.active {
-        // we only listen for `tauri://update`
-        // once we receive the call, we check if an update is available or not
-        // if there is a new update we emit `tauri://update-available` with details
-        // this is the user responsabilities to display dialog and ask if user want to install
-        // to install the update you need to invoke the Event `tauri://update-install`
-        self.listen_updater_events(main_window);
-      }
+      });
+    } else if updater_config.active {
+      // we only listen for `tauri://update`
+      // once we receive the call, we check if an update is available or not
+      // if there is a new update we emit `tauri://update-available` with details
+      // this is the user responsabilities to display dialog and ask if user want to install
+      // to install the update you need to invoke the Event `tauri://update-install`
+      self.listen_updater_events(handle);
     }
   }
 }
@@ -1308,9 +1308,6 @@ impl<R: Runtime> Builder<R> {
       .map(|p| p.label.clone())
       .collect::<Vec<_>>();
 
-    #[cfg(feature = "updater")]
-    let mut main_window = None;
-
     for pending in self.pending_windows {
       let pending =
         app
@@ -1318,16 +1315,12 @@ impl<R: Runtime> Builder<R> {
           .prepare_window(app.handle.clone(), pending, &window_labels, None)?;
       let detached = app.runtime.as_ref().unwrap().create_window(pending)?;
       let _window = app.manager.attach_window(app.handle(), detached);
-      #[cfg(feature = "updater")]
-      if main_window.is_none() {
-        main_window = Some(_window);
-      }
     }
 
     (self.setup)(&mut app).map_err(|e| crate::Error::Setup(e))?;
 
     #[cfg(feature = "updater")]
-    app.run_updater(main_window);
+    app.run_updater();
 
     Ok(app)
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

- The updater logic is executed even if no window is initially created
- The updater emits and listens to events from all windows
