### PR TITLE
fix: generate windows resource directories using resource_relpath, closes #4087.

### DIFF
--- a/.changes/fix-resource-windows.md
+++ b/.changes/fix-resource-windows.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Fixes resource bundling on Windows when the resource path includes root or parent directory components.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -14,6 +14,7 @@ use log::info;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
+use tauri_utils::resources::resource_relpath;
 use std::{
   collections::{BTreeMap, HashMap},
   fs::{create_dir_all, read_to_string, remove_dir_all, rename, write, File},
@@ -796,13 +797,10 @@ fn generate_resource_data(settings: &Settings) -> crate::Result<ResourceMap> {
     };
 
     // split the resource path directories
-    let components_count = src.components().count();
-    let directories = src
+    let target_path = resource_relpath(&src);
+    let components_count = target_path.components().count();
+    let directories = target_path
       .components()
-      .filter(|component| {
-        let comp = component.as_os_str();
-        comp != "." && comp != ".."
-      })
       .take(components_count - 1) // the last component is the file
       .collect::<Vec<_>>();
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
