### PR TITLE
fix: correct MIME type of .txt files (ref: #6762)

### DIFF
--- a/.changes/mime-type-fallback.md
+++ b/.changes/mime-type-fallback.md
@@ -2,5 +2,4 @@
 "tauri-utils": patch
 ---
 
-Change fallback of `MimeType::parse_from_uri` and `MimeType::parse` to `MimeType::Txt`.
-
+Change fallback of `MimeType::parse` to `MimeType::Txt`.

--- a/.changes/mime-type-fallback.md
+++ b/.changes/mime-type-fallback.md
@@ -1,5 +1,0 @@
----
-"tauri-utils": patch
----
-
-Change fallback of `MimeType::parse` to `MimeType::Txt`.

--- a/.changes/mime-type-fallback.md
+++ b/.changes/mime-type-fallback.md
@@ -1,0 +1,6 @@
+---
+"tauri-utils": patch
+---
+
+Change fallback of `MimeType::parse_from_uri` and `MimeType::parse` to `MimeType::Txt`.
+

--- a/.changes/txt-mime-type.md
+++ b/.changes/txt-mime-type.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch
+---
+
+Correctly determine MIME type of `.txt` files.

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -93,6 +93,7 @@ jobs:
           cargo update -p time --precise 0.3.15
           cargo update -p ignore --precise 0.4.18
           cargo update -p raw-window-handle --precise 0.5.0
+          cargo update -p cargo_toml:0.15.3 --precise 0.15.2
 
       - name: test
         run: cargo test --target ${{ matrix.platform.target }} ${{ matrix.features.args }}

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -176,10 +176,10 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
       .tauri
       .security
       .dev_csp
-      .clone()
-      .or_else(|| config.tauri.security.csp.clone())
+      .as_ref()
+      .or(config.tauri.security.csp.as_ref())
   } else {
-    config.tauri.security.csp.clone()
+    config.tauri.security.csp.as_ref()
   };
   if csp.is_some() {
     options = options.with_csp();

--- a/core/tauri-macros/src/command_module.rs
+++ b/core/tauri-macros/src/command_module.rs
@@ -272,12 +272,12 @@ pub fn command_handler(attributes: HandlerAttributes, function: ItemFn) -> Token
 pub fn command_test(attributes: HandlerTestAttributes, function: ItemFn) -> TokenStream2 {
   let allowlist = attributes.allowlist;
   let error_message = attributes.error_message.as_str();
-  let signature = function.sig.clone();
+  let signature = &function.sig;
 
   let enum_variant_name = function.sig.ident.to_string().to_lower_camel_case();
   let response = match attributes.allowlist_check_kind {
     AllowlistCheckKind::Runtime => {
-      let test_name = function.sig.ident.clone();
+      let test_name = &signature.ident;
       quote!(super::Cmd::#test_name(crate::test::mock_invoke_context()))
     }
     AllowlistCheckKind::Serde => quote! {

--- a/core/tauri-utils/src/mime_type.rs
+++ b/core/tauri-utils/src/mime_type.rs
@@ -39,7 +39,7 @@ impl std::fmt::Display for MimeType {
       MimeType::OctetStream => "application/octet-stream",
       MimeType::Rtf => "application/rtf",
       MimeType::Svg => "image/svg+xml",
-      MimeType::Txt => &MIMETYPE_PLAIN,
+      MimeType::Txt => MIMETYPE_PLAIN,
     };
     write!(f, "{mime}")
   }

--- a/core/tauri-utils/src/mime_type.rs
+++ b/core/tauri-utils/src/mime_type.rs
@@ -149,6 +149,6 @@ mod tests {
     assert_eq!(txt, String::from("text/plain"));
 
     let custom_scheme = MimeType::parse_from_uri("wry://tauri.app").to_string();
-    assert_eq!(custom_scheme, String::from("text/html"));
+    assert_eq!(custom_scheme, String::from("text/plain"));
   }
 }

--- a/core/tauri-utils/src/mime_type.rs
+++ b/core/tauri-utils/src/mime_type.rs
@@ -68,7 +68,7 @@ impl MimeType {
       Some("rtf") => Self::Rtf,
       Some("svg") => Self::Svg,
       Some("txt") => Self::Txt,
-      // use fallback on unknown suffixes
+      // Assume HTML when a TLD is found for eg. `wry:://tauri.app` | `wry://hello.com`
       Some(_) => fallback,
       // using octet stream according to this:
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
@@ -78,7 +78,7 @@ impl MimeType {
 
   /// infer mimetype from content (or) URI if needed.
   pub fn parse(content: &[u8], uri: &str) -> String {
-    Self::parse_with_fallback(content, uri, Self::Txt)
+    Self::parse_with_fallback(content, uri, Self::Html)
   }
   /// infer mimetype from content (or) URI if needed with specified fallback for unknown file extensions.
   pub fn parse_with_fallback(content: &[u8], uri: &str, fallback: MimeType) -> String {

--- a/core/tauri-utils/src/mime_type.rs
+++ b/core/tauri-utils/src/mime_type.rs
@@ -48,7 +48,7 @@ impl std::fmt::Display for MimeType {
 impl MimeType {
   /// parse a URI suffix to convert text/plain mimeType to their actual web compatible mimeType.
   pub fn parse_from_uri(uri: &str) -> MimeType {
-    Self::parse_from_uri_with_fallback(uri, Self::Html)
+    Self::parse_from_uri_with_fallback(uri, Self::Txt)
   }
 
   /// parse a URI suffix to convert text/plain mimeType to their actual web compatible mimeType with specified fallback for unknown file extensions.
@@ -68,7 +68,7 @@ impl MimeType {
       Some("rtf") => Self::Rtf,
       Some("svg") => Self::Svg,
       Some("txt") => Self::Txt,
-      // Assume HTML when a TLD is found for eg. `wry:://tauri.app` | `wry://hello.com`
+      // use fallback on unknown suffixes
       Some(_) => fallback,
       // using octet stream according to this:
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
@@ -78,7 +78,7 @@ impl MimeType {
 
   /// infer mimetype from content (or) URI if needed.
   pub fn parse(content: &[u8], uri: &str) -> String {
-    Self::parse_with_fallback(content, uri, Self::Html)
+    Self::parse_with_fallback(content, uri, Self::Txt)
   }
   /// infer mimetype from content (or) URI if needed with specified fallback for unknown file extensions.
   pub fn parse_with_fallback(content: &[u8], uri: &str, fallback: MimeType) -> String {

--- a/core/tauri-utils/src/mime_type.rs
+++ b/core/tauri-utils/src/mime_type.rs
@@ -18,10 +18,11 @@ pub enum MimeType {
   Js,
   Json,
   Jsonld,
+  Mp4,
   OctetStream,
   Rtf,
   Svg,
-  Mp4,
+  Txt,
 }
 
 impl std::fmt::Display for MimeType {
@@ -34,10 +35,11 @@ impl std::fmt::Display for MimeType {
       MimeType::Js => "text/javascript",
       MimeType::Json => "application/json",
       MimeType::Jsonld => "application/ld+json",
+      MimeType::Mp4 => "video/mp4",
       MimeType::OctetStream => "application/octet-stream",
       MimeType::Rtf => "application/rtf",
       MimeType::Svg => "image/svg+xml",
-      MimeType::Mp4 => "video/mp4",
+      MimeType::Txt => &MIMETYPE_PLAIN,
     };
     write!(f, "{mime}")
   }
@@ -62,9 +64,10 @@ impl MimeType {
       Some("json") => Self::Json,
       Some("jsonld") => Self::Jsonld,
       Some("mjs") => Self::Js,
+      Some("mp4") => Self::Mp4,
       Some("rtf") => Self::Rtf,
       Some("svg") => Self::Svg,
-      Some("mp4") => Self::Mp4,
+      Some("txt") => Self::Txt,
       // Assume HTML when a TLD is found for eg. `wry:://tauri.app` | `wry://hello.com`
       Some(_) => fallback,
       // using octet stream according to this:
@@ -133,14 +136,17 @@ mod tests {
     let mjs: String = MimeType::parse_from_uri("https://example.com/bundled.mjs").to_string();
     assert_eq!(mjs, String::from("text/javascript"));
 
+    let mp4: String = MimeType::parse_from_uri("https://example.com/video.mp4").to_string();
+    assert_eq!(mp4, String::from("video/mp4"));
+
     let rtf: String = MimeType::parse_from_uri("https://example.com/document.rtf").to_string();
     assert_eq!(rtf, String::from("application/rtf"));
 
     let svg: String = MimeType::parse_from_uri("https://example.com/picture.svg").to_string();
     assert_eq!(svg, String::from("image/svg+xml"));
 
-    let mp4: String = MimeType::parse_from_uri("https://example.com/video.mp4").to_string();
-    assert_eq!(mp4, String::from("video/mp4"));
+    let txt: String = MimeType::parse_from_uri("https://example.com/file.txt").to_string();
+    assert_eq!(txt, String::from("text/plain"));
 
     let custom_scheme = MimeType::parse_from_uri("wry://tauri.app").to_string();
     assert_eq!(custom_scheme, String::from("text/html"));

--- a/core/tauri-utils/src/mime_type.rs
+++ b/core/tauri-utils/src/mime_type.rs
@@ -48,7 +48,7 @@ impl std::fmt::Display for MimeType {
 impl MimeType {
   /// parse a URI suffix to convert text/plain mimeType to their actual web compatible mimeType.
   pub fn parse_from_uri(uri: &str) -> MimeType {
-    Self::parse_from_uri_with_fallback(uri, Self::Txt)
+    Self::parse_from_uri_with_fallback(uri, Self::Html)
   }
 
   /// parse a URI suffix to convert text/plain mimeType to their actual web compatible mimeType with specified fallback for unknown file extensions.
@@ -149,6 +149,6 @@ mod tests {
     assert_eq!(txt, String::from("text/plain"));
 
     let custom_scheme = MimeType::parse_from_uri("wry://tauri.app").to_string();
-    assert_eq!(custom_scheme, String::from("text/plain"));
+    assert_eq!(custom_scheme, String::from("text/html"));
   }
 }

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -282,14 +282,13 @@ mod test {
 
     // check to see if on_event properly grabs the stored function from listen.
     #[test]
-    fn check_on_event(e in "[a-z]+", d in "[a-z]+") {
+    fn check_on_event(key in "[a-z]+", d in "[a-z]+") {
       let listeners: Listeners = Default::default();
-      // clone e as the key
-      let key = e.clone();
+
       // call listen with e and the event_fn dummy func
-      listeners.listen(e.clone(), None, event_fn);
+      listeners.listen(key.clone(), None, event_fn);
       // call on event with e and d.
-      listeners.trigger(&e, None, Some(d));
+      listeners.trigger(&key, None, Some(d));
 
       // lock the mutex
       let l = listeners.inner.handlers.lock().unwrap();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

This sets the MIME type for .txt files as `text/plain` instead of `text/html`. See #6762 for more details. (Whether `text/html` is always the right fallback is also a question, but I haven't done anything about that here.)

I also moved MP4 up to its correct place alphabetically in a few places.