### PR TITLE
feat: add attributes for drag region

### DIFF
--- a/.changes/add-attribute-for-drag-region.md
+++ b/.changes/add-attribute-for-drag-region.md
@@ -17,21 +17,12 @@ Description:
 Example:
 
 ```html
-
-<div>
-  <div class="title"
-       data-tauri-drag-region-container="true"
-       data-tauri-drag-region-titlebar="true"
-  >
-    <div>Title</div>
-    <div>Some decoration</div>
-    <button data-tauri-drag-region-exclude>close</button>
-  </div>
-  <div class="content"
-       data-tauri-drag-region-container="true"
-  >
-    <div>content</div>
-    <div>content</div>
-  </div>
+<div class="titlebar"
+     data-tauri-drag-region-container="true"
+     data-tauri-drag-region-titlebar="true"
+>
+  <div>Title</div>
+  <div>Some decoration</div>
+  <button data-tauri-drag-region-exclude>close</button>
 </div>
 ```

--- a/.changes/add-attribute-for-drag-region.md
+++ b/.changes/add-attribute-for-drag-region.md
@@ -5,3 +5,41 @@
 Added
 attribute `data-tauri-drag-region-container`, `data-tauri-drag-region-title`, `data-tauri-drag-region-interactive`, to
 enable drag on children, control maximize on double click, control is or not interactable on button/input/etc.
+
+Description:
+
+`data-tauri-drag-region`: mark this element as "drag region"
+
+`data-tauri-drag-region-container`: mark the "drag region" effects its children
+
+`data-tauri-drag-region-title`: mark the "drag region" maximize on double click (default add when
+only `data-tauri-drag-region` is set)
+
+`data-tauri-drag-region-interactive`: mark the "drag region" wouldn't prevent event to its children that interact-able,
+like button, input, etc. (check by "is property 'value' exists")
+
+Example:
+
+```html
+
+<div>
+  <div class="title"
+       data-tauri-drag-region-container="true"
+       data-tauri-drag-region-title="true"
+       data-tauri-drag-region-interactive="true"
+  >
+    <div>Title</div>
+    <div>Some decoration</div>
+    <button>close</button>
+    <div data-tauri-drag-region="false" onclick="alert('clicked')">
+      some element not interactive by default
+    </div>
+  </div>
+  <div class="content"
+       data-tauri-drag-region-container="true"
+  >
+    <div>content</div>
+    <div>content</div>
+  </div>
+</div>
+```

--- a/.changes/add-attribute-for-drag-region.md
+++ b/.changes/add-attribute-for-drag-region.md
@@ -1,0 +1,7 @@
+---
+"tauri": "minor"
+---
+
+Added
+attribute `data-tauri-drag-region-container`, `data-tauri-drag-region-title`, `data-tauri-drag-region-interactable`, to
+enable drag on children, control maximize on double click, control is or not interactable on button/input/etc.

--- a/.changes/add-attribute-for-drag-region.md
+++ b/.changes/add-attribute-for-drag-region.md
@@ -12,8 +12,7 @@ Description:
 
 `data-tauri-drag-region-titlebar`: the "drag region" maximizes window on double click (default when only `data-tauri-drag-region` is used)
 
-`data-tauri-drag-region-interactive`: mark the "drag region" wouldn't prevent event to its children that interact-able,
-like button, input, etc. (check by "is property 'value' exists")
+`data-tauri-drag-region-exclude`: this element doesn't trigger `drag`
 
 Example:
 
@@ -23,14 +22,10 @@ Example:
   <div class="title"
        data-tauri-drag-region-container="true"
        data-tauri-drag-region-titlebar="true"
-       data-tauri-drag-region-interactive="true"
   >
     <div>Title</div>
     <div>Some decoration</div>
-    <button>close</button>
-    <div data-tauri-drag-region="false" onclick="alert('clicked')">
-      some element not interactive by default
-    </div>
+    <button data-tauri-drag-region-exclude>close</button>
   </div>
   <div class="content"
        data-tauri-drag-region-container="true"

--- a/.changes/add-attribute-for-drag-region.md
+++ b/.changes/add-attribute-for-drag-region.md
@@ -2,7 +2,7 @@
 "tauri": "minor"
 ---
 
