### PR TITLE
fix(bundler): ignore duplicated files in resource iter, closes #4126

### DIFF
--- a/.changes/fix-glob-resource-wix.md
+++ b/.changes/fix-glob-resource-wix.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Fixes processing of resources with glob patterns when there are nested directories on Windows.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -799,6 +799,13 @@ fn generate_resource_data(settings: &Settings) -> crate::Result<ResourceMap> {
       .into_string()
       .expect("failed to read resource path");
 
+    // In some glob resource paths like `assets/**/*` a file might appear twice
+    // because the `tauri_utils::resources::ResourcePaths` iterator also reads a directory
+    // when it finds one. So we must check it before processing the file.
+    if added_resources.contains(&resource_path) {
+      continue;
+    }
+
     added_resources.push(resource_path.clone());
 
     let resource_entry = ResourceFile {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

The ResourcePaths iterator can list a file twice since it also reads a folder when the glob pattern finds it (via the walk_iter usage). This PR adds a guard in the wix bundler to prevent registering the file twice.
