### PR TITLE
DOCS: incorrect descriptions in AboutMetadata fields

### DIFF
--- a/core/tauri-runtime/src/menu.rs
+++ b/core/tauri-runtime/src/menu.rs
@@ -584,13 +584,13 @@ impl AboutMetadata {
     self
   }
 
-  /// Defines the application version.
+  /// Defines the application's website link.
   pub fn website(mut self, website: impl Into<String>) -> Self {
     self.website.replace(website.into());
     self
   }
 
-  /// Defines the application version.
+  /// Defines the application's website link name.
   pub fn website_label(mut self, website_label: impl Into<String>) -> Self {
     self.website_label.replace(website_label.into());
     self


### PR DESCRIPTION
Changed the descriptions of the website and website_label fields in AboutMetadata to reflect there usage, changed from being both defining the application version

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
