### PR TITLE
refactor(core/api): use constants for events in core, add new enum for core events in api

### DIFF
--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -68,6 +68,9 @@ const WINDOW_FOCUS_EVENT: &str = "tauri://focus";
 const WINDOW_BLUR_EVENT: &str = "tauri://blur";
 const WINDOW_SCALE_FACTOR_CHANGED_EVENT: &str = "tauri://scale-change";
 const WINDOW_THEME_CHANGED: &str = "tauri://theme-changed";
+const WINDOW_FILE_DROP_EVENT: &str = "tauri://file-drop";
+const WINDOW_FILE_DROP_HOVER_EVENT: &str = "tauri://file-drop-hover";
+const WINDOW_FILE_DROP_CANCELLED_EVENT: &str = "tauri://file-drop-cancelled";
 const MENU_EVENT: &str = "tauri://menu";
 
 #[derive(Default)]
@@ -1369,7 +1372,7 @@ fn on_window_event<R: Runtime>(
       },
     )?,
     WindowEvent::FileDrop(event) => match event {
-      FileDropEvent::Hovered(paths) => window.emit("tauri://file-drop-hover", paths)?,
+      FileDropEvent::Hovered(paths) => window.emit(WINDOW_FILE_DROP_HOVER_EVENT, paths)?,
       FileDropEvent::Dropped(paths) => {
         let scopes = window.state::<Scopes>();
         for path in paths {
@@ -1379,9 +1382,9 @@ fn on_window_event<R: Runtime>(
             let _ = scopes.allow_directory(path, false);
           }
         }
-        window.emit("tauri://file-drop", paths)?
+        window.emit(WINDOW_FILE_DROP_EVENT, paths)?
       }
-      FileDropEvent::Cancelled => window.emit("tauri://file-drop-cancelled", ())?,
+      FileDropEvent::Cancelled => window.emit(WINDOW_FILE_DROP_CANCELLED_EVENT, ())?,
       _ => unimplemented!(),
     },
     WindowEvent::ThemeChanged(theme) => window.emit(WINDOW_THEME_CHANGED, theme.to_string())?,

--- a/tooling/api/src/helpers/event.ts
+++ b/tooling/api/src/helpers/event.ts
@@ -17,11 +17,32 @@ export interface Event<T> {
   payload: T
 }
 
-export type EventName = string
+export type EventName = TauriEvent | string
 
 export type EventCallback<T> = (event: Event<T>) => void
 
 export type UnlistenFn = () => void
+
+export enum TauriEvent {
+  WINDOW_RESIZED = 'tauri://resize',
+  WINDOW_MOVED = 'tauri://move',
+  WINDOW_CLOSE_REQUESTED = 'tauri://close-requested',
+  WINDOW_CREATED = 'tauri://window-created',
+  WINDOW_DESTROYED = 'tauri://destroyed',
+  WINDOW_FOCUS = 'tauri://focus',
+  WINDOW_BLUR = 'tauri://blur',
+  WINDOW_SCALE_FACTOR_CHANGED = 'tauri://scale-change',
+  WINDOW_THEME_CHANGED = 'tauri://theme-changed',
+  WINDOW_FILE_DROP = 'tauri://file-drop',
+  WINDOW_FILE_DROP_HOVER = 'tauri://file-drop-hover',
+  WINDOW_FILE_DROP_CANCELLED = 'tauri://file-drop-cancelled',
+  MENU = 'tauri://menu',
+  CHECK_UPDATE = 'tauri://update',
+  UPDATE_AVAILABLE = 'tauri://update-available',
+  INSTALL_UPDATE = 'tauri://update-install',
+  STATUS_UPDATE = 'tauri://update-status',
+  DOWNLOAD_PROGRESS = 'tauri://update-download-progress'
+}
 
 /**
  * Unregister the event listener associated with the given name and id.

--- a/tooling/api/src/updater.ts
+++ b/tooling/api/src/updater.ts
@@ -10,6 +10,7 @@
  */
 
 import { once, listen, emit, UnlistenFn } from './event'
+import { TauriEvent } from './helpers/event'
 
 type UpdateStatus = 'PENDING' | 'ERROR' | 'DONE' | 'UPTODATE'
 
