### PR TITLE
fix(core): update metadata before window-created listeners, closes #5191

### DIFF
--- a/.changes/fix-metadata-update.md
+++ b/.changes/fix-metadata-update.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fixes access to the `WebviewWindow.getByLabel` function in a `tauri://window-created` event listener.

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -327,17 +327,26 @@ pub fn listen_js(
   handler: String,
 ) -> String {
   format!(
-    "if (window['{listeners}'] === void 0) {{
-      Object.defineProperty(window, '{listeners}', {{ value: Object.create(null) }});
-    }}
-    if (window['{listeners}'][{event}] === void 0) {{
-      Object.defineProperty(window['{listeners}'], {event}, {{ value: [] }});
-    }}
-    window['{listeners}'][{event}].push({{
-      id: {event_id},
-      windowLabel: {window_label},
-      handler: {handler}
-    }});
+    "
+    (function () {{
+      if (window['{listeners}'] === void 0) {{
+        Object.defineProperty(window, '{listeners}', {{ value: Object.create(null) }});
+      }}
+      if (window['{listeners}'][{event}] === void 0) {{
+        Object.defineProperty(window['{listeners}'], {event}, {{ value: [] }});
+      }}
+      const eventListeners = window['{listeners}'][{event}]
+      const listener = {{
+        id: {event_id},
+        windowLabel: {window_label},
+        handler: {handler}
+      }};
+      if ({event} == 'tauri://window-created') {{
+        eventListeners.splice(eventListeners.length - 1, 0, listener)
+      }} else {{
+        eventListeners.push(listener);
+      }}
+    }})()
   ",
     listeners = listeners_object_name,
     event = event,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Tauri fires event listeners in reverse order, so our own tauri://window-created listener is the last to execute. This commit changes the listen JS code to keep our own listener as the last one in the array, so the metadata is updated before user code is executed.