### PR TITLE
fix(codegen): write output file when contents change

### DIFF
--- a/.changes/write-only-changed.md
+++ b/.changes/write-only-changed.md
@@ -1,0 +1,6 @@
+---
+"tauri-codegen": patch
+"tauri-build": patch
+---
+
+Only rewrite temporary icon files when the content change, avoid needless rebuilds.

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -293,6 +293,10 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
     )?;
   }
 
+  for icon in &config.tauri.bundle.icon {
+    println!("cargo:rerun-if-changed={}", icon);
+  }
+
   #[allow(unused_mut, clippy::redundant_clone)]
   let mut resources = config.tauri.bundle.resources.clone().unwrap_or_default();
   #[cfg(windows)]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Currently an app build is needed even when no code has changed. After some investigation, it was trigger by the writing of the temporary icon file used for embedding.

Even with this change, two builds are required to avoid further rebuilds. Maybe it's better to preprocess the icons in `build.rs`?