### PR TITLE
fix(tauri-runtime-wry): deadlock when window focus change, closes #4533

### DIFF
--- a/.changes/fix-webview-event-handler.md
+++ b/.changes/fix-webview-event-handler.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch
+---
+
+Fixes a deadlock when the window focus change on Windows.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2403,13 +2403,14 @@ fn handle_user_message<T: UserEvent>(
         }
       }
       WebviewMessage::WebviewEvent(event) => {
-        if let Some(window) = windows
+        let window_event_listeners = windows
           .lock()
           .expect("poisoned webview collection")
           .get(&id)
-        {
+          .map(|w| w.window_event_listeners.clone());
+        if let Some(window_event_listeners) = window_event_listeners {
           if let Some(event) = WindowEventWrapper::from(&event).0 {
-            let listeners = window.window_event_listeners.lock().unwrap();
+            let listeners = window_event_listeners.lock().unwrap();
             let handlers = listeners.values();
             for handler in handlers {
               handler(&event);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
