### PR TITLE
fix(bundler): ensure AppImage usr/lib is a dir

### DIFF
--- a/.changes/bundler-appimage-fix.md
+++ b/.changes/bundler-appimage-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Ensure `usr/lib` is a directory in the AppImage bundle.

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -26,6 +26,8 @@ mkdir -p "{{app_name}}.AppDir"
 cp -r "${OUTDIR}/../appimage_deb/data/usr" "{{app_name}}.AppDir"
 
 cd "{{app_name}}.AppDir"
+mkdir -p "usr/bin"
+mkdir -p "usr/lib"
 
 if [[ "$APPIMAGE_BUNDLE_XDG_OPEN" != "0" ]] && [[ -f "/usr/bin/xdg-open" ]]; then
   echo "Copying /usr/bin/xdg-open"


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Possibly the usr/lib directory wasn't yet created before copying the designated tray library. Resulting in a usr/lib _file_ containing libappindicator3.so and following commands failing as it expected a directory.

### Reproducing

1. From a fresh hello Tauri app, enable system tray in config.
```json
{
  "tauri": {
    "systemTray": {
      "iconPath": "icons/icon.png",
      "iconAsTemplate": true
    }
  }
}
```
2. Build with `yarn tauri --verbose build`.

The bundler will cause errors like: `cp: './usr/lib' exists but is not a directory`
And the AppDir contains a file usr/lib containing libappindicator3.so.
![image](https://user-images.githubusercontent.com/497556/174810165-2e09f4a8-4e2b-4130-859c-e67bfa44fb3c.png)

<details><summary>Appimage bundling log</summary>

```
Bundling [tauri_bundler::bundle::linux::appimage] hello_0.1.0_amd64.AppImage (/workdir/hello/src-tauri/target/release/bundle/appimage/hello_0.1.0_amd64.AppImage)
     Running [tauri_bundler::bundle::common] Command `/workdir/hello/src-tauri/target/release/bundle/appimage/build_appimage.sh `
+ export ARCH=x86_64
+ ARCH=x86_64
+ APPIMAGE_BUNDLE_XDG_OPEN=0
+ APPIMAGE_BUNDLE_GSTREAMER=0
+ TRAY_LIBRARY_PATH=/usr/lib/libappindicator3.so
+ '[' x86_64 == i686 ']'
+ linuxdeploy_arch=x86_64
+ OUTDIR=/workdir/hello/src-tauri/target/release/bundle/appimage
+ cd /home/beanow/.cache/tauri
+ rm -rf hello.AppDir
+ mkdir -p hello.AppDir
+ cp -r /workdir/hello/src-tauri/target/release/bundle/appimage/../appimage_deb/data/usr hello.AppDir
+ cd hello.AppDir
+ [[ 0 != \0 ]]
+ [[ /usr/lib/libappindicator3.so != \0 ]]
+ echo 'Copying appindicator library /usr/lib/libappindicator3.so'
+ cp /usr/lib/libappindicator3.so usr/lib
Copying appindicator library /usr/lib/libappindicator3.so
++ dirname '{}'
+ find /usr/lib /usr/lib32 /usr/lib64 -name WebKitNetworkProcess -exec mkdir -p . ';' -exec cp --parents '{}' . ';'
find: ‘/usr/lib/firmware/b43’: Permission denied
find: ‘/usr/lib/firmware/b43legacy’: Permission denied
cp: './usr/lib' exists but is not a directory
cp: './usr/lib' exists but is not a directory
+ true
++ dirname '{}'
+ find /usr/lib /usr/lib32 /usr/lib64 -name WebKitWebProcess -exec mkdir -p . ';' -exec cp --parents '{}' . ';'
find: ‘/usr/lib/firmware/b43’: Permission denied
find: ‘/usr/lib/firmware/b43legacy’: Permission denied
cp: './usr/lib' exists but is not a directory
cp: './usr/lib' exists but is not a directory
+ true
++ dirname '{}'
+ find /usr/lib /usr/lib32 /usr/lib64 -name libwebkit2gtkinjectedbundle.so -exec mkdir -p . ';' -exec cp --parents '{}' . ';'
find: ‘/usr/lib/firmware/b43’: Permission denied
find: ‘/usr/lib/firmware/b43legacy’: Permission denied
cp: './usr/lib' exists but is not a directory
cp: './usr/lib' exists but is not a directory
+ true
+ wget -q -4 -N -O AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64
+ chmod +x AppRun
+ cp usr/share/icons/hicolor/256x256@2/apps/hello.png .DirIcon
+ ln -s usr/share/icons/hicolor/256x256@2/apps/hello.png hello.png
+ ln -s usr/share/applications/hello.desktop hello.desktop
+ cd ..
+ [[ 0 != \0 ]]
+ gst_plugin=
+ wget -q -4 -N -O linuxdeploy-plugin-gtk.sh https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
+ wget -q -4 -N -O linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+ chmod +x linuxdeploy-plugin-gtk.sh
+ chmod +x linuxdeploy-x86_64.AppImage
+ OUTPUT=hello_0.1.0_amd64.AppImage
+ ./linuxdeploy-x86_64.AppImage --appimage-extract-and-run --appdir hello.AppDir --plugin gtk --output appimage
linuxdeploy version 1-alpha (git commit ID 56760df), GitHub actions build 85 built on 2022-06-14 00:36:51 UTC

-- Creating basic AppDir structure -- 
Creating directory hello.AppDir/usr/bin/ 
Creating directory hello.AppDir/usr/lib/ 
ERROR: Failed to create directory hello.AppDir/usr/lib/ERROR: Failed to create basic AppDir structure 
Error running CLI: failed to bundle project: error running appimage.sh: error running appimage.sh: `failed to run /workdir/hello/src-tauri/target/release/bundle/appimage/build_appimage.sh`
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>