### PR TITLE
feat(core): early panic if the PNG icon is not RGBA, closes #6706

### DIFF
--- a/.changes/early-panic-for-png-not-rgba.md
+++ b/.changes/early-panic-for-png-not-rgba.md
@@ -1,0 +1,5 @@
+---
+"tauri-codegen": 'patch:enhance'
+---
+
+Early panic if the PNG icon is not RGBA.

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -516,6 +516,13 @@ fn png_icon<P: AsRef<Path>>(
   let mut reader = decoder
     .read_info()
     .unwrap_or_else(|e| panic!("failed to read icon {}: {}", path.display(), e));
+
+  let (color_type, _) = reader.output_color_type();
+
+  if color_type != png::ColorType::Rgba {
+    panic!("icon {} is not RGBA", path.display());
+  }
+
   let mut buffer: Vec<u8> = Vec::new();
   while let Ok(Some(row)) = reader.next_row() {
     buffer.extend(row.data());


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
