### PR TITLE
fix(cli): Don't add `pkg-config` to `deb`

### DIFF
--- a/.changes/bundler-deb-rm-pkg-config.md
+++ b/.changes/bundler-deb-rm-pkg-config.md
@@ -1,6 +1,6 @@
 ---
-'cli.js': minor
-'cli.rs': minor
+'cli.js': patch
+'cli.rs': patch
 ---
 
 No longer adds the `pkg-config` dependency to `.deb` packages when the `systemTray` is used.

--- a/.changes/bundler-deb-rm-pkg-config.md
+++ b/.changes/bundler-deb-rm-pkg-config.md
@@ -1,0 +1,8 @@
+---
+'cli.js': minor
+'cli.rs': minor
+---
+
+No longer adds the `pkg-config` dependency to `.deb` packages when the `systemTray` is used.
+This only works with recent versions of `libappindicator-sys` (including https://github.com/tauri-apps/libappindicator-rs/pull/38),
+so a `cargo update` may be necessary if you create `.deb` bundles and use the tray feature.

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -862,7 +862,6 @@ fn tauri_config_to_bundle_settings(
   #[cfg(target_os = "linux")]
   {
     if let Some(system_tray_config) = &system_tray_config {
-      depends.push("pkg-config".to_string());
       let tray = std::env::var("TAURI_TRAY").unwrap_or_else(|_| "ayatana".to_string());
       if tray == "ayatana" {
         depends.push("libayatana-appindicator3-1".into());


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #___
- [x] No

:warning: https://github.com/tauri-apps/libappindicator-rs/pull/38 needs to be published :warning:

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

No longer adds the `pkg-config` dependency to `.deb` packages when the `systemTray` is used. This only works with recent versions of `libappindicator-sys` (including https://github.com/tauri-apps/libappindicator-rs/pull/38), so a `cargo update` may be necessary if you create `.deb` bundles and use the tray feature.