### PR TITLE
refactor(core): do not allow JS API to set additional browser args

### DIFF
--- a/.changes/additional-args-api.md
+++ b/.changes/additional-args-api.md
@@ -1,5 +1,0 @@
----
-"api": minor
----
-
-Added the `additionalBrowserArgs` option when creating a window.

--- a/core/tauri/src/endpoints/window.rs
+++ b/core/tauri/src/endpoints/window.rs
@@ -213,8 +213,9 @@ impl Cmd {
   #[module_command_handler(window_create)]
   async fn create_webview<R: Runtime>(
     context: InvokeContext<R>,
-    options: Box<WindowConfig>,
+    mut options: Box<WindowConfig>,
   ) -> super::Result<()> {
+    options.additional_browser_args = None;
     crate::window::WindowBuilder::from_config(&context.window, *options)
       .build()
       .map_err(crate::error::into_anyhow)?;

--- a/tooling/api/src/window.ts
+++ b/tooling/api/src/window.ts
@@ -2141,10 +2141,6 @@ interface WindowOptions {
    * The user agent for the webview.
    */
   userAgent?: string
-  /**
-   * Additional arguments for the webview. **Windows Only**
-   */
-  additionalBrowserArguments?: string
 }
 
 function mapMonitor(m: Monitor | null): Monitor | null {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This was introduced in #5799, but it's dangerous to let the frontend set this option.