### PR TITLE
fix(macros): strip `r#` from command arguments, closes #4654

### DIFF
--- a/.changes/unraw-command-key.md
+++ b/.changes/unraw-command-key.md
@@ -1,0 +1,5 @@
+---
+"tauri-macros": patch
+---
+
+Remove raw identifier (`r#`) prefix from command arguments.

--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -6,6 +6,7 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{
+  ext::IdentExt,
   parse::{Parse, ParseBuffer},
   parse_macro_input,
   spanned::Spanned,
@@ -164,7 +165,7 @@ fn parse_arg(command: &Ident, arg: &FnArg, message: &Ident) -> syn::Result<Token
 
   // we only support patterns that allow us to extract some sort of keyed identifier
   let mut key = match &mut arg {
-    Pat::Ident(arg) => arg.ident.to_string(),
+    Pat::Ident(arg) => arg.ident.unraw().to_string(),
     Pat::Wild(_) => "".into(), // we always convert to camelCase, so "_" will end up empty anyways
     Pat::Struct(s) => super::path_to_command(&mut s.path).ident.to_string(),
     Pat::TupleStruct(s) => super::path_to_command(&mut s.path).ident.to_string(),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
