### PR TITLE
feat: add config links to json schema (closes #5479)

### DIFF
--- a/core/config-schema/schema.json
+++ b/core/config-schema/schema.json
@@ -208,7 +208,7 @@
   "additionalProperties": false,
   "definitions": {
     "PackageConfig": {
-      "description": "The package configuration.",
+      "description": "The package configuration.\n\nSee more: https://tauri.app/v1/api/config#packageconfig",
       "type": "object",
       "properties": {
         "productName": {
@@ -231,7 +231,7 @@
       "additionalProperties": false
     },
     "TauriConfig": {
-      "description": "The Tauri configuration object.",
+      "description": "The Tauri configuration object.\n\nSee more: https://tauri.app/v1/api/config#tauriconfig",
       "type": "object",
       "properties": {
         "pattern": {
@@ -508,7 +508,7 @@
       ]
     },
     "WindowConfig": {
-      "description": "The window configuration object.",
+      "description": "The window configuration object.\n\nSee more: https://tauri.app/v1/api/config#windowconfig",
       "type": "object",
       "properties": {
         "label": {
@@ -764,7 +764,7 @@
       ]
     },
     "CliConfig": {
-      "description": "describes a CLI configuration",
+      "description": "describes a CLI configuration\n\nSee more: https://tauri.app/v1/api/config#cliconfig",
       "type": "object",
       "properties": {
         "description": {
@@ -1010,7 +1010,7 @@
       "additionalProperties": false
     },
     "BundleConfig": {
-      "description": "Configuration for tauri-bundler.",
+      "description": "Configuration for tauri-bundler.\n\nSee more: https://tauri.app/v1/api/config#bundleconfig",
       "type": "object",
       "required": [
         "identifier"
@@ -1236,7 +1236,7 @@
       ]
     },
     "AppImageConfig": {
-      "description": "Configuration for AppImage bundles.",
+      "description": "Configuration for AppImage bundles.\n\nSee more: https://tauri.app/v1/api/config#appimageconfig",
       "type": "object",
       "properties": {
         "bundleMediaFramework": {
@@ -1248,7 +1248,7 @@
       "additionalProperties": false
     },
     "DebConfig": {
-      "description": "Configuration for Debian (.deb) bundles.",
+      "description": "Configuration for Debian (.deb) bundles.\n\nSee more: https://tauri.app/v1/api/config#debconfig",
       "type": "object",
       "properties": {
         "depends": {
@@ -1273,7 +1273,7 @@
       "additionalProperties": false
     },
     "MacConfig": {
-      "description": "Configuration for the macOS bundles.",
+      "description": "Configuration for the macOS bundles.\n\nSee more: https://tauri.app/v1/api/config#macconfig",
       "type": "object",
       "properties": {
         "frameworks": {
@@ -1333,7 +1333,7 @@
       "additionalProperties": false
     },
     "WindowsConfig": {
-      "description": "Windows bundler configuration.",
+      "description": "Windows bundler configuration.\n\nSee more: https://tauri.app/v1/api/config#windowsconfig",
       "type": "object",
       "properties": {
         "digestAlgorithm": {
@@ -1517,7 +1517,7 @@
       ]
     },
     "WixConfig": {
-      "description": "Configuration for the MSI bundle using WiX.",
+      "description": "Configuration for the MSI bundle using WiX.\n\nSee more: https://tauri.app/v1/api/config#wixconfig",
       "type": "object",
       "properties": {
         "language": {
@@ -1642,7 +1642,7 @@
       ]
     },
     "WixLanguageConfig": {
-      "description": "Configuration for a target language for the WiX build.",
+      "description": "Configuration for a target language for the WiX build.\n\nSee more: https://tauri.app/v1/api/config#wixlanguageconfig",
       "type": "object",
       "properties": {
         "localePath": {
@@ -1956,7 +1956,7 @@
       "additionalProperties": false
     },
     "FsAllowlistConfig": {
-      "description": "Allowlist for the file system APIs.",
+      "description": "Allowlist for the file system APIs.\n\nSee more: https://tauri.app/v1/api/config#fsallowlistconfig",
       "type": "object",
       "properties": {
         "scope": {
@@ -2056,7 +2056,7 @@
       ]
     },
     "WindowAllowlistConfig": {
-      "description": "Allowlist for the window APIs.",
+      "description": "Allowlist for the window APIs.\n\nSee more: https://tauri.app/v1/api/config#windowallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2218,7 +2218,7 @@
       "additionalProperties": false
     },
     "ShellAllowlistConfig": {
-      "description": "Allowlist for the shell APIs.",
+      "description": "Allowlist for the shell APIs.\n\nSee more: https://tauri.app/v1/api/config#shellallowlistconfig",
       "type": "object",
       "properties": {
         "scope": {
@@ -2349,7 +2349,7 @@
       ]
     },
     "DialogAllowlistConfig": {
-      "description": "Allowlist for the dialog APIs.",
+      "description": "Allowlist for the dialog APIs.\n\nSee more: https://tauri.app/v1/api/config#dialogallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2386,7 +2386,7 @@
       "additionalProperties": false
     },
     "HttpAllowlistConfig": {
-      "description": "Allowlist for the HTTP APIs.",
+      "description": "Allowlist for the HTTP APIs.\n\nSee more: https://tauri.app/v1/api/config#httpallowlistconfig",
       "type": "object",
       "properties": {
         "scope": {
@@ -2420,7 +2420,7 @@
       }
     },
     "NotificationAllowlistConfig": {
-      "description": "Allowlist for the notification APIs.",
+      "description": "Allowlist for the notification APIs.\n\nSee more: https://tauri.app/v1/api/config#notificationallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2432,7 +2432,7 @@
       "additionalProperties": false
     },
     "GlobalShortcutAllowlistConfig": {
-      "description": "Allowlist for the global shortcut APIs.",
+      "description": "Allowlist for the global shortcut APIs.\n\nSee more: https://tauri.app/v1/api/config#globalshortcutallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2444,7 +2444,7 @@
       "additionalProperties": false
     },
     "OsAllowlistConfig": {
-      "description": "Allowlist for the OS APIs.",
+      "description": "Allowlist for the OS APIs.\n\nSee more: https://tauri.app/v1/api/config#osallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2456,7 +2456,7 @@
       "additionalProperties": false
     },
     "PathAllowlistConfig": {
-      "description": "Allowlist for the path APIs.",
+      "description": "Allowlist for the path APIs.\n\nSee more: https://tauri.app/v1/api/config#pathallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2468,7 +2468,7 @@
       "additionalProperties": false
     },
     "ProtocolAllowlistConfig": {
-      "description": "Allowlist for the custom protocols.",
+      "description": "Allowlist for the custom protocols.\n\nSee more: https://tauri.app/v1/api/config#protocolallowlistconfig",
       "type": "object",
       "properties": {
         "assetScope": {
@@ -2494,7 +2494,7 @@
       "additionalProperties": false
     },
     "ProcessAllowlistConfig": {
-      "description": "Allowlist for the process APIs.",
+      "description": "Allowlist for the process APIs.\n\nSee more: https://tauri.app/v1/api/config#processallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2521,7 +2521,7 @@
       "additionalProperties": false
     },
     "ClipboardAllowlistConfig": {
-      "description": "Allowlist for the clipboard APIs.",
+      "description": "Allowlist for the clipboard APIs.\n\nSee more: https://tauri.app/v1/api/config#clipboardallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2543,7 +2543,7 @@
       "additionalProperties": false
     },
     "AppAllowlistConfig": {
-      "description": "Allowlist for the app APIs.",
+      "description": "Allowlist for the app APIs.\n\nSee more: https://tauri.app/v1/api/config#appallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2565,7 +2565,7 @@
       "additionalProperties": false
     },
     "SecurityConfig": {
-      "description": "Security configuration.",
+      "description": "Security configuration.\n\nSee more: https://tauri.app/v1/api/config#securityconfig",
       "type": "object",
       "properties": {
         "csp": {
@@ -2656,7 +2656,7 @@
       ]
     },
     "UpdaterConfig": {
-      "description": "The Updater configuration object.",
+      "description": "The Updater configuration object.\n\nSee more: https://tauri.app/v1/api/config#updaterconfig",
       "type": "object",
       "properties": {
         "active": {
@@ -2705,7 +2705,7 @@
       "format": "uri"
     },
     "UpdaterWindowsConfig": {
-      "description": "The updater configuration for Windows.",
+      "description": "The updater configuration for Windows.\n\nSee more: https://tauri.app/v1/api/config#updaterwindowsconfig",
       "type": "object",
       "properties": {
         "installerArgs": {
@@ -2755,7 +2755,7 @@
       ]
     },
     "SystemTrayConfig": {
-      "description": "Configuration for application system tray icon.",
+      "description": "Configuration for application system tray icon.\n\nSee more: https://tauri.app/v1/api/config#systemtrayconfig",
       "type": "object",
       "required": [
         "iconPath"
@@ -2786,7 +2786,7 @@
       "additionalProperties": false
     },
     "BuildConfig": {
-      "description": "The Build configuration object.",
+      "description": "The Build configuration object.\n\nSee more: https://tauri.app/v1/api/config#buildconfig",
       "type": "object",
       "properties": {
         "runner": {
@@ -2949,7 +2949,7 @@
       ]
     },
     "PluginConfig": {
-      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.",
+      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.\n\nSee more: https://tauri.app/v1/api/config#pluginconfig",
       "type": "object",
       "additionalProperties": true
     }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -247,6 +247,8 @@ impl BundleTarget {
 }
 
 /// Configuration for AppImage bundles.
+///
+/// See more: https://tauri.app/v1/api/config#appimageconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -258,6 +260,8 @@ pub struct AppImageConfig {
 }
 
 /// Configuration for Debian (.deb) bundles.
+///
+/// See more: https://tauri.app/v1/api/config#debconfig
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -282,6 +286,8 @@ where
 }
 
 /// Configuration for the macOS bundles.
+///
+/// See more: https://tauri.app/v1/api/config#macconfig
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -338,6 +344,8 @@ fn minimum_system_version() -> Option<String> {
 }
 
 /// Configuration for a target language for the WiX build.
+///
+/// See more: https://tauri.app/v1/api/config#wixlanguageconfig
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -367,6 +375,8 @@ impl Default for WixLanguage {
 }
 
 /// Configuration for the MSI bundle using WiX.
+///
+/// See more: https://tauri.app/v1/api/config#wixconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -543,6 +553,8 @@ impl Default for WebviewInstallMode {
 }
 
 /// Windows bundler configuration.
+///
+/// See more: https://tauri.app/v1/api/config#windowsconfig
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -606,6 +618,8 @@ fn default_allow_downgrades() -> bool {
 }
 
 /// Configuration for tauri-bundler.
+///
+/// See more: https://tauri.app/v1/api/config#bundleconfig
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -794,6 +808,8 @@ pub struct CliArg {
 }
 
 /// describes a CLI configuration
+///
+/// See more: https://tauri.app/v1/api/config#cliconfig
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -857,6 +873,8 @@ impl CliConfig {
 }
 
 /// The window configuration object.
+///
+/// See more: https://tauri.app/v1/api/config#windowconfig
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1179,6 +1197,8 @@ impl Default for DisabledCspModificationKind {
 }
 
 /// Security configuration.
+///
+/// See more: https://tauri.app/v1/api/config#securityconfig
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1282,6 +1302,8 @@ impl FsAllowlistScope {
 }
 
 /// Allowlist for the file system APIs.
+///
+/// See more: https://tauri.app/v1/api/config#fsallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1361,6 +1383,8 @@ impl Allowlist for FsAllowlistConfig {
 }
 
 /// Allowlist for the window APIs.
+///
+/// See more: https://tauri.app/v1/api/config#windowallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1707,6 +1731,8 @@ impl Default for ShellAllowlistOpen {
 }
 
 /// Allowlist for the shell APIs.
+///
+/// See more: https://tauri.app/v1/api/config#shellallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1763,6 +1789,8 @@ impl Allowlist for ShellAllowlistConfig {
 }
 
 /// Allowlist for the dialog APIs.
+///
+/// See more: https://tauri.app/v1/api/config#dialogallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1831,6 +1859,8 @@ impl Allowlist for DialogAllowlistConfig {
 pub struct HttpAllowlistScope(pub Vec<Url>);
 
 /// Allowlist for the HTTP APIs.
+///
+/// See more: https://tauri.app/v1/api/config#httpallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1870,6 +1900,8 @@ impl Allowlist for HttpAllowlistConfig {
 }
 
 /// Allowlist for the notification APIs.
+///
+/// See more: https://tauri.app/v1/api/config#notificationallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1897,6 +1929,8 @@ impl Allowlist for NotificationAllowlistConfig {
 }
 
 /// Allowlist for the global shortcut APIs.
+///
+/// See more: https://tauri.app/v1/api/config#globalshortcutallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1924,6 +1958,8 @@ impl Allowlist for GlobalShortcutAllowlistConfig {
 }
 
 /// Allowlist for the OS APIs.
+///
+/// See more: https://tauri.app/v1/api/config#osallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1951,6 +1987,8 @@ impl Allowlist for OsAllowlistConfig {
 }
 
 /// Allowlist for the path APIs.
+///
+/// See more: https://tauri.app/v1/api/config#pathallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1978,6 +2016,8 @@ impl Allowlist for PathAllowlistConfig {
 }
 
 /// Allowlist for the custom protocols.
+///
+/// See more: https://tauri.app/v1/api/config#protocolallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -2017,6 +2057,8 @@ impl Allowlist for ProtocolAllowlistConfig {
 }
 
 /// Allowlist for the process APIs.
+///
+/// See more: https://tauri.app/v1/api/config#processallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -2074,6 +2116,8 @@ impl Allowlist for ProcessAllowlistConfig {
 }
 
 /// Allowlist for the clipboard APIs.
+///
+/// See more: https://tauri.app/v1/api/config#clipboardallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -2114,6 +2158,8 @@ impl Allowlist for ClipboardAllowlistConfig {
 }
 
 /// Allowlist for the app APIs.
+///
+/// See more: https://tauri.app/v1/api/config#appallowlistconfig
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -2275,6 +2321,8 @@ impl Default for PatternKind {
 }
 
 /// The Tauri configuration object.
+///
+/// See more: https://tauri.app/v1/api/config#tauriconfig
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -2453,6 +2501,8 @@ impl<'de> Deserialize<'de> for WindowsUpdateInstallMode {
 }
 
 /// The updater configuration for Windows.
+///
+/// See more: https://tauri.app/v1/api/config#updaterwindowsconfig
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -2467,6 +2517,8 @@ pub struct UpdaterWindowsConfig {
 }
 
 /// The Updater configuration object.
+///
+/// See more: https://tauri.app/v1/api/config#updaterconfig
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -2546,6 +2598,8 @@ impl Default for UpdaterConfig {
 }
 
 /// Configuration for application system tray icon.
+///
+/// See more: https://tauri.app/v1/api/config#systemtrayconfig
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -2635,6 +2689,8 @@ pub enum HookCommand {
 }
 
 /// The Build configuration object.
+///
+/// See more: https://tauri.app/v1/api/config#buildconfig
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -2768,6 +2824,8 @@ impl<'d> serde::Deserialize<'d> for PackageVersion {
 }
 
 /// The package configuration.
+///
+/// See more: https://tauri.app/v1/api/config#packageconfig
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -2897,6 +2955,8 @@ pub struct Config {
 }
 
 /// The plugin configs holds a HashMap mapping a plugin name to its configuration object.
+///
+/// See more: https://tauri.app/v1/api/config#pluginconfig
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct PluginConfig(pub HashMap<String, JsonValue>);

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -208,7 +208,7 @@
   "additionalProperties": false,
   "definitions": {
     "PackageConfig": {
-      "description": "The package configuration.",
+      "description": "The package configuration.\n\nSee more: https://tauri.app/v1/api/config#packageconfig",
       "type": "object",
       "properties": {
         "productName": {
@@ -231,7 +231,7 @@
       "additionalProperties": false
     },
     "TauriConfig": {
-      "description": "The Tauri configuration object.",
+      "description": "The Tauri configuration object.\n\nSee more: https://tauri.app/v1/api/config#tauriconfig",
       "type": "object",
       "properties": {
         "pattern": {
@@ -508,7 +508,7 @@
       ]
     },
     "WindowConfig": {
-      "description": "The window configuration object.",
+      "description": "The window configuration object.\n\nSee more: https://tauri.app/v1/api/config#windowconfig",
       "type": "object",
       "properties": {
         "label": {
@@ -764,7 +764,7 @@
       ]
     },
     "CliConfig": {
-      "description": "describes a CLI configuration",
+      "description": "describes a CLI configuration\n\nSee more: https://tauri.app/v1/api/config#cliconfig",
       "type": "object",
       "properties": {
         "description": {
@@ -1010,7 +1010,7 @@
       "additionalProperties": false
     },
     "BundleConfig": {
-      "description": "Configuration for tauri-bundler.",
+      "description": "Configuration for tauri-bundler.\n\nSee more: https://tauri.app/v1/api/config#bundleconfig",
       "type": "object",
       "required": [
         "identifier"
@@ -1236,7 +1236,7 @@
       ]
     },
     "AppImageConfig": {
-      "description": "Configuration for AppImage bundles.",
+      "description": "Configuration for AppImage bundles.\n\nSee more: https://tauri.app/v1/api/config#appimageconfig",
       "type": "object",
       "properties": {
         "bundleMediaFramework": {
@@ -1248,7 +1248,7 @@
       "additionalProperties": false
     },
     "DebConfig": {
-      "description": "Configuration for Debian (.deb) bundles.",
+      "description": "Configuration for Debian (.deb) bundles.\n\nSee more: https://tauri.app/v1/api/config#debconfig",
       "type": "object",
       "properties": {
         "depends": {
@@ -1273,7 +1273,7 @@
       "additionalProperties": false
     },
     "MacConfig": {
-      "description": "Configuration for the macOS bundles.",
+      "description": "Configuration for the macOS bundles.\n\nSee more: https://tauri.app/v1/api/config#macconfig",
       "type": "object",
       "properties": {
         "frameworks": {
@@ -1333,7 +1333,7 @@
       "additionalProperties": false
     },
     "WindowsConfig": {
-      "description": "Windows bundler configuration.",
+      "description": "Windows bundler configuration.\n\nSee more: https://tauri.app/v1/api/config#windowsconfig",
       "type": "object",
       "properties": {
         "digestAlgorithm": {
@@ -1517,7 +1517,7 @@
       ]
     },
     "WixConfig": {
-      "description": "Configuration for the MSI bundle using WiX.",
+      "description": "Configuration for the MSI bundle using WiX.\n\nSee more: https://tauri.app/v1/api/config#wixconfig",
       "type": "object",
       "properties": {
         "language": {
@@ -1642,7 +1642,7 @@
       ]
     },
     "WixLanguageConfig": {
-      "description": "Configuration for a target language for the WiX build.",
+      "description": "Configuration for a target language for the WiX build.\n\nSee more: https://tauri.app/v1/api/config#wixlanguageconfig",
       "type": "object",
       "properties": {
         "localePath": {
@@ -1956,7 +1956,7 @@
       "additionalProperties": false
     },
     "FsAllowlistConfig": {
-      "description": "Allowlist for the file system APIs.",
+      "description": "Allowlist for the file system APIs.\n\nSee more: https://tauri.app/v1/api/config#fsallowlistconfig",
       "type": "object",
       "properties": {
         "scope": {
@@ -2056,7 +2056,7 @@
       ]
     },
     "WindowAllowlistConfig": {
-      "description": "Allowlist for the window APIs.",
+      "description": "Allowlist for the window APIs.\n\nSee more: https://tauri.app/v1/api/config#windowallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2218,7 +2218,7 @@
       "additionalProperties": false
     },
     "ShellAllowlistConfig": {
-      "description": "Allowlist for the shell APIs.",
+      "description": "Allowlist for the shell APIs.\n\nSee more: https://tauri.app/v1/api/config#shellallowlistconfig",
       "type": "object",
       "properties": {
         "scope": {
@@ -2349,7 +2349,7 @@
       ]
     },
     "DialogAllowlistConfig": {
-      "description": "Allowlist for the dialog APIs.",
+      "description": "Allowlist for the dialog APIs.\n\nSee more: https://tauri.app/v1/api/config#dialogallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2386,7 +2386,7 @@
       "additionalProperties": false
     },
     "HttpAllowlistConfig": {
-      "description": "Allowlist for the HTTP APIs.",
+      "description": "Allowlist for the HTTP APIs.\n\nSee more: https://tauri.app/v1/api/config#httpallowlistconfig",
       "type": "object",
       "properties": {
         "scope": {
@@ -2420,7 +2420,7 @@
       }
     },
     "NotificationAllowlistConfig": {
-      "description": "Allowlist for the notification APIs.",
+      "description": "Allowlist for the notification APIs.\n\nSee more: https://tauri.app/v1/api/config#notificationallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2432,7 +2432,7 @@
       "additionalProperties": false
     },
     "GlobalShortcutAllowlistConfig": {
-      "description": "Allowlist for the global shortcut APIs.",
+      "description": "Allowlist for the global shortcut APIs.\n\nSee more: https://tauri.app/v1/api/config#globalshortcutallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2444,7 +2444,7 @@
       "additionalProperties": false
     },
     "OsAllowlistConfig": {
-      "description": "Allowlist for the OS APIs.",
+      "description": "Allowlist for the OS APIs.\n\nSee more: https://tauri.app/v1/api/config#osallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2456,7 +2456,7 @@
       "additionalProperties": false
     },
     "PathAllowlistConfig": {
-      "description": "Allowlist for the path APIs.",
+      "description": "Allowlist for the path APIs.\n\nSee more: https://tauri.app/v1/api/config#pathallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2468,7 +2468,7 @@
       "additionalProperties": false
     },
     "ProtocolAllowlistConfig": {
-      "description": "Allowlist for the custom protocols.",
+      "description": "Allowlist for the custom protocols.\n\nSee more: https://tauri.app/v1/api/config#protocolallowlistconfig",
       "type": "object",
       "properties": {
         "assetScope": {
@@ -2494,7 +2494,7 @@
       "additionalProperties": false
     },
     "ProcessAllowlistConfig": {
-      "description": "Allowlist for the process APIs.",
+      "description": "Allowlist for the process APIs.\n\nSee more: https://tauri.app/v1/api/config#processallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2521,7 +2521,7 @@
       "additionalProperties": false
     },
     "ClipboardAllowlistConfig": {
-      "description": "Allowlist for the clipboard APIs.",
+      "description": "Allowlist for the clipboard APIs.\n\nSee more: https://tauri.app/v1/api/config#clipboardallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2543,7 +2543,7 @@
       "additionalProperties": false
     },
     "AppAllowlistConfig": {
-      "description": "Allowlist for the app APIs.",
+      "description": "Allowlist for the app APIs.\n\nSee more: https://tauri.app/v1/api/config#appallowlistconfig",
       "type": "object",
       "properties": {
         "all": {
@@ -2565,7 +2565,7 @@
       "additionalProperties": false
     },
     "SecurityConfig": {
-      "description": "Security configuration.",
+      "description": "Security configuration.\n\nSee more: https://tauri.app/v1/api/config#securityconfig",
       "type": "object",
       "properties": {
         "csp": {
@@ -2656,7 +2656,7 @@
       ]
     },
     "UpdaterConfig": {
-      "description": "The Updater configuration object.",
+      "description": "The Updater configuration object.\n\nSee more: https://tauri.app/v1/api/config#updaterconfig",
       "type": "object",
       "properties": {
         "active": {
@@ -2705,7 +2705,7 @@
       "format": "uri"
     },
     "UpdaterWindowsConfig": {
-      "description": "The updater configuration for Windows.",
+      "description": "The updater configuration for Windows.\n\nSee more: https://tauri.app/v1/api/config#updaterwindowsconfig",
       "type": "object",
       "properties": {
         "installerArgs": {
@@ -2755,7 +2755,7 @@
       ]
     },
     "SystemTrayConfig": {
-      "description": "Configuration for application system tray icon.",
+      "description": "Configuration for application system tray icon.\n\nSee more: https://tauri.app/v1/api/config#systemtrayconfig",
       "type": "object",
       "required": [
         "iconPath"
@@ -2786,7 +2786,7 @@
       "additionalProperties": false
     },
     "BuildConfig": {
-      "description": "The Build configuration object.",
+      "description": "The Build configuration object.\n\nSee more: https://tauri.app/v1/api/config#buildconfig",
       "type": "object",
       "properties": {
         "runner": {
@@ -2949,7 +2949,7 @@
       ]
     },
     "PluginConfig": {
-      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.",
+      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.\n\nSee more: https://tauri.app/v1/api/config#pluginconfig",
       "type": "object",
       "additionalProperties": true
     }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Closes #5479

_I am unsure about the need for any package version bumps - this is really just a docs change_ 🤷‍♂️ 

I considered a few approaches for this, but, after fooling around for too long, I decided to just submit the simple solution.

**Future Considerations**

- The links could be automatically generated (updated) - making maintenance easier
- Certain configs did not get links to look as expected (they are overwritten):
  - The `WindowsConfig` is not updated, because it is defined as a `Vec`:

```rust
  /// The windows configuration.
  #[serde(default)]
  pub windows: Vec<WindowConfig>,
```

As such, the doc comment above the field is taken - contrast other definitions where the struct definition doc comment overwrites the field doc comment.

- It would be nice to have full markdown support in the tooltip using the `markdownDescription` property. However, this is a VSCode field, and is not defined in the JSON Schema. So, the implementation would involve more hacking as the `schemars::schema::Metadata` struct does not include a `markdown_description` field.