### PR TITLE
fix(core): fileDropEnabled option is not working when creating a new WebviewWindow

### DIFF
--- a/.changes/fix-window-file-drop-enabled.md
+++ b/.changes/fix-window-file-drop-enabled.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fixes `fileDropEnabled` option not working.

--- a/core/tauri/src/endpoints/window.rs
+++ b/core/tauri/src/endpoints/window.rs
@@ -204,8 +204,13 @@ impl Cmd {
   ) -> super::Result<()> {
     let label = options.label.clone();
     let url = options.url.clone();
+    let file_drop_enabled = options.file_drop_enabled;
 
     let mut builder = crate::window::Window::builder(&context.window, label, url);
+    if !file_drop_enabled {
+      builder = builder.disable_file_drop_handler();
+    }
+
     builder.window_builder =
       <<R::Dispatcher as Dispatch<crate::EventLoopMessage>>::WindowBuilder>::with_config(*options);
     builder.build().map_err(crate::error::into_anyhow)?;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
