### PR TITLE
fix(core): pin time to 0.3.15

### DIFF
--- a/.changes/pin-time.md
+++ b/.changes/pin-time.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch
+"tauri-codegen": patch
+---
+
+Pin `time` to `0.3.15`.

--- a/core/tauri-codegen/Cargo.toml
+++ b/core/tauri-codegen/Cargo.toml
@@ -32,7 +32,7 @@ json-patch = "0.3"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 plist = "1"
-time = { version = "0.3", features = [ "parsing", "formatting" ] }
+time = { version = "=0.3.15", features = [ "parsing", "formatting" ] }
 
 [features]
 default = [ "compression" ]

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -75,7 +75,7 @@ shared_child = { version = "1.0", optional = true }
 os_pipe = { version = "1.0", optional = true }
 raw-window-handle = "0.5"
 minisign-verify = { version = "0.2", optional = true }
-time = { version = "0.3", features = [ "parsing", "formatting" ], optional = true }
+time = { version = "=0.3.15", features = [ "parsing", "formatting" ], optional = true }
 os_info = { version = "=3.5.0", optional = true }
 regex = { version = "1.6.0", optional = true }
 glob = "0.3"

--- a/core/tests/app-updater/Cargo.toml
+++ b/core/tests/app-updater/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tiny_http = "0.11"
 tauri = { path = "../../tauri", features = ["updater"] }
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "=0.3.15", features = ["formatting"] }
 
 [features]
 default = ["custom-protocol"]

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -231,12 +231,11 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.1.0"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1105,9 +1104,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1933,6 +1932,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3394,30 +3402,21 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
 dependencies = [
  "itoa 1.0.5",
- "serde",
- "time-core",
+ "libc",
+ "num_threads",
  "time-macros",
 ]
 
 [[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
-dependencies = [
- "time-core",
-]
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tiny_http"


### PR DESCRIPTION
Latest time requires MSRV 1.62, so we need to pin it to 0.3.15.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
