### PR TITLE
feature: extend tauri builder with updater_header method

### DIFF
--- a/.changes/tauri-builder-updater-header.md
+++ b/.changes/tauri-builder-updater-header.md
@@ -1,0 +1,5 @@
+---
+"tauri": minor:feat
+---
+
+Added `tauri::Builder::updater_header` to add headers to the tauri updater.

--- a/core/tauri/src/updater/mod.rs
+++ b/core/tauri/src/updater/mod.rs
@@ -446,6 +446,13 @@ pub(crate) async fn check_update_with_dialog<R: Runtime>(handle: AppHandle<R>) {
     if let Some(target) = &handle.updater_settings.target {
       builder = builder.target(target);
     }
+    if let Some(headers) = &handle.updater_settings.headers {
+      for (key, value) in headers {
+        builder = builder
+          .header(key, value)
+          .expect("unwrapping because key/value are valid headers");
+      }
+    }
 
     // check updates
     match builder.build().await {
@@ -542,6 +549,13 @@ pub fn builder<R: Runtime>(handle: AppHandle<R>) -> UpdateBuilder<R> {
     .current_version(package_info.version);
   if let Some(target) = &handle.updater_settings.target {
     builder = builder.target(target);
+  }
+  if let Some(headers) = &handle.updater_settings.headers {
+    for (key, value) in headers {
+      builder = builder
+        .header(key, value)
+        .expect("unwrapping because key/value are valid headers");
+    }
   }
   UpdateBuilder {
     inner: builder,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
This change extends `tauri::Builder` with a new method `updater_header` (in the same vein as the existing `updater_target`) to set headers on the default updater instance.