### PR TITLE
fix: add priority field in debian/control

### DIFF
--- a/.changes/debian-priority.md
+++ b/.changes/debian-priority.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Set the Debian control file `Priority` field to `optional`.

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -203,6 +203,7 @@ fn generate_control_file(
       writeln!(file, " {}", line)?;
     }
   }
+  writeln!(file, "Priority: optional")?;
   file.flush()?;
   Ok(())
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Tauri's bundler currently do not add `Priority:` field in `debian/control` file which is [documented here](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-priority). It is a simple addition that may benefit companies which validate content of `debian/control` and require that a `Priority:` field is effectively set.