### PR TITLE
fix(core): pin `winnow` dependency to 0.4.1 to keep 1.60 MSRV

### DIFF
--- a/core/tauri-build/CHANGELOG.md
+++ b/core/tauri-build/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added support for Cargo's workspace inheritance for package information. The cli now also detects inherited `tauri` and `tauri-build` dependencies and disables manifest rewrites accordingly.
   - [cd8c074a](https://www.github.com/tauri-apps/tauri/commit/cd8c074ae6592303d3f6844a4fb6d262eae913b2) feat(cli): add support for Cargo's workspace inheritance for the package version, closes [#5070](https://www.github.com/tauri-apps/tauri/pull/5070) ([#5775](https://www.github.com/tauri-apps/tauri/pull/5775)) on 2022-12-14
   - [d20a7288](https://www.github.com/tauri-apps/tauri/commit/d20a728892eee1858ab525ab6216cd721f473ab5) feat: Further improve workspace inheritance, closes [#6122](https://www.github.com/tauri-apps/tauri/pull/6122), [#5070](https://www.github.com/tauri-apps/tauri/pull/5070) ([#6144](https://www.github.com/tauri-apps/tauri/pull/6144)) on 2023-01-26
+- Pin `winnow` crate to 0.4.1 to keep the 1.60 MSRV.
 
 ## \[1.2.1]
 

--- a/core/tauri-build/Cargo.toml
+++ b/core/tauri-build/Cargo.toml
@@ -22,6 +22,7 @@ quote = { version = "1", optional = true }
 tauri-codegen = { version = "1.3.0", path = "../tauri-codegen", optional = true }
 tauri-utils = { version = "1.3.0", path = "../tauri-utils", features = [ "build", "resources" ] }
 cargo_toml = "0.15"
+winnow = "=0.4.1"
 serde = "1"
 serde_json = "1"
 heck = "0.4"

--- a/core/tauri/CHANGELOG.md
+++ b/core/tauri/CHANGELOG.md
@@ -54,6 +54,7 @@
   - [49dff27e](https://www.github.com/tauri-apps/tauri/commit/49dff27ef1b36c48dbfd49f44b9b3ac07b372bdf) feat(core): create WindowBuilder from WindowConfig ([#6073](https://www.github.com/tauri-apps/tauri/pull/6073)) on 2023-01-17
 - On Windows, Fix missing `WindowEvent::Focused` in `App::run` callback.
   - [ff4ea1ea](https://www.github.com/tauri-apps/tauri/commit/ff4ea1eabbf2874b113c6b4698002929bbac737a) fix: dispatch focus event to app.run on Windows, closes [#6460](https://www.github.com/tauri-apps/tauri/pull/6460) ([#6504](https://www.github.com/tauri-apps/tauri/pull/6504)) on 2023-03-31
+- Pin `winnow` crate to 0.4.1 to keep the 1.60 MSRV.
 
 ## \[1.2.4]
 

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -123,6 +123,7 @@ tauri = { path = ".", default-features = false, features = [ "wry" ] }
 tokio-test = "0.4.2"
 tokio = { version = "1", features = [ "full" ] }
 cargo_toml = "0.11"
+winnow = "=0.4.1"
 
 [features]
 default = [ "wry", "compression", "objc-exception" ]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
