### PR TITLE
fix(cli): use `npm run tauri -- foo` for correctly passing args to tauri

### DIFF
--- a/.changes/npm-pass-args.md
+++ b/.changes/npm-pass-args.md
@@ -1,0 +1,5 @@
+---
+'cli.rs': 'patch'
+---
+
+Correctly pass arguments from `npm run` to `tauri`.

--- a/.changes/npm-pass-args.md
+++ b/.changes/npm-pass-args.md
@@ -1,5 +1,6 @@
 ---
 'cli.rs': 'patch'
+"cli.js": patch
 ---
 
 Correctly pass arguments from `npm run` to `tauri`.

--- a/tooling/cli/src/mobile/init.rs
+++ b/tooling/cli/src/mobile/init.rs
@@ -134,6 +134,7 @@ pub fn exec(
         // remove script path, we'll use `npm_lifecycle_event` instead
         build_args.remove(0);
       }
+      build_args.insert(0, "--".into());
       build_args.insert(0, var("npm_lifecycle_event").unwrap());
       build_args.insert(0, "run".into());
     }

--- a/tooling/cli/src/mobile/ios/xcode_script.rs
+++ b/tooling/cli/src/mobile/ios/xcode_script.rs
@@ -12,7 +12,7 @@ use crate::{
 use clap::Parser;
 use tauri_mobile::{apple::target::Target, opts::Profile, util};
 
-use std::{collections::HashMap, ffi::OsStr, path::PathBuf};
+use std::{collections::HashMap, env::var_os, ffi::OsStr, path::PathBuf};
 
 #[derive(Debug, Parser)]
 pub struct Options {
@@ -55,16 +55,18 @@ pub fn command(options: Options) -> Result<()> {
     }
   }
 
-  // `xcode-script` is ran from the `gen/apple` folder.
-  std::env::set_current_dir(
-    std::env::current_dir()
-      .unwrap()
-      .parent()
-      .unwrap()
-      .parent()
-      .unwrap(),
-  )
-  .unwrap();
+  // `xcode-script` is ran from the `gen/apple` folder when not using NPM.
+  if var_os("npm_lifecycle_event").is_none() {
+    std::env::set_current_dir(
+      std::env::current_dir()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap(),
+    )
+    .unwrap();
+  }
 
   let profile = profile_from_configuration(&options.configuration);
   let macos = macos_from_platform(&options.platform);

--- a/tooling/cli/templates/mobile/ios/project.yml
+++ b/tooling/cli/templates/mobile/ios/project.yml
@@ -116,7 +116,7 @@ targets:
         discoveredDependencyFile: {{this.discovered-dependency-file}}{{/if}}
       {{~/each}}
 
-      - script: {{ tauri-binary }} {{ tauri-binary-args-str }} -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:?}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
+      - script: {{ tauri-binary }} {{ tauri-binary-args-str }} -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
         name: Build Rust Code
         basedOnDependencyAnalysis: false
         outputFiles:


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

If use `npm run tauri android init` for generating Android project, we will get some error like this when `run dev`:

```
error: unexpected argument 'aarch64' found
Usage: npm run tauri android android-studio-script [OPTIONS]
For more information, try '--help'.
```

Executed commandis:

```
npm run  tauri android android-studio-script --target aarch64
```

NPM will consume argument `--target`, then pass `android android-studio-script aarch64` to tauri.

When using npm, we should use `--` for passing args into tauri.

Instead, we should use `npm run  tauri -- android android-studio-script --target aarch64`.

The minimum case is `npm run tauri -v` which will output NPM version.

I have tested with `pnpm` and `yarn`, 

Also see https://github.com/npm/npm/pull/5518




