### PR TITLE
Fix missing quote in Japanese NSIS language file.

### DIFF
--- a/.changes/nsis-japanese-fix.md
+++ b/.changes/nsis-japanese-fix.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch'
+---
+
+Fix missing quote in Japanese NSIS language file.

--- a/.changes/nsis-japanese-fix.md
+++ b/.changes/nsis-japanese-fix.md
@@ -1,5 +1,5 @@
 ---
-'tauri-bundler': 'patch'
+'tauri-bundler': 'patch:bug'
 ---
 
 Fix missing quote in Japanese NSIS language file.

--- a/tooling/bundler/src/bundle/windows/templates/nsis-languages/Japanese.nsh
+++ b/tooling/bundler/src/bundle/windows/templates/nsis-languages/Japanese.nsh
@@ -18,7 +18,7 @@ LangString unableToUninstall ${LANG_JAPANESE} "アンインストールできま
 LangString uninstallApp ${LANG_JAPANESE} "${PRODUCTNAME} をアンインストールする"
 LangString uninstallBeforeInstalling ${LANG_JAPANESE} "インストールする前にアンインストールする"
 LangString unknown ${LANG_JAPANESE} "不明"
-LangString webview2AbortError ${LANG_JAPANESE} WebView2 のインストールに失敗しました。 WebView2 がないとアプリは実行できません。インストーラーを再起動してください。"
+LangString webview2AbortError ${LANG_JAPANESE} "WebView2 のインストールに失敗しました。 WebView2 がないとアプリは実行できません。インストーラーを再起動してください。"
 LangString webview2DownloadError ${LANG_JAPANESE} "エラー: WebView2 のダウンロードに失敗しました - $0"
 LangString webview2DownloadSuccess ${LANG_JAPANESE} "WebView2 ブートストラップ が正常にダウンロードされました"
 LangString webview2Downloading ${LANG_JAPANESE} "WebView2 ブートストラップ をダウンロード中です..."


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Trying to build an NSIS installer with Japanese enabled currently fails with the following error:
```
!include: error in script: "Japanese.nsh" on line 21
Error in script "D:\a\Oyasumi\Oyasumi\src-tauri\target\debug\nsis\x64\installer.nsi" on line 342 -- aborting creation process
Error failed to bundle project: `The system cannot find the file specified. (os error 2)`
```