### PR TITLE
refactor: remove `bitness` crate from bundler

### DIFF
--- a/.changes/remove-bitness.md
+++ b/.changes/remove-bitness.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:deps'
+---
+
+Removed the `bitness` dependency to speed up compile time.

--- a/tooling/bundler/Cargo.toml
+++ b/tooling/bundler/Cargo.toml
@@ -43,9 +43,15 @@ dunce = "1"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 uuid = { version = "1", features = [ "v4", "v5" ] }
-bitness = "0.4"
 winreg = "0.50"
 glob = "0.3"
+
+[target."cfg(target_os = \"windows\")".dependencies.windows-sys]
+version = "0.48"
+features = [
+  "Win32_System_SystemInformation",
+  "Win32_System_Diagnostics_Debug"
+]
 
 [target."cfg(target_os = \"macos\")".dependencies]
 icns = { package = "tauri-icns", version = "0.1" }

--- a/tooling/bundler/src/bundle/windows/sign.rs
+++ b/tooling/bundler/src/bundle/windows/sign.rs
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::{bundle::common::CommandExt, Settings};
-use bitness::{self, Bitness};
+use crate::{
+  bundle::{common::CommandExt, windows::util},
+  Settings,
+};
 use log::{debug, info};
 use std::{
   path::{Path, PathBuf},
@@ -69,11 +71,7 @@ fn locate_signtool() -> crate::Result<PathBuf> {
   kit_bin_paths.push(kits_root_10_bin_path);
 
   // Choose which version of SignTool to use based on OS bitness
-  let arch_dir = match bitness::os_bitness().expect("failed to get os bitness") {
-    Bitness::X86_32 => "x86",
-    Bitness::X86_64 => "x64",
-    _ => return Err(crate::Error::UnsupportedBitness),
-  };
+  let arch_dir = util::os_bitness().ok_or(crate::Error::UnsupportedBitness)?;
 
   /* Iterate through all bin paths, checking for existence of a SignTool executable. */
   for kit_bin_path in &kit_bin_paths {

--- a/tooling/bundler/src/bundle/windows/util.rs
+++ b/tooling/bundler/src/bundle/windows/util.rs
@@ -103,6 +103,7 @@ pub fn extract_zip(data: &[u8], path: &Path) -> crate::Result<()> {
   Ok(())
 }
 
+#[cfg(target_os = "windows")]
 pub fn os_bitness<'a>() -> Option<&'a str> {
   use windows_sys::Win32::System::{
     Diagnostics::Debug::{PROCESSOR_ARCHITECTURE_AMD64, PROCESSOR_ARCHITECTURE_INTEL},

--- a/tooling/bundler/src/bundle/windows/util.rs
+++ b/tooling/bundler/src/bundle/windows/util.rs
@@ -102,3 +102,18 @@ pub fn extract_zip(data: &[u8], path: &Path) -> crate::Result<()> {
 
   Ok(())
 }
+
+pub fn os_bitness<'a>() -> Option<&'a str> {
+  use windows_sys::Win32::System::{
+    Diagnostics::Debug::{PROCESSOR_ARCHITECTURE_AMD64, PROCESSOR_ARCHITECTURE_INTEL},
+    SystemInformation::{GetNativeSystemInfo, SYSTEM_INFO},
+  };
+
+  let mut system_info: SYSTEM_INFO = unsafe { std::mem::zeroed() };
+  unsafe { GetNativeSystemInfo(&mut system_info) };
+  match unsafe { system_info.Anonymous.Anonymous.wProcessorArchitecture } {
+    PROCESSOR_ARCHITECTURE_INTEL => Some("x86"),
+    PROCESSOR_ARCHITECTURE_AMD64 => Some("x64"),
+    _ => None,
+  }
+}

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -280,18 +280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
-name = "bitness"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57792b99d555ebf109c83169228076f7d997e2b37ba1a653850ccd703ac7bab0"
-dependencies = [
- "sysctl",
- "thiserror",
- "uname",
- "winapi",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148"
+checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
 dependencies = [
  "log",
  "mac",
@@ -1637,13 +1625,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "kuchiki"
-version = "0.8.1"
+name = "kuchikiki"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea8e9c6e031377cff82ee3001dc8026cdf431ed4e2e6b51f98ab8c73484a358"
+checksum = "f29e4755b7b995046f510a7520c42b2fed58b77bd94d5a87a8eb43d2fd126da8"
 dependencies = [
  "cssparser",
  "html5ever",
+ "indexmap",
  "matches",
  "selectors",
 ]
@@ -1738,13 +1727,13 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
+checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
- "phf 0.8.0",
- "phf_codegen",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -2307,6 +2296,16 @@ checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
 dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
 ]
 
 [[package]]
@@ -2893,7 +2892,7 @@ dependencies = [
  "log",
  "matches",
  "phf 0.8.0",
- "phf_codegen",
+ "phf_codegen 0.8.0",
  "precomputed-hash",
  "servo_arc",
  "smallvec",
@@ -3293,19 +3292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
-name = "sysctl"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e483f02d0ad107168dc57381a8a40c3aeea6abe47f37506931f861643cfa8"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "thiserror",
- "walkdir",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,7 +3308,6 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "ar",
- "bitness",
  "dirs-next",
  "dunce",
  "glob",
@@ -3352,6 +3337,7 @@ dependencies = [
  "ureq",
  "uuid",
  "walkdir",
+ "windows-sys 0.48.0",
  "winreg 0.50.0",
  "zip",
 ]
@@ -3380,7 +3366,7 @@ dependencies = [
  "itertools",
  "json-patch",
  "jsonschema",
- "kuchiki",
+ "kuchikiki",
  "libc",
  "log",
  "minisign",
@@ -3443,7 +3429,7 @@ dependencies = [
  "infer",
  "json-patch",
  "json5",
- "kuchiki",
+ "kuchikiki",
  "memchr",
  "phf 0.10.1",
  "schemars",
@@ -3769,15 +3755,6 @@ name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
-
-[[package]]
-name = "uname"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "unicode-bidi"


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
`bitness` crates is using `winapi` under the hood while the ecosystem is moving towards using `windows-sys` crate instead, so this is a step towards removing `winapi` crate completely from dependencies.