### PR TITLE
fix(cli.rs): conflicts_with arg doesn't exist closes 

### DIFF
--- a/.changes/fix-signer-cmd.md
+++ b/.changes/fix-signer-cmd.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Fixes a crash on the `signer sign` command.

--- a/tooling/cli/src/signer/sign.rs
+++ b/tooling/cli/src/signer/sign.rs
@@ -15,10 +15,10 @@ use clap::Parser;
 #[clap(about = "Sign a file")]
 pub struct Options {
   /// Load the private key from a file
-  #[clap(short = 'k', long, conflicts_with("private_key_path"))]
+  #[clap(short = 'k', long, conflicts_with("private-key-path"))]
   private_key: Option<String>,
   /// Load the private key from a string
-  #[clap(short = 'f', long, conflicts_with("private_key"))]
+  #[clap(short = 'f', long, conflicts_with("private-key"))]
   private_key_path: Option<PathBuf>,
   /// Set private key password when signing
   #[clap(short, long)]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

If you run the command `cargo run -- signer sign --help` using the latest master commit it will panick with the following message:

```text
$ cargo run -- signer sign --help
   Compiling tauri-cli v1.0.1 (/Users/jonaskruckenberg/Documents/GitHub/tauri/tooling/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 6.01s
     Running `target/debug/cargo-tauri signer sign --help`
thread 'main' panicked at 'Command sign: Argument or group 'private_key_path' specified in 'conflicts_with*' for 'private-key' does not exist', /Users/jonaskruckenberg/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.7/src/builder/debug_asserts.rs:237:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR adds a quick fix for this (cherry picked from #4537)
