### PR TITLE
ci: Use correct native-tls feature flags for win32-arm64 cli, ref #7098

### DIFF
--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -43,7 +43,7 @@ jobs:
           - host: windows-latest
             architecture: x64
             target: aarch64-pc-windows-msvc
-            build: yarn build:release --target aarch64-pc-windows-msvc --features native-tls-vendored --cargo-flags="--no-default-features"
+            build: yarn build:release --target aarch64-pc-windows-msvc --features native-tls,native-tls-vendored --cargo-flags="--no-default-features"
           - host: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian

--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -37,7 +37,7 @@ jobs:
           - os: windows-latest
             rust_target: aarch64-pc-windows-msvc
             ext: '.exe'
-            args: '--no-default-features --features native-tls-vendored'
+            args: '--no-default-features --features native-tls,native-tls-vendored'
 
     steps:
       - name: Checkout

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -97,5 +97,5 @@ lto = true
 default = [ "rustls" ]
 native-tls = [ "tauri-bundler/native-tls", "ureq/native-tls" ]
 # ureq doesn't have a vendored mode but atto's feature should hopefully take care of it.
-native-tls-vendored = [ "tauri-bundler/native-tls-vendored", "ureq/native-tls" ]
+native-tls-vendored = [ "tauri-bundler/native-tls-vendored" ]
 rustls = [ "tauri-bundler/rustls", "ureq/tls" ]

--- a/tooling/cli/node/Cargo.toml
+++ b/tooling/cli/node/Cargo.toml
@@ -18,4 +18,5 @@ napi-build = "2.0"
 
 [features]
 default = ["tauri-cli/default"]
+native-tls = ["tauri-cli/native-tls"]
 native-tls-vendored = ["tauri-cli/native-tls-vendored"]


### PR DESCRIPTION
Follow up of #7098 where i messed up the feature flags a bit ending up with a cli that had tls disabled altogether.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [x] Other, please describe: still no idea what to tick

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Can't wait for the new ring release so this stuff gets easier.....