### PR TITLE
fix(cli): escape "Android Studio" space when opening on unix

### DIFF
--- a/.changes/fix-open-android-studio.md
+++ b/.changes/fix-open-android-studio.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Fixes opening Android Studio on macOS.

--- a/tooling/cli/src/mobile/android.rs
+++ b/tooling/cli/src/mobile/android.rs
@@ -285,7 +285,16 @@ fn detect_target_ok<'a>(env: &Env) -> Option<&'a Target<'a>> {
 
 fn open_and_wait(config: &AndroidConfig, env: &Env) -> ! {
   log::info!("Opening Android Studio");
-  if let Err(e) = os::open_file_with("Android Studio", config.project_dir(), &env.base) {
+  if let Err(e) = os::open_file_with(
+    if cfg!(target_os = "macos") {
+      "Android\\ Studio"
+    } else {
+      // on Windows tauri-mobile actually checks this string :(
+      "Android Studio"
+    },
+    config.project_dir(),
+    &env.base,
+  ) {
     log::error!("{}", e);
   }
   loop {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
