### PR TITLE
chore(deps): use less specific version for tokio and once_cell

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -47,13 +47,13 @@ normal = [ "attohttpc", "reqwest" ]
 [dependencies]
 serde_json = { version = "1.0", features = [ "raw_value" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-tokio = { version = "1.21", features = [ "rt", "rt-multi-thread", "sync", "fs", "io-util" ] }
+tokio = { version = "1", features = [ "rt", "rt-multi-thread", "sync", "fs", "io-util" ] }
 futures = "0.3"
 uuid = { version = "1", features = [ "v4" ] }
 url = { version = "2.3" }
 anyhow = "1.0"
 thiserror = "1.0"
-once_cell = "1.14"
+once_cell = "1"
 tauri-runtime = { version = "0.10.2", path = "../tauri-runtime" }
 tauri-macros = { version = "1.0.4", path = "../tauri-macros" }
 tauri-utils = { version = "1.0.3", features = [ "resources" ], path = "../tauri-utils" }
@@ -116,7 +116,7 @@ features = [ "Win32_Foundation" ]
 
 [build-dependencies]
 heck = "0.4"
-once_cell = "1.14"
+once_cell = "1"
 
 [dev-dependencies]
 mockito = "0.31"
@@ -127,7 +127,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 tauri = { path = ".", default-features = false, features = [ "wry" ] }
 tokio-test = "0.4.2"
-tokio = { version = "1.21", features = [ "full" ] }
+tokio = { version = "1", features = [ "full" ] }
 cargo_toml = "0.11"
 
 [features]

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -32,7 +32,7 @@ clap = { version = "3.2", features = [ "derive" ] }
 anyhow = "1.0"
 tauri-bundler = { version = "1.0.5", path = "../bundler" }
 colored = "2.0"
-once_cell = "1.13"
+once_cell = "1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 serde_with = "2.0"


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
