### PR TITLE
feat(core/tauri): add `try_get_item` for SystemTray and WindowMenu, closes #5491

### DIFF
--- a/.changes/tray_get_item.md
+++ b/.changes/tray_get_item.md
@@ -2,4 +2,4 @@
 'tauri': minor
 ---
 
-Add `MenuHandle::try_get_item` and `SystemTrayHandle::try_get_item` which returns a `Result` instead of panicking.
+Add `MenuHandle::try_get_item` and `SystemTrayHandle::try_get_item` which returns a `Option` instead of panicking.

--- a/.changes/tray_get_item.md
+++ b/.changes/tray_get_item.md
@@ -1,0 +1,5 @@
+---
+'tauri': minor
+---
+
+Add `MenuHandle::try_get_item` and `SystemTrayHandle::try_get_item` which returns a `Result` instead of panicking.

--- a/core/tauri/src/app/tray.rs
+++ b/core/tauri/src/app/tray.rs
@@ -610,6 +610,19 @@ impl<R: Runtime> SystemTrayHandle<R> {
     panic!("item id not found")
   }
 
+  /// Attempts to get a handle to the menu item that has the specified `id`, return an error if `id` is not found.
+  pub fn try_get_item(&self, id: MenuIdRef<'_>) -> Option<SystemTrayMenuItemHandle<R>> {
+    self
+      .ids
+      .lock()
+      .unwrap()
+      .iter()
+      .find(|i| i.1 == id)
+      .map(|i| SystemTrayMenuItemHandle {
+        id: *i.0,
+        tray_handler: self.inner.clone(),
+      })
+  }
   /// Updates the tray icon.
   pub fn set_icon(&self, icon: Icon) -> crate::Result<()> {
     self.inner.set_icon(icon.try_into()?).map_err(Into::into)

--- a/core/tauri/src/window/menu.rs
+++ b/core/tauri/src/window/menu.rs
@@ -80,6 +80,20 @@ impl<R: Runtime> MenuHandle<R> {
     panic!("item id not found")
   }
 
+  /// Attempts to get a handle to the menu item that has the specified `id`, return an error if `id` is not found.
+  pub fn try_get_item(&self, id: MenuIdRef<'_>) -> Option<MenuItemHandle<R>> {
+    self
+      .ids
+      .lock()
+      .unwrap()
+      .iter()
+      .find(|i| i.1 == id)
+      .map(|i| MenuItemHandle {
+        id: *i.0,
+        dispatcher: self.dispatcher.clone(),
+      })
+  }
+
   /// Shows the menu.
   pub fn show(&self) -> crate::Result<()> {
     self.dispatcher.show_menu().map_err(Into::into)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

I opened an issue, [seen here](https://github.com/tauri-apps/tauri/issues/5491), wondering whether Tauri should have methods to return Option<T> for System Tray & and Menu Items, rather than panicking on `get_item(x)`. This PR addressed that issue