### PR TITLE
Adds a `new` method to `InvokeError` (fix #5497)

### DIFF
--- a/core/tauri/src/hooks.rs
+++ b/core/tauri/src/hooks.rs
@@ -90,6 +90,12 @@ pub struct Invoke<R: Runtime> {
 pub struct InvokeError(JsonValue);
 
 impl InvokeError {
+  /// Create a new [`InvokeError`] from a [`serde_json::Value`].
+  #[inline(always)]
+  pub fn new(error: JsonValue) -> Self {
+    InvokeError(error)
+  }
+
   /// Create an [`InvokeError`] as a string of the [`serde_json::Error`] message.
   #[inline(always)]
   pub fn from_serde_json(error: serde_json::Error) -> Self {


### PR DESCRIPTION
Adds a `new` method to `InvokeError` to allow for manual initialization of the struct, as described in Issue #5497 (fix #5497).

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
