### PR TITLE
fix(cli.rs): fix `tauri info` panic when a package isn't installed, closes #3985

### DIFF
--- a/.changes/cli.rs-info-panic.md
+++ b/.changes/cli.rs-info-panic.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Fix `tauri info` panic when a pacakage isn't installed.

--- a/tooling/cli/metadata.json
+++ b/tooling/cli/metadata.json
@@ -1,7 +1,7 @@
 {
   "cli.js": {
     "version": "1.0.0-rc.9",
-    "node": ">= 10"
+    "node": ">= 10.0.0"
   },
   "tauri": "1.0.0-rc.8",
   "tauri-build": "1.0.0-rc.7"

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -494,7 +494,6 @@ struct VersionBlock {
   version: String,
   target_version: String,
   indentation: usize,
-  skip_update_check: bool,
 }
 
 impl VersionBlock {
@@ -504,13 +503,7 @@ impl VersionBlock {
       version: version.into(),
       target_version: "".into(),
       indentation: 2,
-      skip_update_check: false,
     }
-  }
-
-  fn skip_update_check(mut self) -> Self {
-    self.skip_update_check = true;
-    self
   }
 
   fn target_version(mut self, version: impl Into<String>) -> Self {
@@ -531,7 +524,7 @@ impl VersionBlock {
         self.version.clone()
       }
     );
-    if !self.target_version.is_empty() && !self.skip_update_check {
+    if !self.version.is_empty() && !self.target_version.is_empty() {
       let version = semver::Version::parse(self.version.as_str()).unwrap();
       let target_version = semver::Version::parse(self.target_version.as_str()).unwrap();
       if version < target_version {
@@ -630,7 +623,6 @@ pub fn command(_options: Options) -> Result<()> {
       .collect::<String>(),
   )
   .target_version(metadata.js_cli.node.replace(">= ", ""))
-  .skip_update_check()
   .display();
 
   VersionBlock::new(

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -524,7 +524,7 @@ impl VersionBlock {
         self.version.clone()
       }
     );
-    if !self.version.is_empty() && !self.target_version.is_empty() {
+    if !(self.version.is_empty() || self.target_version.is_empty()) {
       let version = semver::Version::parse(self.version.as_str()).unwrap();
       let target_version = semver::Version::parse(self.target_version.as_str()).unwrap();
       if version < target_version {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
