### PR TITLE
Improve compile errors for async commands without `Result` return type

### DIFF
--- a/.changes/improve-async-cmd-error-message.md
+++ b/.changes/improve-async-cmd-error-message.md
@@ -1,0 +1,5 @@
+---
+"tauri-macros": 'patch:enhance'
+---
+
+Improve compiler error message when generating an async command that has a reference input and don't return a Result.

--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -5,7 +5,7 @@
 use heck::{ToLowerCamelCase, ToSnakeCase};
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, quote_spanned};
 use syn::{
   ext::IdentExt,
   parse::{Parse, ParseStream},
@@ -103,6 +103,63 @@ pub fn wrapper(attributes: TokenStream, item: TokenStream) -> TokenStream {
     resolver: format_ident!("__tauri_resolver__"),
   };
 
+  // Tauri currently doesn't support async commands that take a reference as input and don't return
+  // a result. See: https://github.com/tauri-apps/tauri/issues/2533
+  //
+  // For now, we provide an informative error message to the user in that case. Once #2533 is
+  // resolved, this check can be removed.
+  let mut async_command_check = TokenStream2::new();
+  if function.sig.asyncness.is_some() {
+    // This check won't catch all possible problems but it should catch the most common ones.
+    let mut ref_argument_span = None;
+
+    for arg in &function.sig.inputs {
+      if let syn::FnArg::Typed(pat) = arg {
+        match &*pat.ty {
+          syn::Type::Reference(_) => {
+            ref_argument_span = Some(pat.span());
+          }
+          syn::Type::Path(path) => {
+            // Check if the type contains a lifetime argument
+            let last = path.path.segments.last().unwrap();
+            if let syn::PathArguments::AngleBracketed(args) = &last.arguments {
+              if args
+                .args
+                .iter()
+                .any(|arg| matches!(arg, syn::GenericArgument::Lifetime(_)))
+              {
+                ref_argument_span = Some(pat.span());
+              }
+            }
+          }
+          _ => {}
+        }
+
+        if let Some(span) = ref_argument_span {
+          if let syn::ReturnType::Type(_, return_type) = &function.sig.output {
+            // To check if the return type is `Result` we require it to check a trait that is
+            // only implemented by `Result`. That way we don't exclude renamed result types
+            // which we wouldn't otherwise be able to detect purely from the token stream.
+            // The "error message" displayed to the user is simply the trait name.
+            async_command_check = quote_spanned! {return_type.span() =>
+              #[allow(unreachable_code, clippy::diverging_sub_expression)]
+              const _: () = if false {
+                trait AsyncCommandMustReturnResult {}
+                impl<A, B> AsyncCommandMustReturnResult for Result<A, B> {}
+                let _check: #return_type = unreachable!();
+                let _: &dyn AsyncCommandMustReturnResult = &_check;
+              };
+            };
+          } else {
+            return quote_spanned! {
+              span => compile_error!("async commands that contain references as inputs must return a `Result`");
+            }.into();
+          }
+        }
+      }
+    }
+  }
+
   // body to the command wrapper or a `compile_error!` of an error occurred while parsing it.
   let body = syn::parse::<WrapperAttributes>(attributes)
     .map(|mut attrs| {
@@ -121,6 +178,8 @@ pub fn wrapper(attributes: TokenStream, item: TokenStream) -> TokenStream {
 
   // Rely on rust 2018 edition to allow importing a macro from a path.
   quote!(
+    #async_command_check
+
     #function
 
     #maybe_macro_export


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Issue #2533 points out that async commands currently have to return a `Result`, but this is not very obvious from the compile error that is shown to the user.

```rust
#[tauri::command]
async fn myAsyncCommand(name: &str) {
    tokio::time::sleep(Duration::from_secs_f32(1.)).await;
}
```

The above code resulted in the following error, which was not comprehensible to me when I encountered this while writing my first tauri app:

```
error[E0597]: `__tauri_message__` does not live long enough
  --> src/main.rs:15:1
   |
15 | #[tauri::command]
   | ^^^^^^^^^^^^^^^^-
   | |               |
   | |               `__tauri_message__` dropped here while still borrowed
   | borrowed value does not live long enough
   | argument requires that `__tauri_message__` is borrowed for `'static`
...
29 |         .invoke_handler(tauri::generate_handler![myAsyncCommand])
   |                         ---------------------------------------- in this macro invocation
   |
   = note: this error originates in the macro `__cmd__myAsyncCommand` which comes from the expansion of the macro `tauri::generate_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
```

With the change introduced in this PR, the error now appears as follows:

```
error: async commands that contain references as inputs must return a `Result`
  --> src/main.rs:16:25
   |
16 | async fn myAsyncCommand(name: &str) {
   |                         ^^^^

error: cannot find macro `__cmd__myAsyncCommand` in this scope
  --> src/main.rs:27:50
   |
27 |         .invoke_handler(tauri::generate_handler![myAsyncCommand]);
   |                                                  ^^^^^^^^^^^^^^
```

This is what the user sees in their editor:

![image](https://user-images.githubusercontent.com/18399125/213927613-675f1a07-f945-4cf7-be05-fbfb8af4845f.png)

The problem with `State` described in the issue is also caught:

![image](https://user-images.githubusercontent.com/18399125/213927994-af26fd06-2204-4902-a58d-a90ebd7504ee.png)

Errors are also generated on `&'static` references, because they also generate the same `__tauri_message__ does not live long enough` when tested without this change.

This change probably doesn't catch all possible errors, but it should catch the most common ones. It looks for reference types in the arguments, as well as for types that contain lifetime arguments. Can anyone think of a situation where this check would be too strict? The intention here is to rather catch too little than too much, because we don't want this to be a breaking change.

This PR should be reverted as soon as #2533 is resolved.