-Added new drag attributes,`data-tauri-drag-region-container`, `data-tauri-drag-region-title`, `data-tauri-drag-region-interactive`, to enable drag on children, control maximize on double click, control interactive elements behavior.
+Added new drag attributes,`data-tauri-drag-region-container`, `data-tauri-drag-region-titlebar`, `data-tauri-drag-region-interactive`, to enable drag on children, control maximize on double click, control interactive elements' behavior.
 
 Description:
 
@@ -10,7 +10,7 @@ Description:
 
 `data-tauri-drag-region-container`: children are also considered drag regions
 
-`data-tauri-drag-region-title`: the "drag region" maximizes window on double click (default when only `data-tauri-drag-region` is used)
+`data-tauri-drag-region-titlebar`: the "drag region" maximizes window on double click (default when only `data-tauri-drag-region` is used)
 
 `data-tauri-drag-region-interactive`: mark the "drag region" wouldn't prevent event to its children that interact-able,
 like button, input, etc. (check by "is property 'value' exists")
@@ -22,7 +22,7 @@ Example:
 <div>
   <div class="title"
        data-tauri-drag-region-container="true"
-       data-tauri-drag-region-title="true"
+       data-tauri-drag-region-titlebar="true"
        data-tauri-drag-region-interactive="true"
   >
     <div>Title</div>

--- a/.changes/add-attribute-for-drag-region.md
+++ b/.changes/add-attribute-for-drag-region.md
@@ -3,5 +3,5 @@
 ---
 
 Added
-attribute `data-tauri-drag-region-container`, `data-tauri-drag-region-title`, `data-tauri-drag-region-interactable`, to
+attribute `data-tauri-drag-region-container`, `data-tauri-drag-region-title`, `data-tauri-drag-region-interactive`, to
 enable drag on children, control maximize on double click, control is or not interactable on button/input/etc.

--- a/.changes/add-attribute-for-drag-region.md
+++ b/.changes/add-attribute-for-drag-region.md
@@ -2,18 +2,15 @@
 "tauri": "minor"
 ---
 
-Added
-attribute `data-tauri-drag-region-container`, `data-tauri-drag-region-title`, `data-tauri-drag-region-interactive`, to
-enable drag on children, control maximize on double click, control is or not interactable on button/input/etc.
+Added new drag attributes,`data-tauri-drag-region-container`, `data-tauri-drag-region-title`, `data-tauri-drag-region-interactive`, to enable drag on children, control maximize on double click, control interactive elements behavior.
 
 Description:
 
 `data-tauri-drag-region`: mark this element as "drag region"
 
-`data-tauri-drag-region-container`: mark the "drag region" effects its children
+`data-tauri-drag-region-container`: children are also considered drag regions
 
-`data-tauri-drag-region-title`: mark the "drag region" maximize on double click (default add when
-only `data-tauri-drag-region` is set)
+`data-tauri-drag-region-title`: the "drag region" maximizes window on double click (default when only `data-tauri-drag-region` is used)
 
 `data-tauri-drag-region-interactive`: mark the "drag region" wouldn't prevent event to its children that interact-able,
 like button, input, etc. (check by "is property 'value' exists")

--- a/.changes/add-more-option-to-drag-region-attr.md
+++ b/.changes/add-more-option-to-drag-region-attr.md
@@ -1,0 +1,6 @@
+---
+"tauri": "minor"
+---
+
+Added option `none`, `self`, `self-title`, `container`, `container-title` and `container-none` to element
+attribute `data-tauri-drag-region`.

--- a/.changes/add-more-option-to-drag-region-attr.md
+++ b/.changes/add-more-option-to-drag-region-attr.md
@@ -1,6 +1,0 @@
----
-"tauri": "minor"
----
-
-Added option `none`, `self`, `self-title`, `container`, `container-title` and `container-none` to element
-attribute `data-tauri-drag-region`.

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -153,7 +153,7 @@
       const dragAttr = element.getAttribute("data-tauri-drag-region");
       const containerAttr = element.getAttribute("data-tauri-drag-region-container");
       const titleAttr = element.getAttribute("data-tauri-drag-region-title");
-      const interactableAttr = element.getAttribute("data-tauri-drag-region-interactable");
+      const interactableAttr = element.getAttribute("data-tauri-drag-region-interact-able");
 
       // return null if unset
       if (dragAttr == null) return null;

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -156,15 +156,26 @@
 
       // return drag false if exclude
       if (excludeAttr && excludeAttr !== "false") return {drag: false, container: false, titlebar: false};
