### PR TITLE
feature: added variants to the Error enum to help constructive error messages

### DIFF
--- a/core/tauri/src/error.rs
+++ b/core/tauri/src/error.rs
@@ -144,7 +144,7 @@ pub enum Error {
 
   /// a "safety valve" error for authors not finding a more appropriate error variant
   #[error("{0}")]
-  OtherError(String)
+  OtherError(String),
 }
 
 pub(crate) fn into_anyhow<T: std::fmt::Display>(err: T) -> anyhow::Error {

--- a/core/tauri/src/error.rs
+++ b/core/tauri/src/error.rs
@@ -88,6 +88,16 @@ pub enum Error {
   /// Error initializing plugin.
   #[error("failed to initialize plugin `{0}`: {1}")]
   PluginInitialization(String, String),
+
+  /// An error which occurs while trying to fulfil a plugin's `#[command]` request from
+  /// a frontend request during run time.
+  #[error("the {0} Tauri plugin ran into problems executing the \"{1}\" command: {2}")]
+  PluginCommandError(String, String, String),
+  /// An error which occurs while trying to fulfil a locally defined app/user `#[command]` request from
+  /// a frontend request during run time.  
+  #[error("the user/app defined command \"{0}\" ran into problems executing: {1}")]
+  CommandError(String, String),
+
   /// A part of the URL is malformed or invalid. This may occur when parsing and combining
   /// user-provided URLs and paths.
   #[error("invalid url: {0}")]
@@ -131,6 +141,10 @@ pub enum Error {
   /// The Window's raw handle is invalid for the platform.
   #[error("Unexpected `raw_window_handle` for the current platform")]
   InvalidWindowHandle,
+
+  /// a _safety valve_ error for authors not finding a more appropriate error variant
+  #[error("{0)")]
+  OtherError(String)
 }
 
 pub(crate) fn into_anyhow<T: std::fmt::Display>(err: T) -> anyhow::Error {

--- a/core/tauri/src/error.rs
+++ b/core/tauri/src/error.rs
@@ -143,7 +143,7 @@ pub enum Error {
   InvalidWindowHandle,
 
   /// a _safety valve_ error for authors not finding a more appropriate error variant
-  #[error("{0)")]
+  #[error("{0}")]
   OtherError(String)
 }
 

--- a/core/tauri/src/error.rs
+++ b/core/tauri/src/error.rs
@@ -142,7 +142,7 @@ pub enum Error {
   #[error("Unexpected `raw_window_handle` for the current platform")]
   InvalidWindowHandle,
 
-  /// a _safety valve_ error for authors not finding a more appropriate error variant
+  /// a "safety valve" error for authors not finding a more appropriate error variant
   #[error("{0}")]
   OtherError(String)
 }


### PR DESCRIPTION
all user defined `#[command]` blocks -- whether in a plugin or in userland -- must return a `Result<T, tauri::error>` but the variants on **tauri::error** do not provide variants which an author in this situation would typically want to use. To aid them toward a sensible set of variants I have created the following:

1. `PluginCommandError` - forces plugin author to identify the plugin and the command and then allows a textual description of the error
2. `CommandError` - allows the userland author to identify the command and a textual description
3. `OtherError` - a means to allow other unexpected/non-covered use cases to have a safety valve where an appropriate variant is not otherwise available.