### PR TITLE
refactor(cli/core/bundler): use absolute path for msiexec and powershell

### DIFF
--- a/tooling/bundler/src/bundle/windows/templates/install-task.ps1
+++ b/tooling/bundler/src/bundle/windows/templates/install-task.ps1
@@ -16,7 +16,7 @@ if ((Test-Admin) -eq $false) {
     else {
         $InstallDirectory = Get-Location
         $ArgList = ('-File "{0}" -ChangeDir "{1}" -Elevated' -f ($myinvocation.MyCommand.Definition, $InstallDirectory))
-        Start-Process powershell.exe -WindowStyle hidden -Verb RunAs -ArgumentList $ArgList
+        Start-Process "$env:SYSTEMROOT\System32\WindowsPowerShell\v1.0\powershell.exe" -WindowStyle hidden -Verb RunAs -ArgumentList $ArgList
     }
     exit
 }

--- a/tooling/bundler/src/bundle/windows/templates/uninstall-task.ps1
+++ b/tooling/bundler/src/bundle/windows/templates/uninstall-task.ps1
@@ -15,7 +15,7 @@ if ((Test-Admin) -eq $false) {
     }
     else {
         $ArgList = ('-File "{0}" -Elevated' -f $myinvocation.MyCommand.Definition)
-        Start-Process powershell.exe -WindowStyle hidden -Verb RunAs -ArgumentList $ArgList
+        Start-Process "$env:SYSTEMROOT\System32\WindowsPowerShell\v1.0\powershell.exe" -WindowStyle hidden -Verb RunAs -ArgumentList $ArgList
     }
     exit
 }

--- a/tooling/bundler/src/bundle/windows/templates/update-task.xml
+++ b/tooling/bundler/src/bundle/windows/templates/update-task.xml
@@ -37,7 +37,7 @@
   <Actions Context="Author">
     <Exec>
       <Command>cmd.exe</Command>
