### PR TITLE
fix(cli,bundler): prefer AppImage libraries with ABI version

### DIFF
--- a/.changes/bundler-libnames.md
+++ b/.changes/bundler-libnames.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch
+"tauri-bundler": patch
+---
+
+AppImage bundling will now prefer bundling correctly named appincidator library (including `.1` version suffix). With a symlink for compatibility with the old naming.

--- a/.changes/bundler-libnames.md
+++ b/.changes/bundler-libnames.md
@@ -1,5 +1,6 @@
 ---
-"tauri-cli": patch
+"cli.rs": patch
+"cli.js": patch
 "tauri-bundler": patch
 ---
 

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -37,6 +37,15 @@ fi
 if [[ "$TRAY_LIBRARY_PATH" != "0" ]]; then
   echo "Copying appindicator library ${TRAY_LIBRARY_PATH}"
   cp ${TRAY_LIBRARY_PATH} usr/lib
+  # It looks like we're practicing good hygiene by adding the ABI version.
+  # But for compatibility we'll symlink this file to what we did before.
+  # Specifically this prevents breaking libappindicator-sys v0.7.1 and v0.7.2.
+  if [[ "$TRAY_LIBRARY_PATH" == *.so.1 ]]; then
+    readonly soname=$(basename "$TRAY_LIBRARY_PATH")
+    readonly old_name=$(basename "$TRAY_LIBRARY_PATH" .1)
+    echo "Adding compatibility symlink ${old_name} -> ${soname}"
+    ln -s ${soname} usr/lib/${old_name}
+  fi
 fi
 
 # Copy WebKit files.

--- a/tooling/cli/src/build.rs
+++ b/tooling/cli/src/build.rs
@@ -229,13 +229,13 @@ pub fn command(mut options: Options) -> Result<()> {
             "TRAY_LIBRARY_PATH",
             if tray == "ayatana" {
               format!(
-                "{}/libayatana-appindicator3.so",
+                "{}/libayatana-appindicator3.so.1",
                 pkgconfig_utils::get_library_path("ayatana-appindicator3-0.1")
                   .expect("failed to get ayatana-appindicator library path using pkg-config.")
               )
             } else {
               format!(
-                "{}/libappindicator3.so",
+                "{}/libappindicator3.so.1",
                 pkgconfig_utils::get_library_path("appindicator3-0.1")
                   .expect("failed to get libappindicator-gtk library path using pkg-config.")
               )
@@ -301,9 +301,9 @@ mod pkgconfig_utils {
 
   pub fn get_appindicator_library_path() -> PathBuf {
     match get_library_path("ayatana-appindicator3-0.1") {
-      Some(p) => format!("{}/libayatana-appindicator3.so", p).into(),
+      Some(p) => format!("{}/libayatana-appindicator3.so.1", p).into(),
       None => match get_library_path("appindicator3-0.1") {
-        Some(p) => format!("{}/libappindicator3.so", p).into(),
+        Some(p) => format!("{}/libappindicator3.so.1", p).into(),
         None => panic!("Can't detect any appindicator library"),
       },
     }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

AppImage bundling will now prefer bundling correctly named appincidator library (including `.1` version suffix). With a symlink for compatibility with the old naming.

I've done a fair bit of testing on how this interacts with https://github.com/tauri-apps/libappindicator-rs/pull/38
Detailed result at this comment https://github.com/tauri-apps/libappindicator-rs/pull/38#issuecomment-1168664131

TL;DR this PR and the `libappindicator-sys` can be released and upgraded independently without breaking the tray feature.