### PR TITLE
feat(bundler): allow bundling plugins with macOS applications

### DIFF
--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -117,6 +117,8 @@ pub struct MacConfig {
   ///
   /// If a name is used, ".framework" must be omitted and it will look for standard install locations. You may also use a path to a specific framework.
   pub frameworks: Option<Vec<String>>,
+  /// A list of strings indicating any macOS X plugins that need to be bundled with the application.
+  pub plugins: Option<Vec<String>>,
   /// A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.
   ///
   /// Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`
@@ -145,6 +147,7 @@ impl Default for MacConfig {
   fn default() -> Self {
     Self {
       frameworks: None,
+      plugins: None,
       minimum_system_version: minimum_system_version(),
       exception_domain: None,
       license: None,

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -147,6 +147,8 @@ pub struct MacOsSettings {
   ///
   /// - embedding the correct rpath in your binary (e.g. by running `install_name_tool -add_rpath "@executable_path/../Frameworks" path/to/binary` after compiling)
   pub frameworks: Option<Vec<String>>,
+  /// MacOS plugins that need to be bundled with the app.
+  pub plugins: Option<Vec<String>>,
   /// A version string indicating the minimum MacOS version that the bundled app supports (e.g. `"10.11"`).
   /// If you are using this config field, you may also want have your `build.rs` script emit `cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.11`.
   pub minimum_system_version: Option<String>,

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1172,6 +1172,16 @@
             "null"
           ]
         },
+        "plugins": {
+          "description": "A list of strings indicating any macOS X plugins that need to be bundled with the application.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "providerShortName": {
           "description": "Provider short name for notarization.",
           "type": [

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -484,6 +484,7 @@ fn tauri_config_to_bundle_settings(
     },
     macos: MacOsSettings {
       frameworks: config.macos.frameworks,
+      plugins: config.macos.plugins,
       minimum_system_version: config.macos.minimum_system_version,
       license: config.macos.license,
       exception_domain: config.macos.exception_domain,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
This change allows bundling app extensions, like Safari extensions or content blockers, and is quite trivial. I think later on app extensions could be created with Rust and Tauri could provide a simple IPC channel between it and the host app to make these things even simpler to do.