### PR TITLE
fix(codegen): fix relative paths in `version` field of `tauri.config.json`, closes #4723

### DIFF
--- a/.changes/issue-4723.md
+++ b/.changes/issue-4723.md
@@ -1,0 +1,5 @@
+---
+"tauri-codegen": patch
+---
+
+Fix relative paths in `version` field of `tauri.config.json` not being correctly parsed by `generate_context!()`.

--- a/core/tauri-codegen/src/lib.rs
+++ b/core/tauri-codegen/src/lib.rs
@@ -64,5 +64,14 @@ pub fn get_config(path: &Path) -> Result<(Config, PathBuf), CodegenConfigError> 
     json_patch::merge(&mut config, &merge_config);
   }
 
-  Ok((serde_json::from_value(config)?, parent))
+  let old_cwd = std::env::current_dir().map_err(CodegenConfigError::CurrentDir)?;
+  // Set working directory to where `tauri.config.json` is, so that relative paths in it are parsed correctly.
+  std::env::set_current_dir(parent.clone()).map_err(CodegenConfigError::CurrentDir)?;
+
+  let config = serde_json::from_value(config)?;
+
+  // Reset workding directory.
+  std::env::set_current_dir(old_cwd).map_err(CodegenConfigError::CurrentDir)?;
+
+  Ok((config, parent))
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] ~~I have added a convincing reason for adding this feature, if necessary~~ N/A

### Other information

I decided to change the working directory, instead of resolving the relative path by joining it with the parent directory of `tauri.config.json`. The latter requires that `tauri_utils::config::PackageVersion::deserialize` know the path to `tauri.config.json`, which is not trivial to implement.

For more details, please refer to #4723.