### PR TITLE
feat(core): fallback to `{path}.html` in Tauri protocol loader ref #3887

### DIFF
--- a/.changes/asset-default-ext-fallback.md
+++ b/.changes/asset-default-ext-fallback.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fallback to `{path}.html` when `{path}` is not found in the Tauri custom protocol handler.

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -751,6 +751,18 @@ impl<R: Runtime> WindowManager<R> {
     let asset_response = assets
       .get(&path.as_str().into())
       .or_else(|| {
+        eprintln!("Asset `{}` not found; fallback to {}.html", path, path);
+        let fallback = format!("{}.html", path.as_str()).into();
+        let asset = assets.get(&fallback);
+        asset_path = fallback;
+        asset
+      })
+      .or_else(|| {
+        #[cfg(debug_assertions)]
+        eprintln!(
+          "Asset `{}` not found; fallback to {}/index.html",
+          path, path
+        );
         let fallback = format!("{}/index.html", path.as_str()).into();
         let asset = assets.get(&fallback);
         asset_path = fallback;
@@ -758,7 +770,7 @@ impl<R: Runtime> WindowManager<R> {
       })
       .or_else(|| {
         #[cfg(debug_assertions)]
-        eprintln!("Asset `{}` not found; fallback to index.html", path); // TODO log::error!
+        eprintln!("Asset `{}` not found; fallback to index.html", path);
         let fallback = AssetKey::from("index.html");
         let asset = assets.get(&fallback);
         asset_path = fallback;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
