### PR TITLE
feat: add `key.properties` to android gitignore

### DIFF
--- a/.changes/cli-key-properties.md
+++ b/.changes/cli-key-properties.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Add `key.properties` file to android's `.gitignore`.

--- a/tooling/cli/templates/mobile/android/.gitignore
+++ b/tooling/cli/templates/mobile/android/.gitignore
@@ -13,6 +13,7 @@ build
 .externalNativeBuild
 .cxx
 local.properties
+key.properties
 
 /.tauri
 /tauri.settings.gradle


### PR DESCRIPTION
`local.properties` file may get overridden by gradle to store `sdk.dir`

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