+
       // return null if unset
-      if (dragAttr == null) return null;
+      if (!dragAttr && !containerAttr) return null;
 
-      const drag = dragAttr !== "false";
-      const container = containerAttr != null && containerAttr !== "false";
-      // default enable if not set and container not enable; for backwards compatibility
-      const titlebar = (titlebarAttr != null || (drag && !container)) && titlebarAttr !== "false";
+      // enable titlebar if titlebarAttr not set or titlebarAttr is set and not equal to "false"
+      if (dragAttr) return {
+        drag: dragAttr !== "false",
+        container: false,
+        titlebar: titlebarAttr ? titlebarAttr !== "false" : true
+      };
 
-      return {drag, container, titlebar};
+      // enable titlebar only if titlebarAttr is set and not equal to "false"
+      if (containerAttr) return {
+        drag: containerAttr !== "false",
+        container: containerAttr !== "false",
+        titlebar: titlebarAttr ? titlebarAttr !== "false" : false
+      };
+
+      // above code should handle all the conditions
+      return {drag: false, container: false, titlebar: false};
     }
 
     /**

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-; (function () {
+;(function () {
   function uid() {
     return window.crypto.getRandomValues(new Uint32Array(1))[0]
   }
@@ -142,7 +142,7 @@
      * @property {boolean} drag
      * @property {boolean} container
      * @property {boolean} title
-     * @property {boolean} interactable
+     * @property {boolean} interactive
      */
 
     /**
@@ -153,7 +153,7 @@
       const dragAttr = element.getAttribute("data-tauri-drag-region");
       const containerAttr = element.getAttribute("data-tauri-drag-region-container");
       const titleAttr = element.getAttribute("data-tauri-drag-region-title");
-      const interactableAttr = element.getAttribute("data-tauri-drag-region-interact-able");
+      const interactiveAttr = element.getAttribute("data-tauri-drag-region-interactive");
 
       // return null if unset
       if (dragAttr == null) return null;
@@ -163,10 +163,10 @@
       // default enable if not set and container not enable; for backwards compatibility
       const title = (titleAttr != null || (drag && !container)) && titleAttr !== "false";
       // only can enable on container
-      const interactable =
-        interactableAttr != null && interactableAttr !== "false" && container;
+      const interactive =
+        interactiveAttr != null && interactiveAttr !== "false" && container;
 
-      return { drag, container, title, interactable };
+      return {drag, container, title, interactive};
     }
 
     /**
@@ -182,7 +182,7 @@
         current = current.parentElement;
       }
 
-      return { container: false, interactable: false, title: false, drag: false };
+      return {container: false, interactive: false, title: false, drag: false};
     }
 
     if (!event.target) return;
@@ -204,13 +204,13 @@
 
     if (isClick) {
       // prevents click on button in container when interact-able not enable
-      if (info.container && !info.interactable && elementInteractable) {
+      if (info.container && !info.interactive && elementInteractable) {
         event.stopImmediatePropagation();
       }
       return;
     }
 
-    if (elementInteractable && info.interactable) return;
+    if (elementInteractable && info.interactive) return;
 
     if (info.drag) {
       // prevents text cursor

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -132,99 +132,88 @@
   }
 
   // drag region
-  document.addEventListener("mousedown", (e) => {
-    const DragType = {
-      Unset: "",
-      None: "none",
-      Self: "self",
-      SelfTitle: "self-title",
-      Container: "container",
-      ContainerTitle: "container-title",
-      ContainerNone: "container-none",
+  /**
+   * @param {boolean} isClick
+   * @param {MouseEvent} event
+   */
+  function handleDrag(isClick, event) {
+    /**
+     * @typedef {Object} DragInfo
+     * @property {boolean} drag
+     * @property {boolean} container
+     * @property {boolean} title
+     * @property {boolean} interactable
+     */
+
+    /**
+     * @param {HTMLElement} element
+     * @return {DragInfo|null}
+     */
+    function elementDragInfo(element) {
+      const dragAttr = element.getAttribute("data-tauri-drag-region");
+      const containerAttr = element.getAttribute("data-tauri-drag-region-container");
+      const titleAttr = element.getAttribute("data-tauri-drag-region-title");
+      const interactableAttr = element.getAttribute("data-tauri-drag-region-interactable");
+
+      // return null if unset
+      if (dragAttr == null) return null;
+
+      const drag = dragAttr !== "false";
+      const container = containerAttr != null && containerAttr !== "false";
+      // default enable if not set, for backwards compatibility
+      const title = (titleAttr != null || drag) && titleAttr !== "false";
+      // only can enable on container
+      const interactable =
+        interactableAttr != null && interactableAttr !== "false" && container;
+
+      return { drag, container, title, interactable };
     }
 
     /**
      * @param {HTMLElement} element
-     * @return {DragType}
+     * @return {DragInfo}
      */
-    function elementType(element) {
-      const value = element.getAttribute("data-tauri-drag-region");
-      switch (value) {
-        case null:
-        case undefined: {
-          return DragType.Unset;
-        }
-        case "false": {
-          return DragType.None;
-        }
-        case DragType.None:
-        case DragType.Self:
-        case DragType.SelfTitle:
-        case DragType.Container:
-        case DragType.ContainerTitle:
-        case DragType.ContainerNone: {
-          return value;
-        }
-        default: {
-          return DragType.SelfTitle;
-        }
-      }
-    }
-
-    /**
-     * @param {HTMLElement} element
-     * @return {DragType}
-     */
-    function parentsType(element) {
+    function parentsDragInfo(element) {
       let current = element.parentElement;
 
       while (current) {
-        const type = elementType(current);
-        if (
-          type === DragType.Container ||
-          type === DragType.ContainerTitle ||
-          type === DragType.ContainerNone
-        )
-          return type;
+        const info = elementDragInfo(current);
+        if (info && info.container) return info;
         current = current.parentElement;
       }
 
-      return DragType.None;
+      return { container: false, interactable: false, title: false, drag: false };
     }
 
-    if (!e.target) return;
-    if (e.buttons !== 1) return; // check is left click
+    if (!event.target) return;
+    if (event.buttons !== 1 && !isClick) return;
 
     /**
      * @type {HTMLElement}
      */
-    const element = e.target;
+    const element = event.target;
+    const elementInteractable = event.target.value !== undefined;
 
-    let type = elementType(element);
+    let info = elementDragInfo(element);
+    // get parent info if current is unset
+    if (info == null) info = parentsDragInfo(element);
+    // if all unset then directly return
+    if (info == null) return;
 
-    if (type === DragType.Unset) type = parentsType(element);
-
-    let drag = true;
-    let isTitle = false;
-
-    switch (type) {
-      case DragType.Unset:
-      case DragType.None:
-      case DragType.ContainerNone:
-        drag = false;
-        break;
-      case DragType.SelfTitle:
-      case DragType.ContainerTitle:
-        isTitle = true;
-        break;
+    if (isClick) {
+      if (info.container && !info.interactable && elementInteractable) {
+        event.stopImmediatePropagation();
+      }
+      return;
     }
 
-    if (drag) {
+    if (info.drag) {
       // prevents text cursor
-      e.preventDefault();
-      // fix #2549: double click on drag region edge causes content to maximize without window sizing change
+      // prevents button click in container
+      event.preventDefault();
+      // fix #2549: double-click on drag region edge causes content to maximize without window sizing change
       // https://github.com/tauri-apps/tauri/issues/2549#issuecomment-1250036908
-      e.stopImmediatePropagation();
+      event.stopImmediatePropagation();
 
       // start dragging if the element has a `tauri-drag-region` data attribute and maximize on double-clicking it
       window.__TAURI_INVOKE__("tauri", {
@@ -234,13 +223,18 @@
           data: {
             cmd: {
               type:
-                isTitle && e.detail === 2 ? "__toggleMaximize" : "startDragging",
+                info.title && event.detail === 2
+                  ? "__toggleMaximize"
+                  : "startDragging",
             },
           },
         },
       });
     }
-  });
+  }
+
+  document.addEventListener("mousedown", handleDrag.bind(null, false));
+  document.addEventListener("click", handleDrag.bind(null, true), true);
 
   let permissionSettable = false
   let permissionValue = 'default'

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -199,6 +199,8 @@
     if (info == null) info = parentsDragInfo(element);
     // if all unset then directly return
     if (info == null) return;
