### PR TITLE
fix(bundler): do not skip updater bundle target if only a macOS DMG is generated

### DIFF
--- a/.changes/bundler-macos-updater-dmg-only-fix.md
+++ b/.changes/bundler-macos-updater-dmg-only-fix.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:bug'
+---
+
+Fix bundler skipping updater artifacts if only a macOS DMG bundle target is specified.

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -105,6 +105,7 @@ pub fn bundle_project(settings: Settings) -> crate::Result<Vec<Bundle>> {
             p,
             PackageType::AppImage
               | PackageType::MacOsBundle
+              | PackageType::Dmg
               | PackageType::Nsis
               | PackageType::WindowsMsi
           )


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

As explained in https://github.com/tauri-apps/tauri/pull/7189#discussion_r1271316115, this little change addresses recent, unintended behavior changes in how the updater bundle operates.