### PR TITLE
fix(cli): keep dev watcher alive if config is incorrect, closes #5173

### DIFF
--- a/.changes/cli-dev-alive-on-error.md
+++ b/.changes/cli-dev-alive-on-error.md
@@ -1,0 +1,5 @@
+---
+"cli.rs": "patch"
+---
+
+Keep `tauri dev` watcher alive when config contains error.

--- a/.changes/cli-dev-alive-on-error.md
+++ b/.changes/cli-dev-alive-on-error.md
@@ -2,4 +2,4 @@
 "cli.rs": "patch"
 ---
 
-Keep `tauri dev` watcher alive when config contains error.
+Keep `tauri dev` watcher alive when the configuration is invalid.

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Context;
 use json_patch::merge;
+use log::error;
 use once_cell::sync::Lazy;
 use serde_json::Value as JsonValue;
 
@@ -141,12 +142,14 @@ fn get_internal(merge_config: Option<&str>, reload: bool) -> crate::Result<Confi
       for error in errors {
         let path = error.instance_path.clone().into_vec().join(" > ");
         if path.is_empty() {
-          eprintln!("`{config_file_name}` error: {}", error);
+          error!("`{}` error: {}", config_file_name, error);
         } else {
-          eprintln!("`{config_file_name}` error on `{}`: {}", path, error);
+          error!("`{}` error on `{}`: {}", config_file_name, path, error);
         }
       }
-      exit(1);
+      if !reload {
+        exit(1);
+      }
     }
   }
 

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -402,7 +402,12 @@ impl Rust {
                   rewrite_manifest(config.lock().unwrap().as_ref().unwrap())?
               }
               Err(err) => {
-                error!("{}", err)
+                let p = process.lock().unwrap();
+                let is_building_app = p.app_child.lock().unwrap().is_none();
+                if is_building_app {
+                  p.kill().with_context(|| "failed to kill app process")?;
+                }
+                error!("{}", err);
               }
             }
           } else {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
