### PR TITLE
feat(bundler): use known Id for the sidecar files on WiX, ref #4546

### DIFF
--- a/.changes/sidecar-wix-ids.md
+++ b/.changes/sidecar-wix-ids.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Use `Bin_${sidecarFilename}` as the `Id` of sidecar file on WiX so you can reference it in your WiX fragments.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -853,6 +853,7 @@ fn generate_binaries_data(settings: &Settings) -> crate::Result<Vec<Binary>> {
   let mut binaries = Vec::new();
   let cwd = std::env::current_dir()?;
   let tmp_dir = std::env::temp_dir();
+  let regex = Regex::new(r"[^\w\d\.]")?;
   for src in settings.external_binaries() {
     let src = src?;
     let binary_path = cwd.join(&src);
@@ -861,7 +862,7 @@ fn generate_binaries_data(settings: &Settings) -> crate::Result<Vec<Binary>> {
       .expect("failed to extract external binary filename")
       .to_string_lossy()
       .replace(&format!("-{}", settings.target()), "");
-    let dest = tmp_dir.join(dest_filename);
+    let dest = tmp_dir.join(&dest_filename);
     std::fs::copy(binary_path, &dest)?;
 
     binaries.push(Binary {
@@ -870,7 +871,9 @@ fn generate_binaries_data(settings: &Settings) -> crate::Result<Vec<Binary>> {
         .into_os_string()
         .into_string()
         .expect("failed to read external binary path"),
-      id: format!("I{}", Uuid::new_v4().as_simple()),
+      id: regex
+        .replace_all(&dest_filename.replace('-', "_"), "")
+        .to_string(),
     });
   }
 
@@ -883,7 +886,9 @@ fn generate_binaries_data(settings: &Settings) -> crate::Result<Vec<Binary>> {
           .into_os_string()
           .into_string()
           .expect("failed to read binary path"),
-        id: format!("I{}", Uuid::new_v4().as_simple()),
+        id: regex
+          .replace_all(&bin.name().replace('-', "_"), "")
+          .to_string(),
       })
     }
   }

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -116,7 +116,7 @@
             </Component>
             {{#each binaries as |bin| ~}}
             <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
-                <File Id="Path_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>
+                <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>
             </Component>
             {{/each~}}
             {{#if enable_elevated_update_task}}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This PR changes the WiX file Id for sidecars to be a known string instead of a randomly generated one. This allows users to reference the sidecar in their WiX fragments for e.g. adding firewall rules for it.