### PR TITLE
refactor(tauri): add closing comment tag

### DIFF
--- a/core/tauri/build.rs
+++ b/core/tauri/build.rs
@@ -20,7 +20,7 @@ fn has_feature(feature: &str) -> bool {
     .unwrap()
     .push(feature.to_string());
 
-  // when a feature is enabled, Cargo sets the `CARGO_FEATURE_<name` env var to 1
+  // when a feature is enabled, Cargo sets the `CARGO_FEATURE_<name>` env var to 1
   // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
   std::env::var(format!("CARGO_FEATURE_{}", AsShoutySnakeCase(feature)))
     .map(|x| x == "1")


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
## Reason of the change 
When i was reading some of the source code, i found that this comment hasn't got the closing `>` for `<name` i just added this, it's a style PR about a comment.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:


### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No
I didn´t  change any of the source code, as you can see from the preview, so no breaking change,  :smiley:!

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this style fix, if necessary

