### PR TITLE
use handlebars::no_escape instead of closures

### DIFF
--- a/tooling/bundler/src/bundle/linux/appimage.rs
+++ b/tooling/bundler/src/bundle/linux/appimage.rs
@@ -81,7 +81,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   // initialize shell script template.
   let mut handlebars = Handlebars::new();
-  handlebars.register_escape_fn(|s| s.into());
+  handlebars.register_escape_fn(handlebars::no_escape);
   handlebars
     .register_template_string("appimage", include_str!("templates/appimage"))
     .expect("Failed to register template for handlebars");

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -614,7 +614,7 @@ pub fn build_wix_app_installer(
 
   let mut fragment_paths = Vec::new();
   let mut handlebars = Handlebars::new();
-  handlebars.register_escape_fn(|s| s.into());
+  handlebars.register_escape_fn(handlebars::no_escape);
   let mut has_custom_template = false;
   let mut enable_elevated_update_task = false;
 
@@ -693,7 +693,7 @@ pub fn build_wix_app_installer(
 
     // Create the Powershell script to install the task
     let mut skip_uac_task_installer = Handlebars::new();
-    skip_uac_task_installer.register_escape_fn(|s| s.into());
+    skip_uac_task_installer.register_escape_fn(handlebars::no_escape);
     let xml = include_str!("../templates/install-task.ps1");
     skip_uac_task_installer
       .register_template_string("install-task.ps1", xml)
@@ -705,7 +705,7 @@ pub fn build_wix_app_installer(
 
     // Create the Powershell script to uninstall the task
     let mut skip_uac_task_uninstaller = Handlebars::new();
-    skip_uac_task_uninstaller.register_escape_fn(|s| s.into());
+    skip_uac_task_uninstaller.register_escape_fn(handlebars::no_escape);
     let xml = include_str!("../templates/uninstall-task.ps1");
     skip_uac_task_uninstaller
       .register_template_string("uninstall-task.ps1", xml)

--- a/tooling/cli/src/init.rs
+++ b/tooling/cli/src/init.rs
@@ -184,7 +184,7 @@ pub fn command(mut options: Options) -> Result<()> {
 
     let _ = remove_dir_all(&template_target_path);
     let mut handlebars = Handlebars::new();
-    handlebars.register_escape_fn(|s| s.into());
+    handlebars.register_escape_fn(handlebars::no_escape);
 
     let mut data = BTreeMap::new();
     data.insert("tauri_dep", to_json(tauri_dep));

--- a/tooling/cli/src/plugin/init.rs
+++ b/tooling/cli/src/plugin/init.rs
@@ -90,7 +90,7 @@ pub fn command(mut options: Options) -> Result<()> {
 
     let _ = remove_dir_all(&template_target_path);
     let mut handlebars = Handlebars::new();
-    handlebars.register_escape_fn(|s| s.into());
+    handlebars.register_escape_fn(handlebars::no_escape);
 
     let mut data = BTreeMap::new();
     data.insert("plugin_name_original", to_json(&options.plugin_name));


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Simply changes the places where we use a closure of `|s| s.into()` for [`Handlebars::register_escape_fn`](https://docs.rs/handlebars/latest/handlebars/struct.Handlebars.html#method.register_escape_fn) to [`handlebars::no_escape`](https://docs.rs/handlebars/latest/handlebars/fn.no_escape.html) which performs the same action but with a more clear name.