### PR TITLE
fix(cli): don't warn on first dev server connection attempt

### DIFF
--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -212,7 +212,7 @@ fn command_internal(mut options: Options) -> Result<()> {
         if std::net::TcpStream::connect(addrs).is_ok() {
           break;
         }
-        if i != 0 && i % 3 == 0 {
+        if i % 3 == 1 {
           warn!(
             "Waiting for your frontend dev server to start on {}...",
             dev_server_url

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -212,7 +212,7 @@ fn command_internal(mut options: Options) -> Result<()> {
         if std::net::TcpStream::connect(addrs).is_ok() {
           break;
         }
-        if i % 3 == 0 {
+        if i != 0 && i % 3 == 0 {
           warn!(
             "Waiting for your frontend dev server to start on {}...",
             dev_server_url


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
I run a basic setup using Vite with a React frontend. When I run `cargo tauri dev` it always prints an initial warning that my frontend dev server isn't up yet. My dev server usually starts within a second so I have never seen the warning printed twice. See line 3:

```bash
$ cargo tauri dev
     Running BeforeDevCommand (`npm run dev`)
        Warn Waiting for your frontend dev server to start on http://127.0.0.1:3000/...

> $PROJECT@0.0.1 dev
> vite


  vite v2.9.13 dev server running at:

  > Local: http://localhost:3000/
  > Network: use `--host` to expose

  ready in 533ms.

        Info Watching $REPO/src-tauri for changes...
   Compiling $PROJECT v0.1.0 ($REPO/src-tauri)
    Finished dev [unoptimized + debuginfo] target(s) in 8.60s
...
```

I feel like this warning is unnecessary and was a bit jarring the first time I started my dev server. Cleaner to only print this warning if we actually have to wait a bit for the dev server to start.