### PR TITLE
fix(ci): use `workflow-dispatch` action to trigger next branch workflow

### DIFF
--- a/.github/workflows/covector-version-or-publish-next.yml
+++ b/.github/workflows/covector-version-or-publish-next.yml
@@ -72,20 +72,17 @@ jobs:
         if: |
           steps.covector.outputs.successfulPublish == 'true' &&
           contains(steps.covector.outputs.packagesPublished, 'cli.rs')
-        uses: peter-evans/repository-dispatch@v1
+        uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}
-          repository: tauri-apps/tauri
-          event-type: publish-clijs
-          client-payload: '{"releaseId": "${{ steps.covector.outputs.cli.js-releaseId }}", "ref": "${{ github.ref }}" }'
+          workflow: publish-cli-js.yml
+          inputs: '{"releaseId": "${{ steps.covector.outputs.cli.js-releaseId }}", "ref": "${{ github.ref }}" }'
 
       - name: Trigger cli.rs publishing workflow
         if: |
           steps.covector.outputs.successfulPublish == 'true' &&
           contains(steps.covector.outputs.packagesPublished, 'cli.rs')
-        uses: peter-evans/repository-dispatch@v1
+        uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.ORG_TAURI_BOT_PAT }}
-          repository: tauri-apps/tauri
-          event-type: publish-clirs
-          client-payload: '{"ref": "${{ github.ref }}" }'
+          workflow: publish-cli-rs.yml

--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -92,8 +92,6 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.client_payload.ref || '' }}
       - name: Setup node
         uses: actions/setup-node@v3
         if: ${{ !matrix.settings.docker }}
@@ -403,4 +401,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.ORG_NPM_TOKEN }}
-          RELEASE_ID: ${{ github.event.client_payload.releaseId || github.event.inputs.releaseId }}
+          RELEASE_ID: ${{ github.event.client_payload.releaseId || inputs.releaseId }}

--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -33,8 +33,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.client_payload.ref || '' }}
 
       - name: 'Setup Rust'
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

The repository_dispatch action does not support triggering workflow on a custom branch, see [the issue](https://github.com/peter-evans/repository-dispatch/issues/39#issuecomment-671657524). We can't test this before the release but it should work. We need to trigger the workflow from the `next` branch since it differs from the `dev` one. Another approach would be merging the next workflow to dev, but that is confusing and harder to maintain.