### PR TITLE
fix 1.67 clippy warnings (compatible with MSRV)

### DIFF
--- a/core/config-schema/schema.json
+++ b/core/config-schema/schema.json
@@ -720,47 +720,19 @@
     },
     "Theme": {
       "description": "System theme.",
-      "oneOf": [
-        {
-          "description": "Light theme.",
-          "type": "string",
-          "enum": [
-            "Light"
-          ]
-        },
-        {
-          "description": "Dark theme.",
-          "type": "string",
-          "enum": [
-            "Dark"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "Light",
+        "Dark"
       ]
     },
     "TitleBarStyle": {
       "description": "How the window title bar should be displayed on macOS.",
-      "oneOf": [
-        {
-          "description": "A normal title bar.",
-          "type": "string",
-          "enum": [
-            "Visible"
-          ]
-        },
-        {
-          "description": "Makes the title bar transparent, so the window background color is shown instead.\n\nUseful if you don't need to have actual HTML under the title bar. This lets you avoid the caveats of using `TitleBarStyle::Overlay`. Will be more useful when Tauri lets you set a custom window background color.",
-          "type": "string",
-          "enum": [
-            "Transparent"
-          ]
-        },
-        {
-          "description": "Shows the title bar as a transparent overlay over the window's content.\n\nKeep in mind: - The height of the title bar is different on different OS versions, which can lead to window the controls and title not being where you don't expect. - You need to define a custom drag region to make your window draggable, however due to a limitation you can't drag the window when it's not in focus <https://github.com/tauri-apps/tauri/issues/4316>. - The color of the window title depends on the system theme.",
-          "type": "string",
-          "enum": [
-            "Overlay"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "Visible",
+        "Transparent",
+        "Overlay"
       ]
     },
     "CliConfig": {
@@ -1183,56 +1155,15 @@
     },
     "BundleType": {
       "description": "A bundle referenced by tauri-bundler.",
-      "oneOf": [
-        {
-          "description": "The debian bundle (.deb).",
-          "type": "string",
-          "enum": [
-            "deb"
-          ]
-        },
-        {
-          "description": "The AppImage bundle (.appimage).",
-          "type": "string",
-          "enum": [
-            "appimage"
-          ]
-        },
-        {
-          "description": "The Microsoft Installer bundle (.msi).",
-          "type": "string",
-          "enum": [
-            "msi"
-          ]
-        },
-        {
-          "description": "The NSIS bundle (.exe).",
-          "type": "string",
-          "enum": [
-            "nsis"
-          ]
-        },
-        {
-          "description": "The macOS application bundle (.app).",
-          "type": "string",
-          "enum": [
-            "app"
-          ]
-        },
-        {
-          "description": "The Apple Disk Image bundle (.dmg).",
-          "type": "string",
-          "enum": [
-            "dmg"
-          ]
-        },
-        {
-          "description": "The Tauri updater bundle.",
-          "type": "string",
-          "enum": [
-            "updater"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "deb",
+        "appimage",
+        "msi",
+        "nsis",
+        "app",
+        "dmg",
+        "updater"
       ]
     },
     "AppImageConfig": {
@@ -1716,28 +1647,11 @@
     },
     "NSISInstallerMode": {
       "description": "Install Modes for the NSIS installer.",
-      "oneOf": [
-        {
-          "description": "Default mode for the installer.\n\nInstall the app by default in a directory that doesn't require Administrator access.\n\nInstaller metadata will be saved under the `HKCU` registry path.",
-          "type": "string",
-          "enum": [
-            "currentUser"
-          ]
-        },
-        {
-          "description": "Install the app by default in the `Program Files` folder directory requires Administrator access for the installation.\n\nInstaller metadata will be saved under the `HKLM` registry path.",
-          "type": "string",
-          "enum": [
-            "perMachine"
-          ]
-        },
-        {
-          "description": "Combines both modes and allows the user to choose at install time whether to install for the current user or per machine. Note that this mode will require Administrator access even if the user wants to install it for the current user only.\n\nInstaller metadata will be saved under the `HKLM` or `HKCU` registry path based on the user's choice.",
-          "type": "string",
-          "enum": [
-            "both"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "currentUser",
+        "perMachine",
+        "both"
       ]
     },
     "AllowlistConfig": {
@@ -2730,28 +2644,11 @@
     },
     "WindowsUpdateInstallMode": {
       "description": "Install modes for the Windows update.",
-      "oneOf": [
-        {
-          "description": "Specifies there's a basic UI during the installation process, including a final dialog box at the end.",
-          "type": "string",
-          "enum": [
-            "basicUi"
-          ]
-        },
-        {
-          "description": "The quiet mode means there's no user interaction required. Requires admin privileges if the installer does (WiX).",
-          "type": "string",
-          "enum": [
-            "quiet"
-          ]
-        },
-        {
-          "description": "Specifies unattended mode, which means the installation only shows a progress bar.",
-          "type": "string",
-          "enum": [
-            "passive"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "basicUi",
+        "quiet",
+        "passive"
       ]
     },
     "SystemTrayConfig": {

--- a/core/tauri/src/api/file/extract.rs
+++ b/core/tauri/src/api/file/extract.rs
@@ -279,9 +279,8 @@ fn set_perms(
 ) -> crate::api::Result<()> {
   _set_perms(dst, f, mode, preserve).map_err(|_| {
     crate::api::Error::Extract(format!(
-      "failed to set permissions to {:o} \
+      "failed to set permissions to {mode:o} \
                for `{}`",
-      mode,
       dst.display()
     ))
   })

--- a/core/tauri/src/api/ipc.rs
+++ b/core/tauri/src/api/ipc.rs
@@ -57,7 +57,7 @@ const MIN_JSON_PARSE_LEN: usize = 10_240;
 ///   bar: String,
 /// }
 /// let foo = Foo { bar: "x".repeat(20_000).into() };
-/// let value = serialize_js_with(&foo, SerializeOptions::default(), |v| format!("console.log({})", v)).unwrap();
+/// let value = serialize_js_with(&foo, SerializeOptions::default(), |v| format!("console.log({v})")).unwrap();
 /// assert_eq!(value, format!("console.log(JSON.parse('{{\"bar\":\"{}\"}}'))", foo.bar));
 /// ```
 pub fn serialize_js_with<T: Serialize, F: FnOnce(&str) -> String>(
@@ -179,8 +179,7 @@ pub fn format_callback<T: Serialize>(
     }} else {{
       console.warn("[TAURI] Couldn't find callback id {fn} in window. This happens when the app is reloaded while Rust is running an asynchronous operation.")
     }}"#,
-      fn = function_name.0,
-      arg = arg
+      fn = function_name.0
     )
   })
 }

--- a/core/tauri/src/api/notification.rs
+++ b/core/tauri/src/api/notification.rs
@@ -5,7 +5,7 @@
 //! Types and functions related to desktop notifications.
 
 #[cfg(windows)]
-use std::path::MAIN_SEPARATOR;
+use std::path::MAIN_SEPARATOR as SEP;
 
 /// The desktop notification definition.
 ///
@@ -114,8 +114,8 @@ impl Notification {
       let exe_dir = exe.parent().expect("failed to get exe directory");
       let curr_dir = exe_dir.display().to_string();
       // set the notification's System.AppUserModel.ID only when running the installed app
-      if !(curr_dir.ends_with(format!("{S}target{S}debug", S = MAIN_SEPARATOR).as_str())
-        || curr_dir.ends_with(format!("{S}target{S}release", S = MAIN_SEPARATOR).as_str()))
+      if !(curr_dir.ends_with(format!("{SEP}target{SEP}debug").as_str())
+        || curr_dir.ends_with(format!("{SEP}target{SEP}release").as_str()))
       {
         notification.app_id(&self.identifier);
       }

--- a/core/tauri/src/api/process/command.rs
+++ b/core/tauri/src/api/process/command.rs
@@ -137,9 +137,9 @@ pub struct Output {
 fn relative_command_path(command: String) -> crate::Result<String> {
   match platform::current_exe()?.parent() {
     #[cfg(windows)]
-    Some(exe_dir) => Ok(format!("{}\\{}.exe", exe_dir.display(), command)),
+    Some(exe_dir) => Ok(format!("{}\\{command}.exe", exe_dir.display())),
     #[cfg(not(windows))]
-    Some(exe_dir) => Ok(format!("{}/{}", exe_dir.display(), command)),
+    Some(exe_dir) => Ok(format!("{}/{command}", exe_dir.display())),
     None => Err(crate::api::Error::Command("Could not evaluate executable dir".to_string()).into()),
   }
 }

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1503,7 +1503,7 @@ impl<R: Runtime> Builder<R> {
   /// ```
   /// let kind = if cfg!(debug_assertions) { "debug" } else { "release" };
   /// tauri::Builder::default()
-  ///   .updater_target(format!("{}-{}", tauri::updater::target().unwrap(), kind));
+  ///   .updater_target(format!("{}-{kind}", tauri::updater::target().unwrap()));
   /// ```
   ///
   /// - Use the platform's target triple:

--- a/core/tauri/src/endpoints/file_system.rs
+++ b/core/tauri/src/endpoints/file_system.rs
@@ -386,7 +386,7 @@ fn resolve_path<R: Runtime>(
       }
     }
     Err(e) => super::Result::<SafePathBuf>::Err(e.into())
-      .with_context(|| format!("path: {}, base dir: {:?}", path.display(), dir)),
+      .with_context(|| format!("path: {}, base dir: {dir:?}", path.display())),
   }
 }
 

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -342,14 +342,11 @@ pub fn listen_js(
     }})()
   ",
     listeners = listeners_object_name,
-    event = event,
-    event_id = event_id,
     window_label = if let Some(l) = window_label {
       crate::runtime::window::assert_label_is_valid(&l);
       format!("'{l}'")
     } else {
       "null".to_owned()
     },
-    handler = handler
   )
 }

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -621,7 +621,7 @@ impl<R: Runtime> WindowManager<R> {
                 .insert("Content-Length", real_length.to_string());
               data.headers.insert(
                 "Content-Range",
-                format!("bytes {}-{}/{}", range.start, last_byte, file_size),
+                format!("bytes {}-{last_byte}/{file_size}", range.start),
               );
 
               if let Err(e) = file.seek(std::io::SeekFrom::Start(range.start)).await {

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -256,10 +256,9 @@ fn escaped_pattern(p: &str) -> Result<Pattern, glob::PatternError> {
 
 fn escaped_pattern_with(p: &str, append: &str) -> Result<Pattern, glob::PatternError> {
   Pattern::new(&format!(
-    "{}{}{}",
+    "{}{}{append}",
     glob::Pattern::escape(p),
-    MAIN_SEPARATOR,
-    append
+    MAIN_SEPARATOR
   ))
 }
 

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -758,7 +758,7 @@ fn copy_files_and_run<R: Read + Seek>(
           let product_name = bin_name.replace(".exe", "");
 
           // Check if there is a task that enables the updater to skip the UAC prompt
-          let update_task_name = format!("Update {} - Skip UAC", product_name);
+          let update_task_name = format!("Update {product_name} - Skip UAC");
           if let Ok(output) = Command::new("schtasks")
             .arg("/QUERY")
             .arg("/TN")
@@ -1575,11 +1575,10 @@ mod test {
     #[cfg(target_os = "windows")]
     let archive_file = "archive.windows.zip";
 
-    let good_archive_url = format!("{}/{}", mockito::server_url(), archive_file);
+    let good_archive_url = format!("{}/{archive_file}", mockito::server_url());
 
     let mut signature_file = File::open(format!(
-      "./test/updater/fixture/archives/{}.sig",
-      archive_file
+      "./test/updater/fixture/archives/{archive_file}.sig"
     ))
     .expect("Unable to open signature");
     let mut signature = String::new();
@@ -1595,10 +1594,10 @@ mod test {
       .expect("Unable to read signature as string");
 
     // add sample file
-    let _m = mockito::mock("GET", format!("/{}", archive_file).as_str())
+    let _m = mockito::mock("GET", format!("/{archive_file}").as_str())
       .with_status(200)
       .with_header("content-type", "application/octet-stream")
-      .with_body_from_file(format!("./test/updater/fixture/archives/{}", archive_file))
+      .with_body_from_file(format!("./test/updater/fixture/archives/{archive_file}"))
       .create();
 
     // sample mock for update file

--- a/core/tauri/src/updater/mod.rs
+++ b/core/tauri/src/updater/mod.rs
@@ -202,7 +202,7 @@ impl<R: Runtime> UpdateBuilder<R> {
   ///     let handle = app.handle();
   ///     tauri::async_runtime::spawn(async move {
   ///       let kind = if cfg!(debug_assertions) { "debug" } else { "release" };
-  ///       let builder = tauri::updater::builder(handle).target(format!("{}-{}", tauri::updater::target().unwrap(), kind));
+  ///       let builder = tauri::updater::builder(handle).target(format!("{}-{kind}", tauri::updater::target().unwrap()));
   ///       match builder.check().await {
   ///         Ok(update) => {}
   ///         Err(error) => {}
@@ -567,13 +567,13 @@ async fn prompt_for_install<R: Runtime>(
     parent_window,
     format!(r#"A new version of {app_name} is available! "#),
     format!(
-      r#"{} {} is now available -- you have {}.
+      r#"{app_name} {} is now available -- you have {}.
 
 Would you like to install it now?
 
 Release Notes:
-{}"#,
-      app_name, update.version, update.current_version, body,
+{body}"#,
+      update.version, update.current_version
     ),
   );
 

--- a/core/tests/app-updater/tests/update.rs
+++ b/core/tests/app-updater/tests/update.rs
@@ -132,8 +132,7 @@ fn bundle_paths(root_dir: &Path, version: &str) -> Vec<(BundleTarget, PathBuf)> 
   vec![(
     BundleTarget::AppImage,
     root_dir.join(format!(
-      "target/debug/bundle/appimage/app-updater_{}_amd64.AppImage",
-      version
+      "target/debug/bundle/appimage/app-updater_{version}_amd64.AppImage"
     )),
   )]
 }
@@ -160,15 +159,13 @@ fn bundle_paths(root_dir: &Path, version: &str) -> Vec<(BundleTarget, PathBuf)> 
     (
       BundleTarget::Nsis,
       root_dir.join(format!(
-        "target/debug/bundle/nsis/app-updater_{}_x64-setup.exe",
-        version
+        "target/debug/bundle/nsis/app-updater_{version}_x64-setup.exe"
       )),
     ),
     (
       BundleTarget::Msi,
       root_dir.join(format!(
-        "target/debug/bundle/msi/app-updater_{}_x64_en-US.msi",
-        version
+        "target/debug/bundle/msi/app-updater_{version}_x64_en-US.msi"
       )),
     ),
   ]
@@ -221,7 +218,7 @@ fn update_app() {
       .unwrap()
       .replace("exe", "nsis");
     let signature_path =
-      out_bundle_path.with_extension(format!("{}.{}.sig", bundle_updater_ext, updater_zip_ext));
+      out_bundle_path.with_extension(format!("{bundle_updater_ext}.{updater_zip_ext}.sig"));
     let signature = std::fs::read_to_string(&signature_path)
       .unwrap_or_else(|_| panic!("failed to read signature file {}", signature_path.display()));
     let out_updater_path =

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -720,47 +720,19 @@
     },
     "Theme": {
       "description": "System theme.",
-      "oneOf": [
-        {
-          "description": "Light theme.",
-          "type": "string",
-          "enum": [
-            "Light"
-          ]
-        },
-        {
-          "description": "Dark theme.",
-          "type": "string",
-          "enum": [
-            "Dark"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "Light",
+        "Dark"
       ]
     },
     "TitleBarStyle": {
       "description": "How the window title bar should be displayed on macOS.",
-      "oneOf": [
-        {
-          "description": "A normal title bar.",
-          "type": "string",
-          "enum": [
-            "Visible"
-          ]
-        },
-        {
-          "description": "Makes the title bar transparent, so the window background color is shown instead.\n\nUseful if you don't need to have actual HTML under the title bar. This lets you avoid the caveats of using `TitleBarStyle::Overlay`. Will be more useful when Tauri lets you set a custom window background color.",
-          "type": "string",
-          "enum": [
-            "Transparent"
-          ]
-        },
-        {
-          "description": "Shows the title bar as a transparent overlay over the window's content.\n\nKeep in mind: - The height of the title bar is different on different OS versions, which can lead to window the controls and title not being where you don't expect. - You need to define a custom drag region to make your window draggable, however due to a limitation you can't drag the window when it's not in focus <https://github.com/tauri-apps/tauri/issues/4316>. - The color of the window title depends on the system theme.",
-          "type": "string",
-          "enum": [
-            "Overlay"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "Visible",
+        "Transparent",
+        "Overlay"
       ]
     },
     "CliConfig": {
@@ -1183,56 +1155,15 @@
     },
     "BundleType": {
       "description": "A bundle referenced by tauri-bundler.",
-      "oneOf": [
-        {
-          "description": "The debian bundle (.deb).",
-          "type": "string",
-          "enum": [
-            "deb"
-          ]
-        },
-        {
-          "description": "The AppImage bundle (.appimage).",
-          "type": "string",
-          "enum": [
-            "appimage"
-          ]
-        },
-        {
-          "description": "The Microsoft Installer bundle (.msi).",
-          "type": "string",
-          "enum": [
-            "msi"
-          ]
-        },
-        {
-          "description": "The NSIS bundle (.exe).",
-          "type": "string",
-          "enum": [
-            "nsis"
-          ]
-        },
-        {
-          "description": "The macOS application bundle (.app).",
-          "type": "string",
-          "enum": [
-            "app"
-          ]
-        },
-        {
-          "description": "The Apple Disk Image bundle (.dmg).",
-          "type": "string",
-          "enum": [
-            "dmg"
-          ]
-        },
-        {
-          "description": "The Tauri updater bundle.",
-          "type": "string",
-          "enum": [
-            "updater"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "deb",
+        "appimage",
+        "msi",
+        "nsis",
+        "app",
+        "dmg",
+        "updater"
       ]
     },
     "AppImageConfig": {
@@ -1716,28 +1647,11 @@
     },
     "NSISInstallerMode": {
       "description": "Install Modes for the NSIS installer.",
-      "oneOf": [
-        {
-          "description": "Default mode for the installer.\n\nInstall the app by default in a directory that doesn't require Administrator access.\n\nInstaller metadata will be saved under the `HKCU` registry path.",
-          "type": "string",
-          "enum": [
-            "currentUser"
-          ]
-        },
-        {
-          "description": "Install the app by default in the `Program Files` folder directory requires Administrator access for the installation.\n\nInstaller metadata will be saved under the `HKLM` registry path.",
-          "type": "string",
-          "enum": [
-            "perMachine"
-          ]
-        },
-        {
-          "description": "Combines both modes and allows the user to choose at install time whether to install for the current user or per machine. Note that this mode will require Administrator access even if the user wants to install it for the current user only.\n\nInstaller metadata will be saved under the `HKLM` or `HKCU` registry path based on the user's choice.",
-          "type": "string",
-          "enum": [
-            "both"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "currentUser",
+        "perMachine",
+        "both"
       ]
     },
     "AllowlistConfig": {
@@ -2730,28 +2644,11 @@
     },
     "WindowsUpdateInstallMode": {
       "description": "Install modes for the Windows update.",
-      "oneOf": [
-        {
-          "description": "Specifies there's a basic UI during the installation process, including a final dialog box at the end.",
-          "type": "string",
-          "enum": [
-            "basicUi"
-          ]
-        },
-        {
-          "description": "The quiet mode means there's no user interaction required. Requires admin privileges if the installer does (WiX).",
-          "type": "string",
-          "enum": [
-            "quiet"
-          ]
-        },
-        {
-          "description": "Specifies unattended mode, which means the installation only shows a progress bar.",
-          "type": "string",
-          "enum": [
-            "passive"
-          ]
-        }
+      "type": "string",
+      "enum": [
+        "basicUi",
+        "quiet",
+        "passive"
       ]
     },
     "SystemTrayConfig": {


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
I ran `clippy` on `1.67` and found that non-interpolated `format!` calls are now a warning. I updated every single `format!` call my search&find could gather, behavior _should_ be the same. Not sure what the schema changes are about.