### PR TITLE
fix double serialize on invoke

### DIFF
--- a/.changes/fix-invoke-double-serialize.md
+++ b/.changes/fix-invoke-double-serialize.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Fixes a double serialization on the IPC.

--- a/core/tauri/src/hooks.rs
+++ b/core/tauri/src/hooks.rs
@@ -193,7 +193,11 @@ impl<R: Runtime> InvokeResolver<R> {
     F: Future<Output = Result<JsonValue, InvokeError>> + Send + 'static,
   {
     crate::async_runtime::spawn(async move {
-      Self::return_result(self.window, task.await.into(), self.callback, self.error)
+      let response = match task.await {
+        Ok(ok) => InvokeResponse::Ok(ok),
+        Err(err) => InvokeResponse::Err(err),
+      };
+      Self::return_result(self.window, response, self.callback, self.error)
     });
   }
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

When using the `invoke` function asynchronously to run a Rust function and return a value that can be serialized, the serialized value is serialized a second time, uselessly. This is because of a useless conversion in the function `hooks::respond_async_serialized`: The task returns a `Result<JsonValue, InvokeError>` that is converted into a `InvokeResponse` by the call to `into()`. An `InvokeResponse` is in practise exactly equal to a `Result<JsonValue, InvokeError>` so the conversion should be immediate. However, the call to `into()`  use the impl `From<Result<T, InvokeError>> for InvokeResponse` (where `T: Serialize`), which serialize the `JsonValue` into a `JsonValue` (and that is not instantaneous).