### PR TITLE
fix(core): fix `require_literal_leading_dot` flipped behavior (#7227)

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -7,6 +7,7 @@
     "bug": "Bug Fixes",
     "pref": "Performance Improvements",
     "changes": "What's Changed",
+    "sec": "Security fixes",
     "deps": "Dependencies"
   },
   "defaultChangeTag": "changes",

--- a/.changes/core-leading-dot.md
+++ b/.changes/core-leading-dot.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:sec'
+---
+
+Fix regression in `1.4` where the default behavior of the file system scope was changed to allow reading hidden files and directories by default.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1935,7 +1935,7 @@
               }
             },
             "requireLiteralLeadingDot": {
-              "description": "Whether or not paths that contain components that start with a `.` will require that `.` appears literally in the pattern; `*`, `?`, `**`, or `[...]` will not match. This is useful because such files are conventionally considered hidden on Unix systems and it might be desirable to skip them when listing files.\n\nDefaults to `false` on Unix systems and `true` on Windows",
+              "description": "Whether or not paths that contain components that start with a `.` will require that `.` appears literally in the pattern; `*`, `?`, `**`, or `[...]` will not match. This is useful because such files are conventionally considered hidden on Unix systems and it might be desirable to skip them when listing files.\n\nDefaults to `true` on Unix systems and `false` on Windows",
               "type": [
                 "boolean",
                 "null"

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -1195,7 +1195,7 @@ pub enum FsScope {
     /// conventionally considered hidden on Unix systems and it might be
     /// desirable to skip them when listing files.
     ///
-    /// Defaults to `false` on Unix systems and `true` on Windows
+    /// Defaults to `true` on Unix systems and `false` on Windows
     // dotfiles are not supposed to be exposed by default on unix
     #[serde(alias = "require-literal-leading-dot")]
     require_literal_leading_dot: Option<bool>,

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -108,9 +108,9 @@ impl Scope {
       } => *require,
       // dotfiles are not supposed to be exposed by default on unix
       #[cfg(unix)]
-      _ => false,
-      #[cfg(windows)]
       _ => true,
+      #[cfg(windows)]
+      _ => false,
     };
 
     Ok(Self {
@@ -281,9 +281,9 @@ mod tests {
         require_literal_separator: true,
         // dotfiles are not supposed to be exposed by default on unix
         #[cfg(unix)]
-        require_literal_leading_dot: false,
-        #[cfg(windows)]
         require_literal_leading_dot: true,
+        #[cfg(windows)]
+        require_literal_leading_dot: false,
         ..Default::default()
       },
     }

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1935,7 +1935,7 @@
               }
             },
             "requireLiteralLeadingDot": {
-              "description": "Whether or not paths that contain components that start with a `.` will require that `.` appears literally in the pattern; `*`, `?`, `**`, or `[...]` will not match. This is useful because such files are conventionally considered hidden on Unix systems and it might be desirable to skip them when listing files.\n\nDefaults to `false` on Unix systems and `true` on Windows",
+              "description": "Whether or not paths that contain components that start with a `.` will require that `.` appears literally in the pattern; `*`, `?`, `**`, or `[...]` will not match. This is useful because such files are conventionally considered hidden on Unix systems and it might be desirable to skip them when listing files.\n\nDefaults to `true` on Unix systems and `false` on Windows",
               "type": [
                 "boolean",
                 "null"


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
