### PR TITLE
feat(android): with_webview access for jni execution

### DIFF
--- a/.changes/mobile-webview-access.md
+++ b/.changes/mobile-webview-access.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime-wry": minor
+"tauri": minor
+---
+
+Support `with_webview` for Android platform alowing execution of JNI code in context. 

--- a/core/tauri-runtime-wry/src/webview.rs
+++ b/core/tauri-runtime-wry/src/webview.rs
@@ -34,4 +34,10 @@ mod imp {
   }
 }
 
+#[cfg(target_os = "android")]
+mod imp {
+  use wry::webview::JniHandle;
+  pub type Webview = JniHandle;
+}
+
 pub use imp::*;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Feature
- [X] Docs

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
Bring the Android environment in closer feature parity to desktop platforms by supporting the `with_webview` method which, for Android, provides a hook for JNI execution on the WebView java object.

This functionality depends on https://github.com/tauri-apps/wry/pull/689
