### PR TITLE
feat: current_version feature

### DIFF
--- a/.changes/add-webview-version.md
+++ b/.changes/add-webview-version.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch'
+---
+
+Added `tauri::webview_version` , to get webview version.

--- a/.changes/add-webview-version.md
+++ b/.changes/add-webview-version.md
@@ -1,5 +1,5 @@
 ---
-'tauri': 'patch'
+'tauri': 'minor'
 ---
 
 Added `tauri::webview_version` , to get webview version.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -67,6 +67,7 @@ use wry::{
   webview::{FileDropEvent as WryFileDropEvent, Url, WebContext, WebView, WebViewBuilder},
 };
 
+pub use wry::webview::webview_version;
 pub use wry::application::window::{Window, WindowBuilder as WryWindowBuilder, WindowId};
 
 #[cfg(windows)]

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -67,8 +67,8 @@ use wry::{
   webview::{FileDropEvent as WryFileDropEvent, Url, WebContext, WebView, WebViewBuilder},
 };
 
-pub use wry::webview::webview_version;
 pub use wry::application::window::{Window, WindowBuilder as WryWindowBuilder, WindowId};
+pub use wry::webview::webview_version;
 
 #[cfg(windows)]
 use wry::webview::WebviewExtWindows;

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -210,6 +210,10 @@ use std::{collections::HashMap, fmt, sync::Arc};
 // Export types likely to be used by the application.
 pub use runtime::http;
 
+#[cfg(feature = "wry")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "wry")))]
+pub use tauri_runtime_wry::webview_version;
+
 #[cfg(target_os = "macos")]
 #[cfg_attr(doc_cfg, doc(cfg(target_os = "macos")))]
 pub use runtime::{menu::NativeImage, ActivationPolicy};


### PR DESCRIPTION
fixes : #6995 

As I see in this example : 
```rust
  let _webview = WebViewBuilder::new(window)?
    .with_url("https://tauri.studio")?
    .build()?;
```
it will return WindowWrapper and suppose current_version can fetch with it . but with collaborator guide can move it . 