### PR TITLE
fix(bundler/macos): clean up .app bundle if only .dmg is enabled #7081

### DIFF
--- a/.changes/cleanup-app-bundle.md
+++ b/.changes/cleanup-app-bundle.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Remove macOS app bundles from the output if they are not requested by the user.

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -118,8 +118,8 @@ pub fn bundle_project(settings: Settings) -> crate::Result<Vec<Bundle>> {
         for app_bundle_path in &app_bundle_paths {
           info!(action = "Cleaning"; "{}", app_bundle_path.display());
           match app_bundle_path.is_dir() {
-            true => fs::remove_dir_all(&app_bundle_path),
-            false => fs::remove_file(&app_bundle_path),
+            true => fs::remove_dir_all(app_bundle_path),
+            false => fs::remove_file(app_bundle_path),
           }
           .with_context(|| {
             format!(

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -24,11 +24,12 @@ pub use self::{
     Settings, SettingsBuilder, UpdaterSettings,
   },
 };
+#[cfg(target_os = "macos")]
 use anyhow::Context;
 use log::{info, warn};
 pub use settings::{NsisSettings, WindowsSettings, WixLanguage, WixLanguageConfig, WixSettings};
 
-use std::{fmt::Write, fs, path::PathBuf};
+use std::{fmt::Write, path::PathBuf};
 
 /// Generated bundle metadata.
 #[derive(Debug)]
@@ -118,8 +119,8 @@ pub fn bundle_project(settings: Settings) -> crate::Result<Vec<Bundle>> {
         for app_bundle_path in &app_bundle_paths {
           info!(action = "Cleaning"; "{}", app_bundle_path.display());
           match app_bundle_path.is_dir() {
-            true => fs::remove_dir_all(app_bundle_path),
-            false => fs::remove_file(app_bundle_path),
+            true => std::fs::remove_dir_all(app_bundle_path),
+            false => std::fs::remove_file(app_bundle_path),
           }
           .with_context(|| {
             format!(

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -24,10 +24,11 @@ pub use self::{
     Settings, SettingsBuilder, UpdaterSettings,
   },
 };
+use anyhow::Context;
 use log::{info, warn};
 pub use settings::{NsisSettings, WindowsSettings, WixLanguage, WixLanguageConfig, WixSettings};
 
-use std::{fmt::Write, path::PathBuf};
+use std::{fmt::Write, fs, path::PathBuf};
 
 /// Generated bundle metadata.
 #[derive(Debug)]
@@ -41,7 +42,7 @@ pub struct Bundle {
 /// Bundles the project.
 /// Returns the list of paths where the bundles can be found.
 pub fn bundle_project(settings: Settings) -> crate::Result<Vec<Bundle>> {
-  let mut bundles = Vec::new();
+  let mut bundles: Vec<Bundle> = Vec::new();
   let package_types = settings.package_types()?;
 
   let target_os = settings
@@ -56,6 +57,11 @@ pub fn bundle_project(settings: Settings) -> crate::Result<Vec<Bundle>> {
   }
 
   for package_type in &package_types {
+    // bundle was already built! e.g. DMG already built .app
+    if bundles.iter().any(|b| b.package_type == *package_type) {
+      continue;
+    }
+
     let bundle_paths = match package_type {
       #[cfg(target_os = "macos")]
       PackageType::MacOsBundle => macos::app::bundle_project(&settings)?,
@@ -63,7 +69,16 @@ pub fn bundle_project(settings: Settings) -> crate::Result<Vec<Bundle>> {
       PackageType::IosBundle => macos::ios::bundle_project(&settings)?,
       // dmg is dependant of MacOsBundle, we send our bundles to prevent rebuilding
       #[cfg(target_os = "macos")]
-      PackageType::Dmg => macos::dmg::bundle_project(&settings, &bundles)?,
+      PackageType::Dmg => {
+        let bundled = macos::dmg::bundle_project(&settings, &bundles)?;
+        if !bundled.app.is_empty() {
+          bundles.push(Bundle {
+            package_type: PackageType::MacOsBundle,
+            bundle_paths: bundled.app,
+          });
+        }
+        bundled.dmg
+      }
 
       #[cfg(target_os = "windows")]
       PackageType::WindowsMsi => windows::msi::bundle_project(&settings, false)?,
@@ -88,6 +103,33 @@ pub fn bundle_project(settings: Settings) -> crate::Result<Vec<Bundle>> {
       package_type: package_type.to_owned(),
       bundle_paths,
     });
+  }
+
+  #[cfg(target_os = "macos")]
+  {
+    // Clean up .app if only building dmg or updater
+    if !package_types.contains(&PackageType::MacOsBundle) {
+      if let Some(app_bundle_paths) = bundles
+        .iter()
+        .position(|b| b.package_type == PackageType::MacOsBundle)
+        .map(|i| bundles.remove(i))
+        .map(|b| b.bundle_paths)
+      {
+        for app_bundle_path in &app_bundle_paths {
+          info!(action = "Cleaning"; "{}", app_bundle_path.display());
+          match app_bundle_path.is_dir() {
+            true => fs::remove_dir_all(&app_bundle_path),
+            false => fs::remove_file(&app_bundle_path),
+          }
+          .with_context(|| {
+            format!(
+              "Failed to clean the app bundle at {}",
+              app_bundle_path.display()
+            )
+          })?
+        }
+      }
+    }
   }
 
   let pluralised = if bundles.len() == 1 {

--- a/tooling/bundler/src/bundle/macos/app.rs
+++ b/tooling/bundler/src/bundle/macos/app.rs
@@ -219,7 +219,7 @@ fn copy_frameworks_to_bundle(bundle_directory: &Path, settings: &Settings) -> cr
     return Ok(());
   }
   let dest_dir = bundle_directory.join("Frameworks");
-  fs::create_dir_all(&bundle_directory)
+  fs::create_dir_all(bundle_directory)
     .with_context(|| format!("Failed to create Frameworks directory at {:?}", dest_dir))?;
   for framework in frameworks.iter() {
     if framework.ends_with(".framework") {
@@ -227,7 +227,7 @@ fn copy_frameworks_to_bundle(bundle_directory: &Path, settings: &Settings) -> cr
       let src_name = src_path
         .file_name()
         .expect("Couldn't get framework filename");
-      common::copy_dir(&src_path, &dest_dir.join(&src_name))?;
+      common::copy_dir(&src_path, &dest_dir.join(src_name))?;
       continue;
     } else if framework.ends_with(".dylib") {
       let src_path = PathBuf::from(framework);
@@ -238,7 +238,7 @@ fn copy_frameworks_to_bundle(bundle_directory: &Path, settings: &Settings) -> cr
         )));
       }
       let src_name = src_path.file_name().expect("Couldn't get library filename");
-      common::copy_file(&src_path, &dest_dir.join(&src_name))?;
+      common::copy_file(&src_path, &dest_dir.join(src_name))?;
       continue;
     } else if framework.contains('/') {
       return Err(crate::Error::GenericError(format!(

--- a/tooling/bundler/src/bundle/macos/sign.rs
+++ b/tooling/bundler/src/bundle/macos/sign.rs
@@ -288,7 +288,7 @@ pub fn notarize(
     info!("notarization started; waiting for Apple response...");
 
     let uuid = uuid[1].to_string();
-    get_notarization_status(uuid, auth_args, settings)?;
+    get_notarization_status(uuid, auth_args)?;
     staple_app(app_bundle_path.clone())?;
   } else {
     return Err(
@@ -322,11 +322,7 @@ fn staple_app(mut app_bundle_path: PathBuf) -> crate::Result<()> {
   Ok(())
 }
 
-fn get_notarization_status(
-  uuid: String,
-  auth_args: Vec<String>,
-  settings: &Settings,
-) -> crate::Result<()> {
+fn get_notarization_status(uuid: String, auth_args: Vec<String>) -> crate::Result<()> {
   std::thread::sleep(std::time::Duration::from_secs(10));
   let result = Command::new("xcrun")
     .args(vec!["altool", "--notarization-info", &uuid])
@@ -345,7 +341,7 @@ fn get_notarization_status(
     {
       let status = status[1].to_string();
       if status == "in progress" {
-        get_notarization_status(uuid, auth_args, settings)
+        get_notarization_status(uuid, auth_args)
       } else if status == "invalid" {
         Err(
           anyhow::anyhow!(format!(
@@ -366,10 +362,10 @@ fn get_notarization_status(
         Ok(())
       }
     } else {
-      get_notarization_status(uuid, auth_args, settings)
+      get_notarization_status(uuid, auth_args)
     }
   } else {
-    get_notarization_status(uuid, auth_args, settings)
+    get_notarization_status(uuid, auth_args)
   }
 }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

fix #7081. clean up .app bundle if only .dmg is enabled 