### PR TITLE
fix(bundler): fix order of webview2 installer args in nsis bundle

### DIFF
--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -319,7 +319,7 @@ Section Webview2
   install_webview2:
     DetailPrint "Installing Webview2..."
     ; $6 holds the path to the webview2 installer
-    ExecWait "$6 /install ${WEBVIEW2INSTALLERARGS}" $1
+    ExecWait "$6 ${WEBVIEW2INSTALLERARGS} /install" $1
     ${If} $1 == 0
       DetailPrint "Webview2 installed sucessfully"
     ${Else}


### PR DESCRIPTION
Funnily enough it must be `/silent /install` = `/install /silent` doesn't work and results in a crash

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
