### PR TITLE
Remove `futures` & `futures-lite` and use `futures-util` directily.

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -48,7 +48,7 @@ normal = [ "attohttpc", "reqwest" ]
 serde_json = { version = "1.0", features = [ "raw_value" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 tokio = { version = "1", features = [ "rt", "rt-multi-thread", "sync", "fs", "io-util" ] }
-futures = "0.3"
+futures-util = "0.3"
 uuid = { version = "1", features = [ "v4" ] }
 url = { version = "2.3" }
 anyhow = "1.0"
@@ -82,7 +82,6 @@ raw-window-handle = "0.5"
 minisign-verify = { version = "0.2", optional = true }
 time = { version = "0.3", features = [ "parsing", "formatting" ], optional = true }
 os_info = { version = "3.5.0", optional = true }
-futures-lite = "1.12"
 regex = { version = "1.6.0", optional = true }
 glob = "0.3"
 data-url = { version = "0.1", optional = true }

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -599,7 +599,7 @@ impl Response {
   /// # Examples
   ///
   /// ```no_run
-  /// use futures::StreamExt;
+  /// use futures_util::StreamExt;
   ///
   /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
   /// let client = tauri::api::http::ClientBuilder::new().build()?;
@@ -617,8 +617,8 @@ impl Response {
   #[allow(dead_code)]
   pub(crate) fn bytes_stream(
     self,
-  ) -> impl futures::Stream<Item = crate::api::Result<bytes::Bytes>> {
-    use futures::StreamExt;
+  ) -> impl futures_util::Stream<Item = crate::api::Result<bytes::Bytes>> {
+    use futures_util::StreamExt;
     self.1.bytes_stream().map(|res| res.map_err(Into::into))
   }
 

--- a/core/tauri/src/async_runtime.rs
+++ b/core/tauri/src/async_runtime.rs
@@ -10,7 +10,6 @@
 //! one you need isn't here, you could use types in [`tokio`] directly.
 //! For custom command handlers, it's recommended to use a plain `async fn` command.
 
-use futures_lite::future::FutureExt;
 use once_cell::sync::OnceCell;
 pub use tokio::{
   runtime::{Handle as TokioHandle, Runtime as TokioRuntime},
@@ -159,7 +158,7 @@ impl<T> Future for JoinHandle<T> {
   type Output = crate::Result<T>;
   fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
     match self.get_mut() {
-      Self::Tokio(t) => t.poll(cx).map_err(Into::into),
+      Self::Tokio(t) => Pin::new(t).poll(cx).map_err(Into::into),
     }
   }
 }

--- a/core/tauri/src/command.rs
+++ b/core/tauri/src/command.rs
@@ -156,7 +156,7 @@ impl<'de, R: Runtime> Deserializer<'de> for CommandItem<'de, R> {
 #[doc(hidden)]
 pub mod private {
   use crate::{InvokeError, InvokeResolver, Runtime};
-  use futures::{FutureExt, TryFutureExt};
+  use futures_util::{FutureExt, TryFutureExt};
   use serde::Serialize;
   use serde_json::Value;
   use std::future::Future;

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -563,7 +563,7 @@ impl<R: Runtime> Update<R> {
     let mut buffer = Vec::new();
     #[cfg(feature = "reqwest-client")]
     {
-      use futures::StreamExt;
+      use futures_util::StreamExt;
       let mut stream = response.bytes_stream();
       while let Some(chunk) = stream.next().await {
         let chunk = chunk?;

--- a/tooling/webdriver/src/server.rs
+++ b/tooling/webdriver/src/server.rs
@@ -4,7 +4,7 @@
 
 use crate::cli::Args;
 use anyhow::Error;
-use futures::TryFutureExt;
+use futures_util::TryFutureExt;
 use hyper::header::CONTENT_LENGTH;
 use hyper::http::uri::Authority;
 use hyper::service::{make_service_fn, service_fn};
@@ -141,7 +141,7 @@ fn map_capabilities(mut json: Value) -> Value {
 pub async fn run(args: Args, mut _driver: Child) -> Result<(), Error> {
   #[cfg(unix)]
   let (signals_handle, signals_task) = {
-    use futures::StreamExt;
+    use futures_util::StreamExt;
     use signal_hook::consts::signal::*;
 
     let signals = signal_hook_tokio::Signals::new(&[SIGTERM, SIGINT, SIGQUIT])?;


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: cleanup dependencies

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
`futures` crate brings an executor by default, while we have already used `tokio`. `futures-lite` brings another executor here, but we only need *one* method from it, which could be simply replaced with `Pin::new`. This cleanup will make `tauri` build a little faster.