### PR TITLE
fix(core): Invoke event listener in windows safely to avoid causing uncaught errors in windows that have loaded external urls

### DIFF
--- a/.changes/avoid-errors-in-external-urled-windows.md
+++ b/.changes/avoid-errors-in-external-urled-windows.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Invoke event listener in windows safely to avoid causing uncaught errors in windows that have loaded external urls

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -1408,7 +1408,7 @@ fn on_window_event<R: Runtime>(
       let windows = windows_map.values();
       for window in windows {
         window.eval(&format!(
-          r#"window.__TAURI_METADATA__.__windows = window.__TAURI_METADATA__.__windows.filter(w => w.label !== "{}");"#,
+          r#"var metadata = window.__TAURI_METADATA__; if (metadata != null) {{ metadata.__windows = window.__TAURI_METADATA__.__windows.filter(w => w.label !== "{}"); }}"#,
           label
         ))?;
       }

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -1408,7 +1408,7 @@ fn on_window_event<R: Runtime>(
       let windows = windows_map.values();
       for window in windows {
         window.eval(&format!(
-          r#"var metadata = window.__TAURI_METADATA__; if (metadata != null) {{ metadata.__windows = window.__TAURI_METADATA__.__windows.filter(w => w.label !== "{}"); }}"#,
+          r#"(function () {{ var metadata = window.__TAURI_METADATA__; if (metadata != null) {{ metadata.__windows = window.__TAURI_METADATA__.__windows.filter(w => w.label !== "{}"); }} }})()"#,
           label
         ))?;
       }

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -1408,7 +1408,7 @@ fn on_window_event<R: Runtime>(
       let windows = windows_map.values();
       for window in windows {
         window.eval(&format!(
-          r#"(function () {{ var metadata = window.__TAURI_METADATA__; if (metadata != null) {{ metadata.__windows = window.__TAURI_METADATA__.__windows.filter(w => w.label !== "{}"); }} }})()"#,
+          r#"(function () {{ const metadata = window.__TAURI_METADATA__; if (metadata != null) {{ metadata.__windows = window.__TAURI_METADATA__.__windows.filter(w => w.label !== "{}"); }} }})()"#,
           label
         ))?;
       }

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -1448,7 +1448,7 @@ impl<R: Runtime> Window<R> {
     payload: S,
   ) -> crate::Result<()> {
     self.eval(&format!(
-      "var fn = window['{}']; fn && fn({{event: {}, windowLabel: {}, payload: {}}})",
+      "(function () {{ var fn = window['{}']; fn && fn({{event: {}, windowLabel: {}, payload: {}}}) }})()",
       self.manager.event_emit_function_name(),
       serde_json::to_string(event)?,
       serde_json::to_string(&source_window_label)?,

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -1448,7 +1448,7 @@ impl<R: Runtime> Window<R> {
     payload: S,
   ) -> crate::Result<()> {
     self.eval(&format!(
-      "window['{}']({{event: {}, windowLabel: {}, payload: {}}})",
+      "var fn = window['{}']; fn && fn({{event: {}, windowLabel: {}, payload: {}}})",
       self.manager.event_emit_function_name(),
       serde_json::to_string(event)?,
       serde_json::to_string(&source_window_label)?,

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -1448,7 +1448,7 @@ impl<R: Runtime> Window<R> {
     payload: S,
   ) -> crate::Result<()> {
     self.eval(&format!(
-      "(function () {{ var fn = window['{}']; fn && fn({{event: {}, windowLabel: {}, payload: {}}}) }})()",
+      "(function () {{ const fn = window['{}']; fn && fn({{event: {}, windowLabel: {}, payload: {}}}) }})()",
       self.manager.event_emit_function_name(),
       serde_json::to_string(event)?,
       serde_json::to_string(&source_window_label)?,


### PR DESCRIPTION
When opening a tauri window with an External URL, events sent with `emit_all`, including internal events like `tauri://window-created`, are still delivered. 
Since these windows have not loaded the necessary code, the invocation fails and causes an uncaught javascript error in the window's webview.

Functionally speaking, this is fine, but it's not very neat and has some noticeable effects:
* These errors will show up in the target websites error logging, if such is implemented.
* During development of apps with an error view, these errors will show up as a big modal covering the content - see screenshot below.

<img width="400" alt="Screenshot 2022-11-06 at 21 31 15" src="https://user-images.githubusercontent.com/1098408/200194381-ed3e21c7-33f8-4214-8043-784e6eaa22d0.png">
<img width="400" alt="Screenshot 2022-11-08 at 21 38 50" src="https://user-images.githubusercontent.com/1098408/200779816-9942fe7f-2553-4daa-bed3-c98f3c92a99b.png">


This PR adds a simple safeguard that checks that the listener function exists before calling it.

### What kind of change does this PR introduce?
- [x] Bugfix

<!--
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:
- [ ]
- -->

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Implementation approach briefly discussed here: https://discord.com/channels/616186924390023171/986184094050316358/1038527853236592661