### PR TITLE
fix(cli/mobile): strip `\n` before parsing json

### DIFF
--- a/tooling/cli/src/mobile/init.rs
+++ b/tooling/cli/src/mobile/init.rs
@@ -62,7 +62,7 @@ pub fn init_dot_cargo(app: &App, android: Option<(&AndroidEnv, &AndroidConfig)>)
 pub fn exec(
   target: Target,
   wrapper: &TextWrapper,
-  non_interactive: bool,
+  #[allow(unused_variables)] non_interactive: bool,
   #[allow(unused_variables)] reinstall_deps: bool,
 ) -> Result<App> {
   let tauri_config = get_tauri_config(None)?;

--- a/tooling/cli/src/mobile/mod.rs
+++ b/tooling/cli/src/mobile/mod.rs
@@ -184,10 +184,10 @@ fn read_options(config: &TauriConfig, target: Target) -> CliOptions {
 
   let mut attempt = 0;
   let max_tries = 5;
-  let buffer = loop {
+  let (buffer, len) = loop {
     let mut buffer = String::new();
-    if conn.read_line(&mut buffer).is_ok() {
-      break buffer;
+    if let Ok(len) = conn.read_line(&mut buffer) {
+      break (buffer, len);
     }
     std::thread::sleep(std::time::Duration::from_secs(1));
     attempt += 1;
@@ -199,7 +199,8 @@ fn read_options(config: &TauriConfig, target: Target) -> CliOptions {
       std::process::exit(1);
     }
   };
-  let options: CliOptions = serde_json::from_str(&buffer).expect("invalid CLI options");
+
+  let options: CliOptions = serde_json::from_str(&buffer[..len - 1]).expect("invalid CLI options");
   for (k, v) in &options.vars {
     set_var(k, v);
   }


### PR DESCRIPTION
`read_line` reads up to and including `\n` so it needs to be stripped before trying to parse as json

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
