### PR TITLE
Fix: sidecar cleanup when only `shell-sidecar` is enabled

### DIFF
--- a/.changes/fix-sidecar-cleanup.md
+++ b/.changes/fix-sidecar-cleanup.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Kill sidecar processes on app exit even when only the `shell-sidecar` feature is enabled.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -448,7 +448,7 @@ impl<R: Runtime> AppHandle<R> {
 
   /// Runs necessary cleanup tasks before exiting the process
   fn cleanup_before_exit(&self) {
-    #[cfg(shell_execute)]
+    #[cfg(any(shell_execute, shell_sidecar))]
     {
       crate::api::process::kill_children();
     }


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ x] Bugfix

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Sidecar processes are not cleaned up properly unless `shell-execute` is enabled. This is problematic for apps in which only `shell-sidecar` is needed.

This fix calls `crate::api::process::kill_children()` when either `shell-execute` or `shell-sidecar` are enabled.