### PR TITLE
chore: add libc field to node packages

### DIFF
--- a/.changes/libc-field.md
+++ b/.changes/libc-field.md
@@ -1,0 +1,5 @@
+---
+"cli.js": patch
+---
+
+Add `libc` field to Node packages.

--- a/tooling/cli/node/npm/linux-arm64-gnu/package.json
+++ b/tooling/cli/node/npm/linux-arm64-gnu/package.json
@@ -10,6 +10,9 @@
   "cpu": [
     "arm64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "main": "cli.linux-arm64-gnu.node",
   "files": [
     "cli.linux-arm64-gnu.node"

--- a/tooling/cli/node/npm/linux-arm64-musl/package.json
+++ b/tooling/cli/node/npm/linux-arm64-musl/package.json
@@ -10,6 +10,9 @@
   "cpu": [
     "arm64"
   ],
+  "libc": [
+    "musl"
+  ],
   "main": "cli.linux-arm64-musl.node",
   "files": [
     "cli.linux-arm64-musl.node"

--- a/tooling/cli/node/npm/linux-x64-gnu/package.json
+++ b/tooling/cli/node/npm/linux-x64-gnu/package.json
@@ -10,6 +10,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "glibc"
+  ],
   "main": "cli.linux-x64-gnu.node",
   "files": [
     "cli.linux-x64-gnu.node"

--- a/tooling/cli/node/npm/linux-x64-musl/package.json
+++ b/tooling/cli/node/npm/linux-x64-musl/package.json
@@ -10,6 +10,9 @@
   "cpu": [
     "x64"
   ],
+  "libc": [
+    "musl"
+  ],
   "main": "cli.linux-x64-musl.node",
   "files": [
     "cli.linux-x64-musl.node"


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [X] Other, please describe:

This PR adds a [`libc` field](https://dev.to/arcanis/yarn-32-libc-yarn-explain-next-major--o22#libc-field) to the relevant Node packages.

Originally introduced by Yarn 3.2 (https://github.com/yarnpkg/berry/pull/3981), the field is the equivalent of `os` / `cpu` but for `libc` (currently supports `glibc` & `musl`). It allows package managers to skip installing packages with incompatible `libc`s.

It has since been implemented in `pnpm` (https://github.com/pnpm/pnpm/issues/4454) and `cnpm` (https://github.com/cnpm/npminstall/pull/387), and `npm` has plans to implement it too (https://github.com/npm/rfcs/issues/438).

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
