### PR TITLE
fix(ios): use correct class to call plugin command with `throws`

### DIFF
--- a/.changes/fix-ios-plugin-throws-command.md
+++ b/.changes/fix-ios-plugin-throws-command.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+Use actual iOS plugin instance to run command with `throws`.

--- a/core/tauri/mobile/ios-api/Sources/Tauri/Tauri.swift
+++ b/core/tauri/mobile/ios-api/Sources/Tauri/Tauri.swift
@@ -64,7 +64,7 @@ public class PluginManager {
 					var error: NSError? = nil
 					withUnsafeMutablePointer(to: &error) {
 						let methodIMP: IMP! = plugin.instance.method(for: selectorWithThrows)
-						unsafeBitCast(methodIMP, to: (@convention(c)(Any?, Selector, Invoke, OpaquePointer) -> Void).self)(plugin, selectorWithThrows, invoke, OpaquePointer($0))
+						unsafeBitCast(methodIMP, to: (@convention(c)(Any?, Selector, Invoke, OpaquePointer) -> Void).self)(plugin.instance, selectorWithThrows, invoke, OpaquePointer($0))
 					}
 					if let error = error {
 						invoke.reject("\(error)")


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
