### PR TITLE
fix(tauri): export `WindowBuilder` struct instead of trait, closes #3827

### DIFF
--- a/.changes/fix-window-builder-export.md
+++ b/.changes/fix-window-builder-export.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fixes the `WindowBuilder` export.

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -211,7 +211,7 @@ pub use {
   },
   self::manager::Asset,
   self::runtime::{
-    webview::{WebviewAttributes, WindowBuilder},
+    webview::WebviewAttributes,
     window::{
       dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Pixel, Position, Size},
       FileDropEvent,
@@ -224,7 +224,7 @@ pub use {
     config::{Config, WindowUrl},
     Env, PackageInfo,
   },
-  self::window::{Monitor, Window},
+  self::window::{Monitor, Window, WindowBuilder},
   scope::*,
 };
 

--- a/examples/multiwindow/main.rs
+++ b/examples/multiwindow/main.rs
@@ -17,14 +17,16 @@ fn main() {
         println!("got 'clicked' event on window '{}'", label);
       });
     })
-    .create_window(
-      "Rust".to_string(),
-      tauri::WindowUrl::App("index.html".into()),
-      |window_builder, webview_attributes| {
-        (window_builder.title("Tauri - Rust"), webview_attributes)
-      },
-    )
-    .unwrap() // safe to unwrap: window label is valid
+    .setup(|app| {
+      WindowBuilder::new(
+        app,
+        "Rust".to_string(),
+        tauri::WindowUrl::App("index.html".into()),
+      )
+      .title("Tauri - Rust")
+      .build()?;
+      Ok(())
+    })
     .run(tauri::generate_context!(
       "../../examples/multiwindow/tauri.conf.json"
     ))

--- a/examples/parent-window/main.rs
+++ b/examples/parent-window/main.rs
@@ -9,14 +9,14 @@
 
 #[cfg(any(windows, target_os = "macos"))]
 use tauri::Manager;
-use tauri::{command, window, AppHandle, WindowBuilder, WindowUrl};
+use tauri::{command, window::WindowBuilder, AppHandle, WindowUrl};
 
 #[command]
 fn create_child_window(id: String, app: AppHandle) {
   #[cfg(any(windows, target_os = "macos"))]
   let main = app.get_window("main").unwrap();
 
-  let child = window::WindowBuilder::new(&app, id, WindowUrl::default())
+  let child = WindowBuilder::new(&app, id, WindowUrl::default())
     .title("Child")
     .inner_size(400.0, 300.0);
 
@@ -37,17 +37,13 @@ fn main() {
       });
     })
     .invoke_handler(tauri::generate_handler![create_child_window])
-    .create_window(
-      "main".to_string(),
-      WindowUrl::default(),
-      |window_builder, webview_attributes| {
-        (
-          window_builder.title("Main").inner_size(600.0, 400.0),
-          webview_attributes,
-        )
-      },
-    )
-    .unwrap() // safe to unwrap: window label is valid
+    .setup(|app| {
+      WindowBuilder::new(app, "main".to_string(), WindowUrl::default())
+        .title("Main")
+        .inner_size(600.0, 400.0)
+        .build()?;
+      Ok(())
+    }) // safe to unwrap: window label is valid
     .run(tauri::generate_context!(
       "../../examples/parent-window/tauri.conf.json"
     ))


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

The trait won't be needed on the next release, we will drop the `create_new_window` APIs.
