### PR TITLE
feat(cli): Build the CLI for Windows ARM64, closes #7015

### DIFF
--- a/.changes/cli-windows-arm64.md
+++ b/.changes/cli-windows-arm64.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': minor
+'@tauri-apps/cli': minor
+---
+
+Provide prebuilt CLIs for Windows ARM64 targets.

--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -40,6 +40,10 @@ jobs:
             build: yarn build:release --target i686-pc-windows-msvc
             target: i686-pc-windows-msvc
             architecture: x64
+          - host: windows-latest
+            architecture: x64
+            target: aarch64-pc-windows-msvc
+            build: yarn build:release --target aarch64-pc-windows-msvc --features native-tls-vendored --cargo-flags="--no-default-features"
           - host: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
@@ -84,10 +88,6 @@ jobs:
               rustup target add aarch64-unknown-linux-musl
               yarn build:release --target aarch64-unknown-linux-musl
               /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
-          #- host: windows-latest
-          #  architecture: x64
-          #  target: aarch64-pc-windows-msvc
-          #  build: yarn build:release --target aarch64-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
     steps:

--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -21,15 +21,23 @@ jobs:
           - os: ubuntu-20.04
             rust_target: x86_64-unknown-linux-gnu
             ext: ''
+            args: ''
           - os: macos-latest
             rust_target: x86_64-apple-darwin
             ext: ''
+            args: ''
           - os: macos-latest
             rust_target: aarch64-apple-darwin
             ext: ''
+            args: ''
           - os: windows-latest
             rust_target: x86_64-pc-windows-msvc
             ext: '.exe'
+            args: ''
+          - os: windows-latest
+            rust_target: aarch64-pc-windows-msvc
+            ext: '.exe'
+            args: '--no-default-features --features native-tls-vendored'
 
     steps:
       - name: Checkout
@@ -54,7 +62,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ./tooling/cli/Cargo.toml --release
+          args: --manifest-path ./tooling/cli/Cargo.toml --release ${{ matrix.config.args }}
 
       - name: Upload CLI
         uses: actions/upload-artifact@v3

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -3792,6 +3792,7 @@ dependencies = [
  "base64 0.13.1",
  "flate2",
  "log",
+ "native-tls",
  "once_cell",
  "rustls 0.20.8",
  "url",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -59,7 +59,7 @@ handlebars = "4.3"
 include_dir = "0.7"
 minisign = "0.7"
 base64 = "0.21.0"
-ureq = "2.5"
+ureq = {version="2.5", default-features = false, features = ["gzip"]}
 os_info = "3"
 semver = "1.0"
 regex = "1.6.0"
@@ -95,6 +95,7 @@ lto = true
 
 [features]
 default = [ "rustls" ]
-native-tls = [ "tauri-bundler/native-tls" ]
-native-tls-vendored = [ "tauri-bundler/native-tls-vendored" ]
-rustls = [ "tauri-bundler/rustls" ]
+native-tls = [ "tauri-bundler/native-tls", "ureq/native-tls" ]
+# ureq doesn't have a vendored mode but atto's feature should hopefully take care of it.
+native-tls-vendored = [ "tauri-bundler/native-tls-vendored", "ureq/native-tls" ]
+rustls = [ "tauri-bundler/rustls", "ureq/tls" ]

--- a/tooling/cli/node/Cargo.toml
+++ b/tooling/cli/node/Cargo.toml
@@ -10,8 +10,12 @@ crate-type = ["cdylib"]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.12", default-features = false, features = ["napi4"] }
 napi-derive = "2.12"
-tauri-cli = { path = ".." }
+tauri-cli = { path = "..", default-features = false }
 log = "0.4.17"
 
 [build-dependencies]
 napi-build = "2.0"
+
+[features]
+default = ["tauri-cli/default"]
+native-tls-vendored = ["tauri-cli/native-tls-vendored"]

--- a/tooling/cli/node/npm/win32-arm64-msvc/README.md
+++ b/tooling/cli/node/npm/win32-arm64-msvc/README.md
@@ -1,0 +1,3 @@
+# `@tauri-apps/cli-win32-arm64-msvc`
+
+This is the **aarch64-pc-windows-msvc** binary for `@tauri-apps/cli`

--- a/tooling/cli/node/npm/win32-arm64-msvc/package.json
+++ b/tooling/cli/node/npm/win32-arm64-msvc/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@tauri-apps/cli-win32-arm64-msvc",
+  "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "main": "cli.win32-arm64-msvc.node",
+  "files": [
+    "cli.win32-arm64-msvc.node"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">= 10"
+  }
+}


### PR DESCRIPTION
This worked locally, i bet 10 bucks that it will fail in CI

### What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [x] Other, please describe: I have no idea which boxes to tick here

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary: We can't make Microsoft delete the arm64 windows version and ring takes ages for a new version so this is the next best thing.

### Other information

btw, building tauri apps _for_ arm still breaks as soon as people use _something_ that depends on ring (like everything that uses rustls) 🥳 

Closes #7015