### PR TITLE
fix(docs): mark internal interfaces as such to deduplicate markdown output

### DIFF
--- a/tooling/api/src/window.ts
+++ b/tooling/api/src/window.ts
@@ -307,6 +307,7 @@ export type WindowLabel = string
 /**
  * A webview window handle allows emitting and listening to events from the backend that are tied to the window.
  *
+ * @ignore
  * @since 1.0.0
  */
 class WebviewWindowHandle {
@@ -406,6 +407,7 @@ class WebviewWindowHandle {
     return emit(event, this.label, payload)
   }
 
+  /** @ignore */
   _handleTauriEvent<T>(event: string, handler: EventCallback<T>): boolean {
     if (localTauriEvents.includes(event)) {
       if (!(event in this.listeners)) {
@@ -424,6 +426,7 @@ class WebviewWindowHandle {
 /**
  * Manage the current window object.
  *
+ * @ignore
  * @since 1.0.0
  */
 class WindowManager extends WebviewWindowHandle {


### PR DESCRIPTION
quick'n'dirty fix to unbloat https://tauri.app/v1/api/js/window/ a bit. windowmanager and webviewwindowhandle aren't used in a public interface anyway so this change should be fine / should not break anything.

I also thought about marking it as `@internal` or something instead of `@ignore`, to make the intend more clear but then i noticed that we use ignore everywhere so i went with that.

We have a similar issue with EventEmitter and Command, but ignoring EventEmitter causes issues as it's referenced by Command.stdout & stderr. I'm open to ideas about that, but would otherwise postpone that to the astro rewrite.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
