### PR TITLE
fix(bundler): sign the exe before the bundler step

### DIFF
--- a/.changes/bundler-windows-earlier-code-signing.md
+++ b/.changes/bundler-windows-earlier-code-signing.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:enhance'
+---
+
+Code sign the main binary on Windows before trying to create the WiX and NSIS bundles to always sign the executable even if no bundles are enabled.

--- a/.changes/bundler-windows-earlier-code-signing.md
+++ b/.changes/bundler-windows-earlier-code-signing.md
@@ -2,4 +2,6 @@
 'tauri-bundler': 'patch:enhance'
 ---
 
-Code sign the main binary on Windows before trying to create the WiX and NSIS bundles to always sign the executable even if no bundles are enabled.
+On Windows, code sign the application binaries before trying to create the WiX and NSIS bundles to always sign the executables even if no bundle types are enabled.
+
+On Windows, code sign the sidecar binaries if they are not signed already.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -410,8 +410,6 @@ pub fn build_wix_app_installer(
     .ok_or_else(|| anyhow::anyhow!("Failed to get main binary"))?;
   let app_exe_source = settings.binary_path(main_binary);
 
-  try_sign(&app_exe_source, settings)?;
-
   let output_path = settings.project_out_directory().join("wix").join(arch);
 
   if output_path.exists() {

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -157,18 +157,6 @@ fn build_nsis_app_installer(
 
   info!("Target: {}", arch);
 
-  // Code signing is currently only supported on Windows hosts
-  #[cfg(target_os = "windows")]
-  {
-    let main_binary = settings
-      .binaries()
-      .iter()
-      .find(|bin| bin.main())
-      .ok_or_else(|| anyhow::anyhow!("Failed to get main binary"))?;
-    let app_exe_source = settings.binary_path(main_binary);
-    try_sign(&app_exe_source, settings)?;
-  }
-
   #[cfg(not(target_os = "windows"))]
   info!("Code signing is currently only supported on Windows hosts, skipping...");
 

--- a/tooling/bundler/src/bundle/windows/sign.rs
+++ b/tooling/bundler/src/bundle/windows/sign.rs
@@ -88,7 +88,7 @@ fn locate_signtool() -> crate::Result<PathBuf> {
   Err(crate::Error::SignToolNotFound)
 }
 
-/// Check if executable is already signed.
+/// Check if binary is already signed.
 /// Used to skip sidecar binaries that are already signed.
 pub fn verify(path: &Path) -> crate::Result<bool> {
   // Construct SignTool command

--- a/tooling/bundler/src/bundle/windows/sign.rs
+++ b/tooling/bundler/src/bundle/windows/sign.rs
@@ -88,6 +88,20 @@ fn locate_signtool() -> crate::Result<PathBuf> {
   Err(crate::Error::SignToolNotFound)
 }
 
+/// Check if executable is already signed.
+/// Used to skip sidecar binaries that are already signed.
+pub fn verify(path: &Path) -> crate::Result<bool> {
+  // Construct SignTool command
+  let signtool = locate_signtool()?;
+
+  let mut cmd = Command::new(&signtool);
+  cmd.arg("verify");
+  cmd.arg("/pa");
+  cmd.arg(path);
+
+  Ok(cmd.status()?.success())
+}
+
 pub fn sign_command(path: &str, params: &SignParams) -> crate::Result<(Command, PathBuf)> {
   // Construct SignTool command
   let signtool = locate_signtool()?;


### PR DESCRIPTION
https://discord.com/channels/616186924390023171/1010253864110407800

This way there's better support for standalone exe or in case devs create their own bundle formats.

At first i wanted to add that to the cli but thought that'd be a bit awkward since all the signing happens in the bundler and also in case we really end up making the bundler a more general thing for other projects to use, but i'm fine with changing that again.

### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
