### PR TITLE
feat(core): expose additional_browser_args to window config (fix: #5757)

### DIFF
--- a/.changes/additional-args-api.md
+++ b/.changes/additional-args-api.md
@@ -1,0 +1,5 @@
+---
+"api": minor
+---
+
+Added the `additionalBrowserArgs` option when creating a window.

--- a/.changes/additional-args-config.md
+++ b/.changes/additional-args-config.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": minor
+---
+
+Added the `additional_browser_args` option to the window configuration.

--- a/.changes/additional-args.md
+++ b/.changes/additional-args.md
@@ -1,5 +1,4 @@
 ---
-"api": minor
 "tauri": minor
 "tauri-runtime-wry": minor
 "tauri-runtime": minor

--- a/.changes/additional-args.md
+++ b/.changes/additional-args.md
@@ -1,0 +1,8 @@
+---
+"api": minor
+"tauri": minor
+"tauri-runtime-wry": minor
+"tauri-runtime": minor
+---
+
+Added the `additional_browser_args` option when creating a window.

--- a/core/config-schema/schema.json
+++ b/core/config-schema/schema.json
@@ -684,7 +684,7 @@
           ]
         },
         "additionalBrowserArgs": {
-          "description": "Defines additional browser arguments on Windows.",
+          "description": "Defines additional browser arguments on Windows. By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection` so if you use this method, you also need to disable these components by yourself if you want.",
           "type": [
             "string",
             "null"

--- a/core/config-schema/schema.json
+++ b/core/config-schema/schema.json
@@ -682,6 +682,13 @@
             "string",
             "null"
           ]
+        },
+        "additionalBrowserArgs": {
+          "description": "Defines additional browser arguments on Windows.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -33,6 +33,8 @@ use wry::application::platform::macos::WindowBuilderExtMacOS;
 use wry::application::platform::unix::{WindowBuilderExtUnix, WindowExtUnix};
 #[cfg(windows)]
 use wry::application::platform::windows::{WindowBuilderExtWindows, WindowExtWindows};
+#[cfg(windows)]
+use wry::webview::WebViewBuilderExtWindows;
 
 #[cfg(target_os = "macos")]
 use tauri_utils::TitleBarStyle;
@@ -3001,6 +3003,12 @@ fn create_webview<T: UserEvent>(
   if let Some(user_agent) = webview_attributes.user_agent {
     webview_builder = webview_builder.with_user_agent(&user_agent);
   }
+
+  #[cfg(windows)]
+  if let Some(additional_browser_args) = webview_attributes.additional_browser_args {
+    webview_builder = webview_builder.with_additional_browser_args(&additional_browser_args);
+  }
+
   if let Some(handler) = ipc_handler {
     webview_builder = webview_builder.with_ipc_handler(create_ipc_handler(
       context,

--- a/core/tauri-runtime/src/webview.rs
+++ b/core/tauri-runtime/src/webview.rs
@@ -91,7 +91,7 @@ impl WebviewAttributes {
     self
   }
 
-  /// Sets additional browser arguments on **Windows**.
+  /// Sets additional browser arguments. **Windows Only**
   #[must_use]
   pub fn additional_browser_args(mut self, additional_args: &str) -> Self {
     self.additional_browser_args = Some(additional_args.to_string());

--- a/core/tauri-runtime/src/webview.rs
+++ b/core/tauri-runtime/src/webview.rs
@@ -28,6 +28,7 @@ pub struct WebviewAttributes {
   pub file_drop_handler_enabled: bool,
   pub clipboard: bool,
   pub accept_first_mouse: bool,
+  pub additional_browser_args: Option<String>,
 }
 
 impl WebviewAttributes {
@@ -41,6 +42,7 @@ impl WebviewAttributes {
       file_drop_handler_enabled: true,
       clipboard: false,
       accept_first_mouse: false,
+      additional_browser_args: None,
     }
   }
 
@@ -86,6 +88,13 @@ impl WebviewAttributes {
   #[must_use]
   pub fn accept_first_mouse(mut self, accept: bool) -> Self {
     self.accept_first_mouse = accept;
+    self
+  }
+
+  /// Sets additional browser arguments on **Windows**.
+  #[must_use]
+  pub fn additional_browser_args(mut self, additional_args: &str) -> Self {
+    self.additional_browser_args = Some(additional_args.to_string());
     self
   }
 }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -881,7 +881,8 @@ pub struct WindowConfig {
   /// [tabbing identifier]: <https://developer.apple.com/documentation/appkit/nswindow/1644704-tabbingidentifier>
   #[serde(default, alias = "tabbing-identifier")]
   pub tabbing_identifier: Option<String>,
-  /// Defines additional browser arguments. **Windows Only**
+  /// Defines additional browser arguments on Windows. By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
+  /// so if you use this method, you also need to disable these components by yourself if you want.
   #[serde(default, alias = "additional-browser-args")]
   pub additional_browser_args: Option<String>,
 }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -881,6 +881,9 @@ pub struct WindowConfig {
   /// [tabbing identifier]: <https://developer.apple.com/documentation/appkit/nswindow/1644704-tabbingidentifier>
   #[serde(default, alias = "tabbing-identifier")]
   pub tabbing_identifier: Option<String>,
+  /// Defines additional browser arguments on Windows.
+  #[serde(default, alias = "additional-browser-args")]
+  pub additional_browser_args: Option<String>,
 }
 
 impl Default for WindowConfig {
@@ -914,6 +917,7 @@ impl Default for WindowConfig {
       hidden_title: false,
       accept_first_mouse: false,
       tabbing_identifier: None,
+      additional_browser_args: None,
     }
   }
 }
@@ -3046,6 +3050,7 @@ mod build {
       let hidden_title = self.hidden_title;
       let accept_first_mouse = self.accept_first_mouse;
       let tabbing_identifier = opt_str_lit(self.tabbing_identifier.as_ref());
+      let additional_browser_args = opt_str_lit(self.additional_browser_args.as_ref());
 
       literal_struct!(
         tokens,
@@ -3077,7 +3082,8 @@ mod build {
         title_bar_style,
         hidden_title,
         accept_first_mouse,
-        tabbing_identifier
+        tabbing_identifier,
+        additional_browser_args
       );
     }
   }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -881,7 +881,7 @@ pub struct WindowConfig {
   /// [tabbing identifier]: <https://developer.apple.com/documentation/appkit/nswindow/1644704-tabbingidentifier>
   #[serde(default, alias = "tabbing-identifier")]
   pub tabbing_identifier: Option<String>,
-  /// Defines additional browser arguments on Windows.
+  /// Defines additional browser arguments. **Windows Only**
   #[serde(default, alias = "additional-browser-args")]
   pub additional_browser_args: Option<String>,
 }

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1519,6 +1519,9 @@ impl<R: Runtime> Builder<R> {
       if let Some(ua) = &config.user_agent {
         webview_attributes = webview_attributes.user_agent(&ua.to_string());
       }
+      if let Some(args) = &config.additional_browser_args {
+        webview_attributes = webview_attributes.additional_browser_args(&args.to_string());
+      }
       if !config.file_drop_enabled {
         webview_attributes = webview_attributes.disable_file_drop_handler();
       }

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -526,7 +526,16 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
     self
   }
 
-  /// Set additional arguments for the webview. **Windows Only**
+  /// Set additional arguments for the webview.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **macOS / Linux / Android / iOS**: Unsupported.
+  ///
+  /// ## Warning
+  ///
+  /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
+  /// so if you use this method, you also need to disable these components by yourself if you want.
   #[must_use]
   pub fn additional_browser_args(mut self, additional_args: &str) -> Self {
     self.webview_attributes.additional_browser_args = Some(additional_args.to_string());

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -526,7 +526,7 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
     self
   }
 
-  /// Set additional arguments for the webview on **Windows**.
+  /// Set additional arguments for the webview. **Windows Only**
   #[must_use]
   pub fn additional_browser_args(mut self, additional_args: &str) -> Self {
     self.webview_attributes.additional_browser_args = Some(additional_args.to_string());

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -526,6 +526,13 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
     self
   }
 
+  /// Set additional arguments for the webview on **Windows**.
+  #[must_use]
+  pub fn additional_browser_args(mut self, additional_args: &str) -> Self {
+    self.webview_attributes.additional_browser_args = Some(additional_args.to_string());
+    self
+  }
+
   /// Data directory for the webview.
   #[must_use]
   pub fn data_directory(mut self, data_directory: PathBuf) -> Self {

--- a/tooling/api/src/window.ts
+++ b/tooling/api/src/window.ts
@@ -2061,7 +2061,7 @@ interface WindowOptions {
    */
   userAgent?: string
   /**
-   * Additional arguments for the webview on Windows.
+   * Additional arguments for the webview. **Windows Only**
    */
   additionalBrowserArguments?: string
 }

--- a/tooling/api/src/window.ts
+++ b/tooling/api/src/window.ts
@@ -2060,6 +2060,10 @@ interface WindowOptions {
    * The user agent for the webview.
    */
   userAgent?: string
+  /**
+   * Additional arguments for the webview on Windows.
+   */
+  additionalBrowserArguments?: string
 }
 
 function mapMonitor(m: Monitor | null): Monitor | null {

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -684,7 +684,7 @@
           ]
         },
         "additionalBrowserArgs": {
-          "description": "Defines additional browser arguments on Windows.",
+          "description": "Defines additional browser arguments on Windows. By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection` so if you use this method, you also need to disable these components by yourself if you want.",
           "type": [
             "string",
             "null"

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -682,6 +682,13 @@
             "string",
             "null"
           ]
+        },
+        "additionalBrowserArgs": {
+          "description": "Defines additional browser arguments on Windows.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Could probably help various use cases, including mine in #5757.

[Discord thread](https://discord.com/channels/616186924390023171/1048227579066331216).
