### PR TITLE
docs: update grammer

### DIFF
--- a/core/config-schema/schema.json
+++ b/core/config-schema/schema.json
@@ -1431,7 +1431,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Download the bootstrapper and run it. Requires internet connection. Results in a smaller installer size, but is not recommended on Windows 7.",
+          "description": "Download the bootstrapper and run it. Requires an internet connection. Results in a smaller installer size, but is not recommended on Windows 7.",
           "type": "object",
           "required": [
             "type"
@@ -1452,7 +1452,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Embed the bootstrapper and run it. Requires internet connection. Increases the installer size by around 1.8MB, but offers better support on Windows 7.",
+          "description": "Embed the bootstrapper and run it. Requires an internet connection. Increases the installer size by around 1.8MB, but offers better support on Windows 7.",
           "type": "object",
           "required": [
             "type"
@@ -1473,7 +1473,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Embed the offline installer and run it. Does not require internet connection. Increases the installer size by around 127MB.",
+          "description": "Embed the offline installer and run it. Does not require an internet connection. Increases the installer size by around 127MB.",
           "type": "object",
           "required": [
             "type"

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -506,7 +506,7 @@ pub enum WebviewInstallMode {
   /// Do not install the Webview2 as part of the Windows Installer.
   Skip,
   /// Download the bootstrapper and run it.
-  /// Requires internet connection.
+  /// Requires an internet connection.
   /// Results in a smaller installer size, but is not recommended on Windows 7.
   DownloadBootstrapper {
     /// Instructs the installer to run the bootstrapper in silent mode. Defaults to `true`.
@@ -514,7 +514,7 @@ pub enum WebviewInstallMode {
     silent: bool,
   },
   /// Embed the bootstrapper and run it.
-  /// Requires internet connection.
+  /// Requires an internet connection.
   /// Increases the installer size by around 1.8MB, but offers better support on Windows 7.
   EmbedBootstrapper {
     /// Instructs the installer to run the bootstrapper in silent mode. Defaults to `true`.
@@ -522,7 +522,7 @@ pub enum WebviewInstallMode {
     silent: bool,
   },
   /// Embed the offline installer and run it.
-  /// Does not require internet connection.
+  /// Does not require an internet connection.
   /// Increases the installer size by around 127MB.
   OfflineInstaller {
     /// Instructs the installer to run the installer in silent mode. Defaults to `true`.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1431,7 +1431,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Download the bootstrapper and run it. Requires internet connection. Results in a smaller installer size, but is not recommended on Windows 7.",
+          "description": "Download the bootstrapper and run it. Requires an internet connection. Results in a smaller installer size, but is not recommended on Windows 7.",
           "type": "object",
           "required": [
             "type"
@@ -1452,7 +1452,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Embed the bootstrapper and run it. Requires internet connection. Increases the installer size by around 1.8MB, but offers better support on Windows 7.",
+          "description": "Embed the bootstrapper and run it. Requires an internet connection. Increases the installer size by around 1.8MB, but offers better support on Windows 7.",
           "type": "object",
           "required": [
             "type"
@@ -1473,7 +1473,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Embed the offline installer and run it. Does not require internet connection. Increases the installer size by around 127MB.",
+          "description": "Embed the offline installer and run it. Does not require an internet connection. Increases the installer size by around 127MB.",
           "type": "object",
           "required": [
             "type"


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
I originally made a change similar to this in the tauri-docs repo, but was told that I should make the change in this repo instead (see [#3 of this comment](https://github.com/tauri-apps/tauri-docs/pull/1183#issuecomment-1483863398)).

This PR essentially changes:
* Requires internet connection.

to:
* Requires an internet connection.

which is a small change and not necessarily a typo fix since the shorter form was probably intentional. So if you would prefer to just keep it as is, feel free to reject this PR. I mainly just wanted to follow up on that [tauri-docs PR](https://github.com/tauri-apps/tauri-docs/pull/1183), but I also do think it reads better with the added "an."