### PR TITLE
fix(nsis): prefill $INSTDIR with previous install path and respect `/D` flag, closes #6928

### DIFF
--- a/.changes/nsis-restore-installation-path.md
+++ b/.changes/nsis-restore-installation-path.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch'
+---
+
+Fix NSIS installer not using the old installation path as a default.

--- a/.changes/nsis-restore-installation-path.md
+++ b/.changes/nsis-restore-installation-path.md
@@ -2,4 +2,5 @@
 'tauri-bundler': 'patch'
 ---
 
-Fix NSIS installer not using the old installation path as a default.
+- Fix NSIS installer not using the old installation path as a default when using `perMachine` or `currentUser` install modes.
+- NSIS will now respect the `/D` flag which used to set the installation directory from command line.

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -60,11 +60,6 @@ SetCompressor /SOLID lzma
   !define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_VALUENAME "CurrentUser"
   !define MULTIUSER_INSTALLMODEPAGE_SHOWUSERNAME
   !define MULTIUSER_INSTALLMODE_FUNCTION RestorePreviousInstallLocation
-  Function RestorePreviousInstallLocation
-    ReadRegStr $4 SHCTX "${MANUPRODUCTKEY}" ""
-    StrCmp $4 "" +2 0
-      StrCpy $INSTDIR $4
-  FunctionEnd
   !define MULTIUSER_EXECUTIONLEVEL Highest
   !include MultiUser.nsh
 !endif
@@ -307,6 +302,8 @@ Function .onInit
     !else if "${INSTALLMODE}" == "currentUser"
       StrCpy $INSTDIR "$LOCALAPPDATA\${PRODUCTNAME}"
     !endif
+
+    Call RestorePreviousInstallLocation
   ${EndIf}
 
 
@@ -531,3 +528,9 @@ Section Uninstall
 
   DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
 SectionEnd
+
+Function RestorePreviousInstallLocation
+  ReadRegStr $4 SHCTX "${MANUPRODUCTKEY}" ""
+  StrCmp $4 "" +2 0
+    StrCpy $INSTDIR $4
+FunctionEnd


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
