### PR TITLE
fix(api): fs/exists return type previously set to void when it should be boolean

### DIFF
--- a/.changes/api-fs-exists-return-type.md
+++ b/.changes/api-fs-exists-return-type.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Fix incorrect return type on `fs/exists`

--- a/tooling/api/src/fs.ts
+++ b/tooling/api/src/fs.ts
@@ -562,7 +562,7 @@ async function renameFile(
  *
  * @since 1.1.0
  */
-async function exists(path: string, options: FsOptions = {}): Promise<void> {
+async function exists(path: string, options: FsOptions = {}): Promise<boolean> {
   return invokeTauriCommand({
     __tauriModule: 'Fs',
     message: {


### PR DESCRIPTION
Very small fix to the `fs/exists` method in the JS API, commit message should be explanatory enough 🙂 

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Question regarding the second point in the checklist of PRs: How does it work? The link to the doc is dead. Would love to add the file in this or future PRs if required.