### PR TITLE
fix(cli): Pin minisign to 0.7.3 to prevent issues with empty key passwords

### DIFF
--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -57,7 +57,7 @@ toml = "0.5"
 jsonschema = "0.16"
 handlebars = "4.3"
 include_dir = "0.7"
-minisign = "0.7"
+minisign = "=0.7.3"
 base64 = "0.21.0"
 ureq = {version="2.5", default-features = false, features = ["gzip"]}
 os_info = "3"


### PR DESCRIPTION
Using 0.7.5 will give me `Error incorrect updater private key password: Wrong password for that key` and since we want to release soon i thought pinning it would be faster than figuring out the issue (cause i have no idea what's going on lol)

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
![ah shit](https://github.com/tauri-apps/tauri/assets/30730186/73a1b0ee-78ad-4159-9df2-120d314e45eb)
