### PR TITLE
fix(bundler): Build AppImages inside the target folder

### DIFF
--- a/.changes/appimage-bundle-in-target.md
+++ b/.changes/appimage-bundle-in-target.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Build AppImages inside the `src-tauri/target` folder rather than `~/.cache/tauri`. Making it easier to clean and rebuild from scratch.

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -16,14 +16,8 @@ else
     linuxdeploy_arch="$ARCH"
 fi
 
-OUTDIR="${PWD}"
-
-cd "{{tauri_tools_path}}"
-
-# remove the folder if it exists - the rest of the script fails if it does
-rm -rf "{{app_name}}.AppDir"
 mkdir -p "{{app_name}}.AppDir"
-cp -r "${OUTDIR}/../appimage_deb/data/usr" "{{app_name}}.AppDir"
+cp -r ../appimage_deb/data/usr "{{app_name}}.AppDir"
 
 cd "{{app_name}}.AppDir"
 mkdir -p "usr/bin"
@@ -53,8 +47,12 @@ find /usr/lib* -name WebKitNetworkProcess -exec mkdir -p "$(dirname '{}')" \; -e
 find /usr/lib* -name WebKitWebProcess -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
 find /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
 
-wget -q -4 -N -O AppRun https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-${ARCH} || wget -q -4 -N -O AppRun https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-${ARCH}
-chmod +x AppRun
+wget -q -4 -N -O "{{tauri_tools_path}}/AppRun" https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-${ARCH} || wget -q -4 -N -O "{{tauri_tools_path}}/AppRun" https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-${ARCH}
+chmod +x "{{tauri_tools_path}}/AppRun"
+
+# We need AppRun to be installed as {{app_name}}.AppDir/AppRun.
+# Otherwise the linuxdeploy scripts will default to symlinking our main bin instead and will crash on trying to launch.
+cp "{{tauri_tools_path}}/AppRun" .
 
 cp "{{icon_path}}" .DirIcon
 ln -s "{{icon_path}}" "{{app_name}}.png"
@@ -71,14 +69,13 @@ else
   gst_plugin=""
 fi
 
-wget -q -4 -N -O linuxdeploy-plugin-gtk.sh https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
-wget -q -4 -N -O linuxdeploy-${ARCH}.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${linuxdeploy_arch}.AppImage
+wget -q -4 -N -O "{{tauri_tools_path}}/linuxdeploy-plugin-gtk.sh" https://raw.githubusercontent.com/tauri-apps/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
+wget -q -4 -N -O "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage" https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-${linuxdeploy_arch}.AppImage
 
-chmod +x linuxdeploy-plugin-gtk.sh
-chmod +x linuxdeploy-${ARCH}.AppImage
+chmod +x "{{tauri_tools_path}}/linuxdeploy-plugin-gtk.sh"
+chmod +x "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage"
 
 dd if=/dev/zero bs=1 count=3 seek=8 conv=notrunc of=linuxdeploy-${ARCH}.AppImage
 
-OUTPUT="{{appimage_filename}}" ./linuxdeploy-${ARCH}.AppImage --appimage-extract-and-run --appdir "{{app_name}}.AppDir" --plugin gtk ${gst_plugin}  --output appimage
+OUTPUT="{{appimage_filename}}" "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage" --appimage-extract-and-run --appdir "{{app_name}}.AppDir" --plugin gtk ${gst_plugin} --output appimage
 rm -r "{{app_name}}.AppDir"
-mv "{{appimage_filename}}" "$OUTDIR"

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -78,4 +78,3 @@ chmod +x "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage"
 dd if=/dev/zero bs=1 count=3 seek=8 conv=notrunc of=linuxdeploy-${ARCH}.AppImage
 
 OUTPUT="{{appimage_filename}}" "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage" --appimage-extract-and-run --appdir "{{app_name}}.AppDir" --plugin gtk ${gst_plugin} --output appimage
-rm -r "{{app_name}}.AppDir"

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -75,6 +75,6 @@ wget -q -4 -N -O "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage" https://git
 chmod +x "{{tauri_tools_path}}/linuxdeploy-plugin-gtk.sh"
 chmod +x "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage"
 
-dd if=/dev/zero bs=1 count=3 seek=8 conv=notrunc of=linuxdeploy-${ARCH}.AppImage
+dd if=/dev/zero bs=1 count=3 seek=8 conv=notrunc of="{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage"
 
 OUTPUT="{{appimage_filename}}" "{{tauri_tools_path}}/linuxdeploy-${ARCH}.AppImage" --appimage-extract-and-run --appdir "{{app_name}}.AppDir" --plugin gtk ${gst_plugin} --output appimage


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Previously to avoid an issue with AppImage builds we collected all our output files in `~/.cache`. This solves the reason why we did that and moves back to putting our temporary files in the `target` folder again.

The main problem at that time was, #4305 introduced a change where build tools should be stored in `~/.cache/tauri`.
However one particular file that we download, `AppRun`, was supposed to be bundled, instead of executed as a build tool.
The path where it needed to be was in `{{app_name}}.AppDir/AppRun`.

I've fixed it here by still downloading all dependencies to `~/.cache/tauri`, but also making a copy of `AppRun` in the correct place. Allowing builds in `target` to work again.

---

As an aside, building in `target` is preferable because we don't use a conflict-free unique or fully qualified name when building AppImages, so race conditions might happen when building multiple projects.

Also, "cleaning target" is an easy way to remove your project specific caches and intermediate builds, to get a clean slate. Which wouldn't apply for AppImages as they're not always in `target`.