### PR TITLE
fix(tests): only download update when it is available

### DIFF
--- a/core/tests/app-updater/src/main.rs
+++ b/core/tests/app-updater/src/main.rs
@@ -27,9 +27,11 @@ fn main() {
       tauri::async_runtime::spawn(async move {
         match handle.updater().check().await {
           Ok(update) => {
-            if let Err(e) = update.download_and_install().await {
-              println!("{e}");
-              std::process::exit(1);
+            if update.is_update_available() {
+              if let Err(e) = update.download_and_install().await {
+                println!("{e}");
+                std::process::exit(1);
+              }
             }
             std::process::exit(0);
           }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

#6987 exposed an issue on our updater e2e test: it downloads and installs the update even when the version matches. This causes a race condition between the NSIS and WiX test because when the NSIS app restarts, it makes a request to the /download endpoint which closes the server, breaking the other test.