### PR TITLE
feat: add team_id option for apple notarization

### DIFF
--- a/.changes/bundler-team-id.md
+++ b/.changes/bundler-team-id.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": minor:enhance
+---
+
+Read the `APPLE_TEAM_ID` environment variable for macOS notarization arguments.

--- a/tooling/bundler/src/bundle/macos/sign.rs
+++ b/tooling/bundler/src/bundle/macos/sign.rs
@@ -300,9 +300,7 @@ pub fn notarize(
       Err(anyhow::anyhow!("{log_message}").into())
     }
   } else {
-    return Err(
-      anyhow::anyhow!("failed to parse notarytool output as JSON: `{output_str}`").into(),
-    );
+    Err(anyhow::anyhow!("failed to parse notarytool output as JSON: `{output_str}`").into())
   }
 }
 
@@ -327,14 +325,14 @@ fn staple_app(mut app_bundle_path: PathBuf) -> crate::Result<()> {
 
 pub enum NotarizeAuth {
   AppleId {
-    apple_id: String,
-    password: String,
-    team_id: Option<String>,
+    apple_id: OsString,
+    password: OsString,
+    team_id: Option<OsString>,
   },
   ApiKey {
-    key: String,
+    key: OsString,
     key_path: PathBuf,
-    issuer: String,
+    issuer: OsString,
   },
 }
 
@@ -381,39 +379,20 @@ pub fn notarize_auth() -> crate::Result<NotarizeAuth> {
     var_os("APPLE_PASSWORD"),
     var_os("APPLE_TEAM_ID"),
   ) {
-    (Some(apple_id), Some(apple_password), team_id) => {
-      let apple_id = apple_id
-        .to_str()
-        .expect("failed to convert APPLE_ID to string")
-        .to_string();
-      let password = apple_password
-        .to_str()
-        .expect("failed to convert APPLE_PASSWORD to string")
-        .to_string();
-      let team_id = team_id.map(|team_id| {
-        team_id
-          .to_str()
-          .expect("failed to convert APPLE_TEAM_ID to string")
-          .to_string()
-      });
-      Ok(NotarizeAuth::AppleId {
-        apple_id,
-        password,
-        team_id,
-      })
-    }
+    (Some(apple_id), Some(password), team_id) => Ok(NotarizeAuth::AppleId {
+      apple_id,
+      password,
+      team_id,
+    }),
     _ => {
       match (var_os("APPLE_API_KEY"), var_os("APPLE_API_ISSUER"), var("APPLE_API_KEY_PATH")) {
-        (Some(api_key), Some(api_issuer), Ok(key_path)) => {
-          let key = api_key.to_str().expect("failed to convert APPLE_API_KEY to string").to_string();
-          let issuer = api_issuer.to_str().expect("failed to convert APPLE_API_ISSUER to string").to_string();
+        (Some(key), Some(issuer), Ok(key_path)) => {
           Ok(NotarizeAuth::ApiKey { key, key_path: key_path.into(), issuer })
         },
-        (Some(api_key), Some(api_issuer), Err(_)) => {
-          let key = api_key.to_str().expect("failed to convert APPLE_API_KEY to string").to_string();
-          let issuer = api_issuer.to_str().expect("failed to convert APPLE_API_ISSUER to string").to_string();
-
-          let api_key_file_name = format!("AuthKey_{key}.p8");
+        (Some(key), Some(issuer), Err(_)) => {
+          let mut api_key_file_name = OsString::from("AuthKey_");
+          api_key_file_name.push(&key);
+          api_key_file_name.push(".p8");
           let mut key_path = None;
 
           let mut search_paths = vec!["./private_keys".into()];
@@ -433,7 +412,7 @@ pub fn notarize_auth() -> crate::Result<NotarizeAuth> {
           if let Some(key_path) = key_path {
           Ok(NotarizeAuth::ApiKey { key, key_path, issuer })
           } else {
-            Err(anyhow::anyhow!("could not find API key file. Please set the APPLE_API_KEY_PATH environment variables to the path to the {api_key_file_name} file").into())
+            Err(anyhow::anyhow!("could not find API key file. Please set the APPLE_API_KEY_PATH environment variables to the path to the {api_key_file_name:?} file").into())
           }
         }
         _ => Err(anyhow::anyhow!("no APPLE_ID & APPLE_PASSWORD or APPLE_API_KEY & APPLE_API_ISSUER & APPLE_API_KEY_PATH environment variables found").into())
@@ -442,7 +421,7 @@ pub fn notarize_auth() -> crate::Result<NotarizeAuth> {
   }
 }
 
-fn find_api_key(folder: PathBuf, file_name: &str) -> Option<PathBuf> {
+fn find_api_key(folder: PathBuf, file_name: &OsString) -> Option<PathBuf> {
   let path = folder.join(file_name);
   if path.exists() {
     Some(path)

--- a/tooling/cli/ENVIRONMENT_VARIABLES.md
+++ b/tooling/cli/ENVIRONMENT_VARIABLES.md
@@ -25,6 +25,7 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `APPLE_CERTIFICATE_PASSWORD` — The password you used to export the certificate.
 - `APPLE_ID` — The Apple ID used to notarize the application. If this environment variable is provided, `APPLE_PASSWORD` must also be set. Alternatively, `APPLE_API_KEY` and `APPLE_API_ISSUER` can be used to authenticate.
 - `APPLE_PASSWORD` — The Apple password used to authenticate for application notarization. Required if `APPLE_ID` is specified. An app-specific password can be used. Alternatively to entering the password in plaintext, it may also be specified using a '@keychain:' or '@env:' prefix followed by a keychain password item name or environment variable name.
+- `APPLE_TEAM_ID`: Developer team ID. If your Apple ID only belongs to one team then you don’t need to supply a Team ID. However, it’s best practice to include it regardless. That way, joining another team at some point in the future won’t break your notarization workflow. To find your Team ID, go to the [Account](https://developer.apple.com/account) page on the Apple Developer website.
 - `APPLE_API_KEY` — Alternative to `APPLE_ID` and `APPLE_PASSWORD` for notarization authentication using JWT.
   - See [creating API keys](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api) for more information.
 - `APPLE_API_ISSUER` — Issuer ID. Required if `APPLE_API_KEY` is specified.


### PR DESCRIPTION
### What kind of change does this PR introduce?
Adds an optional APPLE_TEAM_ID variable to notarization on MacOS when using Apple ID and Password authentication. This is useful if people belong to multiple teams.

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
