### PR TITLE
fix(bundler): fix problem of macOS bunder while i18n is set, closes #6614

### DIFF
--- a/.changes/fix-dmg-bundle.md
+++ b/.changes/fix-dmg-bundle.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Fixes DMG bundling not finding bundle to set icon position.

--- a/tooling/bundler/src/bundle/macos/dmg.rs
+++ b/tooling/bundler/src/bundle/macos/dmg.rs
@@ -96,7 +96,7 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
     "--volname",
     product_name,
     "--icon",
-    product_name,
+    &bundle_file_name,
     "180",
     "170",
     "--app-drop-link",


### PR DESCRIPTION

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
