### PR TITLE
fix(cli): fix cli connection timeout to dev server (fix #6045)

### DIFF
--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -273,11 +273,15 @@ fn command_internal(mut options: Options) -> Result<()> {
       };
       let mut i = 0;
       let sleep_interval = std::time::Duration::from_secs(2);
+      let timeout_duration = std::time::Duration::from_secs(1);
       let max_attempts = 90;
-      loop {
-        if std::net::TcpStream::connect(addrs).is_ok() {
-          break;
+      'waiting: loop {
+        for addr in addrs.iter() {
+          if std::net::TcpStream::connect_timeout(addr, timeout_duration).is_ok() {
+            break 'waiting;
+          }
         }
+
         if i % 3 == 1 {
           warn!(
             "Waiting for your frontend dev server to start on {}...",


### PR DESCRIPTION
Fix tauri-cli connection to dev server stucks and waits for TCP timeout.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
