### PR TITLE
fix: keep `build` artifacts on Android lib and plugins

### DIFF
--- a/tooling/cli/src/mobile/mod.rs
+++ b/tooling/cli/src/mobile/mod.rs
@@ -25,7 +25,7 @@ use std::{
   env::{set_var, temp_dir},
   ffi::OsString,
   fmt::Write,
-  fs::{create_dir_all, read_to_string, remove_dir_all, write},
+  fs::{create_dir_all, read_to_string, remove_dir_all, rename, write},
   net::SocketAddr,
   path::PathBuf,
   process::ExitStatus,
@@ -317,14 +317,30 @@ fn ensure_init(project_dir: PathBuf, target: Target) -> Result<()> {
     #[allow(irrefutable_let_patterns)]
     if let Target::Android = target {
       let tauri_api_dir_path = project_dir.join("tauri-api");
-      if tauri_api_dir_path.exists() {
+      let build_path = if tauri_api_dir_path.exists() {
+        // keep build folder if it exists
+        let build_path = tauri_api_dir_path.join("build");
+        let out_dir = if build_path.exists() {
+          let out_dir = project_dir.join(".tauri-api-build");
+          rename(&build_path, &out_dir)?;
+          Some(out_dir)
+        } else {
+          None
+        };
         remove_dir_all(&tauri_api_dir_path)?;
-      }
+        out_dir
+      } else {
+        None
+      };
       create_dir_all(&tauri_api_dir_path)?;
 
       ANDROID_API_PROJECT_DIR
-        .extract(tauri_api_dir_path)
+        .extract(&tauri_api_dir_path)
         .context("failed to extract Tauri API project")?;
+
+      if let Some(build_path) = build_path {
+        rename(build_path, tauri_api_dir_path.join("build"))?;
+      }
     }
 
     Ok(())


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
