### PR TITLE
fix doc generation when using `updater-docs` flag

### DIFF
--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -229,7 +229,7 @@ pub use {
 };
 
 /// Updater events.
-#[cfg(feature = "updater")]
+#[cfg(any(feature = "updater", feature = "__updater-docs"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "updater")))]
 #[derive(Debug, Clone)]
 pub enum UpdaterEvent {


### PR DESCRIPTION
ref: https://github.com/tauri-apps/tauri-docs/runs/5568634959?check_suite_focus=true

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
