### PR TITLE
fix: sound for notifications on windows (fix #6652)

### DIFF
--- a/.changes/core-windows-notification-sound.md
+++ b/.changes/core-windows-notification-sound.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch"
+---
+
+Play a sound when showing a notification on Windows.

--- a/core/tauri/src/api/notification.rs
+++ b/core/tauri/src/api/notification.rs
@@ -119,6 +119,9 @@ impl Notification {
       {
         notification.app_id(&self.identifier);
       }
+      
+      // will be parsed as a `::winrt_notification::Sound`
+      notification.sound_name("Default");
     }
     #[cfg(target_os = "macos")]
     {

--- a/core/tauri/src/api/notification.rs
+++ b/core/tauri/src/api/notification.rs
@@ -119,7 +119,7 @@ impl Notification {
       {
         notification.app_id(&self.identifier);
       }
-      
+
       // will be parsed as a `::winrt_notification::Sound`
       notification.sound_name("Default");
     }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Fixes #6652 so that a sound is played when showing a notification on Windows 10.

I tested my changes using:

```toml
[patch.crates-io]
tauri = { git = "https://github.com/Lej77/tauri.git", branch = "patch-1"}
```
on a simple Tauri app and the fix seems to be working.