### PR TITLE
refactor(cli): Use `cargo metadata` to detect the workspace root and target directory, closes #4632, #4928.

### DIFF
--- a/.changes/cli-detect-target-dir.md
+++ b/.changes/cli-detect-target-dir.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": "patch"
+"cli.js": "patch"
+---
+
+Use `cargo metadata` to detect the workspace root and target directory.

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -794,13 +794,12 @@ pub fn command(_options: Options) -> Result<()> {
         } else {
           None
         };
-      let lock: Option<CargoLock> = if let Ok(lock_contents) =
-        read_to_string(get_workspace_dir(&tauri_dir).join("Cargo.lock"))
-      {
-        toml::from_str(&lock_contents).ok()
-      } else {
-        None
-      };
+      let lock: Option<CargoLock> =
+        if let Ok(lock_contents) = read_to_string(get_workspace_dir().join("Cargo.lock")) {
+          toml::from_str(&lock_contents).ok()
+        } else {
+          None
+        };
 
       for (dep, label) in [
         ("tauri", format!("{} {}", "tauri", "[RUST]".dimmed())),

--- a/tooling/cli/src/info.rs
+++ b/tooling/cli/src/info.rs
@@ -794,12 +794,10 @@ pub fn command(_options: Options) -> Result<()> {
         } else {
           None
         };
-      let lock: Option<CargoLock> =
-        if let Ok(lock_contents) = read_to_string(get_workspace_dir().join("Cargo.lock")) {
-          toml::from_str(&lock_contents).ok()
-        } else {
-          None
-        };
+      let lock: Option<CargoLock> = get_workspace_dir()
+        .ok()
+        .and_then(|p| read_to_string(p.join("Cargo.lock")).ok())
+        .and_then(|s| toml::from_str(&s).ok());
 
       for (dep, label) in [
         ("tauri", format!("{} {}", "tauri", "[RUST]".dimmed())),

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -632,7 +632,7 @@ impl RustAppSettings {
   }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(Deserialize)]
 struct CargoMetadata {
   target_directory: PathBuf,
   workspace_root: PathBuf,

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -287,7 +287,7 @@ impl Rust {
     let process = Arc::new(Mutex::new(child));
     let (tx, rx) = channel();
     let tauri_path = tauri_dir();
-    let workspace_path = get_workspace_dir(&tauri_path);
+    let workspace_path = get_workspace_dir();
 
     let watch_folders = if tauri_path == workspace_path {
       vec![tauri_path]
@@ -421,17 +421,6 @@ impl CargoSettings {
       .with_context(|| "failed to parse Cargo.toml")
       .map_err(Into::into)
   }
-}
-
-#[derive(Deserialize)]
-struct CargoBuildConfig {
-  #[serde(rename = "target-dir")]
-  target_dir: Option<String>,
-}
-
-#[derive(Deserialize)]
-struct CargoConfig {
-  build: Option<CargoBuildConfig>,
 }
 
 pub struct RustAppSettings {
@@ -639,50 +628,44 @@ impl RustAppSettings {
   }
 
   pub fn out_dir(&self, target: Option<String>, debug: bool) -> crate::Result<PathBuf> {
-    let tauri_dir = tauri_dir();
-    let workspace_dir = get_workspace_dir(&tauri_dir);
-    get_target_dir(&workspace_dir, target, !debug)
+    get_target_dir(target, !debug)
   }
 }
 
-/// This function determines where 'target' dir is and suffixes it with 'release' or 'debug'
+#[derive(serde::Deserialize)]
+struct CargoMetadata {
+  target_directory: PathBuf,
+  workspace_root: PathBuf,
+}
+
+fn get_cargo_metadata() -> crate::Result<CargoMetadata> {
+  let output = Command::new("cargo")
+    .args(["metadata", "--no-deps", "--format-version", "1"])
+    .current_dir(tauri_dir())
+    .output()?;
+
+  if !output.status.success() {
+    return Err(anyhow::anyhow!(
+      "cargo metadata command exited with a non zero exit code: {}",
+      String::from_utf8(output.stderr)?
+    ));
+  }
+
+  Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+/// This function determines the 'target' directory and suffixes it with 'release' or 'debug'
 /// to determine where the compiled binary will be located.
-fn get_target_dir(
-  project_root_dir: &Path,
-  target: Option<String>,
-  is_release: bool,
-) -> crate::Result<PathBuf> {
-  let mut path: PathBuf = match std::env::var_os("CARGO_TARGET_DIR") {
-    Some(target_dir) => target_dir.into(),
-    None => {
-      let mut root_dir = project_root_dir.to_path_buf();
-      let target_path: Option<PathBuf> = loop {
-        // cargo reads configs under .cargo/config.toml or .cargo/config
-        let mut cargo_config_path = root_dir.join(".cargo/config");
-        if !cargo_config_path.exists() {
-          cargo_config_path = root_dir.join(".cargo/config.toml");
-        }
-        // if the path exists, parse it
-        if cargo_config_path.exists() {
-          let mut config_str = String::new();
-          let mut config_file = File::open(&cargo_config_path)
-            .with_context(|| format!("failed to open {:?}", cargo_config_path))?;
-          config_file
-            .read_to_string(&mut config_str)
-            .with_context(|| "failed to read cargo config file")?;
-          let config: CargoConfig =
-            toml::from_str(&config_str).with_context(|| "failed to parse cargo config file")?;
-          if let Some(build) = config.build {
-            if let Some(target_dir) = build.target_dir {
-              break Some(target_dir.into());
-            }
-          }
-        }
-        if !root_dir.pop() {
-          break None;
-        }
-      };
-      target_path.unwrap_or_else(|| project_root_dir.join("target"))
+fn get_target_dir(target: Option<String>, is_release: bool) -> crate::Result<PathBuf> {
+  let mut path = match get_cargo_metadata() {
+    Ok(meta) => meta.target_directory,
+    // TODO: PR comment: return error instead of log+fallback? If fallback -> Remove Result wrapper
+    Err(err) => {
+      warn!(
+        "Unable to find target directory, falling back to the Tauri source directory. Reason: {:#}",
+        err
+      );
+      tauri_dir().join("target")
     }
   };
 
@@ -693,46 +676,19 @@ fn get_target_dir(
   Ok(path)
 }
 
-/// Walks up the file system, looking for a Cargo.toml file
-/// If one is found before reaching the root, then the current_dir's package belongs to that parent workspace if it's listed on [workspace.members].
-///
-/// If this package is part of a workspace, returns the path to the workspace directory
-/// Otherwise returns the current directory.
-pub fn get_workspace_dir(current_dir: &Path) -> PathBuf {
-  let mut dir = current_dir.to_path_buf();
-  let project_path = dir.clone();
-
-  while dir.pop() {
-    if dir.join("Cargo.toml").exists() {
-      match CargoSettings::load(&dir) {
-        Ok(cargo_settings) => {
-          if let Some(workspace_settings) = cargo_settings.workspace {
-            if let Some(members) = workspace_settings.members {
-              if members.iter().any(|member| {
-                glob::glob(&dir.join(member).to_string_lossy())
-                  .unwrap()
-                  .any(|p| p.unwrap() == project_path)
-              }) {
-                return dir;
-              }
-            }
-          }
-        }
-        Err(e) => {
-          warn!(
-              "Found `{}`, which may define a parent workspace, but \
-            failed to parse it. If this is indeed a parent workspace, undefined behavior may occur: \
-            \n    {:#}",
-              dir.display(),
-              e
-            );
-        }
-      }
+/// Executes `cargo metadata` to get the workspace directory.
+/// It will fall back to the Tauri directory if there was an error.
+pub fn get_workspace_dir() -> PathBuf {
+  match get_cargo_metadata() {
+    Ok(meta) => meta.workspace_root,
+    Err(err) => {
+      warn!(
+        "Unable to find workspace directory, falling back to the Tauri source directory. Reason: {:#}",
+        err
+      );
+      tauri_dir()
     }
   }
-
-  // Nothing found walking up the file system, return the starting directory
-  current_dir.to_path_buf()
 }
 
 #[allow(unused_variables)]

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -7,7 +7,7 @@ use std::{
   fs::{File, FileType},
   io::{Read, Write},
   path::{Path, PathBuf},
-  process::ExitStatus,
+  process::{Command, ExitStatus},
   str::FromStr,
   sync::{
     atomic::{AtomicBool, Ordering},

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -20,7 +20,6 @@ use std::{
 use anyhow::Context;
 #[cfg(target_os = "linux")]
 use heck::ToKebabCase;
-use log::warn;
 use log::{debug, info};
 use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
 use serde::Deserialize;
@@ -287,7 +286,7 @@ impl Rust {
     let process = Arc::new(Mutex::new(child));
     let (tx, rx) = channel();
     let tauri_path = tauri_dir();
-    let workspace_path = get_workspace_dir();
+    let workspace_path = get_workspace_dir()?;
 
     let watch_folders = if tauri_path == workspace_path {
       vec![tauri_path]
@@ -671,7 +670,6 @@ fn get_target_dir(target: Option<String>, is_release: bool) -> crate::Result<Pat
 }
 
 /// Executes `cargo metadata` to get the workspace directory.
-/// It will fall back to the Tauri directory if there was an error.
 pub fn get_workspace_dir() -> crate::Result<PathBuf> {
   Ok(
     get_cargo_metadata()


### PR DESCRIPTION
1. I don't know how this will influence custom runners.
2. Do we want to keep some of the old logic as a fall back? I don't really see much value in that, unless they help for 1), though we should probably fix that more explicitly then.
3. There's a TODO [here](https://github.com/tauri-apps/tauri/compare/refactor/cargo-metadata?expand=1#diff-51403e5aaa4a768c008928cd2323cf62aafe9258b4879273879a205729cf2bedR933), mainly because i forgot to remove that before committing, but should this function return an Error if `cargo metadata` fails? If not i think we should return the PathBuf directly instead of a Result.
4. Although it started as a fix for the target dir, i changed the logic for the workspace root too, should this be reverted? I can't think of a situation where cargo metadata could fail where our custom logic wouldn't.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No, _hopefully_.

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary