### PR TITLE
fix(core): use `u32` for js listeners ids, closes #7119

### DIFF
--- a/.changes/core-js-listenrid-u32.md
+++ b/.changes/core-js-listenrid-u32.md
@@ -1,0 +1,6 @@
+---
+'tauri-runtime': 'patch'
+'tauri-runtime-wry': 'patch'
+---
+
+Use `u32` instead of `u64` for js event listener ids

--- a/.changes/core-js-listners-unlisten.md
+++ b/.changes/core-js-listners-unlisten.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Fix unlistening to window events failing sometimes.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -3308,7 +3308,7 @@ fn create_ipc_handler<T: UserEvent>(
   context: Context<T>,
   label: String,
   menu_ids: Arc<Mutex<HashMap<MenuHash, MenuId>>>,
-  js_event_listeners: Arc<Mutex<HashMap<JsEventListenerKey, HashSet<u64>>>>,
+  js_event_listeners: Arc<Mutex<HashMap<JsEventListenerKey, HashSet<u32>>>>,
   handler: WebviewIpcHandler<T, Wry<T>>,
 ) -> Box<IpcHandler> {
   Box::new(move |window, request| {

--- a/core/tauri-runtime/src/window.rs
+++ b/core/tauri-runtime/src/window.rs
@@ -231,7 +231,7 @@ pub struct PendingWindow<T: UserEvent, R: Runtime<T>> {
   pub menu_ids: Arc<Mutex<HashMap<MenuHash, MenuId>>>,
 
   /// A HashMap mapping JS event names with associated listener ids.
-  pub js_event_listeners: Arc<Mutex<HashMap<JsEventListenerKey, HashSet<u64>>>>,
+  pub js_event_listeners: Arc<Mutex<HashMap<JsEventListenerKey, HashSet<u32>>>>,
 
   /// A handler to decide if incoming url is allowed to navigate.
   pub navigation_handler: Option<Box<dyn Fn(Url) -> bool + Send>>,
@@ -362,7 +362,7 @@ pub struct DetachedWindow<T: UserEvent, R: Runtime<T>> {
   pub menu_ids: Arc<Mutex<HashMap<MenuHash, MenuId>>>,
 
   /// A HashMap mapping JS event names with associated listener ids.
-  pub js_event_listeners: Arc<Mutex<HashMap<JsEventListenerKey, HashSet<u64>>>>,
+  pub js_event_listeners: Arc<Mutex<HashMap<JsEventListenerKey, HashSet<u32>>>>,
 }
 
 impl<T: UserEvent, R: Runtime<T>> Clone for DetachedWindow<T, R> {

--- a/core/tauri/src/endpoints/event.rs
+++ b/core/tauri/src/endpoints/event.rs
@@ -67,7 +67,7 @@ pub enum Cmd {
   },
   /// Unlisten to an event.
   #[serde(rename_all = "camelCase")]
-  Unlisten { event: EventId, event_id: u64 },
+  Unlisten { event: EventId, event_id: u32 },
   /// Emit an event to the webview associated with the given window.
   /// If the window_label is omitted, the event will be triggered on all listeners.
   #[serde(rename_all = "camelCase")]
@@ -84,7 +84,7 @@ impl Cmd {
     event: EventId,
     window_label: Option<WindowLabel>,
     handler: CallbackFn,
-  ) -> super::Result<u64> {
+  ) -> super::Result<u32> {
     let event_id = rand::random();
 
     let window_label = window_label.map(|l| l.0);
@@ -110,7 +110,7 @@ impl Cmd {
   fn unlisten<R: Runtime>(
     context: InvokeContext<R>,
     event: EventId,
-    event_id: u64,
+    event_id: u32,
   ) -> super::Result<()> {
     context
       .window

--- a/core/tauri/src/event.rs
+++ b/core/tauri/src/event.rs
@@ -299,7 +299,7 @@ mod test {
   }
 }
 
-pub fn unlisten_js(listeners_object_name: String, event_name: String, event_id: u64) -> String {
+pub fn unlisten_js(listeners_object_name: String, event_name: String, event_id: u32) -> String {
   format!(
     "
       (function () {{
@@ -318,7 +318,7 @@ pub fn unlisten_js(listeners_object_name: String, event_name: String, event_id: 
 pub fn listen_js(
   listeners_object_name: String,
   event: String,
-  event_id: u64,
+  event_id: u32,
   window_label: Option<String>,
   handler: String,
 ) -> String {

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -1594,7 +1594,7 @@ impl<R: Runtime> Window<R> {
     self.window.dispatcher.eval_script(js).map_err(Into::into)
   }
 
-  pub(crate) fn register_js_listener(&self, window_label: Option<String>, event: String, id: u64) {
+  pub(crate) fn register_js_listener(&self, window_label: Option<String>, event: String, id: u32) {
     self
       .window
       .js_event_listeners
@@ -1608,7 +1608,7 @@ impl<R: Runtime> Window<R> {
       .insert(id);
   }
 
-  pub(crate) fn unregister_js_listener(&self, id: u64) {
+  pub(crate) fn unregister_js_listener(&self, id: u32) {
     let mut empty = None;
     let mut js_listeners = self.window.js_event_listeners.lock().unwrap();
     let iter = js_listeners.iter_mut();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information