-      <Arguments>/c "msiexec.exe /i %TEMP%\\{{{product_name}}}.msi {{{msiexec_args}}} /promptrestart"</Arguments>
+      <Arguments>/c "%SYSTEMROOT%\System32\msiexec.exe /i %TEMP%\\{{{product_name}}}.msi {{{msiexec_args}}} /promptrestart"</Arguments>
     </Exec>
   </Actions>
 </Task>

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -308,15 +308,17 @@ fn kill_before_dev_process() {
       .unwrap()
       .store(true, Ordering::Relaxed);
     #[cfg(windows)]
-    let powershell_path = std::env::var("SYSTEMROOT").map_or_else(
-      |_| "powershell.exe".to_string(),
-      |p| format!("{p}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
-    );
-    let _ = Command::new(powershell_path)
-        .arg("-NoProfile")
-        .arg("-Command")
-        .arg(format!("function Kill-Tree {{ Param([int]$ppid); Get-CimInstance Win32_Process | Where-Object {{ $_.ParentProcessId -eq $ppid }} | ForEach-Object {{ Kill-Tree $_.ProcessId }}; Stop-Process -Id $ppid -ErrorAction SilentlyContinue }}; Kill-Tree {}", child.id()))
-        .status();
+    {
+      let powershell_path = std::env::var("SYSTEMROOT").map_or_else(
+        |_| "powershell.exe".to_string(),
+        |p| format!("{p}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
+      );
+      let _ = Command::new(powershell_path)
+      .arg("-NoProfile")
+      .arg("-Command")
+      .arg(format!("function Kill-Tree {{ Param([int]$ppid); Get-CimInstance Win32_Process | Where-Object {{ $_.ParentProcessId -eq $ppid }} | ForEach-Object {{ Kill-Tree $_.ProcessId }}; Stop-Process -Id $ppid -ErrorAction SilentlyContinue }}; Kill-Tree {}", child.id()))
+      .status();
+    }
     #[cfg(unix)]
     {
       use std::io::Write;

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -308,7 +308,12 @@ fn kill_before_dev_process() {
       .unwrap()
       .store(true, Ordering::Relaxed);
     #[cfg(windows)]
-      let _ = Command::new("powershell")
+    let system_root = std::env::var("SYSTEMROOT");
+    let powershell_path = system_root.as_ref().map_or_else(
+      |_| "powershell.exe".to_string(),
+      |p| format!("{p}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
+    );
+    let _ = Command::new(powershell_path)
         .arg("-NoProfile")
         .arg("-Command")
         .arg(format!("function Kill-Tree {{ Param([int]$ppid); Get-CimInstance Win32_Process | Where-Object {{ $_.ParentProcessId -eq $ppid }} | ForEach-Object {{ Kill-Tree $_.ProcessId }}; Stop-Process -Id $ppid -ErrorAction SilentlyContinue }}; Kill-Tree {}", child.id()))

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -308,8 +308,7 @@ fn kill_before_dev_process() {
       .unwrap()
       .store(true, Ordering::Relaxed);
     #[cfg(windows)]
-    let system_root = std::env::var("SYSTEMROOT");
-    let powershell_path = system_root.as_ref().map_or_else(
+    let powershell_path = std::env::var("SYSTEMROOT").map_or_else(
       |_| "powershell.exe".to_string(),
       |p| format!("{p}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
     );

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -286,8 +286,13 @@ fn get_version(command: &str, args: &[&str]) -> crate::Result<Option<String>> {
 
 #[cfg(windows)]
 fn webview2_version() -> crate::Result<Option<String>> {
+  let system_root = std::env::var("SYSTEMROOT");
+  let powershell_path = system_root.as_ref().map_or_else(
+    |_| "powershell.exe".to_string(),
+    |p| format!("{p}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
+  );
   // check 64bit machine-wide installation
-  let output = Command::new("powershell")
+  let output = Command::new(powershell_path)
       .args(&["-NoProfile", "-Command"])
       .arg("Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' | ForEach-Object {$_.pv}")
       .output()?;
@@ -297,7 +302,7 @@ fn webview2_version() -> crate::Result<Option<String>> {
     ));
   }
   // check 32bit machine-wide installation
-  let output = Command::new("powershell")
+  let output = Command::new(powershell_path)
         .args(&["-NoProfile", "-Command"])
         .arg("Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' | ForEach-Object {$_.pv}")
         .output()?;
@@ -307,7 +312,7 @@ fn webview2_version() -> crate::Result<Option<String>> {
     ));
   }
   // check user-wide installation
-  let output = Command::new("powershell")
+  let output = Command::new(powershell_path)
       .args(&["-NoProfile", "-Command"])
       .arg("Get-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' | ForEach-Object {$_.pv}")
       .output()?;

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -286,8 +286,7 @@ fn get_version(command: &str, args: &[&str]) -> crate::Result<Option<String>> {
 
 #[cfg(windows)]
 fn webview2_version() -> crate::Result<Option<String>> {
-  let system_root = std::env::var("SYSTEMROOT");
-  let powershell_path = system_root.as_ref().map_or_else(
+  let powershell_path = std::env::var("SYSTEMROOT").map_or_else(
     |_| "powershell.exe".to_string(),
     |p| format!("{p}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
   );

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -291,7 +291,7 @@ fn webview2_version() -> crate::Result<Option<String>> {
     |p| format!("{p}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
   );
   // check 64bit machine-wide installation
-  let output = Command::new(powershell_path)
+  let output = Command::new(&powershell_path)
       .args(&["-NoProfile", "-Command"])
       .arg("Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' | ForEach-Object {$_.pv}")
       .output()?;
@@ -301,7 +301,7 @@ fn webview2_version() -> crate::Result<Option<String>> {
     ));
   }
   // check 32bit machine-wide installation
-  let output = Command::new(powershell_path)
+  let output = Command::new(&powershell_path)
         .args(&["-NoProfile", "-Command"])
         .arg("Get-ItemProperty -Path 'HKLM:\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' | ForEach-Object {$_.pv}")
         .output()?;
@@ -311,7 +311,7 @@ fn webview2_version() -> crate::Result<Option<String>> {
     ));
   }
   // check user-wide installation
-  let output = Command::new(powershell_path)
+  let output = Command::new(&powershell_path)
       .args(&["-NoProfile", "-Command"])
       .arg("Get-ItemProperty -Path 'HKCU:\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}' | ForEach-Object {$_.pv}")
       .output()?;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
