### PR TITLE
fix(cli): Split metadata.json per major version.

### DIFF
--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -87,7 +87,7 @@ jobs:
         run: ./.scripts/ci/pack-cli.sh
 
       - name: Get CLI version
-        run: echo "CLI_VERSION=$(cat tooling/cli/metadata.json | jq '."@tauri-apps/cli".version' -r)" >> $GITHUB_ENV
+        run: echo "CLI_VERSION=$(cat tooling/cli/metadata-v2.json | jq '."@tauri-apps/cli".version' -r)" >> $GITHUB_ENV
 
       - name: Publish release
         uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa

--- a/.scripts/covector/sync-cli-metadata.js
+++ b/.scripts/covector/sync-cli-metadata.js
@@ -17,8 +17,8 @@ const { resolve } = require('path')
 const packageNickname = process.argv[2]
 const filePath =
   packageNickname === '@tauri-apps/cli'
-    ? `../../../tooling/cli/metadata.json`
-    : `../../tooling/cli/metadata.json`
+    ? `../../../tooling/cli/metadata-v2.json`
+    : `../../tooling/cli/metadata-v2.json`
 const bump = process.argv[3]
 let index = null
 
@@ -50,7 +50,9 @@ const inc = (version) => {
     }
   }
   if (bump === 'premajor') {
-    const pre = JSON.parse(readFileSync(resolve(filePath, '../../../.changes/pre.json'), 'utf-8'))
+    const pre = JSON.parse(
+      readFileSync(resolve(filePath, '../../../.changes/pre.json'), 'utf-8')
+    )
     return `${v.join('.')}-${pre.tag}.0`
   }
   return v.join('.')
@@ -70,5 +72,5 @@ if (packageNickname === '@tauri-apps/cli') {
 }
 
 writeFileSync(filePath, JSON.stringify(metadata, null, 2) + '\n')
-console.log(`wrote ${version} for ${packageNickname} into metadata.json`)
+console.log(`wrote ${version} for ${packageNickname} into metadata-v2.json`)
 console.dir(metadata)

--- a/tooling/cli/metadata-v2.json
+++ b/tooling/cli/metadata-v2.json
@@ -1,0 +1,8 @@
+{
+  "cli.js": {
+    "version": "2.0.0-alpha.10",
+    "node": ">= 10.0.0"
+  },
+  "tauri": "2.0.0-alpha.10",
+  "tauri-build": "2.0.0-alpha.6"
+}

--- a/tooling/cli/metadata.json
+++ b/tooling/cli/metadata.json
@@ -1,8 +1,8 @@
 {
   "cli.js": {
-    "version": "2.0.0-alpha.10",
+    "version": "1.4.0",
     "node": ">= 10.0.0"
   },
-  "tauri": "2.0.0-alpha.10",
-  "tauri-build": "2.0.0-alpha.6"
+  "tauri": "1.4.0",
+  "tauri-build": "1.4.0"
 }

--- a/tooling/cli/src/info/mod.rs
+++ b/tooling/cli/src/info/mod.rs
@@ -35,7 +35,8 @@ pub struct VersionMetadata {
 }
 
 fn version_metadata() -> Result<VersionMetadata> {
-  serde_json::from_str::<VersionMetadata>(include_str!("../../metadata.json")).map_err(Into::into)
+  serde_json::from_str::<VersionMetadata>(include_str!("../../metadata-v2.json"))
+    .map_err(Into::into)
 }
 
 #[cfg(not(debug_assertions))]
@@ -46,7 +47,7 @@ pub(crate) fn cli_current_version() -> Result<String> {
 #[cfg(not(debug_assertions))]
 pub(crate) fn cli_upstream_version() -> Result<String> {
   let upstream_metadata = match ureq::get(
-    "https://raw.githubusercontent.com/tauri-apps/tauri/dev/tooling/cli/metadata.json",
+    "https://raw.githubusercontent.com/tauri-apps/tauri/dev/tooling/cli/metadata-v2.json",
   )
   .timeout(std::time::Duration::from_secs(3))
   .call()

--- a/tooling/cli/src/init.rs
+++ b/tooling/cli/src/init.rs
@@ -156,7 +156,7 @@ pub fn command(mut options: Options) -> Result<()> {
   options = options.load()?;
 
   let template_target_path = PathBuf::from(&options.directory).join("src-tauri");
-  let metadata = serde_json::from_str::<VersionMetadata>(include_str!("../metadata.json"))?;
+  let metadata = serde_json::from_str::<VersionMetadata>(include_str!("../metadata-v2.json"))?;
 
   if template_target_path.exists() && !options.force {
     warn!(

--- a/tooling/cli/src/plugin/init.rs
+++ b/tooling/cli/src/plugin/init.rs
@@ -201,7 +201,8 @@ pub fn plugin_name_data(data: &mut BTreeMap<&'static str, serde_json::Value>, pl
 }
 
 pub fn crates_metadata() -> Result<VersionMetadata> {
-  serde_json::from_str::<VersionMetadata>(include_str!("../../metadata.json")).map_err(Into::into)
+  serde_json::from_str::<VersionMetadata>(include_str!("../../metadata-v2.json"))
+    .map_err(Into::into)
 }
 
 pub fn generate_android_out_file(


### PR DESCRIPTION
This is a hotfix to prevent the v2-alpha update prompt that all v1 users are seeing right now. releasing just a new cli patch version is not sufficient imo.

Also this is now missing the auto-update so it requires us to update it manually, but i'd prefer not to wait any longer until we can find a solution for this, unless someone else has an idea already because i don't have one i'm comfortable with rn.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No, or maybe it does, but i'd rather have the v2 alpha cli broken than v1 stable.

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
