### PR TITLE
chore: `dirs-next` crate is unmaintained, use `dirs` instead

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -55,7 +55,7 @@ rand = "0.8"
 serde_repr = "0.1"
 state = "0.6"
 http = "0.2"
-dirs-next = "2.0"
+dirs = "2.0"
 percent-encoding = "2.2"
 reqwest = { version = "0.11", default-features = false, features = [ "json", "stream" ] }
 bytes = { version = "1", features = [ "serde" ] }

--- a/core/tauri/src/path/desktop.rs
+++ b/core/tauri/src/path/desktop.rs
@@ -18,7 +18,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Music`.
   /// - **Windows:** Resolves to `{FOLDERID_Music}`.
   pub fn audio_dir(&self) -> Result<PathBuf> {
-    dirs_next::audio_dir().ok_or(Error::UnknownPath)
+    dirs::audio_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's cache directory.
@@ -29,7 +29,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Library/Caches`.
   /// - **Windows:** Resolves to `{FOLDERID_LocalAppData}`.
   pub fn cache_dir(&self) -> Result<PathBuf> {
-    dirs_next::cache_dir().ok_or(Error::UnknownPath)
+    dirs::cache_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's config directory.
@@ -40,7 +40,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Library/Application Support`.
   /// - **Windows:** Resolves to `{FOLDERID_RoamingAppData}`.
   pub fn config_dir(&self) -> Result<PathBuf> {
-    dirs_next::config_dir().ok_or(Error::UnknownPath)
+    dirs::config_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's data directory.
@@ -51,7 +51,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Library/Application Support`.
   /// - **Windows:** Resolves to `{FOLDERID_RoamingAppData}`.
   pub fn data_dir(&self) -> Result<PathBuf> {
-    dirs_next::data_dir().ok_or(Error::UnknownPath)
+    dirs::data_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's local data directory.
@@ -62,7 +62,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Library/Application Support`.
   /// - **Windows:** Resolves to `{FOLDERID_LocalAppData}`.
   pub fn local_data_dir(&self) -> Result<PathBuf> {
-    dirs_next::data_local_dir().ok_or(Error::UnknownPath)
+    dirs::data_local_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's desktop directory.
@@ -73,7 +73,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Desktop`.
   /// - **Windows:** Resolves to `{FOLDERID_Desktop}`.
   pub fn desktop_dir(&self) -> Result<PathBuf> {
-    dirs_next::desktop_dir().ok_or(Error::UnknownPath)
+    dirs::desktop_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's document directory.
@@ -84,7 +84,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Documents`.
   /// - **Windows:** Resolves to `{FOLDERID_Documents}`.
   pub fn document_dir(&self) -> Result<PathBuf> {
-    dirs_next::document_dir().ok_or(Error::UnknownPath)
+    dirs::document_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's download directory.
@@ -95,7 +95,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Downloads`.
   /// - **Windows:** Resolves to `{FOLDERID_Downloads}`.
   pub fn download_dir(&self) -> Result<PathBuf> {
-    dirs_next::download_dir().ok_or(Error::UnknownPath)
+    dirs::download_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's executable directory.
@@ -106,7 +106,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Not supported.
   /// - **Windows:** Not supported.
   pub fn executable_dir(&self) -> Result<PathBuf> {
-    dirs_next::executable_dir().ok_or(Error::UnknownPath)
+    dirs::executable_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's font directory.
@@ -117,7 +117,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Library/Fonts`.
   /// - **Windows:** Not supported.
   pub fn font_dir(&self) -> Result<PathBuf> {
-    dirs_next::font_dir().ok_or(Error::UnknownPath)
+    dirs::font_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's home directory.
@@ -128,7 +128,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME`.
   /// - **Windows:** Resolves to `{FOLDERID_Profile}`.
   pub fn home_dir(&self) -> Result<PathBuf> {
-    dirs_next::home_dir().ok_or(Error::UnknownPath)
+    dirs::home_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's picture directory.
@@ -139,7 +139,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Pictures`.
   /// - **Windows:** Resolves to `{FOLDERID_Pictures}`.
   pub fn picture_dir(&self) -> Result<PathBuf> {
-    dirs_next::picture_dir().ok_or(Error::UnknownPath)
+    dirs::picture_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's public directory.
@@ -150,7 +150,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Public`.
   /// - **Windows:** Resolves to `{FOLDERID_Public}`.
   pub fn public_dir(&self) -> Result<PathBuf> {
-    dirs_next::public_dir().ok_or(Error::UnknownPath)
+    dirs::public_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's runtime directory.
@@ -161,7 +161,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Not supported.
   /// - **Windows:** Not supported.
   pub fn runtime_dir(&self) -> Result<PathBuf> {
-    dirs_next::runtime_dir().ok_or(Error::UnknownPath)
+    dirs::runtime_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's template directory.
@@ -172,7 +172,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Not supported.
   /// - **Windows:** Resolves to `{FOLDERID_Templates}`.
   pub fn template_dir(&self) -> Result<PathBuf> {
-    dirs_next::template_dir().ok_or(Error::UnknownPath)
+    dirs::template_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the user's video dir
@@ -183,7 +183,7 @@ impl<R: Runtime> PathResolver<R> {
   /// - **macOS:** Resolves to `$HOME/Movies`.
   /// - **Windows:** Resolves to `{FOLDERID_Videos}`.
   pub fn video_dir(&self) -> Result<PathBuf> {
-    dirs_next::video_dir().ok_or(Error::UnknownPath)
+    dirs::video_dir().ok_or(Error::UnknownPath)
   }
 
   /// Returns the path to the resource directory of this app.
@@ -196,7 +196,7 @@ impl<R: Runtime> PathResolver<R> {
   ///
   /// Resolves to [`config_dir`]`/${bundle_identifier}`.
   pub fn app_config_dir(&self) -> Result<PathBuf> {
-    dirs_next::config_dir()
+    dirs::config_dir()
       .ok_or(Error::UnknownPath)
       .map(|dir| dir.join(&self.0.config().tauri.bundle.identifier))
   }
@@ -205,7 +205,7 @@ impl<R: Runtime> PathResolver<R> {
   ///
   /// Resolves to [`data_dir`]`/${bundle_identifier}`.
   pub fn app_data_dir(&self) -> Result<PathBuf> {
-    dirs_next::data_dir()
+    dirs::data_dir()
       .ok_or(Error::UnknownPath)
       .map(|dir| dir.join(&self.0.config().tauri.bundle.identifier))
   }
@@ -214,7 +214,7 @@ impl<R: Runtime> PathResolver<R> {
   ///
   /// Resolves to [`local_data_dir`]`/${bundle_identifier}`.
   pub fn app_local_data_dir(&self) -> Result<PathBuf> {
-    dirs_next::data_local_dir()
+    dirs::data_local_dir()
       .ok_or(Error::UnknownPath)
       .map(|dir| dir.join(&self.0.config().tauri.bundle.identifier))
   }
@@ -223,7 +223,7 @@ impl<R: Runtime> PathResolver<R> {
   ///
   /// Resolves to [`cache_dir`]`/${bundle_identifier}`.
   pub fn app_cache_dir(&self) -> Result<PathBuf> {
-    dirs_next::cache_dir()
+    dirs::cache_dir()
       .ok_or(Error::UnknownPath)
       .map(|dir| dir.join(&self.0.config().tauri.bundle.identifier))
   }
@@ -237,14 +237,14 @@ impl<R: Runtime> PathResolver<R> {
   /// - **Windows:** Resolves to [`data_local_dir`]`/${bundle_identifier}/logs`.
   pub fn app_log_dir(&self) -> Result<PathBuf> {
     #[cfg(target_os = "macos")]
-    let path = dirs_next::home_dir().ok_or(Error::UnknownPath).map(|dir| {
+    let path = dirs::home_dir().ok_or(Error::UnknownPath).map(|dir| {
       dir
         .join("Library/Logs")
         .join(&self.0.config().tauri.bundle.identifier)
     });
 
     #[cfg(not(target_os = "macos"))]
-    let path = dirs_next::data_local_dir()
+    let path = dirs::data_local_dir()
       .ok_or(Error::UnknownPath)
       .map(|dir| {
         dir

--- a/core/tauri/src/path/mod.rs
+++ b/core/tauri/src/path/mod.rs
@@ -70,7 +70,7 @@ impl<'de> Deserialize<'de> for SafePathBuf {
 /// The base directory is the optional root of a file system operation.
 /// If informed by the API call, all paths will be relative to the path of the given directory.
 ///
-/// For more information, check the [`dirs_next` documentation](https://docs.rs/dirs_next/).
+/// For more information, check the [`dirs` documentation](https://docs.rs/dirs/).
 #[derive(Serialize_repr, Deserialize_repr, Clone, Copy, Debug)]
 #[repr(u16)]
 #[non_exhaustive]

--- a/tooling/bundler/Cargo.toml
+++ b/tooling/bundler/Cargo.toml
@@ -30,7 +30,7 @@ walkdir = "2"
 handlebars = "4.3"
 tempfile = "3.6.0"
 log = { version = "0.4.19", features = [ "kv_unstable" ] }
-dirs-next = "2.0"
+dirs = "2.0"
 os_pipe = "1"
 ureq = { version = "2.7", default-features = false }
 native-tls = { version = "0.2", optional = true }

--- a/tooling/bundler/src/bundle/linux/appimage.rs
+++ b/tooling/bundler/src/bundle/linux/appimage.rs
@@ -56,7 +56,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   sh_map.insert("app_name", settings.main_binary_name());
   sh_map.insert("app_name_uppercase", &upcase_app_name);
   sh_map.insert("appimage_filename", &appimage_filename);
-  let tauri_tools_path = dirs_next::cache_dir().map_or_else(
+  let tauri_tools_path = dirs::cache_dir().map_or_else(
     || output_path.to_path_buf(),
     |mut p| {
       p.push("tauri");

--- a/tooling/bundler/src/bundle/macos/app.rs
+++ b/tooling/bundler/src/bundle/macos/app.rs
@@ -285,7 +285,7 @@ fn copy_frameworks_to_bundle(bundle_directory: &Path, settings: &Settings) -> cr
         framework
       )));
     }
-    if let Some(home_dir) = dirs_next::home_dir() {
+    if let Some(home_dir) = dirs::home_dir() {
       if copy_framework_from(&dest_dir, framework, &home_dir.join("Library/Frameworks/"))? {
         continue;
       }

--- a/tooling/bundler/src/bundle/windows/msi.rs
+++ b/tooling/bundler/src/bundle/windows/msi.rs
@@ -26,7 +26,7 @@ const WIX_REQUIRED_FILES: &[&str] = &[
 /// Runs all of the commands to build the MSI installer.
 /// Returns a vector of PathBuf that shows where the MSI was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let mut wix_path = dirs_next::cache_dir().unwrap();
+  let mut wix_path = dirs::cache_dir().unwrap();
   wix_path.push("tauri/WixTools");
 
   if !wix_path.exists() {

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -489,7 +489,7 @@ pub fn build_wix_app_installer(
       } else {
         WEBVIEW2_X86_INSTALLER_GUID
       };
-      let offline_installer_path = dirs_next::cache_dir()
+      let offline_installer_path = dirs::cache_dir()
         .unwrap()
         .join("tauri")
         .join("Webview2OfflineInstaller")

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -66,7 +66,7 @@ const NSIS_REQUIRED_FILES: &[&str] = &[
 /// Runs all of the commands to build the NSIS installer.
 /// Returns a vector of PathBuf that shows where the NSIS installer was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let tauri_tools_path = dirs_next::cache_dir().unwrap().join("tauri");
+  let tauri_tools_path = dirs::cache_dir().unwrap().join("tauri");
   let nsis_toolset_path = tauri_tools_path.join("NSIS");
 
   if !nsis_toolset_path.exists() {
@@ -189,7 +189,7 @@ fn build_nsis_app_installer(
 
   #[cfg(not(target_os = "windows"))]
   {
-    let mut dir = dirs_next::cache_dir().unwrap();
+    let mut dir = dirs::cache_dir().unwrap();
     dir.extend(["tauri", "NSIS", "Plugins", "x86-unicode"]);
     data.insert("additional_plugins_path", to_json(dir));
   }


### PR DESCRIPTION
Closes #6063 

### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
- In 2020, package [`dirs` was replaced with `dirs-next`](https://github.com/tauri-apps/tauri/blob/dev/tooling/bundler/CHANGELOG.md#094)
- `dirs-next` is a fork of `dirs`

Links:
- https://github.com/xdg-rs/dirs/tree/master/dirs
- https://github.com/dirs-dev/dirs-rs
