### PR TITLE
fix: symlink issue bundling for linux #5781

### DIFF
--- a/.changes/fix-5781.md
+++ b/.changes/fix-5781.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch'
+---
+
+Fixed error during bundling process for the appimage target on subsequent bundling attempts.

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -55,9 +55,9 @@ chmod +x "{{tauri_tools_path}}/AppRun-${ARCH}"
 cp "{{tauri_tools_path}}/AppRun-${ARCH}" AppRun
 
 cp "{{icon_path}}" .DirIcon
-ln -s "{{icon_path}}" "{{app_name}}.png"
+ln -sf "{{icon_path}}" "{{app_name}}.png"
 
-ln -s "usr/share/applications/{{app_name}}.desktop" "{{app_name}}.desktop"
+ln -sf "usr/share/applications/{{app_name}}.desktop" "{{app_name}}.desktop"
 
 cd ..
 


### PR DESCRIPTION
### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Frankly, this fix is more from @ca0v who suggested it in the issue thread #5781, rather than me just putting it in.

I have test run this on a single project with success, but I haven't tested beyond that.

About the issue:
The bundling script fails if it has run once before, as the links it creates already exist, and it _does not like that_. The added `-f` overwrites the existing links with a new one, which should be the desired behavior.