### PR TITLE
[Tests] Add a constructor for State that is available for unittests only

### DIFF
--- a/core/tauri/src/state.rs
+++ b/core/tauri/src/state.rs
@@ -19,6 +19,13 @@ impl<'r, T: Send + Sync + 'static> State<'r, T> {
   pub fn inner(&self) -> &'r T {
     self.0
   }
+
+  /// Create a State for testing commands in unittests
+  #[cfg(test)]
+  pub fn new_testonly(r: &'r T) -> Self {
+      State(r)
+  }
+
 }
 
 impl<T: Send + Sync + 'static> std::ops::Deref for State<'_, T> {


### PR DESCRIPTION
This adds a cfg(test) guarded method for directly constructing a State object, which enables writing unittests against tauri commands. Otherwise, tauri commands need an internal helper function to get references and call the method for testing, and can't get 100% coverage.

### What kind of change does this PR introduce?
- [x] Other, please describe: Improvement to testing infrastructure

### Does this PR introduce a breaking change?

- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
