### PR TITLE
enhance(cli): Add Cargo Tauri CLI version to `tauri info` output

### DIFF
--- a/.changes/enhance-cli-cargo-tauri-cli-version-info.md
+++ b/.changes/enhance-cli-cargo-tauri-cli-version-info.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": minor:enhance
+"@tauri-apps/cli": minor:enhance
+---
+
+Add version of Rust Tauri CLI installed with Cargo to `tauri info` command.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Enhancement

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
The version number for the Cargo install of the CLI is missing from `tauri info`; developers using Cargo often don't provide the version of Tauri's CLI used as a result.