@@ -49,7 +50,7 @@ interface UpdateResult {
 async function onUpdaterEvent(
   handler: (status: UpdateStatusResult) => void
 ): Promise<UnlistenFn> {
-  return listen('tauri://update-status', (data: { payload: any }) => {
+  return listen(TauriEvent.STATUS_UPDATE, (data: { payload: any }) => {
     handler(data?.payload as UpdateStatusResult)
   })
 }
@@ -105,7 +106,7 @@ async function installUpdate(): Promise<void> {
 
     // start the process we dont require much security as it's
     // handled by rust
-    emit('tauri://update-install').catch((e) => {
+    emit(TauriEvent.INSTALL_UPDATE).catch((e) => {
       cleanListener()
       // dispatch the error to our checkUpdate
       throw e
@@ -158,7 +159,7 @@ async function checkUpdate(): Promise<UpdateResult> {
     }
 
     // wait to receive the latest update
-    once('tauri://update-available', (data: { payload: any }) => {
+    once(TauriEvent.UPDATE_AVAILABLE, (data: { payload: any }) => {
       onUpdateAvailable(data?.payload as UpdateManifest)
     }).catch((e) => {
       cleanListener()
@@ -178,7 +179,7 @@ async function checkUpdate(): Promise<UpdateResult> {
       })
 
     // start the process
-    emit('tauri://update').catch((e) => {
+    emit(TauriEvent.CHECK_UPDATE).catch((e) => {
       cleanListener()
       // dispatch the error to our checkUpdate
       throw e

--- a/tooling/api/src/window.ts
+++ b/tooling/api/src/window.ts
@@ -62,7 +62,7 @@
 
 import { invokeTauriCommand } from './helpers/tauri'
 import type { EventName, EventCallback, UnlistenFn } from './event'
-import { emit, Event, listen, once } from './helpers/event'
+import { emit, Event, listen, once, TauriEvent } from './helpers/event'
 
 type Theme = 'light' | 'dark'
 
@@ -1523,7 +1523,7 @@ class WindowManager extends WebviewWindowHandle {
    * Note that removing the listener is required if your listener goes out of scope e.g. the component is unmounted.
    */
   async onResized(handler: EventCallback<PhysicalSize>): Promise<UnlistenFn> {
-    return this.listen<PhysicalSize>('tauri://resize', handler)
+    return this.listen<PhysicalSize>(TauriEvent.WINDOW_RESIZED, handler)
   }
 
   /**
@@ -1545,7 +1545,7 @@ class WindowManager extends WebviewWindowHandle {
    * Note that removing the listener is required if your listener goes out of scope e.g. the component is unmounted.
    */
   async onMoved(handler: EventCallback<PhysicalPosition>): Promise<UnlistenFn> {
-    return this.listen<PhysicalPosition>('tauri://move', handler)
+    return this.listen<PhysicalPosition>(TauriEvent.WINDOW_MOVED, handler)
   }
 
   /**
@@ -1574,7 +1574,7 @@ class WindowManager extends WebviewWindowHandle {
   async onCloseRequested(
     handler: (event: CloseRequestedEvent) => void
   ): Promise<UnlistenFn> {
-    return this.listen<null>('tauri://close-requested', (event) => {
+    return this.listen<null>(TauriEvent.WINDOW_CLOSE_REQUESTED, (event) => {
       const evt = new CloseRequestedEvent(event)
       void Promise.resolve(handler(evt)).then(() => {
         if (!evt.isPreventDefault()) {
@@ -1604,13 +1604,13 @@ class WindowManager extends WebviewWindowHandle {
    */
   async onFocusChanged(handler: EventCallback<boolean>): Promise<UnlistenFn> {
     const unlistenFocus = await this.listen<PhysicalPosition>(
-      'tauri://focus',
+      TauriEvent.WINDOW_FOCUS,
       (event) => {
         handler({ ...event, payload: true })
       }
     )
     const unlistenBlur = await this.listen<PhysicalPosition>(
-      'tauri://blur',
+      TauriEvent.WINDOW_BLUR,
       (event) => {
         handler({ ...event, payload: false })
       }
@@ -1646,7 +1646,10 @@ class WindowManager extends WebviewWindowHandle {
   async onScaleChanged(
     handler: EventCallback<ScaleFactorChanged>
   ): Promise<UnlistenFn> {
-    return this.listen<ScaleFactorChanged>('tauri://scale-change', handler)
+    return this.listen<ScaleFactorChanged>(
+      TauriEvent.WINDOW_SCALE_FACTOR_CHANGED,
+      handler
+    )
   }
 
   /**
@@ -1668,7 +1671,7 @@ class WindowManager extends WebviewWindowHandle {
    * Note that removing the listener is required if your listener goes out of scope e.g. the component is unmounted.
    */
   async onMenuClicked(handler: EventCallback<string>): Promise<UnlistenFn> {
-    return this.listen<string>('tauri://menu', handler)
+    return this.listen<string>(TauriEvent.MENU, handler)
   }
 
   /**
@@ -1701,21 +1704,21 @@ class WindowManager extends WebviewWindowHandle {
     handler: EventCallback<FileDropEvent>
   ): Promise<UnlistenFn> {
     const unlistenFileDrop = await this.listen<string[]>(
-      'tauri://file-drop',
+      TauriEvent.WINDOW_FILE_DROP,
       (event) => {
         handler({ ...event, payload: { type: 'drop', paths: event.payload } })
       }
     )
 
     const unlistenFileHover = await this.listen<string[]>(
-      'tauri://file-drop-hover',
+      TauriEvent.WINDOW_FILE_DROP_HOVER,
       (event) => {
         handler({ ...event, payload: { type: 'hover', paths: event.payload } })
       }
     )
 
     const unlistenCancel = await this.listen<null>(
-      'tauri://file-drop-cancelled',
+      TauriEvent.WINDOW_FILE_DROP_CANCELLED,
       (event) => {
         handler({ ...event, payload: { type: 'cancel' } })
       }
@@ -1747,7 +1750,7 @@ class WindowManager extends WebviewWindowHandle {
    * Note that removing the listener is required if your listener goes out of scope e.g. the component is unmounted.
    */
   async onThemeChanged(handler: EventCallback<Theme>): Promise<UnlistenFn> {
-    return this.listen<Theme>('tauri://theme-changed', handler)
+    return this.listen<Theme>(TauriEvent.WINDOW_THEME_CHANGED, handler)
   }
 }
 


### PR DESCRIPTION
Hi there,

This change does the two following things:
- Declares new constants for the File Drop events in `core` and uses them in the code. This follows the same pattern as the other events declared as constants too.
- Creates a new enum in `api` for events coming from the backend (`core`) and uses it in the `EventName` type declaration. This makes it easier to find which event to listen to and should hopefully be documented (not sure if Docosorus will automagically pick up on this, I'm unfamiliar with this documentation system). I am also using this new enum across `api` where strings were previously used. 

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [x] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
N/A