### PR TITLE
feat(core): metadata for runtime fs scope path additions, closes #5875

### DIFF
--- a/.changes/fs-scope-metadata.md
+++ b/.changes/fs-scope-metadata.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Add metadata getters for runtime allowed and forbidden paths.

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -343,6 +343,8 @@ mod tests {
       allowed_patterns: Default::default(),
       forbidden_patterns: Default::default(),
       event_listeners: Default::default(),
+      allowed_paths_metadata: Default::default(),
+      forbidden_paths_metadata: Default::default(),
     }
   }
 

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -29,12 +29,33 @@ pub enum Event {
 
 type EventListener = Box<dyn Fn(&Event) + Send>;
 
+/// Metadata for an allowed or forbidden path.
+#[derive(Clone)]
+pub struct PathMetadata {
+  is_dir: bool,
+  recursive: bool,
+}
+
+impl PathMetadata {
+  /// Whether the path represents a directory or not.
+  pub fn is_dir(&self) -> bool {
+    self.is_dir
+  }
+
+  /// Whether the path represents a recursive directory or not.
+  pub fn recursive(&self) -> bool {
+    self.recursive
+  }
+}
+
 /// Scope for filesystem access.
 #[derive(Clone)]
 pub struct Scope {
   allowed_patterns: Arc<Mutex<HashSet<Pattern>>>,
   forbidden_patterns: Arc<Mutex<HashSet<Pattern>>>,
   event_listeners: Arc<Mutex<HashMap<Uuid, EventListener>>>,
+  allowed_paths_metadata: Arc<Mutex<HashMap<PathBuf, PathMetadata>>>,
+  forbidden_paths_metadata: Arc<Mutex<HashMap<PathBuf, PathMetadata>>>,
 }
 
 impl fmt::Debug for Scope {
@@ -110,6 +131,8 @@ impl Scope {
       allowed_patterns: Arc::new(Mutex::new(allowed_patterns)),
       forbidden_patterns: Arc::new(Mutex::new(forbidden_patterns)),
       event_listeners: Default::default(),
+      allowed_paths_metadata: Default::default(),
+      forbidden_paths_metadata: Default::default(),
     })
   }
 
@@ -128,6 +151,26 @@ impl Scope {
     let id = Uuid::new_v4();
     self.event_listeners.lock().unwrap().insert(id, Box::new(f));
     id
+  }
+
+  /// Gets the metadata for the given allowed path.
+  pub fn allowed_path_metadata(&self, path: &Path) -> Option<PathMetadata> {
+    self
+      .allowed_paths_metadata
+      .lock()
+      .unwrap()
+      .get(path)
+      .cloned()
+  }
+
+  /// Gets the metadata for the given fobidden path.
+  pub fn forbidden_path_metadata(&self, path: &Path) -> Option<PathMetadata> {
+    self
+      .forbidden_paths_metadata
+      .lock()
+      .unwrap()
+      .get(path)
+      .cloned()
   }
 
   fn trigger(&self, event: Event) {
@@ -154,6 +197,13 @@ impl Scope {
         escaped_pattern_with(p, if recursive { "**" } else { "*" })
       })?;
     }
+    self.allowed_paths_metadata.lock().unwrap().insert(
+      path.to_path_buf(),
+      PathMetadata {
+        is_dir: true,
+        recursive,
+      },
+    );
     self.trigger(Event::PathAllowed(path.to_path_buf()));
     Ok(())
   }
@@ -168,6 +218,13 @@ impl Scope {
       path,
       escaped_pattern,
     )?;
+    self.allowed_paths_metadata.lock().unwrap().insert(
+      path.to_path_buf(),
+      PathMetadata {
+        is_dir: false,
+        recursive: false,
+      },
+    );
     self.trigger(Event::PathAllowed(path.to_path_buf()));
     Ok(())
   }
@@ -187,6 +244,13 @@ impl Scope {
         escaped_pattern_with(p, if recursive { "**" } else { "*" })
       })?;
     }
+    self.forbidden_paths_metadata.lock().unwrap().insert(
+      path.to_path_buf(),
+      PathMetadata {
+        is_dir: true,
+        recursive,
+      },
+    );
     self.trigger(Event::PathForbidden(path.to_path_buf()));
     Ok(())
   }
@@ -201,6 +265,13 @@ impl Scope {
       path,
       escaped_pattern,
     )?;
+    self.forbidden_paths_metadata.lock().unwrap().insert(
+      path.to_path_buf(),
+      PathMetadata {
+        is_dir: false,
+        recursive: false,
+      },
+    );
     self.trigger(Event::PathForbidden(path.to_path_buf()));
     Ok(())
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
