### PR TITLE
ci: Don't trigger docs update when no packages were published

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -155,7 +155,9 @@ jobs:
           body: ${{ steps.covector.outputs.change }}
 
       - name: Trigger doc update
-        if: steps.covector.outputs.successfulPublish == 'true'
+        if: |
+          steps.covector.outputs.successfulPublish == 'true' &&
+          steps.covector.outputs.packagesPublished != ''
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.TAURI_BOT_PAT }}


### PR DESCRIPTION
Let's hope this actually works lol

The reason for this is that every commit to dev triggers an update if there is no changefile present.

### What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: CI

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary