### PR TITLE
feat(updater): use full path to msiexec

### DIFF
--- a/.changes/msiexec-full-path.md
+++ b/.changes/msiexec-full-path.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Use full path to `msiexec.exe` in the updater.

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -802,7 +802,7 @@ fn copy_files_and_run<R: Read + Seek>(
           "Start-Process",
           "-Wait",
           "-FilePath",
-          "msiexec",
+          "C:\\Windows\\system32\\msiexec.exe",
           "-ArgumentList",
         ])
         .arg("/i,")
@@ -814,7 +814,7 @@ fn copy_files_and_run<R: Read + Seek>(
       if powershell_install_res.is_err() {
         // fallback to running msiexec directly - relaunch won't be available
         // we use this here in case powershell fails in an older machine somehow
-        let _ = Command::new("msiexec.exe")
+        let _ = Command::new("C:\\Windows\\system32\\msiexec.exe")
           .arg("/i")
           .arg(found_path)
           .args(msiexec_args)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
