### PR TITLE
fix(cli): manual config lookup to handle gitignored folders, fixes #3527

### DIFF
--- a/.changes/cli-fix-gitignored-conf-lookup.md
+++ b/.changes/cli-fix-gitignored-conf-lookup.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Check if `$CWD/src-tauri/tauri.conf.json` exists before walking through the file tree to find the tauri dir in case the whole project is gitignored.

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -56,7 +56,15 @@ fn lookup<F: Fn(&PathBuf, FileType) -> bool>(dir: &Path, checker: F) -> Option<P
 }
 
 fn get_tauri_dir() -> PathBuf {
-  lookup(&current_dir().expect("failed to read cwd"), |path, file_type| if file_type.is_dir() {
+  let cwd = current_dir().expect("failed to read cwd");
+
+  if cwd.join("src-tauri/tauri.conf.json").exists()
+    || cwd.join("src-tauri/tauri.conf.json5").exists()
+  {
+    return cwd.join("src-tauri/");
+  }
+
+  lookup(&cwd, |path, file_type| if file_type.is_dir() {
     path.join("tauri.conf.json").exists() || path.join("tauri.conf.json5").exists()
   } else if let Some(file_name) = path.file_name() {
     file_name == OsStr::new("tauri.conf.json") || file_name == OsStr::new("tauri.conf.json5")


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Turns out more people than expected have (parts of) their project gitignored and we currently only check if `$CWD/tauri.conf.json` exists which doesn't work for the most common structure == the one you get via CTA/`tauri init`.

The proposed workaround is really straightforward, we just manually check for `src-tauri/tauri.conf.json` before starting the actual lookup.
A nice-to-have side-effect is that this slightly improves performance for projects with the default structure 🤷 