### PR TITLE
refactor(core): generate TauriActivity on build script

### DIFF
--- a/.changes/generate-tauri-activity.md
+++ b/.changes/generate-tauri-activity.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Generate `TauriActivity` Kotlin class on the build script.

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-License-Identifier: MIT
 
-name: test mobile
+name: test android
 
 on:
   pull_request:
@@ -14,6 +14,7 @@ on:
       - '!tooling/cli/src/mobile/ios/**'
       - 'core/tauri-build/src/mobile.rs'
       - 'core/tauri/mobile/android/**'
+      - 'core/tauri/mobile/android-codegen/**'
   workflow_dispatch:
 
 concurrency:

--- a/core/tauri-runtime-wry/Cargo.toml
+++ b/core/tauri-runtime-wry/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [ "CHANGELOG.md", "/target" ]
 readme = "README.md"
 
 [dependencies]
-wry = { version = "0.28.1", default-features = false, features = [ "file-drop", "protocol" ] }
+wry = { version = "0.28.2", default-features = false, features = [ "file-drop", "protocol" ] }
 tauri-runtime = { version = "0.13.0-alpha.4", path = "../tauri-runtime" }
 tauri-utils = { version = "2.0.0-alpha.4", path = "../tauri-utils" }
 uuid = { version = "1", features = [ "v4" ] }

--- a/core/tauri/mobile/android-codegen/TauriActivity.kt
+++ b/core/tauri/mobile/android-codegen/TauriActivity.kt
@@ -1,3 +1,7 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
 /* THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!! */
 
 package {{package}}

--- a/core/tauri/mobile/android-codegen/TauriActivity.kt
+++ b/core/tauri/mobile/android-codegen/TauriActivity.kt
@@ -1,4 +1,6 @@
-package {{reverse-domain app.domain}}.{{snake-case app.name}}
+/* THIS FILE IS AUTO-GENERATED. DO NOT MODIFY!! */
+
+package {{package}}
 
 import android.os.Bundle
 import app.tauri.plugin.PluginManager

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -4001,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc4072414a89ef95559d499f3b1930c773fb4457759ec78fe3a9849883ee22d"
+checksum = "77dbd1fe0556bf87517db301c9be2bdc18f6311c0826c73b2c80a7f79ac0e31f"
 dependencies = [
  "base64 0.13.1",
  "block",


### PR DESCRIPTION
With this change, modifications to the TauriActivity are handled by Tauri itself instead of relying on an Android project update by users.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
