### PR TITLE
fix: put linux high dpi icons in the correct dir

### DIFF
--- a/.changes/linux-icon-high-dpi.md
+++ b/.changes/linux-icon-high-dpi.md
@@ -1,0 +1,6 @@
+---
+"tauri-bundler": patch
+---
+
+On Linux, high-dpi icons are now placed in the correct directory
+and should be recognized by the desktop environment.

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -276,7 +276,7 @@ fn generate_icon_files(settings: &Settings, data_dir: &Path) -> crate::Result<BT
       "{}x{}{}/apps/{}.png",
       width,
       height,
-      if is_high_density { "@2x" } else { "" },
+      if is_high_density { "@2" } else { "" },
       settings.main_binary_name()
     ))
   };


### PR DESCRIPTION

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

It wasn't trivial to find a spec for this, but I think this is the right one: https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html