### PR TITLE
feat(codegen): use TARGET environment variable if set

### DIFF
--- a/.changes/codegen-check-target.md
+++ b/.changes/codegen-check-target.md
@@ -1,0 +1,5 @@
+---
+"tauri-codegen": patch
+---
+
+Use `TARGET` environment variable for code generation inside build scripts.

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -28,6 +28,7 @@ pub struct ContextData {
 
 fn map_core_assets(
   options: &AssetOptions,
+  target: Target,
 ) -> impl Fn(&AssetKey, &Path, &mut Vec<u8>, &mut CspHashes) -> Result<(), EmbeddedAssetsError> {
   #[cfg(feature = "isolation")]
   let pattern = tauri_utils::html::PatternObject::from(&options.pattern);
@@ -40,8 +41,9 @@ fn map_core_assets(
 
       #[allow(clippy::collapsible_if)]
       if csp {
-        #[cfg(target_os = "linux")]
-        ::tauri_utils::html::inject_csp_token(&mut document);
+        if target == Target::Linux {
+          ::tauri_utils::html::inject_csp_token(&mut document);
+        }
 
         inject_nonce_token(&mut document, &dangerous_disable_asset_csp_modification);
 
@@ -106,6 +108,16 @@ fn map_isolation(
   }
 }
 
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum Target {
+  Linux,
+  Windows,
+  Darwin,
+  Android,
+  // iOS.
+  IOS,
+}
+
 /// Build a `tauri::Context` for including in application code.
 pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsError> {
   let ContextData {
@@ -114,6 +126,34 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
     config_parent,
     root,
   } = data;
+
+  let target = if let Ok(target) = std::env::var("TARGET") {
+    if target.contains("unknown-linux") {
+      Target::Linux
+    } else if target.contains("pc-windows") {
+      Target::Windows
+    } else if target.contains("apple-darwin") {
+      Target::Darwin
+    } else if target.contains("android") {
+      Target::Android
+    } else if target.contains("apple-ios") {
+      Target::IOS
+    } else {
+      panic!("unknown codegen target {}", target);
+    }
+  } else if cfg!(target_os = "linux") {
+    Target::Linux
+  } else if cfg!(windows) {
+    Target::Windows
+  } else if cfg!(target_os = "macos") {
+    Target::Darwin
+  } else if cfg!(target_os = "android") {
+    Target::Android
+  } else if cfg!(target_os = "ios") {
+    Target::IOS
+  } else {
+    panic!("unknown codegen target");
+  };
 
   let mut options = AssetOptions::new(config.tauri.pattern.clone())
     .freeze_prototype(config.tauri.security.freeze_prototype)
@@ -162,7 +202,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
             path
           )
         }
-        EmbeddedAssets::new(assets_path, &options, map_core_assets(&options))?
+        EmbeddedAssets::new(assets_path, &options, map_core_assets(&options, target))?
       }
       _ => unimplemented!(),
     },
@@ -172,7 +212,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
         .map(|p| config_parent.join(p))
         .collect::<Vec<_>>(),
       &options,
-      map_core_assets(&options),
+      map_core_assets(&options, target),
     )?,
     _ => unimplemented!(),
   };
@@ -189,18 +229,28 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
     out_dir
   };
 
