### PR TITLE
refactor(wry): emit `RunEvent::Exit` on `Event::LoopDestroyed`

### DIFF
--- a/.changes/exit-loop-destroyed.md
+++ b/.changes/exit-loop-destroyed.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch
+---
+
+Emit `RunEvent::Exit` on `tao::event::Event::LoopDestroyed` instead of after `RunEvent::ExitRequested`.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2300,13 +2300,9 @@ fn handle_event_loop<T: UserEvent>(
     #[cfg(feature = "system-tray")]
     tray_context,
   } = context;
-  if *control_flow == ControlFlow::Exit {
-    return RunIteration {
-      window_count: windows.lock().expect("poisoned webview collection").len(),
-    };
+  if *control_flow != ControlFlow::Exit {
+    *control_flow = ControlFlow::Wait;
   }
-
-  *control_flow = ControlFlow::Wait;
 
   match event {
     Event::NewEvents(StartCause::Init) => {
@@ -2319,6 +2315,10 @@ fn handle_event_loop<T: UserEvent>(
 
     Event::MainEventsCleared => {
       callback(RunEvent::MainEventsCleared);
+    }
+
+    Event::LoopDestroyed => {
+      callback(RunEvent::Exit);
     }
 
     Event::GlobalShortcutEvent(accelerator_id) => {
@@ -2565,7 +2565,6 @@ fn on_window_close<'a, T: UserEvent>(
 
       if !should_prevent {
         *control_flow = ControlFlow::Exit;
-        callback(RunEvent::Exit);
       }
     }
     Some(webview)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This allows Tauri to run cleanup code when the exit is not related to the `CloseRequested` event e.g. macOS dock "quit" click.