### PR TITLE
fix: add a default icon to notifications on linux

### DIFF
--- a/.changes/linux-notification-icon.md
+++ b/.changes/linux-notification-icon.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Set notification icon to app icon on Linux.

--- a/core/tauri/src/api/notification.rs
+++ b/core/tauri/src/api/notification.rs
@@ -83,6 +83,8 @@ impl Notification {
     }
     if let Some(icon) = self.icon {
       notification.icon(&icon);
+    } else {
+      notification.auto_icon();
     }
     #[cfg(windows)]
     {


### PR DESCRIPTION
Currently, the notification api allows an optional icon. This has no effect on Windows and MacOS, where the icon is always taken from the application. This change has no effect on those platforms, but sets a default icon based on the binary path, which ensures notifications, by default, uses the app's icon.

This icon is also shown in dev mode if the app is installed. Otherwise, it just displays no icon.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
