### PR TITLE
feat: reduce the amount of `heck`-related allocations

### DIFF
--- a/.changes/heck-allocations.md
+++ b/.changes/heck-allocations.md
@@ -1,0 +1,9 @@
+---
+"tauri-build": patch
+"tauri": patch
+"tauri-bundler": patch
+"cli.rs": patch
+"cli.js": patch
+---
+
+Reduce the amount of allocations when converting cases.

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -5,7 +5,8 @@
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 
 pub use anyhow::Result;
-use heck::ToSnakeCase;
+use heck::AsShoutySnakeCase;
+
 use tauri_utils::resources::{external_binaries, resource_relpath, ResourcePaths};
 
 use std::path::{Path, PathBuf};
@@ -68,12 +69,9 @@ fn copy_resources(resources: ResourcePaths<'_>, path: &Path) -> Result<()> {
 fn has_feature(feature: &str) -> bool {
   // when a feature is enabled, Cargo sets the `CARGO_FEATURE_<name` env var to 1
   // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
-  std::env::var(format!(
-    "CARGO_FEATURE_{}",
-    feature.to_snake_case().to_uppercase()
-  ))
-  .map(|x| x == "1")
-  .unwrap_or(false)
+  std::env::var(format!("CARGO_FEATURE_{}", AsShoutySnakeCase(feature)))
+    .map(|x| x == "1")
+    .unwrap_or(false)
 }
 
 // creates a cfg alias if `has_feature` is true.

--- a/core/tauri/build.rs
+++ b/core/tauri/build.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use heck::AsShoutySnakeCase;
+use heck::AsSnakeCase;
 use heck::ToSnakeCase;
+
 use once_cell::sync::OnceCell;
 
 use std::{path::Path, sync::Mutex};
@@ -19,12 +22,9 @@ fn has_feature(feature: &str) -> bool {
 
   // when a feature is enabled, Cargo sets the `CARGO_FEATURE_<name` env var to 1
   // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
-  std::env::var(format!(
-    "CARGO_FEATURE_{}",
-    feature.to_snake_case().to_uppercase()
-  ))
-  .map(|x| x == "1")
-  .unwrap_or(false)
+  std::env::var(format!("CARGO_FEATURE_{}", AsShoutySnakeCase(feature)))
+    .map(|x| x == "1")
+    .unwrap_or(false)
 }
 
 // creates a cfg alias if `has_feature` is true.
@@ -148,11 +148,11 @@ fn alias_module(module: &str, apis: &[&str], api_all: bool) {
   for api in apis {
     let has = has_feature(&format!("{}-{}", module, api)) || all;
     alias(
-      &format!("{}_{}", module.to_snake_case(), api.to_snake_case()),
+      &format!("{}_{}", AsSnakeCase(module), AsSnakeCase(api)),
       has,
     );
     any = any || has;
   }
 
-  alias(&format!("{}_any", module.to_snake_case()), any);
+  alias(&format!("{}_any", AsSnakeCase(module)), any);
 }

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -25,7 +25,7 @@
 use super::super::common;
 use crate::Settings;
 use anyhow::Context;
-use heck::ToKebabCase;
+use heck::AsKebabCase;
 use image::{self, codecs::png::PngDecoder, ImageDecoder};
 use libflate::gzip;
 use log::info;
@@ -170,11 +170,7 @@ fn generate_control_file(
   // https://www.debian.org/doc/debian-policy/ch-controlfields.html
   let dest_path = control_dir.join("control");
   let mut file = common::create_file(&dest_path)?;
-  writeln!(
-    file,
-    "Package: {}",
-    settings.product_name().to_kebab_case().to_ascii_lowercase()
-  )?;
+  writeln!(file, "Package: {}", AsKebabCase(settings.product_name()))?;
   writeln!(file, "Version: {}", settings.version_string())?;
   writeln!(file, "Architecture: {}", arch)?;
   // Installed-Size must be divided by 1024, see https://www.debian.org/doc/debian-policy/ch-controlfields.html#installed-size

--- a/tooling/cli/src/plugin/init.rs
+++ b/tooling/cli/src/plugin/init.rs
@@ -10,7 +10,7 @@ use crate::{
 use anyhow::Context;
 use clap::Parser;
 use handlebars::{to_json, Handlebars};
-use heck::{ToKebabCase, ToSnakeCase};
+use heck::{AsKebabCase, ToKebabCase, ToSnakeCase};
 use include_dir::{include_dir, Dir};
 use log::warn;
 use std::{collections::BTreeMap, env::current_dir, fs::remove_dir_all, path::PathBuf};
@@ -58,7 +58,7 @@ pub fn command(mut options: Options) -> Result<()> {
   options.load();
   let template_target_path = PathBuf::from(options.directory).join(&format!(
     "tauri-plugin-{}",
-    options.plugin_name.to_kebab_case()
+    AsKebabCase(options.plugin_name)
   ));
   let metadata = serde_json::from_str::<VersionMetadata>(include_str!("../../metadata.json"))?;
   if template_target_path.exists() {

--- a/tooling/cli/src/plugin/init.rs
+++ b/tooling/cli/src/plugin/init.rs
@@ -58,7 +58,7 @@ pub fn command(mut options: Options) -> Result<()> {
   options.load();
   let template_target_path = PathBuf::from(options.directory).join(&format!(
     "tauri-plugin-{}",
-    AsKebabCase(options.plugin_name)
+    AsKebabCase(&options.plugin_name)
   ));
   let metadata = serde_json::from_str::<VersionMetadata>(include_str!("../../metadata.json"))?;
   if template_target_path.exists() {


### PR DESCRIPTION

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Super slight performance improvements

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Hi! This small PR avoids heap allocations caused by casing conversions, whenever possible.

Example:

```rust
// Current code
// Three Strings are allocated below, two of them immediately freed after
format!(
    "CARGO_FEATURE_{}",
    feature
         .to_snake_case()
         .to_uppercase()
  )
```

```rust
// Proposed code
// Only the string returned by `format` is allocated
format!("CARGO_FEATURE_{}", AsShoutySnakeCase(feature))
// AsShoutySnakeCase is a struct which performs the conversion in its Display implementation
```