+    // if drag disabled then directly return
+    if (!info.drag) return;
 
     if (isClick) {
       // prevents click on button in container when interact-able not enable

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -208,6 +208,8 @@
       return;
     }
 
+    if (elementInteractable && info.interactable) return;
+
     if (info.drag) {
       // prevents text cursor
       event.preventDefault();

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -201,6 +201,7 @@
     if (info == null) return;
 
     if (isClick) {
+      // prevents click on button in container when interact-able not enable
       if (info.container && !info.interactable && elementInteractable) {
         event.stopImmediatePropagation();
       }
@@ -209,7 +210,6 @@
 
     if (info.drag) {
       // prevents text cursor
-      // prevents button click in container
       event.preventDefault();
       // fix #2549: double-click on drag region edge causes content to maximize without window sizing change
       // https://github.com/tauri-apps/tauri/issues/2549#issuecomment-1250036908

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -141,7 +141,7 @@
      * @typedef {Object} DragInfo
      * @property {boolean} drag
      * @property {boolean} container
-     * @property {boolean} title
+     * @property {boolean} titlebar
      * @property {boolean} interactive
      */
 
@@ -152,7 +152,7 @@
     function elementDragInfo(element) {
       const dragAttr = element.getAttribute("data-tauri-drag-region");
       const containerAttr = element.getAttribute("data-tauri-drag-region-container");
-      const titleAttr = element.getAttribute("data-tauri-drag-region-title");
+      const titlebarAttr = element.getAttribute("data-tauri-drag-region-titlebar");
       const interactiveAttr = element.getAttribute("data-tauri-drag-region-interactive");
 
       // return null if unset
@@ -161,12 +161,12 @@
       const drag = dragAttr !== "false";
       const container = containerAttr != null && containerAttr !== "false";
       // default enable if not set and container not enable; for backwards compatibility
-      const title = (titleAttr != null || (drag && !container)) && titleAttr !== "false";
+      const titlebar = (titlebarAttr != null || (drag && !container)) && titlebarAttr !== "false";
       // only can enable on container
       const interactive =
         interactiveAttr != null && interactiveAttr !== "false" && container;
 
-      return {drag, container, title, interactive};
+      return {drag, container, titlebar, interactive};
     }
 
     /**
@@ -182,7 +182,7 @@
         current = current.parentElement;
       }
 
-      return {container: false, interactive: false, title: false, drag: false};
+      return {container: false, interactive: false, titlebar: false, drag: false};
     }
 
     if (!event.target) return;
@@ -227,7 +227,7 @@
           data: {
             cmd: {
               type:
-                info.title && event.detail === 2
+                info.titlebar && event.detail === 2
                   ? "__toggleMaximize"
                   : "startDragging",
             },

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -160,8 +160,8 @@
 
       const drag = dragAttr !== "false";
       const container = containerAttr != null && containerAttr !== "false";
-      // default enable if not set, for backwards compatibility
-      const title = (titleAttr != null || drag) && titleAttr !== "false";
+      // default enable if not set and container not enable; for backwards compatibility
+      const title = (titleAttr != null || (drag && !container)) && titleAttr !== "false";
       // only can enable on container
       const interactable =
         interactableAttr != null && interactableAttr !== "false" && container;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
It's useful for set a element that has many children draggable.

eg.

A floating window need to be draggable when drag on any where, and can toggle maximize on double click on title.

Use to need set data-tauri-drag-region everywhere, and need to manually implement it for region that doesn't need maximize.

This PR let developer could achieve this just by set body attributes to `data-tauri-drag-region-container` and title container to `data-tauri-drag-region-container` `data-tauri-drag-region-titlebar`.

### Description:

`data-tauri-drag-region`: mark this element as "drag region"

`data-tauri-drag-region-container`: children are also considered drag regions

`data-tauri-drag-region-titlebar`: the "drag region" maximizes window on double click (default when only `data-tauri-drag-region` is used)

`data-tauri-drag-region-exclude`: this element doesn't trigger `drag`

### Example:

```html
<div class="titlebar"
     data-tauri-drag-region-container="true"
     data-tauri-drag-region-titlebar="true"
>
  <div>Title</div>
  <div>Some decoration</div>
  <button data-tauri-drag-region-exclude>close</button>
</div>
```