### PR TITLE
refactor: Replace once_cell with std lib

### DIFF
--- a/core/tauri/build.rs
+++ b/core/tauri/build.rs
@@ -6,11 +6,11 @@ use heck::AsShoutySnakeCase;
 use heck::AsSnakeCase;
 use heck::ToSnakeCase;
 
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 
 use std::{path::Path, sync::Mutex};
 
-static CHECKED_FEATURES: OnceCell<Mutex<Vec<String>>> = OnceCell::new();
+static CHECKED_FEATURES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 
 // checks if the given Cargo feature is enabled.
 fn has_feature(feature: &str) -> bool {

--- a/core/tauri/src/api/mod.rs
+++ b/core/tauri/src/api/mod.rs
@@ -45,7 +45,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 // Not public API
 #[doc(hidden)]
 pub mod private {
-  pub use once_cell::sync::OnceCell;
+  pub use std::sync::OnceLock;
 
   pub trait AsTauriContext {
     fn config() -> &'static crate::Config;

--- a/core/tauri/src/async_runtime.rs
+++ b/core/tauri/src/async_runtime.rs
@@ -10,7 +10,7 @@
 //! one you need isn't here, you could use types in [`tokio`] directly.
 //! For custom command handlers, it's recommended to use a plain `async fn` command.
 
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 pub use tokio::{
   runtime::{Handle as TokioHandle, Runtime as TokioRuntime},
   sync::{
@@ -26,7 +26,7 @@ use std::{
   task::{Context, Poll},
 };
 
-static RUNTIME: OnceCell<GlobalRuntime> = OnceCell::new();
+static RUNTIME: OnceLock<GlobalRuntime> = OnceLock::new();
 
 struct GlobalRuntime {
   runtime: Option<Runtime>,

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -846,10 +846,10 @@ pub mod test;
 #[cfg(test)]
 mod tests {
   use cargo_toml::Manifest;
-  use once_cell::sync::OnceCell;
+  use std::sync::OnceLock;
   use std::{env::var, fs::read_to_string, path::PathBuf};
 
-  static MANIFEST: OnceCell<Manifest> = OnceCell::new();
+  static MANIFEST: OnceLock<Manifest> = OnceLock::new();
   const CHECKED_FEATURES: &str = include_str!(concat!(env!("OUT_DIR"), "/checked_features"));
 
   fn get_manifest() -> &'static Manifest {

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -15,8 +15,8 @@ use clap::{ArgAction, Parser};
 
 use anyhow::{bail, Context};
 use log::{error, info, warn};
-use once_cell::sync::OnceCell;
 use shared_child::SharedChild;
+use std::sync::OnceLock;
 
 use std::{
   env::set_current_dir,
@@ -27,8 +27,8 @@ use std::{
   },
 };
 
-static BEFORE_DEV: OnceCell<Mutex<Arc<SharedChild>>> = OnceCell::new();
-static KILL_BEFORE_DEV_FLAG: OnceCell<AtomicBool> = OnceCell::new();
+static BEFORE_DEV: OnceLock<Mutex<Arc<SharedChild>>> = OnceLock::new();
+static KILL_BEFORE_DEV_FLAG: OnceLock<AtomicBool> = OnceLock::new();
 
 #[cfg(unix)]
 const KILL_CHILDREN_SCRIPT: &[u8] = include_bytes!("../scripts/kill-children.sh");


### PR DESCRIPTION
In version 1.70.0 OnceCell and OnceLock have been stabilized.  

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
