### PR TITLE
fix: dialog open supports multiple dirs, fixes #4091

### DIFF
--- a/.changes/dialog-multiple-folders.md
+++ b/.changes/dialog-multiple-folders.md
@@ -1,0 +1,6 @@
+---
+'api': patch
+'tauri': patch
+---
+
+Allow choosing multiple folders in `dialog.open`.

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -79,7 +79,7 @@ attohttpc = { version = "0.19", features = [ "json", "form" ], optional = true }
 open = { version = "3.0", optional = true }
 shared_child = { version = "1.0", optional = true }
 os_pipe = { version = "1.0", optional = true }
-rfd = { version = "0.8", optional = true }
+rfd = { version = "0.9", optional = true }
 raw-window-handle = "0.4.3"
 minisign-verify = { version = "0.2", optional = true }
 time = { version = "0.3", features = [ "parsing", "formatting" ], optional = true }

--- a/core/tauri/src/endpoints/dialog.rs
+++ b/core/tauri/src/endpoints/dialog.rs
@@ -181,24 +181,26 @@ impl Cmd {
 
     let scopes = context.window.state::<Scopes>();
 
-    let res = if options.directory && options.multiple {
-      let folders = dialog_builder.pick_folders();
-      if let Some(folders) = &folders {
-        for folder in folders {
+    let res = if options.directory {
+      if options.multiple {
+        let folders = dialog_builder.pick_folders();
+        if let Some(folders) = &folders {
+          for folder in folders {
+            scopes
+              .allow_directory(folder, options.recursive)
+              .map_err(crate::error::into_anyhow)?;
+          }
+        }
+        folders.into()
+      } else {
+        let folder = dialog_builder.pick_folder();
+        if let Some(path) = &folder {
           scopes
-            .allow_directory(folder, options.recursive)
+            .allow_directory(path, options.recursive)
             .map_err(crate::error::into_anyhow)?;
         }
+        folder.into()
       }
-      folders.into()
-    } else if options.directory {
-      let folder = dialog_builder.pick_folder();
-      if let Some(path) = &folder {
-        scopes
-          .allow_directory(path, options.recursive)
-          .map_err(crate::error::into_anyhow)?;
-      }
-      folder.into()
     } else if options.multiple {
       let files = dialog_builder.pick_files();
       if let Some(files) = &files {

--- a/core/tauri/src/endpoints/dialog.rs
+++ b/core/tauri/src/endpoints/dialog.rs
@@ -181,7 +181,17 @@ impl Cmd {
 
     let scopes = context.window.state::<Scopes>();
 
-    let res = if options.directory {
+    let res = if options.directory && options.multiple {
+      let folders = dialog_builder.pick_folders();
+      if let Some(folders) = &folders {
+        for folder in folders {
+          scopes
+            .allow_directory(folder, options.recursive)
+            .map_err(crate::error::into_anyhow)?;
+        }
+      }
+      folders.into()
+    } else if options.directory {
       let folder = dialog_builder.pick_folder();
       if let Some(path) = &folder {
         scopes


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This requires no change to the dialog.open endpoint  since `multiple` is an existing parameter.