### PR TITLE
Fix appimage creation in container when host has appimagelauncher enabled

### DIFF
--- a/.changes/appimage-fix.md
+++ b/.changes/appimage-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Fix AppImage bundling when appimagelauncher is enabled.

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -68,6 +68,8 @@ wget -q -4 -N -O linuxdeploy-${ARCH}.AppImage https://github.com/linuxdeploy/lin
 chmod +x linuxdeploy-plugin-gtk.sh
 chmod +x linuxdeploy-${ARCH}.AppImage
 
+dd if=/dev/zero bs=1 count=3 seek=8 conv=notrunc of=linuxdeploy-${ARCH}.AppImage
+
 OUTPUT="{{appimage_filename}}" ./linuxdeploy-${ARCH}.AppImage --appimage-extract-and-run --appdir "{{app_name}}.AppDir" --plugin gtk ${gst_plugin}  --output appimage
 rm -r "{{app_name}}.AppDir"
 mv "{{appimage_filename}}" $OUTDIR


### PR DESCRIPTION
I ran into a problem that building the very same project in the very same container worked on one machine but not on the other (same host OS, roughly same version). The error was `./linuxdeploy-x86_64.AppImage: No such file or directory`. As I looked into the problem I found this:

If Appimagelauncher is enabled on the host, it modifies binfmt to inject itself as a launcher for appimages. This also applies to appimages in containers although the appimagelauncher binary is most likely not available there. So the "No such file" does not mean the appimage itself but the launcher it tries to execute.

The easiest way to fix this is to modify the appimage ELF header so that binfmt no longer identifies it as an appimage and lets the binary run itself. This is my PR.


### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
