### PR TITLE
feat(cli): check and notify about updates on `tauri dev`, closes #3789

### DIFF
--- a/.changes/cli-dev-update.md
+++ b/.changes/cli-dev-update.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Notify CLI update when running `tauri dev`.

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -22,14 +22,14 @@ jobs:
             target: x86_64-apple-darwin
             architecture: x64
             build: |
-              yarn build
+              yarn build:release
               strip -x *.node
           - host: windows-latest
-            build: yarn build
+            build: yarn build:release
             target: x86_64-pc-windows-msvc
             architecture: x64
           - host: windows-latest
-            build: yarn build --target i686-pc-windows-msvc
+            build: yarn build:release --target i686-pc-windows-msvc
             target: i686-pc-windows-msvc
             architecture: x64
           - host: ubuntu-18.04
@@ -39,16 +39,16 @@ jobs:
               set -e &&
               rustup target add x86_64-unknown-linux-gnu &&
               cd tooling/cli/node
-              yarn build --target x86_64-unknown-linux-gnu --zig --zig-abi-suffix 2.12 &&
+              yarn build:release --target x86_64-unknown-linux-gnu --zig --zig-abi-suffix 2.12 &&
               llvm-strip -x *.node
           - host: ubuntu-18.04
             target: x86_64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-            build: set -e && cd tooling/cli/node && yarn build && strip *.node
+            build: set -e && cd tooling/cli/node && yarn build:release && strip *.node
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
-              yarn build --target=aarch64-apple-darwin
+              yarn build:release --target=aarch64-apple-darwin
               strip -x *.node
           - host: ubuntu-18.04
             architecture: x64
@@ -57,7 +57,7 @@ jobs:
               sudo apt-get update
               sudo apt-get install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu -y
             build: |
-              yarn build --target=aarch64-unknown-linux-gnu
+              yarn build:release --target=aarch64-unknown-linux-gnu
               aarch64-linux-gnu-strip *.node
           - host: ubuntu-18.04
             architecture: x64
@@ -66,7 +66,7 @@ jobs:
               sudo apt-get update
               sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf -y
             build: |
-              yarn build --target=armv7-unknown-linux-gnueabihf
+              yarn build:release --target=armv7-unknown-linux-gnueabihf
               arm-linux-gnueabihf-strip *.node
           - host: ubuntu-18.04
             architecture: x64
@@ -76,12 +76,12 @@ jobs:
               set -e &&
               rustup target add aarch64-unknown-linux-musl &&
               cd tooling/cli/node &&
-              yarn build --target aarch64-unknown-linux-musl &&
+              yarn build:release --target aarch64-unknown-linux-musl &&
               /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
           #- host: windows-latest
           #  architecture: x64
           #  target: aarch64-pc-windows-msvc
-          #  build: yarn build --target aarch64-pc-windows-msvc
+          #  build: yarn build:release --target aarch64-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
     steps:
@@ -173,7 +173,7 @@ jobs:
   #            freebsd-version
   #            cd ./tooling/cli/node/
   #            yarn install --ignore-scripts --frozen-lockfile --registry https://registry.npmjs.org --network-timeout 300000
-  #            yarn build
+  #            yarn build:release
   #            strip -x *.node
   #            rm -rf node_modules
   #            rm -rf ../target

