### PR TITLE
Improve docs for updater signing CLI usage

### DIFF
--- a/core/tauri/src/updater/mod.rs
+++ b/core/tauri/src/updater/mod.rs
@@ -404,9 +404,11 @@
 //!
 //! The *Private key* (privkey) is used to sign your update and should NEVER be shared with anyone. Also, if you lost this key, you'll NOT be able to publish a new update to the current user base (if pubkey is set in tauri.conf.json). It's important to save it at a safe place and you can always access it.
 //!
-//! To generate your keys you need to use the Tauri cli.
+//! To generate your keys you need to use the Tauri cli. 
 //!
 //! ```bash
+//! # Generate the keys, follow the instructions
+//! tauri signer generate
 //! tauri signer sign -g -w ~/.tauri/myapp.key
 //! ```
 //!


### PR DESCRIPTION
The `generate` command wasn't mentioned in the docs, although it feels like quite an essential step in setting up the updater. This should help clear things up a bit.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
