### PR TITLE
fix(windows): check if webview is focused for `is_focused`

### DIFF
--- a/.changes/windows_is_focused.md
+++ b/.changes/windows_is_focused.md
@@ -1,0 +1,7 @@
+---
+"tauri": "patch:bug"
+"tauri-runtime-wry": "patch"
+---
+
+Fix `Window::is_focused` returning `false` on Windows even though the window is indeed focused.
+

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -104,6 +104,7 @@ jobs:
           cargo update -p flate2 --precise 1.0.26
           cargo update -p h2 --precise 0.3.20
           cargo update -p reqwest --precise 0.11.18
+          cargo update -p memchr --precise 2.6.2
 
       - name: test
         run: cargo test --target ${{ matrix.platform.target }} ${{ matrix.features.args }}

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -5,7 +5,7 @@
 //! The [`wry`] Tauri [`Runtime`].
 
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle};
-use std::{rc::Rc, sync::atomic::AtomicBool};
+use std::rc::Rc;
 use tauri_runtime::{
   http::{header::CONTENT_TYPE, Request as HttpRequest, RequestParts, Response as HttpResponse},
   menu::{AboutMetadata, CustomMenuItem, Menu, MenuEntry, MenuHash, MenuId, MenuItem, MenuUpdate},
@@ -1677,7 +1677,7 @@ enum WindowHandle {
     // the key of the WebContext if it's not shared
     context_key: Option<PathBuf>,
     #[cfg(windows)]
-    webview_focused: Arc<AtomicBool>,
+    webview_focused: Arc<std::sync::atomic::AtomicBool>,
   },
   Window(Arc<Window>),
 }
@@ -3274,7 +3274,7 @@ fn create_webview<T: UserEvent>(
     .map_err(|e| Error::CreateWebview(Box::new(e)))?;
 
   #[cfg(windows)]
-  let webview_focused = Arc::new(AtomicBool::new(false));
+  let webview_focused = Arc::new(std::sync::atomic::AtomicBool::new(false));
   #[cfg(windows)]
   {
     let controller = webview.controller();


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
