### PR TITLE
feat(cli): expose iOS project path and app name as env vars

### DIFF
--- a/.changes/cli-ios-metadata-env-var.md
+++ b/.changes/cli-ios-metadata-env-var.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:feat
+"@tauri-apps/cli": patch:feat
+---
+
+Expose the `TAURI_IOS_PROJECT_PATH` and `TAURI_IOS_APP_NAME` environment variables when using `ios` commands.

--- a/tooling/cli/src/mobile/ios.rs
+++ b/tooling/cli/src/mobile/ios.rs
@@ -30,7 +30,7 @@ use super::{
 };
 use crate::{helpers::config::Config as TauriConfig, Result};
 
-use std::{process::exit, thread::sleep, time::Duration};
+use std::{env::set_var, process::exit, thread::sleep, time::Duration};
 
 mod build;
 mod dev;
@@ -139,6 +139,9 @@ pub fn get_config(
     },
     macos: Default::default(),
   };
+
+  set_var("TAURI_IOS_PROJECT_PATH", config.project_dir());
+  set_var("TAURI_IOS_APP_NAME", config.app().name());
 
   (config, metadata)
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
