### PR TITLE
VS Code: Ubuntu development container via Docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ubuntu/.devcontainer/base.Dockerfile
+# [Choice] Ubuntu version (use jammy or bionic on local arm64/Apple Silicon): jammy, focal, bionic
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# Derived from Tauri contribution and setup guides:
+# See: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#development-guide
+# See: https://tauri.studio/v1/guides/getting-started/prerequisites/#setting-up-linux
+ARG TAURI_BUILD_DEPS="build-essential curl libappindicator3-dev libgtk-3-dev librsvg2-dev libssl-dev libwebkit2gtk-4.0-dev wget"
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends $TAURI_BUILD_DEPS

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# VS Code Devcontainer for Tauri
+
+## Overview
+
+Please note that most of these instructions are derived from Microsoft's VS Code documentation: [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers). Check the official documentation if you encounter problems and submit a PR with any corrections you find for the instructions below.
+
+The development container included in this repository is derived from [Microsoft's default Ubuntu development container](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ubuntu). Contents of the Ubuntu Docker image can be in the [VS Code devcontainer Ubuntu base Dockerfile](https://github.com/microsoft/vscode-dev-containers/blob/main/containers/ubuntu/.devcontainer/base.Dockerfile). The contents of the container used for development can be found in the [Dockerfile](./Dockerfile) located in the same directory as this README.
+
+## Usage
+
+1. Ensure you have all [Devcontainer Prerequisites](#devcontainer-prerequisites)
+2. Open the directory containing your [`tauri-apps/tauri`](https://github.com/tauri-apps/tauri) code.
+3. Install the [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension pack for VS Code. This will be included if you install recommended workspace extensions upon opening this repository.
+4. Ensure Docker is running
+5. [Open your workspace in the provided devcontainer](https://code.visualstudio.com/docs/remote/containers#_open-an-existing-workspace-in-a-container): Open this repository in VS Code and run **Remote-Containers: Reopen in Container...** from the Command Palette (<kbd>F1</kbd>).
+
+### Devcontainer Prerequisites
+
+Prerequisites are mainly derived from VS Code's instructions for usage of development containers, documented here: [Developing inside a Container: Getting Started](https://code.visualstudio.com/docs/remote/containers#_getting-started).
+
+1. Docker (Docker Desktop recommended)
+2. VS Code
+3. X window host - required if you want to be able to interact with a GUI from your Docker host
+
+### A note on filesystem performance
+
+Due to limititations in how Docker shares files between the Docker host and a container, it's also recommended that developers [clone Tauri source code into a container volume](https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-clone-repository-in-container-volume). This is optional, but highly advised as many filesystem/IO heavy opearations (`cargo build`, `yarn install`, etc) will be very slow if they operate on directories shared with a Docker container from the Docker host.
+
+To do this, open your project with VS Code and run **Remote-Containers: Clone Repository in Container Volume...** from the Command Palette (<kbd>F1</kbd>).
+
+### Accessing a Tauri application running you the devcontainer
+
+Docker Desktop provides facilities for [allowing the development container to connect to a service on the Docker host](https://docs.docker.com/desktop/windows/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host). So long as you have an X window server running on your Docker host, the devcontainer can connect to it and expose your Tauri GUI via an X window.
+
+**Export the `DISPLAY` variable within the devcontainer terminal you launch your Tauri application from to expose your GUI outside of the devcontainer**.
+```bash
+export DISPLAY="host.docker.internal:0"
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.234.0/containers/ubuntu
+{
+  "name": "Ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
+    // Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
+    "args": { "VARIANT": "ubuntu-22.04" }
+  },
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "uname -a",
+
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "features": {
+    "node": "lts",
+    "rust": "latest"
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-vscode-remote.vscode-remote-extensionpack",
+    "EditorConfig.EditorConfig",
+    "esbenp.prettier-vscode"
+  ]
+}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
I'm new to Tauri but have contributed to a number of other projects in the past. I find contributions that smooth over developer onboarding tend to have a lot of bang for their buck, especially while things are new and it's easy to spot friction one encounters.

This PR adds a quick and dirty Docker container and relevant VS Code configurations to allow for developers using VS Code start making changes quickly without fussing over provisioning of a compatible development environment.

The VS Code development container provided in this PR is based off of Microsoft's Ubuntu devcontainer (jammy, Ubuntu 22.04 LTS) that includes built-in support for Rust and NodeJS+yarn (backed by NVM).

**Some preliminary documentation on usage can be found here:** https://github.com/damien/tauri/blob/vscode-devcontainer/.devcontainer/README.md

Additionally, there are a number of objective reasons to offer a pre-configured container for development:

1. A containerized development environment is easily reproducible. Upgrades can be managed via the included Dockerfile and are distributed to contributors using it whenever changes are pulled.
2. Containerized environments are excellent for segregating a development environment from a host operating system, mitigating potential issues around global system configuration (e.g. system packages) and security (anything fishy introduced is limited to the container barring a 0-day or gross misconfiguration).
3. With some additional work, tools required for cutting releases or cross-compilation can be bundled to enable workflows for cutting ad-hoc releases or testing additional build targets.

Let me know what you think! I've found this development methodology to be great for folks who work with a wide variety of projects with differing requirements or conflicting development environment requirements.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Development tooling

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Manually tested and confirmed the following tasks work as expected:

1. Fresh checkout opened in VS Code prompts to open in the devcontainer and recommends appropriate extensions
5. VS Code offers to open browser on Docker host to access server ports within the devcontainer when appropriate (e.g. during tests, when running processes that bind to a port and serve HTTP)
6. `.scripts/setup.sh` succeeds
7. `cargo build --workspace --all-targets` succeeds
8. `cargo test --workspace --all-targets` succeeds
9. `cd tooling/cli/node; yarn build:release --target x86_64-unknown-linux-gnu` succeeds (note: `zig` and `llvm-strip` segments of this flow don't work, but that can be fixed by adding more dependencies to the devcontainer)
10. `cd tooling/api; yarn build` succeeds
