### PR TITLE
docs: fixed readdir example code

### DIFF
--- a/tooling/api/src/fs.ts
+++ b/tooling/api/src/fs.ts
@@ -357,12 +357,12 @@ async function writeBinaryFile(
  * @example Reads the `$APPDIR/users` directory recursively
  * ```typescript
  * import { readDir, BaseDirectory } from '@tauri-apps/api/fs';
- * const entries = await readDir('users', new Uint8Array([]), { dir: BaseDirectory.App, recursive: true });
+ * const entries = await readDir('users', { dir: BaseDirectory.App, recursive: true });
  *
  * function processEntries(entries) {
  *   for (const entry of entries) {
  *     console.log(`Entry: ${entry.path}`);
- *     if (entry.children !== null) {
+ *     if (entry.children) {
  *       processEntries(entry.children)
  *     }
  *   }


### PR DESCRIPTION
arguments doesn't take a data type. Using truthiness check to make sure example also works with 'recursive: false'

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