--- a/tooling/cli/node/package.json
+++ b/tooling/cli/node/package.json
@@ -52,8 +52,8 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --platform --release",
-    "build:debug": "napi build --platform",
+    "build:release": "napi build --platform --release",
+    "build": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "jest --runInBand --forceExit --no-cache",
     "version": "napi version",

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -78,6 +78,7 @@ pub fn command(options: Options) -> Result<()> {
 fn command_internal(options: Options) -> Result<()> {
   let logger = Logger::new("tauri:dev");
 
+  #[cfg(not(debug_assertions))]
   match check_for_updates() {
     Ok((msg, sleep)) => {
       if sleep {
@@ -295,6 +296,7 @@ fn command_internal(options: Options) -> Result<()> {
   }
 }
 
+#[cfg(not(debug_assertions))]
 fn check_for_updates() -> Result<(String, bool)> {
   let current_version = crate::info::cli_current_version()?;
   let current = semver::Version::parse(&current_version)?;

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -78,6 +78,20 @@ pub fn command(options: Options) -> Result<()> {
 fn command_internal(options: Options) -> Result<()> {
   let logger = Logger::new("tauri:dev");
 
+  match check_for_updates() {
+    Ok((msg, sleep)) => {
+      if sleep {
+        logger.log(msg);
+        std::thread::sleep(std::time::Duration::from_secs(3));
+      } else {
+        logger.log(msg);
+      }
+    }
+    Err(e) => {
+      logger.log(e.to_string());
+    }
+  };
+
   let tauri_path = tauri_dir();
   set_current_dir(&tauri_path).with_context(|| "failed to change current working directory")?;
   let merge_config = if let Some(config) = &options.config {
@@ -279,6 +293,22 @@ fn command_internal(options: Options) -> Result<()> {
   } else {
     Ok(())
   }
+}
+
+fn check_for_updates() -> Result<(String, bool)> {
+  let current_version = crate::info::cli_current_version()?;
+  let current = semver::Version::parse(&current_version)?;
+
+  let upstream_version = crate::info::cli_upstream_version()?;
+  let upstream = semver::Version::parse(&upstream_version)?;
+  if upstream.gt(&current) {
+    let message = format!(
+      "🚀 A new version of Tauri CLI is avaliable! [{}]",
+      upstream.to_string()
+    );
+    return Ok((message, true));
+  }
+  Ok(("🎉 Tauri CLI is up-to-date!".into(), false))
 }
 
 fn lookup<F: FnMut(FileType, PathBuf)>(dir: &Path, mut f: F) {

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -89,10 +89,12 @@ fn version_metadata() -> Result<VersionMetadata> {
   serde_json::from_str::<VersionMetadata>(include_str!("../metadata.json")).map_err(Into::into)
 }
 
+#[cfg(not(debug_assertions))]
 pub(crate) fn cli_current_version() -> Result<String> {
   version_metadata().map(|meta| meta.js_cli.version)
 }
 
+#[cfg(not(debug_assertions))]
 pub(crate) fn cli_upstream_version() -> Result<String> {
   let upstream_metadata = match ureq::get(
     "https://raw.githubusercontent.com/tauri-apps/tauri/dev/tooling/cli/metadata.json",

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -85,9 +85,12 @@ enum PackageManager {
 #[clap(about = "Shows information about Tauri dependencies and project configuration")]
 pub struct Options;
 
+fn version_metadata() -> Result<VersionMetadata> {
+  serde_json::from_str::<VersionMetadata>(include_str!("../metadata.json")).map_err(Into::into)
+}
+
 pub(crate) fn cli_current_version() -> Result<String> {
-  let meta = serde_json::from_str::<VersionMetadata>(include_str!("../metadata.json"))?;
-  Ok(meta.js_cli.version)
+  version_metadata().map(|meta| meta.js_cli.version)
 }
 
 pub(crate) fn cli_upstream_version() -> Result<String> {
@@ -614,7 +617,7 @@ pub fn command(_options: Options) -> Result<()> {
     .unwrap_or_default();
   panic::set_hook(hook);
 
-  let metadata = serde_json::from_str::<VersionMetadata>(include_str!("../metadata.json"))?;
+  let metadata = version_metadata()?;
   VersionBlock::new(
     "Node.js",
     get_version("node", &[])


### PR DESCRIPTION
this feature helps the users of tauri know that there is a new version of CLI avaliable. it uses `metadata.json` from the tooling/cli directory (raw asset from github) and checks with the bundled version of metadata.json.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ x] I have added a convincing reason for adding this feature, if necessary

### Other information
