### PR TITLE
feat(core): Expose wry and tao

### DIFF
--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -83,7 +83,7 @@ pub use wry::application::platform::macos::{
 };
 
 pub use wry;
-pub use wry::tao;
+pub use wry::application as tao;
 
 use std::{
   collections::{

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -82,6 +82,9 @@ pub use wry::application::platform::macos::{
   NativeImage as WryNativeImage, WindowExtMacOS,
 };
 
+pub use wry;
+pub use wry::tao;
+
 use std::{
   collections::{
     hash_map::Entry::{Occupied, Vacant},

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -169,6 +169,10 @@ pub use tauri_utils as utils;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "wry")))]
 pub type Wry = tauri_runtime_wry::Wry<EventLoopMessage>;
 
+/// Expose wry and tao
+#[cfg(feature = "wry")]
+pub use tauri_runtime_wry::{tao, wry};
+
 /// `Result<T, ::tauri::Error>`
 pub type Result<T> = std::result::Result<T, Error>;
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

The goal of this change is to be able to call tao APIs (like platform-native ones on WindowBuilder) from Tauri without having to separately depend on tao.

This change depends on this one in wry: https://github.com/tauri-apps/wry/pull/549 
