### PR TITLE
feat: adding copyright text to BrandingText

### DIFF
--- a/.changes/nsis-branding.md
+++ b/.changes/nsis-branding.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:enhance'
+---
+
+Added Copyright field as BrandingText to the NSIS bundler.

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -177,6 +177,7 @@ fn build_nsis_app_installer(
   data.insert("bundle_id", to_json(bundle_id));
   data.insert("manufacturer", to_json(manufacturer));
   data.insert("product_name", to_json(settings.product_name()));
+  data.insert("copyright", to_json(settings.copyright_string()));
 
   let version = settings.version_string();
   data.insert("version", to_json(version));

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -30,6 +30,7 @@ Var ReinstallPageCheck
 !define MANUPRODUCTKEY "Software\${MANUFACTURER}\${PRODUCTNAME}"
 
 Name "${PRODUCTNAME}"
+BrandingText "{{copyright}}"
 OutFile "${OUTFILE}"
 Unicode true
 SetCompressor /SOLID lzma


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
I added the `copyright` field from the bundle configuration as BrandingText in NSIS in order for users to be able to get rid of the `Nullsoft Install System vX.X.X` text from their installer.

I wouldn't consider BrandingText to be a breaking change. If you leave the copyright field blank you still get the Nullsoft message. If you set the copyright text to something, it'll show up there.