### PR TITLE
fix(core): Send updater status events when default dialog is enabled, closes #7128

### DIFF
--- a/.changes/updater-dialog-events.md
+++ b/.changes/updater-dialog-events.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:enhance
+---
+
+Send updater status events even if default dialog is enabled.

--- a/core/tauri/src/updater/mod.rs
+++ b/core/tauri/src/updater/mod.rs
@@ -423,8 +423,10 @@ pub(crate) async fn check_update_with_dialog<R: Runtime>(handle: AppHandle<R>) {
       Ok(updater) => {
         let pubkey = updater_config.pubkey.clone();
 
-        // if dialog enabled only
-        if updater.should_update && updater_config.dialog {
+        if !updater.should_update {
+          send_status_update(&handle, UpdaterEvent::AlreadyUpToDate);
+        } else if updater_config.dialog {
+          // if dialog enabled only
           let body = updater.body.clone().unwrap_or_else(|| String::from(""));
           let dialog =
             prompt_for_install(&updater.clone(), &package_info.name, &body.clone(), pubkey).await;
@@ -591,22 +593,41 @@ Release Notes:
   );
 
   if should_install {
+    let handle = update.app.clone();
+    let handle_ = handle.clone();
+
     // Launch updater download process
     // macOS we display the `Ready to restart dialog` asking to restart
     // Windows is closing the current App and launch the downloaded MSI when ready (the process stop here)
     // Linux we replace the AppImage by launching a new install, it start a new AppImage instance, so we're closing the previous. (the process stop here)
-    update
-      .download_and_install(pubkey.clone(), |_, _| (), || ())
-      .await?;
+    let update_result = update
+      .download_and_install(
+        pubkey.clone(),
+        move |chunk_length, content_length| {
+          send_download_progress_event(&handle, chunk_length, content_length);
+        },
+        move || {
+          send_status_update(&handle_, UpdaterEvent::Downloaded);
+        },
+      )
+      .await;
 
-    // Ask user if we need to restart the application
-    let should_exit = ask(
-      parent_window,
-      "Ready to Restart",
-      "The installation was successful, do you want to restart the application now?",
-    );
-    if should_exit {
-      update.app.restart();
+    if let Err(err) = &update_result {
+      // emit {"status": "ERROR", "error": "The error message"}
+      send_status_update(&update.app, UpdaterEvent::Error(err.to_string()));
+    } else {
+      // emit {"status": "DONE"}
+      send_status_update(&update.app, UpdaterEvent::Updated);
+
+      // Ask user if we need to restart the application
+      let should_exit = ask(
+        parent_window,
+        "Ready to Restart",
+        "The installation was successful, do you want to restart the application now?",
+      );
+      if should_exit {
+        update.app.restart();
+      }
     }
   }
 

--- a/core/tauri/src/updater/mod.rs
+++ b/core/tauri/src/updater/mod.rs
@@ -612,18 +612,17 @@ Release Notes:
       )
       .await?;
 
-      // emit {"status": "DONE"}
-      send_status_update(&update.app, UpdaterEvent::Updated);
+    // emit {"status": "DONE"}
+    send_status_update(&update.app, UpdaterEvent::Updated);
 
-      // Ask user if we need to restart the application
-      let should_exit = ask(
-        parent_window,
-        "Ready to Restart",
-        "The installation was successful, do you want to restart the application now?",
-      );
-      if should_exit {
-        update.app.restart();
-      }
+    // Ask user if we need to restart the application
+    let should_exit = ask(
+      parent_window,
+      "Ready to Restart",
+      "The installation was successful, do you want to restart the application now?",
+    );
+    if should_exit {
+      update.app.restart();
     }
   }
 

--- a/core/tauri/src/updater/mod.rs
+++ b/core/tauri/src/updater/mod.rs
@@ -600,7 +600,7 @@ Release Notes:
     // macOS we display the `Ready to restart dialog` asking to restart
     // Windows is closing the current App and launch the downloaded MSI when ready (the process stop here)
     // Linux we replace the AppImage by launching a new install, it start a new AppImage instance, so we're closing the previous. (the process stop here)
-    let update_result = update
+    update
       .download_and_install(
         pubkey.clone(),
         move |chunk_length, content_length| {
@@ -610,12 +610,8 @@ Release Notes:
           send_status_update(&handle_, UpdaterEvent::Downloaded);
         },
       )
-      .await;
+      .await?;
 
-    if let Err(err) = &update_result {
-      // emit {"status": "ERROR", "error": "The error message"}
-      send_status_update(&update.app, UpdaterEvent::Error(err.to_string()));
-    } else {
       // emit {"status": "DONE"}
       send_status_update(&update.app, UpdaterEvent::Updated);
 


### PR DESCRIPTION
I'm not sure if i catched everything, quite tricky to grasp the whole flow here tbh and like we said in the issue i didn't do much more than the bare minimum here.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
