### PR TITLE
macOS: Expose new Tao APIs

### DIFF
--- a/.changes/set-activation-policy-at-runtime.md
+++ b/.changes/set-activation-policy-at-runtime.md
@@ -1,0 +1,7 @@
+---
+"tauri": patch
+---
+
+MacOS: Added `Window.set_activation_policy_at_runtime` method, which allows
+dynamically changing the activation policy (previously only possible at
+application-build time).

--- a/.changes/set-activation-policy-at-runtime.md
+++ b/.changes/set-activation-policy-at-runtime.md
@@ -2,6 +2,6 @@
 "tauri": patch
 ---
 
-MacOS: Added `Window.set_activation_policy_at_runtime` method, which allows
+macOS: Added `Window.set_activation_policy_at_runtime` method, which allows
 dynamically changing the activation policy (previously only possible at
 application-build time).

--- a/.changes/show-hide-application.md
+++ b/.changes/show-hide-application.md
@@ -1,0 +1,7 @@
+---
+"tauri": patch
+---
+
+MacOS: Added `Window.show_application` and `Window.hide_application` method,
+which shows or hides the entire app. The `Window.show` and `Window.hide`
+methods are unaffected by this change.

--- a/.changes/show-hide-application.md
+++ b/.changes/show-hide-application.md
@@ -2,6 +2,6 @@
 "tauri": patch
 ---
 
-MacOS: Added `Window.show_application` and `Window.hide_application` method,
+macOS: Added `Window.show_application` and `Window.hide_application` method,
 which shows or hides the entire app. The `Window.show` and `Window.hide`
 methods are unaffected by this change.

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -528,6 +528,14 @@ pub trait Dispatch<T: UserEvent>: Debug + Clone + Send + Sync + Sized + 'static 
   /// Hides the window.
   fn hide(&self) -> Result<()>;
 
