### PR TITLE
fix: benchmark build error

### DIFF
--- a/tooling/bench/tests/Cargo.toml
+++ b/tooling/bench/tests/Cargo.toml
@@ -9,3 +9,27 @@ codegen-units = 1
 lto = true
 incremental = false
 opt-level = "s"
+
+# See https://github.com/rust-lang/cargo/issues/10118#issuecomment-1006000210
+# And https://github.com/rust-lang/rust/issues/96486
+[profile.release.package.compiler_builtins]
+# The compiler-builtins crate cannot reference libcore, and it's own CI will
+# verify that this is the case. This requires, however, that the crate is built
+# without overflow checks and debug assertions. Forcefully disable debug
+# assertions and overflow checks here which should ensure that even if these
+# assertions are enabled for libstd we won't enable then for compiler_builtins
+# which should ensure we still link everything correctly.
+debug-assertions = false
+overflow-checks = false
+
+# For compiler-builtins we always use a high number of codegen units.
+# The goal here is to place every single intrinsic into its own object
+# file to avoid symbol clashes with the system libgcc if possible. Note
+# that this number doesn't actually produce this many object files, we
+# just don't create more than this number of object files.
+#
+# It's a bit of a bummer that we have to pass this here, unfortunately.
+# Ideally this would be specified through an env var to Cargo so Cargo
+# knows how many CGUs are for this specific crate, but for now
+# per-crate configuration isn't specifiable in the environment.
+codegen-units = 10000


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [x] Other, please describe:

A bugfix, not in the Tauri codebase but benchmark tooling.

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

The specifics are a bit over my head here, but my understanding is:

We're using compiler optimizations for the benchmarks here
https://github.com/tauri-apps/tauri/blob/0c635959162dd9e2ef70897f7792034db7e66435/tooling/bench/tests/Cargo.toml#L6-L11

The `panic=abort` one prompts us to compile the std as well https://github.com/tauri-apps/tauri/blob/0c635959162dd9e2ef70897f7792034db7e66435/.github/workflows/bench.yml#L106

And it seems there's a known issue with `-Z build-std` and the LTO we've enabled:
https://github.com/rust-lang/rust/issues/96486

The workaround for which seems to be copying a profile from `rust-lang/rust` to our own `Cargo.toml`:
https://github.com/rust-lang/cargo/issues/10118#issuecomment-1006000210

So that's what I've done here, and it seems to work in a local Docker container test as well as GH actions on my fork:
https://github.com/Beanow/tauri/runs/6671511937?check_suite_focus=true