### PR TITLE
Extend context.rs to dynamically find the OUT_DIR for certain assets

### DIFF
--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -470,15 +470,20 @@ fn ico_icon<P: AsRef<Path>>(
   let width = entry.width();
   let height = entry.height();
 
-  let out_path = out_dir.join(path.file_name().unwrap());
+  let icon_file_name = path.file_name().unwrap();
+  let out_path = out_dir.join(icon_file_name);
   write_if_changed(&out_path, &rgba).map_err(|error| EmbeddedAssetsError::AssetWrite {
     path: path.to_owned(),
     error,
   })?;
 
-  let out_path = out_path.display().to_string();
-
-  let icon = quote!(Some(#root::Icon::Rgba { rgba: include_bytes!(#out_path).to_vec(), width: #width, height: #height }));
+  let icon_file_name = icon_file_name.to_str().unwrap();
+  let icon = quote!(Some(
+  #root::Icon::Rgba {
+    rgba: include_bytes!(concat!(std::env!("OUT_DIR"), "/", #icon_file_name)).to_vec(),
+    width: #width,
+    height: #height
+  }));
   Ok(icon)
 }
 
@@ -528,16 +533,17 @@ fn png_icon<P: AsRef<Path>>(
   let width = reader.info().width;
   let height = reader.info().height;
 
-  let out_path = out_dir.join(path.file_name().unwrap());
+  let icon_file_name = path.file_name().unwrap();
+  let out_path = out_dir.join(icon_file_name);
   write_if_changed(&out_path, &buffer).map_err(|error| EmbeddedAssetsError::AssetWrite {
     path: path.to_owned(),
     error,
   })?;
 
-  let icon_path = path.file_name().unwrap().to_str().unwrap().to_string();
+  let icon_file_name = icon_file_name.to_str().unwrap();
   let icon = quote!(Some(
     #root::Icon::Rgba {
-      rgba: include_bytes!(#icon_path).to_vec(),
+      rgba: include_bytes!(concat!(std::env!("OUT_DIR"), "/", #icon_file_name)).to_vec(),
       width: #width,
       height: #height,
     }


### PR DESCRIPTION
Hello, my team is moving to Bazel, and we can not use tauri-cli or any of your custom cargo-based tooling. We would like to contribute our changes to you all, so you can better support Bazel. 

These changes should be non-breaking, as it just recalculates the OUT_DIR at build.rs-time and compile-time separately. So it should not affect Cargo builds.


I think that TODO, if this is going to be fully generalized we need to add this functionality to some other parts of at least this file.

### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
