### PR TITLE
fix(core): Don't manually create userDataDir on Windows, closes #7491

### DIFF
--- a/.changes/fix-datadir-admin.md
+++ b/.changes/fix-datadir-admin.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+On Windows, don't create the user data directory manually but leave it to WebView2 instead to prevent permission errors when running Tauri apps with admin privileges.

--- a/core/tauri/src/manager.rs
+++ b/core/tauri/src/manager.rs
@@ -1002,7 +1002,9 @@ impl<R: Runtime> WindowManager<R> {
       }
     }
 
-    // make sure the directory is created and available to prevent a panic
+    // make sure the directory is created and available to prevent a panic.
+    // On Windows we let WebView2 handle it so that the dir has the correct permissions.
+    #[cfg(not(windows))]
     if let Some(user_data_dir) = &pending.webview_attributes.data_directory {
       if !user_data_dir.exists() {
         create_dir_all(user_data_dir)?;


### PR DESCRIPTION
**Waiting for confirmation in #7491 !!!**

If someone has a better idea to create the dir with less permissions than the current processes i'm all ears, not too happy with that either.

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
fixes #7491