### PR TITLE
fix(bundler): ensure that there are no duplicate extension arguments when bundling on Windows, fixes #6103

### DIFF
--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -356,10 +356,7 @@ fn run_light(
 ) -> crate::Result<()> {
   let light_exe = wix_toolset_path.join("light.exe");
 
-  let mut args: Vec<String> = vec![
-    "-o".to_string(),
-    display_path(output_path),
-  ];
+  let mut args: Vec<String> = vec!["-o".to_string(), display_path(output_path)];
 
   args.extend(arguments);
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
This PR fixes #6103 .

Suppose we intend to enhance the installer by extending WIX fragments. In one of these fragments, we utilized the wix util/ui extension. However, the initial code would add any extension used in fragments as `light` arguments, which resulting in a bug.

This pull request replaced the previous `fragment_extensions` vector with a hashset in order to resolve the bug.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
