### PR TITLE
[feat] On Windows, set name of Window Class, closes #7498

### DIFF
--- a/.changes/window-class-name.md
+++ b/.changes/window-class-name.md
@@ -1,0 +1,8 @@
+---
+"tauri": 'minor:feat'
+"tauri-runtime-wry": 'minor:feat'
+"tauri-runtime": 'minor:feat'
+"tauri-utils": 'minor:feat'
+---
+
+Added the `window_classname` configuration option to `WindowBuilder`, `Window`, and `WindowConfig`. In order to set the name of the window class on Windows.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -460,6 +460,11 @@
           "default": false,
           "type": "boolean"
         },
+        "windowClassname": {
+          "description": "The name of the window class created on Windows to create the window.",
+          "default": "Window Class",
+          "type": "string"
+        },
         "theme": {
           "description": "The initial window theme. Defaults to the system theme. Only implemented on Windows and macOS 10.14+.",
           "anyOf": [

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -752,6 +752,7 @@ impl WindowBuilder for WindowBuilderWrapper {
         .visible_on_all_workspaces(config.visible_on_all_workspaces)
         .content_protected(config.content_protected)
         .skip_taskbar(config.skip_taskbar)
+        .window_classname(config.window_classname.to_string())
         .theme(config.theme)
         .shadow(config.shadow);
 
@@ -966,6 +967,17 @@ impl WindowBuilder for WindowBuilderWrapper {
 
   #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
   fn skip_taskbar(self, _skip: bool) -> Self {
+    self
+  }
+
+  #[cfg(windows)]
+  fn window_classname<S: Into<String>>(mut self, window_classname: S) -> Self {
+    self.inner = self.inner.with_window_classname(window_classname);
+    self
+  }
+
+  #[cfg(not(windows))]
+  fn window_classname<S: Into<String>>(self, _window_classname: S) -> Self {
     self
   }
 

--- a/core/tauri-runtime/src/webview.rs
+++ b/core/tauri-runtime/src/webview.rs
@@ -263,6 +263,14 @@ pub trait WindowBuilder: WindowBuilderBase {
   #[must_use]
   fn skip_taskbar(self, skip: bool) -> Self;
 
+  /// Sets custom name for Windows' window class.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux / iOS / Android:** Unsupported.
+  #[must_use]
+  fn window_classname<S: Into<String>>(self, window_classname: S) -> Self;
+
   /// Sets whether or not the window has shadow.
   ///
   /// ## Platform-specific

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -971,6 +971,9 @@ pub struct WindowConfig {
   /// If `true`, hides the window icon from the taskbar on Windows and Linux.
   #[serde(default, alias = "skip-taskbar")]
   pub skip_taskbar: bool,
+  /// The name of the window class created on Windows to create the window.
+  #[serde(default = "default_window_classname")]
+  pub window_classname: String,
   /// The initial window theme. Defaults to the system theme. Only implemented on Windows and macOS 10.14+.
   pub theme: Option<crate::Theme>,
   /// The style of the macOS title bar.
@@ -1055,6 +1058,7 @@ impl Default for WindowConfig {
       visible_on_all_workspaces: false,
       content_protected: false,
       skip_taskbar: false,
+      window_classname: default_window_classname(),
       theme: None,
       title_bar_style: Default::default(),
       hidden_title: false,
@@ -1082,6 +1086,10 @@ fn default_height() -> f64 {
 
 fn default_title() -> String {
   "Tauri App".to_string()
+}
+
+fn default_window_classname() -> String {
+  "Window Class".to_string()
 }
 
 /// A Content-Security-Policy directive source list.
@@ -2240,6 +2248,7 @@ mod build {
       let visible_on_all_workspaces = self.visible_on_all_workspaces;
       let content_protected = self.content_protected;
       let skip_taskbar = self.skip_taskbar;
+      let window_classname = str_lit(&self.window_classname);
       let theme = opt_lit(self.theme.as_ref());
       let title_bar_style = &self.title_bar_style;
       let hidden_title = self.hidden_title;
@@ -2281,6 +2290,7 @@ mod build {
         visible_on_all_workspaces,
         content_protected,
         skip_taskbar,
+        window_classname,
         theme,
         title_bar_style,
         hidden_title,

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -67,6 +67,9 @@ infer = { version = "0.9", optional = true }
 png = { version = "0.17", optional = true }
 ico = { version = "0.2.0", optional = true }
 
+[patch.crates-io]
+tao = {git = "https://github.com/geraudloup/tao"}
+
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = { version = "0.16", features = [ "v3_24" ] }
 glib = "0.16"

--- a/core/tauri/src/test/mock_runtime.rs
+++ b/core/tauri/src/test/mock_runtime.rs
@@ -316,6 +316,10 @@ impl WindowBuilder for MockWindowBuilder {
     self
   }
 
+  fn window_classname<S: Into<String>>(self, classname: S) -> Self {
+    self
+  }
+
   fn shadow(self, enable: bool) -> Self {
     self
   }

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -561,6 +561,17 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
     self
   }
 
+  /// Sets custom name for Windows' window class.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux / iOS / Android:** Unsupported.
+  #[must_use]
+  pub fn window_classname<S: Into<String>>(mut self, classname: S) -> Self {
+    self.window_builder = self.window_builder.window_classname(classname);
+    self
+  }
+
   /// Sets whether or not the window has shadow.
   ///
   /// ## Platform-specific

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -460,6 +460,11 @@
           "default": false,
           "type": "boolean"
         },
+        "windowClassname": {
+          "description": "The name of the window class created on Windows to create the window.",
+          "default": "Window Class",
+          "type": "string"
+        },
         "theme": {
           "description": "The initial window theme. Defaults to the system theme. Only implemented on Windows and macOS 10.14+.",
           "anyOf": [


### PR DESCRIPTION
allow to customize it instead of current value hard coded "Window Class" for all Tauri windows...

From #7498 : Currently, on Windows, all app windows created by tauri have the same class named "Window Class", it would be neet to allow for customization of the Windows' window class name.

One use case: some windows custom hotkey managers leverage window class names to select windows...

Non breaking, since the default value passed corresponds to the previous value that was hard-coded.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
This feature depends on an evolution of Tao, which has been already merged today by @amrbashir : https://github.com/tauri-apps/tao/pull/770