### PR TITLE
example/commands: fix readme

### DIFF
--- a/examples/commands/README.md
+++ b/examples/commands/README.md
@@ -2,4 +2,4 @@
 
 A simple Tauri Application showcasing the command API.
 
-To execute run the following on the root directory of the repository: `cargo run --example commands`.
+To execute run the following on the root directory of the repository: `cargo run --bin=commands`.


### PR DESCRIPTION
With the current instruction, running `cargo run --example commands` from the root of the repository,
it shows that

> no example target named `commands`

This commit fixes that.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
