### PR TITLE
fix(cli.js): detect node-20 binary

### DIFF
--- a/.changes/clijs-node-version-20.md
+++ b/.changes/clijs-node-version-20.md
@@ -1,5 +1,5 @@
 ---
-'cli.js': patch
+'@tauri-apps/cli': patch
 ---
 
 Fix nodejs binary regex when `0` is in the version name, for example `node-20`

--- a/.changes/clijs-node-version-20.md
+++ b/.changes/clijs-node-version-20.md
@@ -1,0 +1,5 @@
+---
+'cli.js': patch
+---
+
+Fix nodejs binary regex when `0` is in the version name, for example `node-20`

--- a/tooling/cli/node/tauri.js
+++ b/tooling/cli/node/tauri.js
@@ -20,7 +20,7 @@ if (bin === '@tauri-apps/cli') {
 }
 // Even if started by a package manager, the binary will be NodeJS.
 // Some distribution still use "nodejs" as the binary name.
-else if (binStem.match(/(nodejs|node)\-?([1-9]*)*$/g)) {
+else if (binStem.match(/(nodejs|node)\-?([0-9]*)*$/g)) {
   const managerStem = process.env.npm_execpath
     ? path.parse(process.env.npm_execpath).name.toLowerCase()
     : null


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

While looking at #6427 I noticed the regex for the node version was [1-9], but according to the [nodejs release schedule](https://github.com/nodejs/Release) v20 will release on the 18th, and this regex will not work for node version 20.
