### PR TITLE
chore: Move to a modem resolver when using workspaces.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   # integration tests
   "core/tests/restart",
 ]
+resolver = "2"
 
 exclude = [
   # examples that can be compiled with the tauri CLI
@@ -24,10 +25,10 @@ exclude = [
 ]
 
 [workspace.package]
-authors = [ "Tauri Programme within The Commons Conservancy" ]
+authors = ["Tauri Programme within The Commons Conservancy"]
 homepage = "https://tauri.app/"
 repository = "https://github.com/tauri-apps/tauri"
-categories = [ "gui", "web-programming" ]
+categories = ["gui", "web-programming"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"
 rust-version = "1.65"


### PR DESCRIPTION
I saw this lint warning in the build logs 

> some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`

This fix is a single line fix to the appropiate Cargo.toml file.

<!--
Update "[x]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
