### PR TITLE
feat(cli): check `cwd` for config file before traversing

### DIFF
--- a/.changes/tauri-app-in-same-dir.md
+++ b/.changes/tauri-app-in-same-dir.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:feat'
+'@tauri-apps/cli': 'patch:feat'
+---
+
+Support Tauri configuration (`tauri.conf.json(5)` / `Tauri.toml`) and `package.json` to be in the same directory.

--- a/.changes/tauri-app-in-same-dir.md
+++ b/.changes/tauri-app-in-same-dir.md
@@ -1,6 +1,0 @@
----
-'tauri-cli': 'patch:feat'
-'@tauri-apps/cli': 'patch:feat'
----
-
-Support Tauri configuration (`tauri.conf.json(5)` / `Tauri.toml`) and `package.json` to be in the same directory.

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -62,6 +62,13 @@ fn lookup<F: Fn(&PathBuf) -> bool>(dir: &Path, checker: F) -> Option<PathBuf> {
 fn get_tauri_dir() -> PathBuf {
   let cwd = current_dir().expect("failed to read cwd");
 
+  if cwd.join(ConfigFormat::Json.into_file_name()).exists()
+    || cwd.join(ConfigFormat::Json5.into_file_name()).exists()
+    || cwd.join(ConfigFormat::Toml.into_file_name()).exists()
+  {
+    return cwd;
+  }
+
   if cwd.join("src-tauri/tauri.conf.json").exists()
     || cwd.join("src-tauri/tauri.conf.json5").exists()
   {
@@ -80,7 +87,13 @@ fn get_tauri_dir() -> PathBuf {
 }
 
 fn get_app_dir() -> Option<PathBuf> {
-  lookup(&current_dir().expect("failed to read cwd"), |path| {
+  let cwd = current_dir().expect("failed to read cwd");
+
+  if cwd.join("package.json").exists(){
+    return Some(cwd);
+  }
+
+  lookup(&cwd, |path| {
     if let Some(file_name) = path.file_name() {
       file_name == OsStr::new("package.json")
     } else {

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -71,7 +71,9 @@ fn get_tauri_dir() -> PathBuf {
 
   let src_tauri = cwd.join("src-tauri");
   if src_tauri.join(ConfigFormat::Json.into_file_name()).exists()
-    || src_tauri.join(ConfigFormat::Json5.into_file_name()).exists()
+    || src_tauri
+      .join(ConfigFormat::Json5.into_file_name())
+      .exists()
     || src_tauri.join(ConfigFormat::Toml.into_file_name()).exists()
   {
     return src_tauri;
@@ -91,7 +93,7 @@ fn get_tauri_dir() -> PathBuf {
 fn get_app_dir() -> Option<PathBuf> {
   let cwd = current_dir().expect("failed to read cwd");
 
-  if cwd.join("package.json").exists(){
+  if cwd.join("package.json").exists() {
     return Some(cwd);
   }
 

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -69,10 +69,12 @@ fn get_tauri_dir() -> PathBuf {
     return cwd;
   }
 
-  if cwd.join("src-tauri/tauri.conf.json").exists()
-    || cwd.join("src-tauri/tauri.conf.json5").exists()
+  let src_tauri = cwd.join("src-tauri");
+  if src_tauri.join(ConfigFormat::Json.into_file_name()).exists()
+    || src_tauri.join(ConfigFormat::Json5.into_file_name()).exists()
+    || src_tauri.join(ConfigFormat::Toml.into_file_name()).exists()
   {
-    return cwd.join("src-tauri/");
+    return src_tauri;
   }
 
   lookup(&cwd, |path| folder_has_configuration_file(path) || is_configuration_file(path))


### PR DESCRIPTION
Now allows Tauri configuration and `package.json` to be in the same directory.

```
.
├── src
├── Cargo.toml
├── Tauri.toml
└── package.json
```

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
