### PR TITLE
Fix dialog.save return type

### DIFF
--- a/.changes/dialog-save-return-fix.md
+++ b/.changes/dialog-save-return-fix.md
@@ -1,0 +1,5 @@
+---
+"api": patch
+---
+
+Fix `dialog.save` return type

--- a/tooling/api/src/dialog.ts
+++ b/tooling/api/src/dialog.ts
@@ -189,7 +189,7 @@ async function open(
  *
  * @since 1.0.0
  */
-async function save(options: SaveDialogOptions = {}): Promise<string | string> {
+async function save(options: SaveDialogOptions = {}): Promise<string | null> {
   if (typeof options === 'object') {
     Object.freeze(options)
   }

--- a/tooling/api/src/dialog.ts
+++ b/tooling/api/src/dialog.ts
@@ -189,7 +189,7 @@ async function open(
  *
  * @since 1.0.0
  */
-async function save(options: SaveDialogOptions = {}): Promise<string> {
+async function save(options: SaveDialogOptions = {}): Promise<string | string> {
   if (typeof options === 'object') {
     Object.freeze(options)
   }


### PR DESCRIPTION
Can return `null` when user cancels save dialog

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
