### PR TITLE
feat(build): Use `embed-resource` for windows resource compilation

### DIFF
--- a/core/tauri-build/Cargo.toml
+++ b/core/tauri-build/Cargo.toml
@@ -28,8 +28,9 @@ heck = "0.4"
 json-patch = "0.3"
 walkdir = "2"
 filetime = "0.2"
-tauri-winres = "0.1"
+winres = "0.1"
 semver = "1"
+embed-resource = "2.1"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 swift-rs = { version = "1.0.4", features = [ "build" ] }


### PR DESCRIPTION
First draft for resolving #6746

`embed-resource` has a better compiler detection that `winres`, this improves the cross compilation support.

Also remove the need for `winres` fork for the cross-compilation support.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [X] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

But it could by removing `tauri_build::WindowsAttributes::sdk_dir()` if integrated in `2.0.0`, as is I only deprecated the API.

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
