### PR TITLE
refactor(cli): use environment variables instead of .config/cargo

### DIFF
--- a/tooling/cli/src/mobile/android.rs
+++ b/tooling/cli/src/mobile/android.rs
@@ -26,7 +26,7 @@ use tauri_mobile::{
 
 use super::{
   ensure_init, get_app,
-  init::{command as init_command, init_dot_cargo},
+  init::{command as init_command, configure_cargo},
   log_finished, read_options, setup_dev_config, CliOptions, Target as MobileTarget,
   MIN_DEVICE_MATCH_SCORE,
 };

--- a/tooling/cli/src/mobile/android/build.rs
+++ b/tooling/cli/src/mobile/android/build.rs
@@ -1,5 +1,5 @@
 use super::{
-  delete_codegen_vars, ensure_init, env, init_dot_cargo, log_finished, open_and_wait, with_config,
+  configure_cargo, delete_codegen_vars, ensure_init, env, log_finished, open_and_wait, with_config,
   MobileTarget,
 };
 use crate::{
@@ -79,7 +79,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
       ensure_init(config.project_dir(), MobileTarget::Android)?;
 
       let mut env = env()?;
-      init_dot_cargo(app, Some((&env, config)))?;
+      configure_cargo(app, Some((&mut env, config)))?;
 
       let open = options.open;
       run_build(options, config, &mut env, noise_level)?;

--- a/tooling/cli/src/mobile/android/dev.rs
+++ b/tooling/cli/src/mobile/android/dev.rs
@@ -1,5 +1,5 @@
 use super::{
-  delete_codegen_vars, device_prompt, ensure_init, env, init_dot_cargo, open_and_wait,
+  configure_cargo, delete_codegen_vars, device_prompt, ensure_init, env, open_and_wait,
   setup_dev_config, with_config, MobileTarget,
 };
 use crate::{
@@ -98,7 +98,7 @@ fn run_dev(
   noise_level: NoiseLevel,
 ) -> Result<()> {
   setup_dev_config(&mut options.config)?;
-  let env = env()?;
+  let mut env = env()?;
   let device = if options.open {
     None
   } else {
@@ -131,7 +131,7 @@ fn run_dev(
   let out_dir = bin_path.parent().unwrap();
   let _lock = flock::open_rw(out_dir.join("lock").with_extension("android"), "Android")?;
 
-  init_dot_cargo(app, Some((&env, config)))?;
+  configure_cargo(app, Some((&mut env, config)))?;
 
   // run an initial build to initialize plugins
   interface.build(interface_options)?;

--- a/tooling/cli/src/mobile/ios.rs
+++ b/tooling/cli/src/mobile/ios.rs
@@ -24,7 +24,7 @@ use tauri_mobile::{
 
 use super::{
   ensure_init, env, get_app,
-  init::{command as init_command, init_dot_cargo},
+  init::{command as init_command, configure_cargo},
   log_finished, read_options, setup_dev_config, CliOptions, Target as MobileTarget,
   MIN_DEVICE_MATCH_SCORE,
 };

--- a/tooling/cli/src/mobile/ios/build.rs
+++ b/tooling/cli/src/mobile/ios/build.rs
@@ -1,5 +1,5 @@
 use super::{
-  detect_target_ok, ensure_init, env, init_dot_cargo, log_finished, open_and_wait, with_config,
+  configure_cargo, detect_target_ok, ensure_init, env, log_finished, open_and_wait, with_config,
   MobileTarget,
 };
 use crate::{
@@ -71,7 +71,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
       ensure_init(config.project_dir(), MobileTarget::Ios)?;
 
       let mut env = env()?;
-      init_dot_cargo(app, None)?;
+      configure_cargo(app, None)?;
 
       let open = options.open;
       run_build(options, config, &mut env, noise_level)?;

--- a/tooling/cli/src/mobile/ios/dev.rs
+++ b/tooling/cli/src/mobile/ios/dev.rs
@@ -1,5 +1,5 @@
 use super::{
-  device_prompt, ensure_init, env, init_dot_cargo, open_and_wait, setup_dev_config, with_config,
+  configure_cargo, device_prompt, ensure_init, env, open_and_wait, setup_dev_config, with_config,
   MobileTarget, APPLE_DEVELOPMENT_TEAM_ENV_VAR_NAME,
 };
 use crate::{
@@ -142,7 +142,7 @@ fn run_dev(
   let out_dir = bin_path.parent().unwrap();
   let _lock = flock::open_rw(&out_dir.join("lock").with_extension("ios"), "iOS")?;
 
-  init_dot_cargo(app, None)?;
+  configure_cargo(app, None)?;
 
   let open = options.open;
   let exit_on_panic = options.exit_on_panic;

--- a/tooling/cli/src/mobile/mod.rs
+++ b/tooling/cli/src/mobile/mod.rs
@@ -179,6 +179,7 @@ fn env_vars() -> HashMap<String, OsString> {
     let k = k.to_string_lossy();
     if (k.starts_with("TAURI") && k != "TAURI_PRIVATE_KEY" && k != "TAURI_KEY_PASSWORD")
       || k.starts_with("WRY")
+      || k.starts_with("CARGO_")
       || k == "TMPDIR"
       || k == "PATH"
     {


### PR DESCRIPTION
Configure linker and rustflags via environment variables. This removes absolute paths from .cargo/config file, allowing user changes to be commited.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
