### PR TITLE
fix(cli): detect deno

### DIFF
--- a/.changes/cli.js-node-shim-and-deno.md
+++ b/.changes/cli.js-node-shim-and-deno.md
@@ -1,0 +1,5 @@
+---
+"cli.js": patch
+---
+
+Fix crash when nodejs binary has the version in its name, for example `node18` or when running through deno.

--- a/.changes/cli.js-node-shim.md
+++ b/.changes/cli.js-node-shim.md
@@ -1,5 +1,0 @@
----
-"cli.js": patch
----
-
-Fix crash when nodejs binary has the version in its name, for example `node18`

--- a/tooling/cli/node/tauri.js
+++ b/tooling/cli/node/tauri.js
@@ -32,8 +32,8 @@ if (binStem.match(/(((nodejs|node)([1-9]*)*)|cli)$/g)) {
     }
 
     binName = `${manager} run ${process.env.npm_lifecycle_event}`
-  } else if (binStem == "cli") {
-    binName = "@tauri-apps/cli"
+  } else if (binStem == 'cli') {
+    binName = '@tauri-apps/cli'
   } else {
     // Assume running NodeJS if we didn't detect a manager from the env.
     // We normalize the path to prevent the script's absolute path being used.

--- a/tooling/cli/node/tauri.js
+++ b/tooling/cli/node/tauri.js
@@ -10,9 +10,13 @@ const binStem = path.parse(bin).name.toLowerCase()
 // can successfully detect what command likely started the execution.
 let binName
 
+// deno run -A --unstable --node-modules-dir npm:@tauri-apps/cli
+if (bin === '@tauri-apps/cli') {
+  binName = '@tauri-apps/cli'
+}
 // Even if started by a package manager, the binary will be NodeJS.
 // Some distribution still use "nodejs" as the binary name.
-if (binStem.match(/(((nodejs|node)([1-9]*)*)|cli)$/g)) {
+else if (binStem.match(/(nodejs|node)([1-9]*)*$/g)) {
   const managerStem = process.env.npm_execpath
     ? path.parse(process.env.npm_execpath).name.toLowerCase()
     : null
@@ -32,8 +36,6 @@ if (binStem.match(/(((nodejs|node)([1-9]*)*)|cli)$/g)) {
     }
 
     binName = `${manager} run ${process.env.npm_lifecycle_event}`
-  } else if (binStem == 'cli') {
-    binName = '@tauri-apps/cli'
   } else {
     // Assume running NodeJS if we didn't detect a manager from the env.
     // We normalize the path to prevent the script's absolute path being used.

--- a/tooling/cli/node/tauri.js
+++ b/tooling/cli/node/tauri.js
@@ -12,7 +12,7 @@ let binName
 
 // Even if started by a package manager, the binary will be NodeJS.
 // Some distribution still use "nodejs" as the binary name.
-if (binStem.match(/(nodejs|node)([1-9]*)*$/g)) {
+if (binStem.match(/(((nodejs|node)([1-9]*)*)|cli)$/g)) {
   const managerStem = process.env.npm_execpath
     ? path.parse(process.env.npm_execpath).name.toLowerCase()
     : null

--- a/tooling/cli/node/tauri.js
+++ b/tooling/cli/node/tauri.js
@@ -32,6 +32,8 @@ if (binStem.match(/(((nodejs|node)([1-9]*)*)|cli)$/g)) {
     }
 
     binName = `${manager} run ${process.env.npm_lifecycle_event}`
+  } else if (binStem == "cli") {
+    binName = "@tauri-apps/cli"
   } else {
     // Assume running NodeJS if we didn't detect a manager from the env.
     // We normalize the path to prevent the script's absolute path being used.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information

Using `deno run -A --unstable --node-modules-dir npm:@tauri-apps/cli dev` arguments passed to the cli are `['@tauri-apps/cli', 'dev']` 

This is part of including deno templates in CTA.