### PR TITLE
fix(cli): web_dev_server html template serialization (fix #6165)

### DIFF
--- a/.changes/fix-dev-server-html-serialization.md
+++ b/.changes/fix-dev-server-html-serialization.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Fixes HTML serialization removing template tags on the dev server.

--- a/tooling/cli/src/helpers/web_dev_server.rs
+++ b/tooling/cli/src/helpers/web_dev_server.rs
@@ -126,7 +126,7 @@ async fn handler<T>(req: Request<T>, state: Arc<State>) -> impl IntoResponse {
           head.prepend(script_el);
         });
 
-        f = document.to_string().as_bytes().to_vec();
+        f = tauri_utils::html::serialize_node(&document);
       }
 
       (StatusCode::OK, [(CONTENT_TYPE, mime_type)], f)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

I believe this change is safe because this serialization is already used in https://github.com/tauri-apps/tauri/pull/5247/files#diff-45b0f313a4e403c382fbd52d97cb3cc15d75f09a30a9cca633c4c6d29a24590eR83 (note that there, the function has been aliased, but it is actually the same) and hence is already used when compiling assets.

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Related issue, see https://github.com/tauri-apps/tauri/issues/6165

Also note that according to html5ever issue https://github.com/servo/html5ever/issues/464, html (template) serialization has to be handled by the crate that uses html5ever, i.e. tauri so to speak.