### PR TITLE
feat: added url scheme for linux and mac

### DIFF
--- a/.changes/schema-association-config.md
+++ b/.changes/schema-association-config.md
@@ -1,0 +1,6 @@
+---
+"tauri-utils": minor:feat
+---
+
+Add a configuration object for schema associations under `BundleConfig`.
+Add support for schema associations in the bundler.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -940,6 +940,16 @@
             "$ref": "#/definitions/FileAssociation"
           }
         },
+        "schemeAssociations": {
+          "description": "Scheme associations to application.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemeAssociation"
+          }
+        },
         "shortDescription": {
           "description": "A short description of your application.",
           "type": [
@@ -1227,6 +1237,36 @@
           ]
         }
       ]
+    },
+    "SchemeAssociation": {
+      "description": "Schema association",
+      "type": "object",
+      "required": [
+        "scheme"
+      ],
+      "properties": {
+        "scheme": {
+          "description": "Schema name to associate with this app. e.g. 'https'",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Scheme"
+          }
+        },
+        "role": {
+          "description": "The app’s role with respect to the type. Maps to `CFBundleTypeRole` on macOS.",
+          "default": "Editor",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BundleTypeRole"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Scheme": {
+      "description": "An extension for a [`SchemaAssociation`].",
+      "type": "string"
     },
     "AppImageConfig": {
       "description": "Configuration for AppImage bundles.\n\nSee more: https://tauri.app/v1/api/config#appimageconfig",

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -696,6 +696,28 @@ pub struct FileAssociation {
   pub mime_type: Option<String>,
 }
 
+/// An extension for a [`SchemaAssociation`].
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct Scheme(pub String);
+
+impl fmt::Display for Scheme {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}", self.0)
+  }
+}
+
+/// Schema association
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SchemeAssociation {
+  /// Schema name to associate with this app. e.g. 'https'
+  pub scheme: Vec<Scheme>,
+  /// The app’s role with respect to the type. Maps to `CFBundleTypeRole` on macOS.
+  #[serde(default)]
+  pub role: BundleTypeRole,
+}
 /// The Updater configuration object.
 ///
 /// See more: https://tauri.app/v1/api/config#updaterconfig
@@ -794,6 +816,8 @@ pub struct BundleConfig {
   pub category: Option<String>,
   /// File associations to application.
   pub file_associations: Option<Vec<FileAssociation>>,
+  /// Scheme associations to application.
+  pub scheme_associations: Option<Vec<SchemeAssociation>>,
   /// A short description of your application.
   #[serde(alias = "short-description")]
   pub short_description: Option<String>,
@@ -2374,6 +2398,7 @@ mod build {
       let copyright = quote!(None);
       let category = quote!(None);
       let file_associations = quote!(None);
+      let scheme_associations = quote!(None);
       let short_description = quote!(None);
       let long_description = quote!(None);
       let appimage = quote!(Default::default());
@@ -2397,6 +2422,7 @@ mod build {
         copyright,
         category,
         file_associations,
+        scheme_associations,
         short_description,
         long_description,
         appimage,
@@ -2703,6 +2729,7 @@ mod test {
         copyright: None,
         category: None,
         file_associations: None,
+        scheme_associations: None,
         short_description: None,
         long_description: None,
         appimage: Default::default(),

--- a/tooling/bundler/src/bundle/linux/templates/main.desktop
+++ b/tooling/bundler/src/bundle/linux/templates/main.desktop
@@ -3,11 +3,14 @@ Categories={{categories}}
 {{#if comment}}
 Comment={{comment}}
 {{/if}}
-Exec={{exec}}
+Exec={{exec}} %U
 Icon={{icon}}
 Name={{name}}
 Terminal=false
 Type=Application
 {{#if mime_type}}
 MimeType={{mime_type}}
+{{/if}}
+{{#if url_schema}}
+X-KDE-Protocols={{url_schema}};
 {{/if}}

--- a/tooling/bundler/src/bundle/macos/app.rs
+++ b/tooling/bundler/src/bundle/macos/app.rs
@@ -202,6 +202,39 @@ fn create_info_plist(
     );
   }
 
+  if let Some(associations) = settings.scheme_associations() {
+    plist.insert(
+      "CFBundleURLTypes".into(),
+      plist::Value::Array(
+        associations
+            .iter()
+            .map(|association| {
+              let mut dict = plist::Dictionary::new();
+              dict.insert(
+                "CFBundleURLSchemes".into(),
+                plist::Value::Array(
+                  association
+                      .scheme
+                      .iter()
+                      .map(|url| url.to_string().into())
+                      .collect(),
+                ),
+              );
+              dict.insert(
+                "CFBundleURLName".into(),
+                settings.bundle_identifier().into()
+              );
+              dict.insert(
+                "CFBundleTypeRole".into(),
+                association.role.to_string().into(),
+              );
+              plist::Value::Dictionary(dict)
+            })
+            .collect(),
+      ),
+    );
+  }
+
   plist.insert("LSRequiresCarbon".into(), true.into());
   plist.insert("NSHighResolutionCapable".into(), true.into());
   if let Some(copyright) = settings.copyright_string() {

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -7,7 +7,7 @@ use super::category::AppCategory;
 use crate::bundle::{common, platform::target_triple};
 pub use tauri_utils::config::WebviewInstallMode;
 use tauri_utils::{
-  config::{BundleType, FileAssociation, NSISInstallerMode},
+  config::{BundleType, FileAssociation, SchemeAssociation, NSISInstallerMode},
   resources::{external_binaries, ResourcePaths},
 };
 
@@ -364,6 +364,8 @@ pub struct BundleSettings {
   pub category: Option<AppCategory>,
   /// the file associations
   pub file_associations: Option<Vec<FileAssociation>>,
+  /// the scheme associations
+  pub scheme_associations: Option<Vec<SchemeAssociation>>,
   /// the app's short description.
   pub short_description: Option<String>,
   /// the app's long description.
@@ -791,6 +793,11 @@ impl Settings {
   /// Return file associations.
   pub fn file_associations(&self) -> &Option<Vec<FileAssociation>> {
     &self.bundle_settings.file_associations
+  }
+
+  /// Return scheme associations.
+  pub fn scheme_associations(&self) -> &Option<Vec<SchemeAssociation>> {
+    &self.bundle_settings.scheme_associations
   }
 
   /// Returns the app's short description.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -940,6 +940,16 @@
             "$ref": "#/definitions/FileAssociation"
           }
         },
+        "schemeAssociations": {
+          "description": "Scheme associations to application.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SchemeAssociation"
+          }
+        },
         "shortDescription": {
           "description": "A short description of your application.",
           "type": [
@@ -1227,6 +1237,36 @@
           ]
         }
       ]
+    },
+    "SchemeAssociation": {
+      "description": "Schema association",
+      "type": "object",
+      "required": [
+        "scheme"
+      ],
+      "properties": {
+        "scheme": {
+          "description": "Schema name to associate with this app. e.g. 'https'",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Scheme"
+          }
+        },
+        "role": {
+          "description": "The app’s role with respect to the type. Maps to `CFBundleTypeRole` on macOS.",
+          "default": "Editor",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BundleTypeRole"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Scheme": {
+      "description": "An extension for a [`SchemaAssociation`].",
+      "type": "string"
     },
     "AppImageConfig": {
       "description": "Configuration for AppImage bundles.\n\nSee more: https://tauri.app/v1/api/config#appimageconfig",

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1155,6 +1155,7 @@ fn tauri_config_to_bundle_settings(
       None => None,
     },
     file_associations: config.file_associations,
+    scheme_associations: config.scheme_associations,
     short_description: config.short_description,
     long_description: config.long_description,
     external_bin: config.external_bin,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->
This change complements the recent file association feature by adding the support for custom URL schema registration in the operating system on macOS and Linux.
This is useful to allow direct interaction with the application from any environment, such as a browser or a native email client.

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [X] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
On the Linux side, the developer is still expected to explicitly handle the URL passed as an argument.
In the Debian package, there is no post-install script to register the URL scheme because Debian has an automatic hook to register `.desktop` files.