### PR TITLE
chore: resolves a warning seen while running cargo update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "1"
 members = [
   # core
   "core/tauri",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "1"
+resolver = "2"
 members = [
   # core
   "core/tauri",


### PR DESCRIPTION
This my third attempt to generate a PR with a "verified" signature.
Sorry for the noise, and thanks for all the technical support/advice 
#7747 
#7743 

I can see the "Verified" badge on this PR. Anyway back to the reason for the PR

... 

This PR resolves a warning seen while running cargo update

warning: some crates are on edition 2021 which defaults to resolver = "2", but virtual workspaces default to resolver = "1"
note: to keep the current resolver, specify workspace.resolver = "1" in the workspace root's manifest
note: to use the edition 2021 resolver, specify workspace.resolver = "2" in the workspace root's manifest