### PR TITLE
chore: reuse `defaultArchList`

### DIFF
--- a/tooling/cli/templates/mobile/android/buildSrc/src/main/kotlin/RustPlugin.kt
+++ b/tooling/cli/templates/mobile/android/buildSrc/src/main/kotlin/RustPlugin.kt
@@ -21,7 +21,7 @@ open class RustPlugin : Plugin<Project> {
         val abiList = (findProperty("abiList") as? String)?.split(',') ?: defaultAbiList
 
         val defaultArchList = listOf({{quote-and-join arch-list}});
-        val archList = (findProperty("archList") as? String)?.split(',') ?: listOf({{quote-and-join arch-list}})
+        val archList = (findProperty("archList") as? String)?.split(',') ?: defaultArchList
 
         val targetsList = (findProperty("targetList") as? String)?.split(',') ?: listOf({{quote-and-join target-list}})
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
