### PR TITLE
chore(deps): update unmaintained dependency from kuchiki to kuchikiki

### DIFF
--- a/.changes/kuchikiki.md
+++ b/.changes/kuchikiki.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:sec
+---
+
+Changed HTML implementation from unmaintained `kuchiki` to `kuchikiki`.

--- a/core/tauri-utils/Cargo.toml
+++ b/core/tauri-utils/Cargo.toml
@@ -19,8 +19,8 @@ thiserror = "1"
 phf = { version = "0.10", features = [ "macros" ] }
 brotli = { version = "3", optional = true, default-features = false, features = [ "std" ] }
 url = { version = "2", features = [ "serde" ] }
-kuchiki = "0.8"
-html5ever = "0.25"
+html5ever = "0.26"
+kuchiki = { package = "kuchikiki", version = "0.8" }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "1", optional = true }
 schemars = { version = "0.8", features = [ "url" ], optional = true }

--- a/core/tauri-utils/src/html.rs
+++ b/core/tauri-utils/src/html.rs
@@ -302,7 +302,7 @@ mod tests {
       assert_eq!(
         document.to_string(),
         format!(
-          r#"<html><head><meta content="{}" http-equiv="Content-Security-Policy"></head><body></body></html>"#,
+          r#"<html><head><meta http-equiv="Content-Security-Policy" content="{}"></head><body></body></html>"#,
           super::CSP_TOKEN
         )
       );

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -86,8 +86,8 @@ env_logger = "0.9.1"
 icns = { package = "tauri-icns", version = "0.1" }
 image = { version = "0.24", default-features = false, features = [ "ico" ] }
 axum = { version = "0.5.16", features = [ "ws" ] }
-html5ever = "0.25"
-kuchiki = "0.8"
+html5ever = "0.26"
+kuchiki = { package = "kuchikiki", version = "0.8" }
 tokio = { version = "1", features = [ "macros", "sync" ] }
 common-path = "1"
 serde-value = "0.7.0"


### PR DESCRIPTION
### What kind of change does this PR introduce?
Kuchiki is an unmainted dependency,  closes #6123 , closes #6411

Brave adopted kuchiki, renaming it to [kuchikiki](https://github.com/brave/kuchikiki), this PR switched from kuchiki to kuchikiki and update html5ever to version 0.26 to align the 2 versions.

### Does this PR introduce a breaking change?
No - As far I understand.

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
Using an unmaintained dependency is risky as it allows for vulnerabilities to slip through old cracks, it also block upgrading other packages (`html5ever` in this case). It should be addressed as quickly as possible, since the price to migrate only increases over time.
