### PR TITLE
feat: add `tauri::version`, similar to `getTauriVersion` available on JS API

### DIFF
--- a/.changes/add-tauri-get-version.md
+++ b/.changes/add-tauri-get-version.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch"
+---
+
+Added `tauri::version` function to retrieve Tauri's version from Rust.

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -326,6 +326,11 @@ pub trait Runtime: runtime::Runtime<EventLoopMessage> {}
 
 impl<W: runtime::Runtime<EventLoopMessage>> Runtime for W {}
 
+/// Returns Tauri version.
+pub fn version() -> &'static str {
+  env!("CARGO_PKG_VERSION")
+}
+
 /// Reads the config file at compile time and generates a [`Context`] based on its content.
 ///
 /// The default config file path is a `tauri.conf.json` file inside the Cargo manifest directory of


### PR DESCRIPTION

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Just like getTauriVersion, but available exposed on tauri crate so it can be retrieve from rust. 
Getting Tauri version is useful for logging and instrumentation