### PR TITLE
fix(tauri-runtime-wry): menu even panic on macOS inspector, closes #3875

### DIFF
--- a/.changes/fix-menu-crash.md
+++ b/.changes/fix-menu-crash.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch
+---
+
+Fixes a crash when using the menu with the inspector window focused on macOS. In this case the `window_id` will be the id of the first app window.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Unfortunately I don't think there's a way to properly fix this, the webkit API for the inspector window is really a private thing and does not expose the methods we'd need to get the inspector window id and the inspected window.