+  /// Shows the application on MacOS (independent of current window).
+  #[cfg(target_os = "macos")]
+  fn show_application(&self) -> crate::Result<()>;
+
+  /// Hides the application on MacOS (independent of current window).
+  #[cfg(target_os = "macos")]
+  fn hide_application(&self) -> crate::Result<()>;
+
   /// Closes the window.
   fn close(&self) -> Result<()>;
 

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -261,6 +261,7 @@ pub struct RunIteration {
 /// Application's activation policy. Corresponds to NSApplicationActivationPolicy.
 #[cfg(target_os = "macos")]
 #[cfg_attr(doc_cfg, doc(cfg(target_os = "macos")))]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum ActivationPolicy {
   /// Corresponds to NSApplicationActivationPolicyRegular.
@@ -535,6 +536,13 @@ pub trait Dispatch<T: UserEvent>: Debug + Clone + Send + Sync + Sized + 'static 
   /// Hides the application on MacOS (independent of current window).
   #[cfg(target_os = "macos")]
   fn hide_application(&self) -> crate::Result<()>;
+
+  /// Sets the activation policy at runtime on MacOS (independent of current window).
+  #[cfg(target_os = "macos")]
+  fn set_activation_policy_at_runtime(
+    &self,
+    activation_policy: ActivationPolicy,
+  ) -> crate::Result<()>;
 
   /// Closes the window.
   fn close(&self) -> Result<()>;

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -529,15 +529,15 @@ pub trait Dispatch<T: UserEvent>: Debug + Clone + Send + Sync + Sized + 'static 
   /// Hides the window.
   fn hide(&self) -> Result<()>;
 
-  /// Shows the application on MacOS (independent of current window).
+  /// Shows the application on macOS (independent of current window).
   #[cfg(target_os = "macos")]
   fn show_application(&self) -> crate::Result<()>;
 
-  /// Hides the application on MacOS (independent of current window).
+  /// Hides the application on macOS (independent of current window).
   #[cfg(target_os = "macos")]
   fn hide_application(&self) -> crate::Result<()>;
 
-  /// Sets the activation policy at runtime on MacOS (independent of current window).
+  /// Sets the activation policy at runtime on macOS (independent of current window).
   #[cfg(target_os = "macos")]
   fn set_activation_policy_at_runtime(
     &self,

--- a/core/tauri/src/test/mock_runtime.rs
+++ b/core/tauri/src/test/mock_runtime.rs
@@ -437,6 +437,11 @@ impl<T: UserEvent> Dispatch<T> for MockDispatcher {
     Ok(())
   }
 
+  #[cfg(target_os = "macos")]
+  fn set_activation_policy_at_runtime(&self, _: tauri_runtime::ActivationPolicy) -> Result<()> {
+    Ok(())
+  }
+
   fn close(&self) -> Result<()> {
     Ok(())
   }

--- a/core/tauri/src/test/mock_runtime.rs
+++ b/core/tauri/src/test/mock_runtime.rs
@@ -427,6 +427,16 @@ impl<T: UserEvent> Dispatch<T> for MockDispatcher {
     Ok(())
   }
 
+  #[cfg(target_os = "macos")]
+  fn show_application(&self) -> Result<()> {
+    Ok(())
+  }
+
+  #[cfg(target_os = "macos")]
+  fn hide_application(&self) -> Result<()> {
+    Ok(())
+  }
+
   fn close(&self) -> Result<()> {
     Ok(())
   }

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -1058,6 +1058,26 @@ impl<R: Runtime> Window<R> {
     self.window.dispatcher.hide().map_err(Into::into)
   }
 
+  /// Shows the application on MacOS (independent of current window).
+  #[cfg(target_os = "macos")]
+  pub fn show_application(&self) -> crate::Result<()> {
+    self
+      .window
+      .dispatcher
+      .show_application()
+      .map_err(Into::into)
+  }
+
+  /// Hides the application on MacOS (independent of current window).
+  #[cfg(target_os = "macos")]
+  pub fn hide_application(&self) -> crate::Result<()> {
+    self
+      .window
+      .dispatcher
+      .hide_application()
+      .map_err(Into::into)
+  }
+
   /// Closes this window.
   /// # Panics
   ///

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -32,6 +32,9 @@ use crate::{
   PageLoadPayload, Runtime, WindowEvent,
 };
 
+#[cfg(target_os = "macos")]
+use crate::runtime::ActivationPolicy;
+
 use serde::Serialize;
 #[cfg(windows)]
 use windows::Win32::Foundation::HWND;
@@ -1075,6 +1078,19 @@ impl<R: Runtime> Window<R> {
       .window
       .dispatcher
       .hide_application()
+      .map_err(Into::into)
+  }
+
+  /// Sets the activation policy at runtime on MacOS (independent of current window).
+  #[cfg(target_os = "macos")]
+  pub fn set_activation_policy_at_runtime(
+    &self,
+    activation_policy: ActivationPolicy,
+  ) -> crate::Result<()> {
+    self
+      .window
+      .dispatcher
+      .set_activation_policy_at_runtime(activation_policy)
       .map_err(Into::into)
   }
 

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -1061,7 +1061,7 @@ impl<R: Runtime> Window<R> {
     self.window.dispatcher.hide().map_err(Into::into)
   }
 
-  /// Shows the application on MacOS (independent of current window).
+  /// Shows the application on macOS (independent of current window).
   #[cfg(target_os = "macos")]
   pub fn show_application(&self) -> crate::Result<()> {
     self
@@ -1071,7 +1071,7 @@ impl<R: Runtime> Window<R> {
       .map_err(Into::into)
   }
 
-  /// Hides the application on MacOS (independent of current window).
+  /// Hides the application on macOS (independent of current window).
   #[cfg(target_os = "macos")]
   pub fn hide_application(&self) -> crate::Result<()> {
     self
@@ -1081,7 +1081,7 @@ impl<R: Runtime> Window<R> {
       .map_err(Into::into)
   }
 
-  /// Sets the activation policy at runtime on MacOS (independent of current window).
+  /// Sets the activation policy at runtime on macOS (independent of current window).
   #[cfg(target_os = "macos")]
   pub fn set_activation_policy_at_runtime(
     &self,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

These changes exposes Tao APIs that are only affecting MacOS:

- `Window.show_application()`
- `Window.hide_application()`
- `Window.set_application_policy_at_runtime(..)`

Following precedent set by `set_activation_policy`, these APIs are all target-gated to MacOS only.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Related to #2358.