### PR TITLE
fix(driver): expose native-host option and set default to 127.0.0.1, closes #3815

### DIFF
--- a/.changes/webdriver-native-host.md
+++ b/.changes/webdriver-native-host.md
@@ -1,0 +1,5 @@
+---
+"tauri-driver": patch
+---
+
+Expose `native-host` option in tauri-driver and set default to `127.0.0.1`.

--- a/tooling/webdriver/src/cli.rs
+++ b/tooling/webdriver/src/cli.rs
@@ -13,6 +13,7 @@ FLAGS:
 OPTIONS:
   --port NUMBER           Sets the tauri-driver intermediary port
   --native-port NUMBER    Sets the port of the underlying WebDriver
+  --native-host HOST      Sets the host of the underlying WebDriver (Linux only)
   --native-driver PATH    Sets the path to the native WebDriver binary
 ";
 
@@ -20,6 +21,7 @@ OPTIONS:
 pub struct Args {
   pub port: u16,
   pub native_port: u16,
+  pub native_host: String,
   pub native_driver: Option<PathBuf>,
 }
 
@@ -42,6 +44,7 @@ impl From<pico_args::Arguments> for Args {
     let parsed = Args {
       port: args.value_from_str("--port").unwrap_or(4444),
       native_port: args.value_from_str("--native-port").unwrap_or(4445),
+      native_host: args.value_from_str("--native-host").unwrap_or(String::from("127.0.0.1")),
       native_driver,
     };
 

--- a/tooling/webdriver/src/webdriver.rs
+++ b/tooling/webdriver/src/webdriver.rs
@@ -47,5 +47,6 @@ pub fn native(args: &Args) -> Command {
   let mut cmd = Command::new(native_binary);
   cmd.env("TAURI_AUTOMATION", "true");
   cmd.arg(format!("--port={}", args.native_port));
+  cmd.arg(format!("--host={}", args.native_host));
   cmd
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Closes #3815.

Adding the `--host` option has no effect in Windows, but it does not harm either.
