### PR TITLE
fix(macos): fix regression in `with_menu_on_left_click`, closes #5220

### DIFF
--- a/.changes/menu-on-left-click.md
+++ b/.changes/menu-on-left-click.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime-wry": "patch"
+---
+
+Fix regression in `SystemTray::with_menu_on_left_click`
+

--- a/core/tauri-runtime-wry/src/system_tray.rs
+++ b/core/tauri-runtime-wry/src/system_tray.rs
@@ -107,7 +107,7 @@ pub fn create_tray<T>(
   {
     builder = builder
       .with_icon_as_template(system_tray.icon_as_template)
-      .with_icon_as_template(system_tray.menu_on_left_click)
+      .with_menu_on_left_click(system_tray.menu_on_left_click)
   }
 
   let tray = builder

--- a/core/tauri-runtime-wry/src/system_tray.rs
+++ b/core/tauri-runtime-wry/src/system_tray.rs
@@ -105,7 +105,9 @@ pub fn create_tray<T>(
 
   #[cfg(target_os = "macos")]
   {
-    builder = builder.with_icon_as_template(system_tray.icon_as_template)
+    builder = builder
+      .with_icon_as_template(system_tray.icon_as_template)
+      .with_icon_as_template(system_tray.menu_on_left_click)
   }
 
   let tray = builder


### PR DESCRIPTION
The regression was introduced in https://github.com/tauri-apps/tauri/commit/4d063ae9ee9538cd6fa5e01b80070c6edf8eaeb9

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
