### PR TITLE
feat(core): allow a plugin build script to read the plugin config object

### DIFF
--- a/.changes/cli-expose-plugin-config.md
+++ b/.changes/cli-expose-plugin-config.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:feat
+"@tauri-apps/cli": patch:feat
+---
+
+Expose an environment variable `TAURI_${PLUGIN_NAME}_PLUGIN_CONFIG` for each defined plugin configuration object.

--- a/.changes/plugin-config-getter.md
+++ b/.changes/plugin-config-getter.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch:feat
+---
+
+Added the `config::plugin_config` function to read the plugin configuration set from the CLI.

--- a/core/tauri-build/src/config.rs
+++ b/core/tauri-build/src/config.rs
@@ -1,0 +1,13 @@
+use serde::de::DeserializeOwned;
+
+use std::{env::var, io::Cursor};
+
+pub fn plugin_config<T: DeserializeOwned>(name: &str) -> Option<T> {
+  if let Ok(config_str) = var(format!("TAURI_{name}_PLUGIN_CONFIG")) {
+    serde_json::from_reader(Cursor::new(config_str))
+      .map(Some)
+      .expect("failed to parse configuration")
+  } else {
+    None
+  }
+}

--- a/core/tauri-build/src/config.rs
+++ b/core/tauri-build/src/config.rs
@@ -7,7 +7,10 @@ use serde::de::DeserializeOwned;
 use std::{env::var, io::Cursor};
 
 pub fn plugin_config<T: DeserializeOwned>(name: &str) -> Option<T> {
-  if let Ok(config_str) = var(format!("TAURI_{name}_PLUGIN_CONFIG")) {
+  if let Ok(config_str) = var(format!(
+    "TAURI_{}_PLUGIN_CONFIG",
+    name.to_uppercase().replace('-', "_")
+  )) {
     serde_json::from_reader(Cursor::new(config_str))
       .map(Some)
       .expect("failed to parse configuration")

--- a/core/tauri-build/src/config.rs
+++ b/core/tauri-build/src/config.rs
@@ -1,3 +1,7 @@
+// Copyright 2019-2023 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
 use serde::de::DeserializeOwned;
 
 use std::{env::var, io::Cursor};

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -30,6 +30,8 @@ use std::{
 mod allowlist;
 #[cfg(feature = "codegen")]
 mod codegen;
+/// Tauri configuration functions.
+pub mod config;
 /// Mobile build functions.
 pub mod mobile;
 mod static_vcruntime;

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -175,6 +175,13 @@ fn get_internal(merge_config: Option<&str>, reload: bool) -> crate::Result<Confi
   // revert to previous working directory
   set_current_dir(current_dir)?;
 
+  for (plugin, conf) in &config.plugins.0 {
+    set_var(
+      format!("TAURI_{plugin}_PLUGIN_CONFIG"),
+      serde_json::to_string(&conf)?,
+    );
+  }
+
   *config_handle().lock().unwrap() = Some(ConfigMetadata {
     inner: config,
     extensions,

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -177,7 +177,10 @@ fn get_internal(merge_config: Option<&str>, reload: bool) -> crate::Result<Confi
 
   for (plugin, conf) in &config.plugins.0 {
     set_var(
-      format!("TAURI_{plugin}_PLUGIN_CONFIG"),
+      format!(
+        "TAURI_{}_PLUGIN_CONFIG",
+        plugin.to_uppercase().replace('-', "_")
+      ),
       serde_json::to_string(&conf)?,
     );
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
