### PR TITLE
fix: add supported OSs to readme, update status badges to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For **running** Tauri apps we support the below configurations (these are automa
 - Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
   - `libwebkit2gtk-4.0-37`, `libssl`, `libgtk-3-0`, `libayatana-appindicator3-1`<sup>1</sup>
 - Arch with the following packages installed:
-  - `webkit2gtk`, `appmenu-gtk-module`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>1</sup>, `libvips`
+  - `webkit2gtk`, `appmenu-gtk-module`, `gtk3`, `libayatana-appindicator`<sup>1</sup>
 - Fedora (latest 2 versions) with the following packages installed:
   - `webkit2gtk3`, `openssl`, `gtk3`, `libappindicator-gtk3`<sup>1</sup>
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ For **running** Tauri apps we support the below configurations (these are automa
 - Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
   - `libwebkit2gtk-4.0-37`, `libgtk-3-0`, `libayatana-appindicator3-1`<sup>1</sup>
 - Arch with the following packages installed:
-  - `webkit2gtk`, `appmenu-gtk-module`, `gtk3`, `libayatana-appindicator`<sup>1</sup>
+  - `webkit2gtk`, `gtk3`, `libayatana-appindicator`<sup>1</sup>
 - Fedora (latest 2 versions) with the following packages installed:
-  - `webkit2gtk3`, `openssl`, `gtk3`, `libappindicator-gtk3`<sup>1</sup>
+  - `webkit2gtk3`, `gtk3`, `libappindicator-gtk3`<sup>1</sup>
 
 <sup>1</sup> `appindicator` is only required if system trays are used
 

--- a/README.md
+++ b/README.md
@@ -49,27 +49,16 @@ Tauri currently supports development and distribution on the following platforms
 
 **Linux Support**
 
-For **developing** Tauri apps we support the following configurations:
+For **developing** Tauri apps refer to the [Getting Started guide on tauri.app](https://tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux).
 
-- Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
-  - `libwebkit2gtk-4.0-dev`, `build-essential`, `curl`, `wget`, `libssl-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`<sup>1</sup>, `librsvg2-dev`<sup>2</sup>
-- Arch with the following packages installed:
-  - `webkit2gtk`, `appmenu-gtk-module`, `base-devel`, `curl`, `wget`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>1</sup>, `librsvg`<sup>2</sup>, `libvips`
-- Fedora with the following packages installed:
-  - `webkit2gtk3-devel.x86_64`, `openssl-devel`, `curl`, `wget`, `libappindicator-gtk3`<sup>1</sup>, `librsvg2-devel`<sup>2</sup>
-
-<sup>1</sup> `appindicator` is only required if system trays are used
-
-<sup>2</sup> `librsvg` is only required for appimage bundling
-
-For **running** Tauri apps we support the following configurations:
+For **running** Tauri apps we support the below configurations (these are automatically added as dependencies for .deb and are bundled for AppImage so that your users don't need to manually install them):
 
 - Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
   - `libwebkit2gtk-4.0`, `libssl`, `libgtk-3`, `libayatana-appindicator3`<sup>1</sup>
 - Arch with the following packages installed:
-  - `webkit2gtk`, `appmenu-gtk-module`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>2</sup>, `libvips`
-- Fedora with the following packages installed:
-  - `webkit2gtk3-devel.x86_64`, `openssl-devel`, `libappindicator-gtk3`<sup>1</sup>
+  - `webkit2gtk`, `appmenu-gtk-module`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>1</sup>, `libvips`
+- Fedora (latest 2 versions) with the following packages installed:
+  - `webkit2gtk3`, `openssl`, `gtk3`, `libappindicator-gtk3`<sup>1</sup>
 
 <sup>1</sup> `appindicator` is only required if system trays are used
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src=".github/splash.png" alt="Tauri" />
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri/tree/dev)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri/tree/dev)
 [![License](https://img.shields.io/badge/License-MIT%20or%20Apache%202-green.svg)](https://opencollective.com/tauri)
 [![test library](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)](https://github.com/tauri-apps/tauri/actions?query=workflow%3A%22test+library%22)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftauri-apps%2Ftauri.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftauri-apps%2Ftauri?ref=badge_shield)

--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@
 
 | Component                                                                       | Description                              | Version                                                                                                          | Lin | Win | Mac |
 | ------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --- | --- | --- |
-| [**cli.rs**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli)          | create, develop and build apps           | [![](https://img.shields.io/crates/v/tauri-cli.svg)](https://crates.io/crates/tauri-cli)                         | ✅   | ✅   | ✅   |
-| [**cli.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli/node)     | Node.js CLI wrapper for cli.rs           | [![](https://img.shields.io/npm/v/@tauri-apps/cli.svg)](https://www.npmjs.com/package/@tauri-apps/cli)           | ✅   | ✅   | ✅   |
-| [**api.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/api)          | JS API for interaction with Rust backend | [![](https://img.shields.io/npm/v/@tauri-apps/api.svg)](https://www.npmjs.com/package/@tauri-apps/api)           | ✅   | ✅   | ✅   |
-| [**create-tauri-app**](https://github.com/tauri-apps/create-tauri-app)          | Get started with your first Tauri app    | [![](https://img.shields.io/npm/v/create-tauri-app.svg)](https://www.npmjs.com/package/create-tauri-app)         | ✅   | ✅   | ✅   |
-| [**vue-cli-plugin-tauri**](https://github.com/tauri-apps/vue-cli-plugin-tauri/) | Vue CLI plugin for Tauri                 | [![](https://img.shields.io/npm/v/vue-cli-plugin-tauri.svg)](https://www.npmjs.com/package/vue-cli-plugin-tauri) | ✅   | ✅   | ✅   |
-| [**core**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri)             | runtime core                             | [![](https://img.shields.io/crates/v/tauri.svg)](https://crates.io/crates/tauri)                                 | ✅   | ✅   | ✅   |
-| [**bundler**](https://github.com/tauri-apps/tauri/tree/dev/tooling/bundler)     | manufacture the final binaries           | [![](https://img.shields.io/crates/v/tauri-bundler.svg)](https://crates.io/crates/tauri-bundler)                 | ✅   | ✅   | ✅   |
+| [**cli.rs**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli)          | create, develop and build apps           | [![](https://img.shields.io/crates/v/tauri-cli.svg)](https://crates.io/crates/tauri-cli)                         | ✅  | ✅  | ✅  |
+| [**cli.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli/node)     | Node.js CLI wrapper for cli.rs           | [![](https://img.shields.io/npm/v/@tauri-apps/cli.svg)](https://www.npmjs.com/package/@tauri-apps/cli)           | ✅  | ✅  | ✅  |
+| [**api.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/api)          | JS API for interaction with Rust backend | [![](https://img.shields.io/npm/v/@tauri-apps/api.svg)](https://www.npmjs.com/package/@tauri-apps/api)           | ✅  | ✅  | ✅  |
+| [**create-tauri-app**](https://github.com/tauri-apps/create-tauri-app)          | Get started with your first Tauri app    | [![](https://img.shields.io/npm/v/create-tauri-app.svg)](https://www.npmjs.com/package/create-tauri-app)         | ✅  | ✅  | ✅  |
+| [**vue-cli-plugin-tauri**](https://github.com/tauri-apps/vue-cli-plugin-tauri/) | Vue CLI plugin for Tauri                 | [![](https://img.shields.io/npm/v/vue-cli-plugin-tauri.svg)](https://www.npmjs.com/package/vue-cli-plugin-tauri) | ✅  | ✅  | ✅  |
+| [**core**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri)             | runtime core                             | [![](https://img.shields.io/crates/v/tauri.svg)](https://crates.io/crates/tauri)                                 | ✅  | ✅  | ✅  |
+| [**bundler**](https://github.com/tauri-apps/tauri/tree/dev/tooling/bundler)     | manufacture the final binaries           | [![](https://img.shields.io/crates/v/tauri-bundler.svg)](https://crates.io/crates/tauri-bundler)                 | ✅  | ✅  | ✅  |
 
 ## Introduction
+
 Tauri is a framework for building tiny, blazingly fast binaries for all major desktop platforms. Developers can integrate any front-end framework that compiles to HTML, JS and CSS for building their user interface. The backend of the application is a rust-sourced binary with an API that the front-end can interact with.
 
 The user interface in Tauri apps currently leverages [`tao`](https://docs.rs/tao) as a window handling library on macOS and Windows, and [`gtk`](https://gtk-rs.org/docs/gtk/) on Linux via the **Tauri-team** incubated and maintained [WRY](https://github.com/tauri-apps/wry), which creates a unified interface to the system webview (and other goodies like Menu and Taskbar), leveraging WebKit on macOS, WebView2 on Windows and WebKitGTK on Linux.
@@ -31,16 +32,49 @@ The user interface in Tauri apps currently leverages [`tao`](https://docs.rs/tao
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
 ## Get Started
+
 If you are interested in making a tauri app, please visit the [documentation website](https://tauri.studio). This README is directed towards those who are interested in contributing to the core library. But if you just want a quick overview about where `tauri` is at in its development, here's a quick burndown:
 
 ### Platforms
-- [x] Windows 7,8,10
-- [x] Linux
-- [x] macOS
-- [ ] iOS (in progress)
-- [ ] android (soon)
+
+Tauri currently supports development and distribution on the following platforms:
+
+| Platform                 | Versions                |
+| :----------------------- | :---------------------- |
+| Windows                  | 7 (64-bit), 8 and above |
+| macOS                    | 10.15 and above         |
+| Linux                    | See below               |
+| iOS/iPadOS (coming soon) |                         |
+| Android (coming soon)    |                         |
+
+**Linux Support**
+
+For **developing** Tauri apps we support the following configurations:
+
+- Debian (Ubuntu 18.04 and above or equivalent)
+  - For development you must have `libwebkit2gtk-4.0-dev`, `build-essential`<sup>1</sup>, `curl`, `wget`, `libssl-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`<sup>2</sup>, and `librsvg2-dev`<sup>3</sup> installed
+- Arch
+  - For development you must have `webkit2gtk`, `appmenu-gtk-module`, `base-devel`, `curl`, `wget`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>2</sup>, `librsvg`<sup>3</sup>, and `libvips` installed
+- Fedora
+  - For development you must have `webkit2gtk3-devel.x86_64`, `openssl-devel`, `curl`, `wget`, `libappindicator-gtk3`<sup>2</sup>, and `librsvg2-devel`<sup>3</sup> installed
+
+For **running** Tauri apps we support the following configurations:
+
+- Debian (Ubuntu 18.04 and above or equivalent)
+  - For development you must have `libwebkit2gtk-4.0-dev`, `build-essential`<sup>1</sup>, `curl`, `wget`, `libssl-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`<sup>2</sup>, and `librsvg2-dev`<sup>3</sup> installed
+- Arch
+  - For development you must have `webkit2gtk`, `appmenu-gtk-module`, `base-devel`, `curl`, `wget`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>2</sup>, `librsvg`<sup>3</sup>, and `libvips` installed
+- Fedora
+  - For development you must have `webkit2gtk3-devel.x86_64`, `openssl-devel`, `curl`, `wget`, `libappindicator-gtk3`<sup>2</sup>, and `librsvg2-devel`<sup>3</sup> installed
+
+<sup>1</sup> `build-essential` is only required on the build system
+
+<sup>2</sup> `appindicator` is only required if system trays are used
+
+<sup>3</sup> `librsvg` is only required for appimage bundling
 
 ### App Bundles
+
 - [x] App Icons
 - [x] Build on macOS (.app, .dmg)
 - [x] Build on Linux (.deb, AppImage)
@@ -57,6 +91,7 @@ If you are interested in making a tauri app, please visit the [documentation web
 - [ ] One-Time commands (coming soon)
 
 ### Security Features
+
 - [x] localhost-free (:fire:)
 - [x] custom protocol for secure mode
 - [x] Dynamic ahead of Time Compilation (dAoT) with functional tree-shaking
@@ -65,6 +100,7 @@ If you are interested in making a tauri app, please visit the [documentation web
 - [x] CSP Injection
 
 ### Utilities
+
 - [x] GH Action for creating binaries for all platforms
 - [x] VS Code Extension
 - [x] Tauri Core Plugins
@@ -96,6 +132,7 @@ If you are interested in making a tauri app, please visit the [documentation web
 | Sidecar Binaries           | Yes    | No                   |
 
 #### Notes
+
 1. Electron has no native auto updater on Linux, but is offered by electron-packager
 
 ## Development
@@ -103,6 +140,7 @@ If you are interested in making a tauri app, please visit the [documentation web
 Tauri is a system composed of a number of moving pieces:
 
 ### Infrastructure
+
 - Git for code management
 - GitHub for project management
 - GitHub actions for CI and CD
@@ -111,19 +149,23 @@ Tauri is a system composed of a number of moving pieces:
 - DigitalOcean Meilisearch instance
 
 ### Major Runtimes
+
 - Node.js for running the CLI (deno and pure rust are on the roadmap)
 - Cargo for testing, running the dev service, building binaries and as the runtime harness for the webview
 
 ### Major Languages
+
 - Rust for the CLI
 - ECMAScript bindings to the Rust API, written in typescript
 - Rust for bindings, rust side of the API, harnesses
 - Rust plugins to Tauri backend
 
 ### Operating systems
+
 Tauri core can be developed on Mac, Linux and Windows, but you are encouraged to use the latest possible operating systems and build tools for your OS.
 
 ### Contributing
+
 Before you start working on something, it's best to check if there is an existing issue first. It's also a good idea to stop by the Discord server and confirm with the team if it makes sense or if someone else is already working on it.
 
 Please make sure to read the [Contributing Guide](./.github/CONTRIBUTING.md) before making a pull request.
@@ -131,31 +173,38 @@ Please make sure to read the [Contributing Guide](./.github/CONTRIBUTING.md) bef
 Thank you to everyone contributing to Tauri!
 
 ### Documentation
+
 Documentation in a polyglot system is a tricky proposition. To this end, we prefer to use inline documentation of Rust code and at JSDoc in typescript / javascript code. We autocollect these and publish them using Docusaurus v2 and netlify. Here is the hosting repository for the documentation site: https://github.com/tauri-apps/tauri-docs
 
 ### Testing & Linting
+
 Test all the things! We have a number of test suites, but are always looking to improve our coverage:
+
 - Rust (`cargo test`) => sourced via inline `#[cfg(test)]` declarations
 - TS (`jest`) => via spec files
 - Smoke Tests (run on merges to latest)
 - eslint, clippy
 
 ### CI/CD
+
 We recommend you read this article to understand better how we run our pipelines: https://www.jacobbolda.com/setting-up-ci-and-cd-for-tauri/
 
 ## Organization
+
 Tauri aims to be a sustainable collective based on principles that guide [sustainable free and open software communities](https://sfosc.org). To this end it has become a Programme within the [Commons Conservancy](https://commonsconservancy.org/), and you can contribute financially via [Open Collective](https://opencollective.com/tauri).
 
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
 
 ## Licenses
+
 Code: (c) 2015 - 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
-- Original Tauri Logo Designs by [Alve Larsson](https://alve.io/), [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)
 
+- Original Tauri Logo Designs by [Alve Larsson](https://alve.io/), [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftauri-apps%2Ftauri.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftauri-apps%2Ftauri?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ If you are interested in making a tauri app, please visit the [documentation web
 
 Tauri currently supports development and distribution on the following platforms:
 
-| Platform                 | Versions                |
-| :----------------------- | :---------------------- |
-| Windows                  | 7 and above |
-| macOS                    | 10.15 and above         |
-| Linux                    | See below               |
-| iOS/iPadOS (coming soon) |                         |
-| Android (coming soon)    |                         |
+| Platform                 | Versions        |
+| :----------------------- | :-------------- |
+| Windows                  | 7 and above     |
+| macOS                    | 10.15 and above |
+| Linux                    | See below       |
+| iOS/iPadOS (coming soon) |                 |
+| Android (coming soon)    |                 |
 
 **Linux Support**
 
@@ -54,7 +54,7 @@ For **developing** Tauri apps refer to the [Getting Started guide on tauri.app](
 For **running** Tauri apps we support the below configurations (these are automatically added as dependencies for .deb and are bundled for AppImage so that your users don't need to manually install them):
 
 - Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
-  - `libwebkit2gtk-4.0-37`, `libssl`, `libgtk-3-0`, `libayatana-appindicator3-1`<sup>1</sup>
+  - `libwebkit2gtk-4.0-37`, `libgtk-3-0`, `libayatana-appindicator3-1`<sup>1</sup>
 - Arch with the following packages installed:
   - `webkit2gtk`, `appmenu-gtk-module`, `gtk3`, `libayatana-appindicator`<sup>1</sup>
 - Fedora (latest 2 versions) with the following packages installed:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For **developing** Tauri apps refer to the [Getting Started guide on tauri.app](
 For **running** Tauri apps we support the below configurations (these are automatically added as dependencies for .deb and are bundled for AppImage so that your users don't need to manually install them):
 
 - Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
-  - `libwebkit2gtk-4.0`, `libssl`, `libgtk-3`, `libayatana-appindicator3`<sup>1</sup>
+  - `libwebkit2gtk-4.0-37`, `libssl`, `libgtk-3-0`, `libayatana-appindicator3-1`<sup>1</sup>
 - Arch with the following packages installed:
   - `webkit2gtk`, `appmenu-gtk-module`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>1</sup>, `libvips`
 - Fedora (latest 2 versions) with the following packages installed:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Tauri currently supports development and distribution on the following platforms
 
 | Platform                 | Versions                |
 | :----------------------- | :---------------------- |
-| Windows                  | 7 (64-bit), 8 and above |
+| Windows                  | 7 and above |
 | macOS                    | 10.15 and above         |
 | Linux                    | See below               |
 | iOS/iPadOS (coming soon) |                         |

--- a/README.md
+++ b/README.md
@@ -51,27 +51,27 @@ Tauri currently supports development and distribution on the following platforms
 
 For **developing** Tauri apps we support the following configurations:
 
-- Debian (Ubuntu 18.04 and above or equivalent)
-  - For development you must have `libwebkit2gtk-4.0-dev`, `build-essential`<sup>1</sup>, `curl`, `wget`, `libssl-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`<sup>2</sup>, and `librsvg2-dev`<sup>3</sup> installed
-- Arch
-  - For development you must have `webkit2gtk`, `appmenu-gtk-module`, `base-devel`, `curl`, `wget`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>2</sup>, `librsvg`<sup>3</sup>, and `libvips` installed
-- Fedora
-  - For development you must have `webkit2gtk3-devel.x86_64`, `openssl-devel`, `curl`, `wget`, `libappindicator-gtk3`<sup>2</sup>, and `librsvg2-devel`<sup>3</sup> installed
+- Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
+  - `libwebkit2gtk-4.0-dev`, `build-essential`, `curl`, `wget`, `libssl-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`<sup>1</sup>, `librsvg2-dev`<sup>2</sup>
+- Arch with the following packages installed:
+  - `webkit2gtk`, `appmenu-gtk-module`, `base-devel`, `curl`, `wget`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>1</sup>, `librsvg`<sup>2</sup>, `libvips`
+- Fedora with the following packages installed:
+  - `webkit2gtk3-devel.x86_64`, `openssl-devel`, `curl`, `wget`, `libappindicator-gtk3`<sup>1</sup>, `librsvg2-devel`<sup>2</sup>
+
+<sup>1</sup> `appindicator` is only required if system trays are used
+
+<sup>2</sup> `librsvg` is only required for appimage bundling
 
 For **running** Tauri apps we support the following configurations:
 
-- Debian (Ubuntu 18.04 and above or equivalent)
-  - For development you must have `libwebkit2gtk-4.0-dev`, `build-essential`<sup>1</sup>, `curl`, `wget`, `libssl-dev`, `libgtk-3-dev`, `libayatana-appindicator3-dev`<sup>2</sup>, and `librsvg2-dev`<sup>3</sup> installed
-- Arch
-  - For development you must have `webkit2gtk`, `appmenu-gtk-module`, `base-devel`, `curl`, `wget`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>2</sup>, `librsvg`<sup>3</sup>, and `libvips` installed
-- Fedora
-  - For development you must have `webkit2gtk3-devel.x86_64`, `openssl-devel`, `curl`, `wget`, `libappindicator-gtk3`<sup>2</sup>, and `librsvg2-devel`<sup>3</sup> installed
+- Debian (Ubuntu 18.04 and above or equivalent) with the following packages installed:
+  - `libwebkit2gtk-4.0`, `libssl`, `libgtk-3`, `libayatana-appindicator3`<sup>1</sup>
+- Arch with the following packages installed:
+  - `webkit2gtk`, `appmenu-gtk-module`, `openssl`, `gtk3`, `libayatana-appindicator`<sup>2</sup>, `libvips`
+- Fedora with the following packages installed:
+  - `webkit2gtk3-devel.x86_64`, `openssl-devel`, `libappindicator-gtk3`<sup>1</sup>
 
-<sup>1</sup> `build-essential` is only required on the build system
-
-<sup>2</sup> `appindicator` is only required if system trays are used
-
-<sup>3</sup> `librsvg` is only required for appimage bundling
+<sup>1</sup> `appindicator` is only required if system trays are used
 
 ### App Bundles
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,33 @@
 
 ## Current Releases
 
-| Component                                                                       | Description                              | Version                                                                                                          | Lin | Win | Mac |
-| ------------------------------------------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --- | --- | --- |
-| [**cli.rs**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli)          | create, develop and build apps           | [![](https://img.shields.io/crates/v/tauri-cli.svg)](https://crates.io/crates/tauri-cli)                         | ✅  | ✅  | ✅  |
-| [**cli.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli/node)     | Node.js CLI wrapper for cli.rs           | [![](https://img.shields.io/npm/v/@tauri-apps/cli.svg)](https://www.npmjs.com/package/@tauri-apps/cli)           | ✅  | ✅  | ✅  |
-| [**api.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/api)          | JS API for interaction with Rust backend | [![](https://img.shields.io/npm/v/@tauri-apps/api.svg)](https://www.npmjs.com/package/@tauri-apps/api)           | ✅  | ✅  | ✅  |
-| [**create-tauri-app**](https://github.com/tauri-apps/create-tauri-app)          | Get started with your first Tauri app    | [![](https://img.shields.io/npm/v/create-tauri-app.svg)](https://www.npmjs.com/package/create-tauri-app)         | ✅  | ✅  | ✅  |
-| [**vue-cli-plugin-tauri**](https://github.com/tauri-apps/vue-cli-plugin-tauri/) | Vue CLI plugin for Tauri                 | [![](https://img.shields.io/npm/v/vue-cli-plugin-tauri.svg)](https://www.npmjs.com/package/vue-cli-plugin-tauri) | ✅  | ✅  | ✅  |
-| [**core**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri)             | runtime core                             | [![](https://img.shields.io/crates/v/tauri.svg)](https://crates.io/crates/tauri)                                 | ✅  | ✅  | ✅  |
-| [**bundler**](https://github.com/tauri-apps/tauri/tree/dev/tooling/bundler)     | manufacture the final binaries           | [![](https://img.shields.io/crates/v/tauri-bundler.svg)](https://crates.io/crates/tauri-bundler)                 | ✅  | ✅  | ✅  |
+### Core
+
+| Component                                                                                    | Description                               | Version                                                                                                  | Lin | Win | Mac |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------- | --- | --- | --- |
+| [**tauri**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri)                         | runtime core                              | [![](https://img.shields.io/crates/v/tauri.svg)](https://crates.io/crates/tauri)                         | ✅  | ✅  | ✅  |
+| [**tauri-build**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-build)             | applies macros at build-time              | [![](https://img.shields.io/crates/v/tauri-build.svg)](https://crates.io/crates/tauri-build)             | ✅  | ✅  | ✅  |
+| [**tauri-codegen**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-codegen)         | handles assets, parses tauri.conf.json    | [![](https://img.shields.io/crates/v/tauri-codegen.svg)](https://crates.io/crates/tauri-codegen)         | ✅  | ✅  | ✅  |
+| [**tauri-macros**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-macros)           | creates macros using tauri-codegen        | [![](https://img.shields.io/crates/v/tauri-macros.svg)](https://crates.io/crates/tauri-macros)           | ✅  | ✅  | ✅  |
+| [**tauri-runtime**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-runtime)         | layer between Tauri and webview libraries | [![](https://img.shields.io/crates/v/tauri-runtime.svg)](https://crates.io/crates/tauri-runtime)         | ✅  | ✅  | ✅  |
+| [**tauri-runtime-wry**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-runtime-wry) | enables system-level interaction via WRY  | [![](https://img.shields.io/crates/v/tauri-runtime-wry.svg)](https://crates.io/crates/tauri-runtime-wry) | ✅  | ✅  | ✅  |
+| [**tauri-utils**](https://github.com/tauri-apps/tauri/tree/dev/core/tauri-utils)             | common code used across the tauri crates  | [![](https://img.shields.io/crates/v/tauri-utils.svg)](https://crates.io/crates/tauri-utils)             | ✅  | ✅  | ✅  |
+
+### Tooling
+
+| Component                                                                   | Description                              | Version                                                                                                | Lin | Win | Mac |
+| --------------------------------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------ | --- | --- | --- |
+| [**bundler**](https://github.com/tauri-apps/tauri/tree/dev/tooling/bundler) | manufacture the final binaries           | [![](https://img.shields.io/crates/v/tauri-bundler.svg)](https://crates.io/crates/tauri-bundler)       | ✅  | ✅  | ✅  |
+| [**api.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/api)      | JS API for interaction with Rust backend | [![](https://img.shields.io/npm/v/@tauri-apps/api.svg)](https://www.npmjs.com/package/@tauri-apps/api) | ✅  | ✅  | ✅  |
+| [**cli.rs**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli)      | create, develop and build apps           | [![](https://img.shields.io/crates/v/tauri-cli.svg)](https://crates.io/crates/tauri-cli)               | ✅  | ✅  | ✅  |
+| [**cli.js**](https://github.com/tauri-apps/tauri/tree/dev/tooling/cli/node) | Node.js CLI wrapper for cli.rs           | [![](https://img.shields.io/npm/v/@tauri-apps/cli.svg)](https://www.npmjs.com/package/@tauri-apps/cli) | ✅  | ✅  | ✅  |
+
+### Utilities and Plugins
+
+| Component                                                                       | Description                           | Version                                                                                                          | Lin | Win | Mac |
+| ------------------------------------------------------------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --- | --- | --- |
+| [**create-tauri-app**](https://github.com/tauri-apps/create-tauri-app)          | Get started with your first Tauri app | [![](https://img.shields.io/npm/v/create-tauri-app.svg)](https://www.npmjs.com/package/create-tauri-app)         | ✅  | ✅  | ✅  |
+| [**vue-cli-plugin-tauri**](https://github.com/tauri-apps/vue-cli-plugin-tauri/) | Vue CLI plugin for Tauri              | [![](https://img.shields.io/npm/v/vue-cli-plugin-tauri.svg)](https://www.npmjs.com/package/vue-cli-plugin-tauri) | ✅  | ✅  | ✅  |
 
 ## Introduction
 

--- a/core/tauri-build/README.md
+++ b/core/tauri-build/README.md
@@ -2,38 +2,42 @@
 
  <img align="right" src="https://github.com/tauri-apps/tauri/raw/dev/app-icon.png" height="128" width="128">
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 [![support](https://img.shields.io/badge/sponsor-Opencollective-blue.svg)](https://opencollective.com/tauri)
 
-| Component | Version                                     |
-| --------- | ------------------------------------------- |
-| tauri-build  | [![](https://img.shields.io/crates/v/tauri-build?style=flat-square)](https://crates.io/crates/tauri-build) |
+| Component   | Version                                                                                                    |
+| ----------- | ---------------------------------------------------------------------------------------------------------- |
+| tauri-build | [![](https://img.shields.io/crates/v/tauri-build?style=flat-square)](https://crates.io/crates/tauri-build) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 This applies the macros at build-time in order to rig some special features needed by `cargo`.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
-
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)

--- a/core/tauri-codegen/README.md
+++ b/core/tauri-codegen/README.md
@@ -2,38 +2,43 @@
 
  <img align="right" src="https://github.com/tauri-apps/tauri/raw/dev/app-icon.png" height="128" width="128">
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 [![support](https://img.shields.io/badge/sponsor-Opencollective-blue.svg)](https://opencollective.com/tauri)
 
-| Component | Version                                     |
-| --------- | ------------------------------------------- |
-| tauri-codegen  | [![](https://img.shields.io/crates/v/tauri-codegen?style=flat-square)](https://crates.io/crates/tauri-codegen) |
+| Component     | Version                                                                                                        |
+| ------------- | -------------------------------------------------------------------------------------------------------------- |
+| tauri-codegen | [![](https://img.shields.io/crates/v/tauri-codegen?style=flat-square)](https://crates.io/crates/tauri-codegen) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 - Embed, hash, and compress assets, including icons for the app as well as the system-tray.
 - Parse `tauri.conf.json` at compile time and generate the Config struct.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)

--- a/core/tauri-macros/README.md
+++ b/core/tauri-macros/README.md
@@ -2,37 +2,42 @@
 
  <img align="right" src="https://github.com/tauri-apps/tauri/raw/dev/app-icon.png" height="128" width="128">
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 [![support](https://img.shields.io/badge/sponsor-Opencollective-blue.svg)](https://opencollective.com/tauri)
 
-| Component | Version                                     |
-| --------- | ------------------------------------------- |
-| tauri-macros  | [![](https://img.shields.io/crates/v/tauri-macros?style=flat-square)](https://crates.io/crates/tauri-macros) |
+| Component    | Version                                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------------------ |
+| tauri-macros | [![](https://img.shields.io/crates/v/tauri-macros?style=flat-square)](https://crates.io/crates/tauri-macros) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 Create macros for the context, handler, and commands by leveraging the `tauri-codegen` crate.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)

--- a/core/tauri-runtime/README.md
+++ b/core/tauri-runtime/README.md
@@ -6,33 +6,38 @@
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 [![support](https://img.shields.io/badge/sponsor-Opencollective-blue.svg)](https://opencollective.com/tauri)
 
-| Component | Version                                     |
-| --------- | ------------------------------------------- |
-| tauri-runtime  | [![](https://img.shields.io/crates/v/tauri-runtime?style=flat-square)](https://crates.io/crates/tauri-runtime) |
+| Component     | Version                                                                                                        |
+| ------------- | -------------------------------------------------------------------------------------------------------------- |
+| tauri-runtime | [![](https://img.shields.io/crates/v/tauri-runtime?style=flat-square)](https://crates.io/crates/tauri-runtime) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 This is the glue layer between tauri itself and lower level webview libraries.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)

--- a/core/tauri-utils/README.md
+++ b/core/tauri-utils/README.md
@@ -2,37 +2,42 @@
 
  <img align="right" src="https://github.com/tauri-apps/tauri/raw/dev/app-icon.png" height="128" width="128">
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 [![support](https://img.shields.io/badge/sponsor-Opencollective-blue.svg)](https://opencollective.com/tauri)
 
-| Component | Version                                     |
-| --------- | ------------------------------------------- |
+| Component   | Version                                                                                              |
+| ----------- | ---------------------------------------------------------------------------------------------------- |
 | tauri-utils | [![](https://img.shields.io/crates/v/tauri-utils?style=flat-square)](https://crates.io/crates/utils) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 This is common code that is reused in many places and offers useful utilities like parsing configuration files, detecting platform triples, injecting the CSP, and managing assets.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)

--- a/core/tauri/README.md
+++ b/core/tauri/README.md
@@ -2,38 +2,42 @@
 
  <img align="right" src="https://github.com/tauri-apps/tauri/raw/dev/app-icon.png" height="128" width="128">
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 [![support](https://img.shields.io/badge/sponsor-Opencollective-blue.svg)](https://opencollective.com/tauri)
 
-| Component | Version                                     |
-| --------- | ------------------------------------------- |
-| tauri  | [![](https://img.shields.io/crates/v/tauri?style=flat-square)](https://crates.io/crates/tauri) |
+| Component | Version                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------- |
+| tauri     | [![](https://img.shields.io/crates/v/tauri?style=flat-square)](https://crates.io/crates/tauri) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 This is the glue crate that holds everything together. It brings the runtimes, macros, utilities and API into one final product. It reads the `tauri.conf.json` file at compile time in order to bring in features and undertake actual configuration of the app (and even the `Cargo.toml` file in the project's folder). It handles script injection (for polyfills / prototype revision) at runtime, hosts the API for systems interaction, and even manages updating.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
-
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2019 - 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)

--- a/tooling/api/README.md
+++ b/tooling/api/README.md
@@ -1,12 +1,12 @@
 # @tauri-apps/api
+
  <img align="right" src="https://github.com/tauri-apps/tauri/raw/dev/app-icon.png" height="128" width="128">
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
@@ -17,30 +17,36 @@
 | @tauri-apps/api | ![](https://img.shields.io/npm/v/@tauri-apps/api.svg) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 This is a typescript library that creates `cjs` and `esm` Javascript endpoints for you to import into your Frontend framework so that the Webview can call and listen to backend activity. We also ship the pure typescript, because for some frameworks this is more optimal. It uses the message passing of webviews to their hosts.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
-
 ## Installation
 
 The preferred method is to install this module locally as a dependency:
+
 ```
 $ npm install --save @tauri-apps/api
 $ yarn add @tauri-apps/api
 ```
 
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2019 - 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)

--- a/tooling/cli/README.md
+++ b/tooling/cli/README.md
@@ -2,48 +2,54 @@
 
  <img align="right" src="https://github.com/tauri-apps/tauri/raw/dev/app-icon.png" height="128" width="128">
 
-[![status](https://img.shields.io/badge/Status-Beta-green.svg)](https://github.com/tauri-apps/tauri)
+[![status](https://img.shields.io/badge/Status-Stable-green.svg)](https://github.com/tauri-apps/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-on%20discord-7289da.svg)](https://discord.gg/SpmNs4S)
 [![devto](https://img.shields.io/badge/blog-dev.to-black.svg)](https://dev.to/tauri)
 
-![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library
-)
+![](https://img.shields.io/github/workflow/status/tauri-apps/tauri/test%20library?label=test%20library)
 [![devto](https://img.shields.io/badge/documentation-site-purple.svg)](https://tauri.app)
 
 [![https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg](https://good-labs.github.io/greater-good-affirmation/assets/images/badge.svg)](https://good-labs.github.io/greater-good-affirmation)
 [![support](https://img.shields.io/badge/sponsor-Opencollective-blue.svg)](https://opencollective.com/tauri)
 
-| Component | Version                                     |
-| --------- | ------------------------------------------- |
-| tauri-cli  | [![](https://img.shields.io/crates/v/tauri-cli?style=flat-square)](https://crates.io/crates/tauri-cli) |
+| Component | Version                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------ |
+| tauri-cli | [![](https://img.shields.io/crates/v/tauri-cli?style=flat-square)](https://crates.io/crates/tauri-cli) |
 
 ## About Tauri
+
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
 Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
+
 This rust executable provides the full interface to all of the required activities for which the CLI is required. It will run on macOS, Windows, and Linux.
 
 To learn more about the details of how all of these pieces fit together, please consult this [ARCHITECTURE.md](https://github.com/tauri-apps/tauri/blob/dev/ARCHITECTURE.md) document.
 
-
 ## Semver
+
 **tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+
 ## Licenses
+
 Code: (c) 2015 - 2021 - The Tauri Programme within The Commons Conservancy.
 
 MIT or MIT/Apache 2.0 where applicable.
 
 Logo: CC-BY-NC-ND
+
 - Original Tauri Logo Designs by [Daniel Thompson-Yvetot](https://github.com/nothingismagick) and [Guillaume Chau](https://github.com/akryum)
 
 ## Licensing Errata:
+
 Because of publishing issues upstream, we soft-forked (and patched) both [`console`](https://github.com/mitsuhiko/console/blob/278de9dc2bf0fa28db69adee351072f668beec8f/Cargo.toml#L7) and [`dialoguer`](https://github.com/mitsuhiko/dialoguer/blob/2c3fe6b64641cfb57eb0e1d428274f63976ec150/Cargo.toml#L12) crates because of untenable issues surrounding expected use on Windows.
 
 This soft fork was introduced to the Tauri Codebase [here](https://github.com/tauri-apps/tauri/pull/1610).
 
 `console`
+
 ```
 license = "MIT"
 authors = [
@@ -52,6 +58,7 @@ authors = [
 ```
 
 `dialoguer`
+
 ```
 license = "MIT"
 authors = [


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

- Adds the release OS versions that Tauri supports.
- Updates status badges across the monorepo with stable instead of beta where relevant
- Prettier had a fun time so a lot of whitespace was moved around in the readme files

CC @FabianLars for all of the crazy help on Linux :)