### PR TITLE
fix(build): statically link VC runtime only on `tauri build`

### DIFF
--- a/.changes/set-static-vcruntime-envvar.md
+++ b/.changes/set-static-vcruntime-envvar.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Configure the `STATIC_VCRUNTIME` environment variable so `tauri-build` statically links it on the build command.

--- a/.changes/static-vcruntime-config-envvar.md
+++ b/.changes/static-vcruntime-config-envvar.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch
+---
+
+Only statically link the VC runtime when the `STATIC_VCRUNTIME` environment variable is set to `true` (automatically done by the Tauri CLI).

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -187,7 +187,9 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
   };
 
   #[cfg(windows)]
-  static_vcruntime::build();
+  if std::env::var("STATIC_VCRUNTIME").map_or(false, |v| v == "true") {
+    static_vcruntime::build();
+  }
 
   cfg_alias("dev", !has_feature("custom-protocol"));
 

--- a/core/tests/app-updater/build.rs
+++ b/core/tests/app-updater/build.rs
@@ -2,4 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-fn main() {}
+fn main() {
+  tauri_build::build()
+}

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -104,6 +104,7 @@ pub fn build_project(runner: String, args: Vec<String>) -> crate::Result<()> {
   Command::new(&runner)
     .args(&["build", "--features=custom-protocol"])
     .args(args)
+    .env("STATIC_VCRUNTIME", "true")
     .pipe()?
     .output_ok()
     .with_context(|| format!("Result of `{} build` operation was unsuccessful", runner))?;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Fixes `cargo test` not working in some configurations.