### PR TITLE
fix(bundler/nsis): revert shell context change before deleting appdata, closes #7588

### DIFF
--- a/.changes/fix-nsis-uninstall-delete-app-data.md
+++ b/.changes/fix-nsis-uninstall-delete-app-data.md
@@ -2,4 +2,4 @@
 'tauri-bundler': 'patch:bug'
 ---
 
-On Windows, NSIS uninstall.exe will delete application data in local app data dir of current user if the delete the application data checkbox is checked.
+On Windows, Fix NSIS uninstaller deleting the wrong application data if the delete the application data checkbox is checked.

--- a/.changes/fix-nsis-uninstall-delete-app-data.md
+++ b/.changes/fix-nsis-uninstall-delete-app-data.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:bug'
+---
+
+On Windows, NSIS uninstall.exe will delete application data in local app data dir of current user if the delete the application data checkbox is checked.

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -645,13 +645,6 @@ Section Uninstall
   ; Remove desktop shortcuts
   Delete "$DESKTOP\${MAINBINARYNAME}.lnk"
 
-  ; Delete app data
-  ${If} $DeleteAppDataCheckboxState == 1
-    SetShellVarContext current
-    RmDir /r "$APPDATA\${BUNDLEID}"
-    RmDir /r "$LOCALAPPDATA\${BUNDLEID}"
-  ${EndIf}
-
   ; Remove registry information for add/remove programs
   !if "${INSTALLMODE}" == "both"
     DeleteRegKey SHCTX "${UNINSTKEY}"
@@ -662,6 +655,13 @@ Section Uninstall
   !endif
 
   DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
+
+  ; Delete app data
+  ${If} $DeleteAppDataCheckboxState == 1
+    SetShellVarContext current
+    RmDir /r "$APPDATA\${BUNDLEID}"
+    RmDir /r "$LOCALAPPDATA\${BUNDLEID}"
+  ${EndIf}
 
   ${GetOptions} $CMDLINE "/P" $R0
   IfErrors +2 0

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -647,6 +647,7 @@ Section Uninstall
 
   ; Delete app data
   ${If} $DeleteAppDataCheckboxState == 1
+    SetShellVarContext current
     RmDir /r "$APPDATA\${BUNDLEID}"
     RmDir /r "$LOCALAPPDATA\${BUNDLEID}"
   ${EndIf}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
