### PR TITLE
fix: updated appimage script to follow symlinks for /usr/lib* (fix: #6992)

### DIFF
--- a/.changes/appimage-follow-symlinks.md
+++ b/.changes/appimage-follow-symlinks.md
@@ -1,0 +1,6 @@
+---
+'tauri-bundler': 'patch'
+---
+
+- Updated the AppImage bundler to follow symlinks for `/usr/lib*`.
+- Fixes AppImage bundling for Void Linux, which was failing to bundle webkit2gtk because the `/usr/lib64` is a symlink to `/usr/lib`.

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -42,10 +42,10 @@ if [[ "$TRAY_LIBRARY_PATH" != "0" ]]; then
   fi
 fi
 
-# Copy WebKit files.
-find /usr/lib* -name WebKitNetworkProcess -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
-find /usr/lib* -name WebKitWebProcess -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
-find /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
+# Copy WebKit files. Follow symlinks in case `/usr/lib64` is a symlink to `/usr/lib`
+find -L /usr/lib* -name WebKitNetworkProcess -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
+find -L /usr/lib* -name WebKitWebProcess -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
+find -L /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec mkdir -p "$(dirname '{}')" \; -exec cp --parents '{}' "." \; || true
 
 ( cd "{{tauri_tools_path}}" && ( wget -q -4 -N https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-${ARCH} || wget -q -4 -N https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-${ARCH} ) )
 chmod +x "{{tauri_tools_path}}/AppRun-${ARCH}"


### PR DESCRIPTION
# Fix: updated appimage script to follow symlinks for /usr/lib* (fix: #6992)

### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
