### PR TITLE
fix(api): add async `mockIPC()` handler signature

### DIFF
--- a/.changes/fix-async-mockipc.md
+++ b/.changes/fix-async-mockipc.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Update `mockIPC()` handler signature to allow async handler functions.

--- a/tooling/api/src/mocks.ts
+++ b/tooling/api/src/mocks.ts
@@ -38,7 +38,7 @@ interface IPCMessage {
  * @param cb
  */
 export function mockIPC(
-  cb: (cmd: string, args: Record<string, unknown>) => any
+  cb: (cmd: string, args: Record<string, unknown>) => any | Promise<any>
 ): void {
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   window.__TAURI_IPC__ = async ({

--- a/tooling/api/src/mocks.ts
+++ b/tooling/api/src/mocks.ts
@@ -35,6 +35,27 @@ interface IPCMessage {
  * })
  * ```
  *
+ * The callback function can also return a Promise:
+ * ```js
+ * import { mockIPC, clearMocks } from "@tauri-apps/api/mocks"
+ * import { invoke } from "@tauri-apps/api/tauri"
+ *
+ * afterEach(() => {
+ *    clearMocks()
+ * })
+ *
+ * test("mocked command", () => {
+ *  mockIPC((cmd, args) => {
+ *   if(cmd === "get_data") {
+ *    return fetch("https://example.com/data.json")
+ *      .then((response) => response.json())
+ *   }
+ *  });
+ *
+ *  expect(invoke('get_data')).resolves.toBe({ foo: 'bar' });
+ * })
+ * ```
+ *
  * @param cb
  */
 export function mockIPC(


### PR DESCRIPTION
The `mockIPC()` function accepted async functions and Promise returns from the beginning, but the handler function signature didn't reflect it.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
