### PR TITLE
fix(docs): use appdir instead of resourcedir in writeFile examples. Fix dialog docs.

### DIFF
--- a/tooling/api/src/dialog.ts
+++ b/tooling/api/src/dialog.ts
@@ -107,6 +107,7 @@ interface MessageDialogOptions {
  * } else {
  *   // user selected a single file
  * }
+ * ```
  *
  * @example Open a selection dialog for directories
  * ```typescript

--- a/tooling/api/src/fs.ts
+++ b/tooling/api/src/fs.ts
@@ -271,10 +271,10 @@ async function writeTextFile(
 
 /**
  * Writes a byte array content to a file.
- * @example Write a binary file to the `$RESOURCEDIR/avatar.png` path
+ * @example Write a binary file to the `$APPDIR/avatar.png` path
  * ```typescript
  * import { writeBinaryFile, BaseDirectory } from '@tauri-apps/api/fs';
- * await writeBinaryFile('avatar.png', new Uint8Array([]), { dir: BaseDirectory.Resource });
+ * await writeBinaryFile('avatar.png', new Uint8Array([]), { dir: BaseDirectory.App });
  * ```
  *
  * @param path The file path.
@@ -290,10 +290,10 @@ async function writeBinaryFile(
 
 /**
  * Writes a byte array content to a file.
- * @example Write a binary file to the `$RESOURCEDIR/avatar.png` path
+ * @example Write a binary file to the `$APPEDIR/avatar.png` path
  * ```typescript
  * import { writeBinaryFile, BaseDirectory } from '@tauri-apps/api/fs';
- * await writeBinaryFile({ path: 'avatar.png', contents: new Uint8Array([]) }, { dir: BaseDirectory.Resource });
+ * await writeBinaryFile({ path: 'avatar.png', contents: new Uint8Array([]) }, { dir: BaseDirectory.App });
  * ```
  *
  * @param file The object containing the file path and contents.


### PR DESCRIPTION
the resourcedir is generally not writable in bundled apps 🤷 

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary
