### PR TITLE
feat(api): use AsyncMessageDialog for non Linux, closes #7182

### DIFF
--- a/.changes/api-rs-dialog-center-dialog.md
+++ b/.changes/api-rs-dialog-center-dialog.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:feat'
+---
+
+On macOS, center the message dialog on the window.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Issue #7182 

This patch is trying to follow how `FileDialog` deals with the async dialog. Non-Linux systems will use the `AsyncMessageDialog`.

Tested in macOS, Windows, and Linux. Only macOS will center the dialog.

Although the issue requests to center the dialog on the `window`, I think someone might want to center the dialog on the `screen`.