### PR TITLE
fix: allow return value of fs::canonicalize on fs scope, closes #4130

### DIFF
--- a/.changes/fix-fs-scope-windows.md
+++ b/.changes/fix-fs-scope-windows.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Allow the canonical, absolute form of a path for the filesystem scope on Windows if `std::fs::canonicalize` returns a path, fallback to `\\?\$PATH`.

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -69,7 +69,11 @@ fn push_pattern<P: AsRef<Path>>(list: &mut HashSet<Pattern>, pattern: P) -> crat
   list.insert(Pattern::new(&path.to_string_lossy())?);
   #[cfg(windows)]
   {
-    list.insert(Pattern::new(&format!("\\\\?\\{}", path.display()))?);
+    if let Ok(p) = std::fs::canonicalize(&path) {
+      list.insert(Pattern::new(&p.to_string_lossy())?);
+    } else {
+      list.insert(Pattern::new(&format!("\\\\?\\{}", path.display()))?);
+    }
   }
   Ok(())
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

I hope this fixes #4130 (at least it fixes usage with the dialog when reading files from the network).
