### PR TITLE
fix(README.md): module is not a "development" dependency

### DIFF
--- a/tooling/api/README.md
+++ b/tooling/api/README.md
@@ -29,7 +29,7 @@ To learn more about the details of how all of these pieces fit together, please 
 
 ## Installation
 
-The preferred method is to install this module locally as a development dependency:
+The preferred method is to install this module locally as a dependency:
 ```
 $ npm install --save @tauri-apps/api
 $ yarn add @tauri-apps/api


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Development dependencies are `devDependency` in package.json. They are added with `--dev` or `-D` flag but this module is **not** a development dependency. This module is included in the built file. Development dependencies are tools that help with development but not in the final code, like bundlers like webpack, preprocessors like babel, etc.

Unless, I misunderstood, I think it's "incorrect" to call this a "development" dependency. 