### PR TITLE
fix(bundler): NSIS: default to user permission level

### DIFF
--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -38,6 +38,8 @@ SetCompressor /SOLID lzma
     !addplugindir "${PLUGINSPATH}"
 !endif
 
+RequestExecutionLevel user
+
 !if "${INSTALLMODE}" == "perMachine"
   RequestExecutionLevel highest
 !endif


### PR DESCRIPTION
I intentionally didn't wrap it in an `if` because it looks cleaner like this imo, especially because we'd probably check for an empty string _and_ `"currentUser"`?
The other install modes simply overwrite this without any complains 🤷 

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
