### PR TITLE
feat(core): expose Wry's `with_incognito` to Tauri on the `WindowBuilder::incognito` function.

### DIFF
--- a/.changes/config-incognito.md
+++ b/.changes/config-incognito.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:feat'
+---
+
+Add `incognito` option to the window configuration object.

--- a/.changes/core-incognito.md
+++ b/.changes/core-incognito.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:feat'
+---
+
+Add `WindowBuilder::incognito`

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -184,10 +184,10 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
       .tauri
       .security
       .dev_csp
-      .clone()
-      .or_else(|| config.tauri.security.csp.clone())
+      .as_ref()
+      .or(config.tauri.security.csp.as_ref())
   } else {
-    config.tauri.security.csp.clone()
+    config.tauri.security.csp.as_ref()
   };
   if csp.is_some() {
     options = options.with_csp();

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -514,6 +514,11 @@
               "type": "null"
             }
           ]
+        },
+        "incognito": {
+          "description": "Whether or not the webview should be launched in incognito  mode.\n\n## Platform-specific:\n\n- **Android**: Unsupported.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/core/tauri-macros/src/mobile.rs
+++ b/core/tauri-macros/src/mobile.rs
@@ -34,7 +34,7 @@ fn get_env_var<R: FnOnce(String) -> String>(
 
 pub fn entry_point(_attributes: TokenStream, item: TokenStream) -> TokenStream {
   let function = parse_macro_input!(item as ItemFn);
-  let function_name = function.sig.ident.clone();
+  let function_name = &function.sig.ident;
 
   let mut error = None;
   let domain = get_env_var("TAURI_ANDROID_PACKAGE_PREFIX", |r| r, &mut error, &function);

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -3133,6 +3133,10 @@ fn create_webview<T: UserEvent>(
     webview_builder.webview.clipboard = true;
   }
 
+  if webview_attributes.incognito {
+    webview_builder.webview.incognito = true;
+  }
+
   #[cfg(any(debug_assertions, feature = "devtools"))]
   {
     webview_builder = webview_builder.with_devtools(true);

--- a/core/tauri-runtime/src/webview.rs
+++ b/core/tauri-runtime/src/webview.rs
@@ -30,11 +30,13 @@ pub struct WebviewAttributes {
   pub accept_first_mouse: bool,
   pub additional_browser_args: Option<String>,
   pub window_effects: Option<WindowEffectsConfig>,
+  pub incognito: bool,
 }
 
 impl From<&WindowConfig> for WebviewAttributes {
   fn from(config: &WindowConfig) -> Self {
     let mut builder = Self::new(config.url.clone());
+    builder = builder.incognito(config.incognito);
     builder = builder.accept_first_mouse(config.accept_first_mouse);
     if !config.file_drop_enabled {
       builder = builder.disable_file_drop_handler();
@@ -65,6 +67,7 @@ impl WebviewAttributes {
       accept_first_mouse: false,
       additional_browser_args: None,
       window_effects: None,
+      incognito: false,
     }
   }
 
@@ -124,6 +127,13 @@ impl WebviewAttributes {
   #[must_use]
   pub fn window_effects(mut self, effects: WindowEffectsConfig) -> Self {
     self.window_effects = Some(effects);
+    self
+  }
+
+  /// Enable or disable incognito mode for the WebView.
+  #[must_use]
+  pub fn incognito(mut self, incognito: bool) -> Self {
+    self.incognito = incognito;
     self
   }
 }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -938,6 +938,13 @@ pub struct WindowConfig {
   /// - **Linux**: Unsupported
   #[serde(default, alias = "window-effects")]
   pub window_effects: Option<WindowEffectsConfig>,
+  /// Whether or not the webview should be launched in incognito  mode.
+  ///
+  ///  ## Platform-specific:
+  ///
+  ///  - **Android**: Unsupported.
+  #[serde(default)]
+  pub incognito: bool,
 }
 
 impl Default for WindowConfig {
@@ -978,6 +985,7 @@ impl Default for WindowConfig {
       additional_browser_args: None,
       shadow: true,
       window_effects: None,
+      incognito: false,
     }
   }
 }
@@ -2161,6 +2169,7 @@ mod build {
       let additional_browser_args = opt_str_lit(self.additional_browser_args.as_ref());
       let shadow = self.shadow;
       let window_effects = opt_lit(self.window_effects.as_ref());
+      let incognito = self.incognito;
 
       literal_struct!(
         tokens,
@@ -2199,7 +2208,8 @@ mod build {
         tabbing_identifier,
         additional_browser_args,
         shadow,
-        window_effects
+        window_effects,
+        incognito
       );
     }
   }

--- a/core/tauri/src/event/listener.rs
+++ b/core/tauri/src/event/listener.rs
@@ -235,14 +235,12 @@ mod test {
 
     // check to see if on_event properly grabs the stored function from listen.
     #[test]
-    fn check_on_event(e in "[a-z]+", d in "[a-z]+") {
+    fn check_on_event(key in "[a-z]+", d in "[a-z]+") {
       let listeners: Listeners = Default::default();
-      // clone e as the key
-      let key = e.clone();
       // call listen with e and the event_fn dummy func
-      listeners.listen(e.clone(), None, event_fn);
+      listeners.listen(key.clone(), None, event_fn);
       // call on event with e and d.
-      listeners.trigger(&e, None, Some(d));
+      listeners.trigger(&key, None, Some(d));
 
       // lock the mutex
       let l = listeners.inner.handlers.lock().unwrap();

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -741,6 +741,17 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
     self.webview_attributes.clipboard = true;
     self
   }
+
+  /// Enable or disable incognito mode for the WebView..
+  ///
+  ///  ## Platform-specific:
+  ///
+  ///  **Android**: Unsupported.
+  #[must_use]
+  pub fn incognito(mut self, incognito: bool) -> Self {
+    self.webview_attributes.incognito = incognito;
+    self
+  }
 }
 
 /// Key for a JS event listener.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -514,6 +514,11 @@
               "type": "null"
             }
           ]
+        },
+        "incognito": {
+          "description": "Whether or not the webview should be launched in incognito  mode.\n\n## Platform-specific:\n\n- **Android**: Unsupported.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
While `WebViewBuilder::data_directory` could simulate incognito mode by setting this to a temporary directory, that is annoying to use and error-prone as users could forget deleting the directory, thus creating large unnecessary directories, filling up the user's storage.

This PR merely exposes `with_incognito` from https://github.com/tauri-apps/wry/pull/916 to Tauri though the new `enable_incognito` function at the `WindowBuilder`, which would allow for a real incognito mode that would be useful for things that need incognito mode, like webview sign-ins.

NOTE: Requires Wry 0.27.3 or higher, thus this should be merged for 2.0.