### PR TITLE
feat(cli): load Cargo configuration to check default build target

### DIFF
--- a/.changes/cargo-config-target.md
+++ b/.changes/cargo-config-target.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Check if the default build target is set in the Cargo configuration.

--- a/tooling/cli/src/interface/rust/cargo_config.rs
+++ b/tooling/cli/src/interface/rust/cargo_config.rs
@@ -1,0 +1,123 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::{
+  fs,
+  path::{Path, PathBuf},
+};
+
+struct PathAncestors<'a> {
+  current: Option<&'a Path>,
+}
+
+impl<'a> PathAncestors<'a> {
+  fn new(path: &'a Path) -> PathAncestors<'a> {
+    PathAncestors {
+      current: Some(path),
+    }
+  }
+}
+
+impl<'a> Iterator for PathAncestors<'a> {
+  type Item = &'a Path;
+
+  fn next(&mut self) -> Option<&'a Path> {
+    if let Some(path) = self.current {
+      self.current = path.parent();
+
+      Some(path)
+    } else {
+      None
+    }
+  }
+}
+
+#[derive(Default, Deserialize)]
+pub struct BuildConfig {
+  target: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct ConfigSchema {
+  build: Option<BuildConfig>,
+}
+
+#[derive(Default)]
+pub struct Config {
+  build: BuildConfig,
+}
+
+impl Config {
+  pub fn load(path: &Path) -> Result<Self> {
+    let mut config = Self::default();
+
+    for current in PathAncestors::new(path) {
+      if let Some(path) = get_file_path(&current.join(".cargo"), "config", true)? {
+        let contents = fs::read_to_string(&path)
+          .with_context(|| format!("failed to read configuration file `{}`", path.display()))?;
+        let toml: ConfigSchema = toml::from_str(&contents)
+          .with_context(|| format!("could not parse TOML configuration in `{}`", path.display()))?;
+
+        if let Some(target) = toml.build.and_then(|b| b.target) {
+          config.build.target = Some(target);
+          break;
+        }
+      }
+    }
+
+    Ok(config)
+  }
+
+  pub fn build(&self) -> &BuildConfig {
+    &self.build
+  }
+}
+
+impl BuildConfig {
+  pub fn target(&self) -> Option<&str> {
+    self.target.as_deref()
+  }
+}
+
+/// The purpose of this function is to aid in the transition to using
+/// .toml extensions on Cargo's config files, which were historically not used.
+/// Both 'config.toml' and 'credentials.toml' should be valid with or without extension.
+/// When both exist, we want to prefer the one without an extension for
+/// backwards compatibility, but warn the user appropriately.
+fn get_file_path(
+  dir: &Path,
+  filename_without_extension: &str,
+  warn: bool,
+) -> Result<Option<PathBuf>> {
+  let possible = dir.join(filename_without_extension);
+  let possible_with_extension = dir.join(format!("{}.toml", filename_without_extension));
+
+  if possible.exists() {
+    if warn && possible_with_extension.exists() {
+      // We don't want to print a warning if the version
+      // without the extension is just a symlink to the version
+      // WITH an extension, which people may want to do to
+      // support multiple Cargo versions at once and not
+      // get a warning.
+      let skip_warning = if let Ok(target_path) = fs::read_link(&possible) {
+        target_path == possible_with_extension
+      } else {
+        false
+      };
+
+      if !skip_warning {
+        log::warn!(
+          "Both `{}` and `{}` exist. Using `{}`",
+          possible.display(),
+          possible_with_extension.display(),
+          possible.display()
+        );
+      }
+    }
+
+    Ok(Some(possible))
+  } else if possible_with_extension.exists() {
+    Ok(Some(possible_with_extension))
+  } else {
+    Ok(None)
+  }
+}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This is mostly useful for the future mobile implementation since cargo-mobile sets the default target in the Cargo configuration to avoid cache issues (we didn't check if the issues still exists though). See [the commit](https://github.com/BrainiumLLC/cargo-mobile/commit/57d4b886af4d8613d42b38c2b2b5dd6630771c7c).