### PR TITLE
fix(build): append .exe binary based on target triple instead of running OS, closes #3870

### DIFF
--- a/.changes/cli-bin-ext-from-target-triple.md
+++ b/.changes/cli-bin-ext-from-target-triple.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Resolve binary file extension from target triple instead of compile-time checks to allow cross compilation.

--- a/core/tauri-utils/src/resources.rs
+++ b/core/tauri-utils/src/resources.rs
@@ -29,7 +29,11 @@ pub fn external_binaries(external_binaries: &[String], target_triple: &str) -> V
       "{}-{}{}",
       curr_path,
       target_triple,
-      if target_triple.contains("windows") { ".exe" } else { "" }
+      if target_triple.contains("windows") {
+        ".exe"
+      } else {
+        ""
+      }
     ));
   }
   paths

--- a/core/tauri-utils/src/resources.rs
+++ b/core/tauri-utils/src/resources.rs
@@ -29,7 +29,7 @@ pub fn external_binaries(external_binaries: &[String], target_triple: &str) -> V
       "{}-{}{}",
       curr_path,
       target_triple,
-      if cfg!(windows) { ".exe" } else { "" }
+      if target_triple.contains("windows") { ".exe" } else { "" }
     ));
   }
   paths

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -322,11 +322,7 @@ impl BundleBinary {
   /// Creates a new bundle binary.
   pub fn new(name: String, main: bool) -> Self {
     Self {
-      name: if cfg!(windows) {
-        format!("{}.exe", name)
-      } else {
-        name
-      },
+      name,
       src_path: None,
       main,
     }

--- a/tooling/cli/src/build.rs
+++ b/tooling/cli/src/build.rs
@@ -169,10 +169,19 @@ pub fn command(options: Options) -> Result<()> {
     .clone()
     .expect("Cargo manifest must have the `package.name` field");
 
-  let target: String = if options.target.is_some() { options.target.clone().unwrap().into() } else { "".into() };
-  let binary_suffix: String = if target.contains("windows") { ".exe" } else { "" }.into();
+  let target: String = if let Some(target) = options.target.clone() {
+    target
+  } else {
+    tauri_utils::platform::target_triple()?
+  };
+  let binary_extension: String = if target.contains("windows") {
+    ".exe"
+  } else {
+    ""
+  }
+  .into();
 
-  let bin_path = out_dir.join(format!("{}{}", &bin_name, &binary_suffix));
+  let bin_path = out_dir.join(&bin_name).with_extension(&binary_extension);
 
   let no_default_features = args.contains(&"--no-default-features".into());
 
@@ -215,7 +224,9 @@ pub fn command(options: Options) -> Result<()> {
     #[cfg(target_os = "linux")]
     let product_name = product_name.to_kebab_case();
 
-    let product_path = out_dir.join(format!("{}{}", product_name, binary_suffix));
+    let product_path = out_dir
+      .join(&product_name)
+      .with_extension(&binary_extension);
 
     rename(&bin_path, &product_path).with_context(|| {
       format!(
@@ -314,7 +325,7 @@ pub fn command(options: Options) -> Result<()> {
     }
     let settings = crate::interface::get_bundler_settings(
       app_settings,
-      options.target.clone(),
+      target,
       &enabled_features,
       &manifest,
       config_,

--- a/tooling/cli/src/build.rs
+++ b/tooling/cli/src/build.rs
@@ -168,10 +168,11 @@ pub fn command(options: Options) -> Result<()> {
     .name
     .clone()
     .expect("Cargo manifest must have the `package.name` field");
-  #[cfg(windows)]
-  let bin_path = out_dir.join(format!("{}.exe", bin_name));
-  #[cfg(not(windows))]
-  let bin_path = out_dir.join(&bin_name);
+
+  let target: String = if options.target.is_some() { options.target.clone().unwrap().into() } else { "".into() };
+  let binary_suffix: String = if target.contains("windows") { ".exe" } else { "" }.into();
+
+  let bin_path = out_dir.join(format!("{}{}", &bin_name, &binary_suffix));
 
   let no_default_features = args.contains(&"--no-default-features".into());
 
@@ -211,12 +212,11 @@ pub fn command(options: Options) -> Result<()> {
   }
 
   if let Some(product_name) = config_.package.product_name.clone() {
-    #[cfg(windows)]
-    let product_path = out_dir.join(format!("{}.exe", product_name));
-    #[cfg(target_os = "macos")]
-    let product_path = out_dir.join(product_name);
     #[cfg(target_os = "linux")]
-    let product_path = out_dir.join(product_name.to_kebab_case());
+    let product_name = product_name.to_kebab_case();
+
+    let product_path = out_dir.join(format!("{}{}", product_name, binary_suffix));
+
     rename(&bin_path, &product_path).with_context(|| {
       format!(
         "failed to rename `{}` to `{}`",

--- a/tooling/cli/src/interface/mod.rs
+++ b/tooling/cli/src/interface/mod.rs
@@ -23,7 +23,7 @@ pub fn get_bundler_settings(
   let mut settings_builder = SettingsBuilder::new()
     .package_settings(app_settings.get_package_settings())
     .bundle_settings(app_settings.get_bundle_settings(config, manifest, features)?)
-    .binaries(app_settings.get_binaries(config)?)
+    .binaries(app_settings.get_binaries(config, target.clone())?)
     .project_out_directory(out_dir);
 
   if verbose {

--- a/tooling/cli/src/interface/mod.rs
+++ b/tooling/cli/src/interface/mod.rs
@@ -12,7 +12,7 @@ use tauri_bundler::bundle::{PackageType, Settings, SettingsBuilder};
 #[allow(clippy::too_many_arguments)]
 pub fn get_bundler_settings(
   app_settings: rust::AppSettings,
-  target: Option<String>,
+  target: String,
   features: &[String],
   manifest: &Manifest,
   config: &Config,
@@ -23,8 +23,9 @@ pub fn get_bundler_settings(
   let mut settings_builder = SettingsBuilder::new()
     .package_settings(app_settings.get_package_settings())
     .bundle_settings(app_settings.get_bundle_settings(config, manifest, features)?)
-    .binaries(app_settings.get_binaries(config, target.clone())?)
-    .project_out_directory(out_dir);
+    .binaries(app_settings.get_binaries(config, &target)?)
+    .project_out_directory(out_dir)
+    .target(target);
 
   if verbose {
     settings_builder = settings_builder.verbose();
@@ -32,10 +33,6 @@ pub fn get_bundler_settings(
 
   if let Some(types) = package_types {
     settings_builder = settings_builder.package_types(types);
-  }
-
-  if let Some(target) = target {
-    settings_builder = settings_builder.target(target);
   }
 
   settings_builder.build().map_err(Into::into)

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -198,8 +198,12 @@ impl AppSettings {
     self.package_settings.clone()
   }
 
-  pub fn get_binaries(&self, config: &Config) -> crate::Result<Vec<BundleBinary>> {
+  pub fn get_binaries(&self, config: &Config, target: Option<String>) -> crate::Result<Vec<BundleBinary>> {
     let mut binaries: Vec<BundleBinary> = vec![];
+
+    let target = target.unwrap_or(String::from(""));
+    let binary_suffix: String = if target.contains("windows") { ".exe" } else { "" }.into();
+
     if let Some(bin) = &self.cargo_settings.bin {
       let default_run = self
         .package_settings
@@ -212,14 +216,20 @@ impl AppSettings {
             || binary.name.as_str() == default_run
           {
             BundleBinary::new(
-              config
-                .package
-                .binary_name()
-                .unwrap_or_else(|| binary.name.clone()),
+              format!("{}{}",
+                config
+                  .package
+                  .binary_name()
+                  .unwrap_or_else(|| binary.name.clone()),
+                &binary_suffix
+              ),
               true,
             )
           } else {
-            BundleBinary::new(binary.name.clone(), false)
+            BundleBinary::new(
+              format!("{}{}", binary.name.clone(), &binary_suffix),
+              false
+            )
           }
           .set_src_path(binary.path.clone()),
         )
@@ -236,7 +246,10 @@ impl AppSettings {
             bin.name() == name || path.ends_with(bin.src_path().unwrap_or(&"".to_string()))
           });
           if !bin_exists {
-            binaries.push(BundleBinary::new(name.to_string_lossy().to_string(), false))
+            binaries.push(BundleBinary::new(
+              format!("{}{}", name.to_string_lossy().to_string(), &binary_suffix),
+              false
+            ))
           }
         }
       }
@@ -251,10 +264,13 @@ impl AppSettings {
         }
         None => {
           binaries.push(BundleBinary::new(
-            config
-              .package
-              .binary_name()
-              .unwrap_or_else(|| default_run.to_string()),
+            format!("{}{}",
+              config
+                .package
+                .binary_name()
+                .unwrap_or_else(|| default_run.to_string()),
+              &binary_suffix
+            ),
             true,
           ));
         }
@@ -266,7 +282,7 @@ impl AppSettings {
         #[cfg(target_os = "linux")]
         self.package_settings.product_name.to_kebab_case(),
         #[cfg(not(target_os = "linux"))]
-        self.package_settings.product_name.clone(),
+        format!("{}{}", self.package_settings.product_name.clone(), &binary_suffix),
         true,
       )),
       1 => binaries.get_mut(0).unwrap().set_main(true),

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -291,7 +291,7 @@ impl AppSettings {
         format!(
           "{}{}",
           self.package_settings.product_name.clone(),
-          &binary_suffix
+          &binary_extension
         ),
         true,
       )),

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -198,11 +198,15 @@ impl AppSettings {
     self.package_settings.clone()
   }
 
-  pub fn get_binaries(&self, config: &Config, target: Option<String>) -> crate::Result<Vec<BundleBinary>> {
+  pub fn get_binaries(&self, config: &Config, target: &str) -> crate::Result<Vec<BundleBinary>> {
     let mut binaries: Vec<BundleBinary> = vec![];
 
-    let target = target.unwrap_or(String::from(""));
-    let binary_suffix: String = if target.contains("windows") { ".exe" } else { "" }.into();
+    let binary_extension: String = if target.contains("windows") {
+      ".exe"
+    } else {
+      ""
+    }
+    .into();
 
     if let Some(bin) = &self.cargo_settings.bin {
       let default_run = self
@@ -216,19 +220,20 @@ impl AppSettings {
             || binary.name.as_str() == default_run
           {
             BundleBinary::new(
-              format!("{}{}",
+              format!(
+                "{}{}",
                 config
                   .package
                   .binary_name()
                   .unwrap_or_else(|| binary.name.clone()),
-                &binary_suffix
+                &binary_extension
               ),
               true,
             )
           } else {
             BundleBinary::new(
-              format!("{}{}", binary.name.clone(), &binary_suffix),
-              false
+              format!("{}{}", binary.name.clone(), &binary_extension),
+              false,
             )
           }
           .set_src_path(binary.path.clone()),
@@ -247,8 +252,8 @@ impl AppSettings {
           });
           if !bin_exists {
             binaries.push(BundleBinary::new(
-              format!("{}{}", name.to_string_lossy().to_string(), &binary_suffix),
-              false
+              format!("{}{}", name.to_string_lossy(), &binary_extension),
+              false,
             ))
           }
         }
@@ -264,12 +269,13 @@ impl AppSettings {
         }
         None => {
           binaries.push(BundleBinary::new(
-            format!("{}{}",
+            format!(
+              "{}{}",
               config
                 .package
                 .binary_name()
                 .unwrap_or_else(|| default_run.to_string()),
-              &binary_suffix
+              &binary_extension
             ),
             true,
           ));
@@ -282,7 +288,11 @@ impl AppSettings {
         #[cfg(target_os = "linux")]
         self.package_settings.product_name.to_kebab_case(),
         #[cfg(not(target_os = "linux"))]
-        format!("{}{}", self.package_settings.product_name.clone(), &binary_suffix),
+        format!(
+          "{}{}",
+          self.package_settings.product_name.clone(),
+          &binary_suffix
+        ),
         true,
       )),
       1 => binaries.get_mut(0).unwrap().set_main(true),


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

Yes, a minor one I hope:

`cli::interface::rust::get_binaries()` gets a new `target: Option<String>` argument, which is the target triple you want to build your application for.

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

The side-effect of this is that it enables using [cross](https://github.com/cross-rs/cross) as build runner to attempt cross-compiling projects.

**Request for suggestions:**

As the target is currently optional because it should fall back to the current target triple, I need some help knowing how to get the current target triple (in a cleaner way than [what I currently found](https://codeutility.org/how-can-i-find-the-current-rust-compilers-default-llvm-target-triple-stack-overflow/)) so that we can no longer depend on an optional value.

I thought we could use these build-in constants ARCH, OS and FAMILY (from there: https://doc.rust-lang.org/std/env/consts/index.html ), but not sure of their reliability regarding Tauri's ecosystem.