-  // handle default window icons for Windows targets
-  #[cfg(windows)]
   let default_window_icon = {
-    let icon_path = find_icon(
-      &config,
-      &config_parent,
-      |i| i.ends_with(".ico"),
-      "icons/icon.ico",
-    );
-    if icon_path.exists() {
-      ico_icon(&root, &out_dir, icon_path)?
-    } else {
+    if target == Target::Windows {
+      // handle default window icons for Windows targets
+      let icon_path = find_icon(
+        &config,
+        &config_parent,
+        |i| i.ends_with(".ico"),
+        "icons/icon.ico",
+      );
+      if icon_path.exists() {
+        ico_icon(&root, &out_dir, icon_path)?
+      } else {
+        let icon_path = find_icon(
+          &config,
+          &config_parent,
+          |i| i.ends_with(".png"),
+          "icons/icon.png",
+        );
+        png_icon(&root, &out_dir, icon_path)?
+      }
+    } else if target == Target::Linux {
+      // handle default window icons for Linux targets
       let icon_path = find_icon(
         &config,
         &config_parent,
@@ -208,23 +258,12 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
         "icons/icon.png",
       );
       png_icon(&root, &out_dir, icon_path)?
+    } else {
+      quote!(None)
     }
   };
-  #[cfg(target_os = "linux")]
-  let default_window_icon = {
-    let icon_path = find_icon(
-      &config,
-      &config_parent,
-      |i| i.ends_with(".png"),
-      "icons/icon.png",
-    );
-    png_icon(&root, &out_dir, icon_path)?
-  };
-  #[cfg(not(any(windows, target_os = "linux")))]
-  let default_window_icon = quote!(None);
 
-  #[cfg(target_os = "macos")]
-  let app_icon = if dev {
+  let app_icon = if target == Target::Darwin && dev {
     let mut icon_path = find_icon(
       &config,
       &config_parent,
@@ -243,8 +282,6 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
   } else {
     quote!(None)
   };
-  #[cfg(not(target_os = "macos"))]
-  let app_icon = quote!(None);
 
   let package_name = if let Some(product_name) = &config.package.product_name {
     quote!(#product_name.to_string())
@@ -283,43 +320,40 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
   };
 
   #[cfg(target_os = "macos")]
-  let info_plist = {
-    if dev {
-      let info_plist_path = config_parent.join("Info.plist");
-      let mut info_plist = if info_plist_path.exists() {
-        plist::Value::from_file(&info_plist_path)
-          .unwrap_or_else(|e| panic!("failed to read plist {}: {}", info_plist_path.display(), e))
-      } else {
-        plist::Value::Dictionary(Default::default())
-      };
-
-      if let Some(plist) = info_plist.as_dictionary_mut() {
-        if let Some(product_name) = &config.package.product_name {
-          plist.insert("CFBundleName".into(), product_name.clone().into());
-        }
-        if let Some(version) = &config.package.version {
-          plist.insert("CFBundleShortVersionString".into(), version.clone().into());
-        }
-        let format =
-          time::format_description::parse("[year][month][day].[hour][minute][second]").unwrap();
-        if let Ok(build_number) = time::OffsetDateTime::now_utc().format(&format) {
-          plist.insert("CFBundleVersion".into(), build_number.into());
-        }
-      }
-
-      let out_path = out_dir.join("Info.plist");
-      info_plist
-        .to_file_xml(&out_path)
-        .expect("failed to write Info.plist");
-
-      let info_plist_path = out_path.display().to_string();
-      quote!({
-        #[cfg(desktop)]
-        tauri::embed_plist::embed_info_plist!(#info_plist_path);
-      })
+  let info_plist = if target == Target::Darwin && dev {
+    let info_plist_path = config_parent.join("Info.plist");
+    let mut info_plist = if info_plist_path.exists() {
+      plist::Value::from_file(&info_plist_path)
+        .unwrap_or_else(|e| panic!("failed to read plist {}: {}", info_plist_path.display(), e))
     } else {
-      quote!(())
+      plist::Value::Dictionary(Default::default())
+    };
+
+    if let Some(plist) = info_plist.as_dictionary_mut() {
+      if let Some(product_name) = &config.package.product_name {
+        plist.insert("CFBundleName".into(), product_name.clone().into());
+      }
+      if let Some(version) = &config.package.version {
+        plist.insert("CFBundleShortVersionString".into(), version.clone().into());
+      }
+      let format =
+        time::format_description::parse("[year][month][day].[hour][minute][second]").unwrap();
+      if let Ok(build_number) = time::OffsetDateTime::now_utc().format(&format) {
+        plist.insert("CFBundleVersion".into(), build_number.into());
+      }
     }
+
+    let out_path = out_dir.join("Info.plist");
+    info_plist
+      .to_file_xml(&out_path)
+      .expect("failed to write Info.plist");
+
+    let info_plist_path = out_path.display().to_string();
+    quote!({
+      tauri::embed_plist::embed_info_plist!(#info_plist_path);
+    })
+  } else {
+    quote!(())
   };
   #[cfg(not(target_os = "macos"))]
   let info_plist = quote!(());
@@ -443,7 +477,6 @@ fn ico_icon<P: AsRef<Path>>(
   Ok(icon)
 }
 
-#[cfg(target_os = "macos")]
 fn raw_icon<P: AsRef<Path>>(out_dir: &Path, path: P) -> Result<TokenStream, EmbeddedAssetsError> {
   let path = path.as_ref();
   let bytes = std::fs::read(&path)
@@ -508,7 +541,6 @@ fn write_if_changed(out_path: &Path, data: &[u8]) -> std::io::Result<()> {
   out_file.write_all(data)
 }
 
-#[cfg(any(windows, target_os = "macos", target_os = "linux"))]
 fn find_icon<F: Fn(&&String) -> bool>(
   config: &Config,
   config_parent: &Path,

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -115,7 +115,7 @@ enum Target {
   Darwin,
   Android,
   // iOS.
-  IOS,
+  Ios,
 }
 
 /// Build a `tauri::Context` for including in application code.
@@ -137,7 +137,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
     } else if target.contains("android") {
       Target::Android
     } else if target.contains("apple-ios") {
-      Target::IOS
+      Target::Ios
     } else {
       panic!("unknown codegen target {}", target);
     }
@@ -150,7 +150,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
   } else if cfg!(target_os = "android") {
     Target::Android
   } else if cfg!(target_os = "ios") {
-    Target::IOS
+    Target::Ios
   } else {
     panic!("unknown codegen target");
   };


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This PR enhances the codegen implementation when used in build scripts by checking the TARGET environment variable set by Tauri to support cross compilation. This feature is important for the mobile implementation, but I'm targeting a merge to dev to avoid conflicts since it doesn't impact desktop app development.
