### PR TITLE
fix(cli): clear plugin JSON file before rebuilding

### DIFF
--- a/.changes/fix-plugin-removal.md
+++ b/.changes/fix-plugin-removal.md
@@ -1,0 +1,6 @@
+---
+"cli.rs": patch
+"cli.js": patch
+---
+
+Clear Android plugin JSON file before building Rust library to ensure removed plugins are propagated to the Android project.

--- a/tooling/cli/src/mobile/mod.rs
+++ b/tooling/cli/src/mobile/mod.rs
@@ -24,7 +24,7 @@ use std::{
   env::{set_var, temp_dir},
   ffi::OsString,
   fmt::Write,
-  fs::{create_dir_all, read_to_string, write},
+  fs::{create_dir_all, read_to_string, remove_file, write},
   net::SocketAddr,
   path::PathBuf,
   process::{exit, ExitStatus},
@@ -318,6 +318,7 @@ fn ensure_init(project_dir: PathBuf, target: Target) -> Result<()> {
   } else {
     if target == Target::Android {
       create_dir_all(project_dir.join(".tauri"))?;
+      let _ = remove_file(project_dir.join(".tauri").join("plugins.json"));
     }
     Ok(())
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Ensures removal of plugins are propagated to the Android project.