### PR TITLE
fix: use `button` property for `data-tauri-drag-region` mouse button detection, closes #7694

### DIFF
--- a/.changes/tauri-tap-drag-region-detection.md
+++ b/.changes/tauri-tap-drag-region-detection.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+On macOS, fixed tapping on custom title bar doesn't maximize the window.

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -134,7 +134,7 @@
 
   // drag region
   document.addEventListener('mousedown', (e) => {
-    if (e.target.hasAttribute('data-tauri-drag-region') && e.buttons === 1) {
+    if (e.target.hasAttribute('data-tauri-drag-region') && e.button === 0) {
       // prevents text cursor
       e.preventDefault()
       // fix #2549: double click on drag region edge causes content to maximize without window sizing change


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #____
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

#7694 

Updated the `data-tauri-drag-region` attribute to use the `button` property instead of the `buttons` property to check if the left mouse button was pressed. 

This change is intended to fix an issue that if the "Tap to Click" option is enabled on the macOS, `event.buttons` will return `0` and `1` randomly when tapping the element.

**Behavior changed**
Before this patch, the `drag` event will be triggered only when the left mouse button is pressed. In this patch, if multiple mouse buttons are clicked along with the left mouse button simultaneously, it would see as the left mouse button clicked and trigger the `drag` event.


