### PR TITLE
fix(tauri-build): escape path to tauri-android project

### DIFF
--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -318,8 +318,8 @@ dependencies {"
       gradle_settings.push_str(&format!("include ':{plugin_name}'"));
       gradle_settings.push('\n');
       gradle_settings.push_str(&format!(
-        "project(':{plugin_name}').projectDir = new File('{}')",
-        plugin.path.display()
+        "project(':{plugin_name}').projectDir = new File({:?})",
+        tauri_utils::display_path(plugin.path)
       ));
       gradle_settings.push('\n');
 


### PR DESCRIPTION
On Windows, the previous behavior rendered it as `'D:\dev\tauri-app\src-tauri\gen'` and it will trigger and error, we need to escape the backslash.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
