### PR TITLE
fix(core): dialog crashing on macOS when the parent is empty

### DIFF
--- a/.changes/fix-dialog-default-path-crash.md
+++ b/.changes/fix-dialog-default-path-crash.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fix dialog crash on macOS when the `default_path` value is just the file name.

--- a/core/tauri/src/endpoints/dialog.rs
+++ b/core/tauri/src/endpoints/dialog.rs
@@ -205,7 +205,9 @@ fn set_default_path(
 ) -> FileDialogBuilder {
   if default_path.is_file() || !default_path.exists() {
     if let (Some(parent), Some(file_name)) = (default_path.parent(), default_path.file_name()) {
-      dialog_builder = dialog_builder.set_directory(parent);
+      if parent.components().count() > 0 {
+        dialog_builder = dialog_builder.set_directory(parent);
+      }
       dialog_builder = dialog_builder.set_file_name(&file_name.to_string_lossy().to_string());
     } else {
       dialog_builder = dialog_builder.set_directory(default_path);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
