### PR TITLE
chore(examples): remove the legacy X-UA-Compatible meta

### DIFF
--- a/examples/commands/index.html
+++ b/examples/commands/index.html
@@ -3,7 +3,6 @@
 
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tauri</title>
 </head>

--- a/examples/helloworld/index.html
+++ b/examples/helloworld/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Welcome to Tauri!</title>
   </head>

--- a/examples/navigation/public/index.html
+++ b/examples/navigation/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri</title>
   </head>

--- a/examples/navigation/public/nested/index.html
+++ b/examples/navigation/public/nested/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri</title>
   </head>

--- a/examples/navigation/public/nested/secondary.html
+++ b/examples/navigation/public/nested/secondary.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri</title>
   </head>

--- a/examples/navigation/public/secondary.html
+++ b/examples/navigation/public/secondary.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri</title>
   </head>

--- a/examples/resources/index.html
+++ b/examples/resources/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sidecar</title>
   </head>

--- a/examples/sidecar/index.html
+++ b/examples/sidecar/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sidecar</title>
     <style>

--- a/examples/state/index.html
+++ b/examples/state/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tauri</title>
   </head>

--- a/examples/streaming/index.html
+++ b/examples/streaming/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <style>
       video {

--- a/examples/tauri-dynamic-lib/src-tauri/src/index.html
+++ b/examples/tauri-dynamic-lib/src-tauri/src/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Welcome to Tauri!</title>
   </head>

--- a/examples/updater/index.html
+++ b/examples/updater/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Welcome to Tauri!</title>
   </head>

--- a/tooling/bench/tests/files_transfer/public/index.html
+++ b/tooling/bench/tests/files_transfer/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Welcome to Tauri!</title>
   </head>

--- a/tooling/bench/tests/helloworld/public/index.html
+++ b/tooling/bench/tests/helloworld/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Welcome to Tauri!</title>
   </head>


### PR DESCRIPTION

We aren't targeting Internet Exploder, so it's safe to bury its legacy.