### PR TITLE
Append binary extension to filename based on target in Settings

### DIFF
--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2434,9 +2434,9 @@ fn handle_user_message<T: UserEvent>(
           .get(&id)
           .and_then(|w| w.inner.as_ref())
         {
-          if let Err(e) = webview.evaluate_script(&script) {
+          if let Err(_e) = webview.evaluate_script(&script) {
             #[cfg(debug_assertions)]
-            eprintln!("{}", e);
+            eprintln!("{}", _e);
           }
         }
       }
@@ -2473,9 +2473,9 @@ fn handle_user_message<T: UserEvent>(
           .expect("poisoned webview collection")
           .insert(window_id, webview);
       }
-      Err(e) => {
+      Err(_e) => {
         #[cfg(debug_assertions)]
-        eprintln!("{}", e);
+        eprintln!("{}", _e);
       }
     },
     Message::CreateWindow(window_id, handler, sender) => {
@@ -2771,9 +2771,9 @@ fn handle_event_loop<T: UserEvent>(
             .get(&window_id)
             .and_then(|w| w.inner.as_ref())
           {
-            if let Err(e) = webview.resize() {
+            if let Err(_e) = webview.resize() {
               #[cfg(debug_assertions)]
-              eprintln!("{}", e);
+              eprintln!("{}", _e);
             }
           }
         }

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -517,7 +517,15 @@ impl Settings {
   /// Returns the path to the specified binary.
   pub fn binary_path(&self, binary: &BundleBinary) -> PathBuf {
     let mut path = self.project_out_directory.clone();
-    let binary_name = format!("{}{}", binary.name(), if self.target.contains("windows") { ".exe" } else { "" });
+    let binary_name = format!(
+      "{}{}",
+      binary.name(),
+      if self.target.contains("windows") {
+        ".exe"
+      } else {
+        ""
+      }
+    );
     path.push(binary_name);
     path
   }

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -517,7 +517,8 @@ impl Settings {
   /// Returns the path to the specified binary.
   pub fn binary_path(&self, binary: &BundleBinary) -> PathBuf {
     let mut path = self.project_out_directory.clone();
-    path.push(binary.name());
+    let binary_name = format!("{}{}", binary.name(), if self.target.contains("windows") { ".exe" } else { "" });
+    path.push(binary_name);
     path
   }
 

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -607,7 +607,7 @@
           "type": "boolean"
         },
         "theme": {
-          "description": "The initial window theme. Defaults to the system theme. Only implemented on Windows and macOs 10.14+.",
+          "description": "The initial window theme. Defaults to the system theme. Only implemented on Windows and macOS 10.14+.",
           "anyOf": [
             {
               "$ref": "#/definitions/Theme"


### PR DESCRIPTION
This is a followup of #4032 and #4055, for the issue #3870.

I'm still attempting to cross-compile using `cross`, and I don't know if this specific change will break compat, so I'm creating this PR so that CI tests it on several other tools :)