### PR TITLE
fix: added command line argument to successfully run multiwindow example

### DIFF
--- a/examples/multiwindow/README.md
+++ b/examples/multiwindow/README.md
@@ -2,4 +2,4 @@
 
 An example Tauri Multi-Window Application.
 
-To execute run the following on the root directory of the repository: `cargo run --example multiwindow --features="window-create"`.
+To execute run the following on the root directory of the repository: `cargo run --example multiwindow --features window-create`.

--- a/examples/multiwindow/README.md
+++ b/examples/multiwindow/README.md
@@ -2,4 +2,4 @@
 
 An example Tauri Multi-Window Application.
 
-To execute run the following on the root directory of the repository: `cargo run --example multiwindow`.
+To execute run the following on the root directory of the repository: `cargo run --example multiwindow --features="window-create"`.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

When executing `cargo run --example multiwindow` the terminal prompts: 

```bash
error: target `multiwindow` in package `tauri` requires the features: `window-create`
Consider enabling them by passing, e.g., `--features="window-create"`
```

Tested on macOS. 