### PR TITLE
fix: Cleared warnings seen while running ```cargo doc```

### DIFF
--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -113,7 +113,7 @@
   "additionalProperties": false,
   "definitions": {
     "PackageConfig": {
-      "description": "The package configuration.\n\nSee more: https://tauri.app/v1/api/config#packageconfig",
+      "description": "The package configuration.\n\nSee more: <https://tauri.app/v1/api/config#packageconfig>",
       "type": "object",
       "properties": {
         "productName": {
@@ -136,7 +136,7 @@
       "additionalProperties": false
     },
     "TauriConfig": {
-      "description": "The Tauri configuration object.\n\nSee more: https://tauri.app/v1/api/config#tauriconfig",
+      "description": "The Tauri configuration object.\n\nSee more: <https://tauri.app/v1/api/config#tauriconfig>",
       "type": "object",
       "properties": {
         "pattern": {
@@ -291,7 +291,7 @@
       ]
     },
     "WindowConfig": {
-      "description": "The window configuration object.\n\nSee more: https://tauri.app/v1/api/config#windowconfig",
+      "description": "The window configuration object.\n\nSee more: <https://tauri.app/v1/api/config#windowconfig>",
       "type": "object",
       "properties": {
         "label": {
@@ -510,7 +510,7 @@
           "type": "boolean"
         },
         "windowEffects": {
-          "description": "Window effects.\n\nRequires the window to be transparent.\n\n## Platform-specific:\n\n- **Windows**: If using decorations or shadows, you may want to try this workaround https://github.com/tauri-apps/tao/issues/72#issuecomment-975607891 - **Linux**: Unsupported",
+          "description": "Window effects.\n\nRequires the window to be transparent.\n\n## Platform-specific:\n\n- **Windows**: If using decorations or shadows, you may want to try this workaround <https://github.com/tauri-apps/tao/issues/72#issuecomment-975607891> - **Linux**: Unsupported",
           "anyOf": [
             {
               "$ref": "#/definitions/WindowEffectsConfig"
@@ -867,7 +867,7 @@
       "minItems": 4
     },
     "BundleConfig": {
-      "description": "Configuration for tauri-bundler.\n\nSee more: https://tauri.app/v1/api/config#bundleconfig",
+      "description": "Configuration for tauri-bundler.\n\nSee more: <https://tauri.app/v1/api/config#bundleconfig>",
       "type": "object",
       "required": [
         "identifier"
@@ -1229,7 +1229,7 @@
       ]
     },
     "AppImageConfig": {
-      "description": "Configuration for AppImage bundles.\n\nSee more: https://tauri.app/v1/api/config#appimageconfig",
+      "description": "Configuration for AppImage bundles.\n\nSee more: <https://tauri.app/v1/api/config#appimageconfig>",
       "type": "object",
       "properties": {
         "bundleMediaFramework": {
@@ -1241,7 +1241,7 @@
       "additionalProperties": false
     },
     "DebConfig": {
-      "description": "Configuration for Debian (.deb) bundles.\n\nSee more: https://tauri.app/v1/api/config#debconfig",
+      "description": "Configuration for Debian (.deb) bundles.\n\nSee more: <https://tauri.app/v1/api/config#debconfig>",
       "type": "object",
       "properties": {
         "depends": {
@@ -1273,7 +1273,7 @@
       "additionalProperties": false
     },
     "MacConfig": {
-      "description": "Configuration for the macOS bundles.\n\nSee more: https://tauri.app/v1/api/config#macconfig",
+      "description": "Configuration for the macOS bundles.\n\nSee more: <https://tauri.app/v1/api/config#macconfig>",
       "type": "object",
       "properties": {
         "frameworks": {
@@ -1333,7 +1333,7 @@
       "additionalProperties": false
     },
     "WindowsConfig": {
-      "description": "Windows bundler configuration.\n\nSee more: https://tauri.app/v1/api/config#windowsconfig",
+      "description": "Windows bundler configuration.\n\nSee more: <https://tauri.app/v1/api/config#windowsconfig>",
       "type": "object",
       "properties": {
         "digestAlgorithm": {
@@ -1517,7 +1517,7 @@
       ]
     },
     "WixConfig": {
-      "description": "Configuration for the MSI bundle using WiX.\n\nSee more: https://tauri.app/v1/api/config#wixconfig",
+      "description": "Configuration for the MSI bundle using WiX.\n\nSee more: <https://tauri.app/v1/api/config#wixconfig>",
       "type": "object",
       "properties": {
         "language": {
@@ -1642,7 +1642,7 @@
       ]
     },
     "WixLanguageConfig": {
-      "description": "Configuration for a target language for the WiX build.\n\nSee more: https://tauri.app/v1/api/config#wixlanguageconfig",
+      "description": "Configuration for a target language for the WiX build.\n\nSee more: <https://tauri.app/v1/api/config#wixlanguageconfig>",
       "type": "object",
       "properties": {
         "localePath": {
@@ -1786,7 +1786,7 @@
       "additionalProperties": false
     },
     "UpdaterConfig": {
-      "description": "The Updater configuration object.\n\nSee more: https://tauri.app/v1/api/config#updaterconfig",
+      "description": "The Updater configuration object.\n\nSee more: <https://tauri.app/v1/api/config#updaterconfig>",
       "type": "object",
       "properties": {
         "active": {
@@ -1814,7 +1814,7 @@
       "additionalProperties": false
     },
     "UpdaterWindowsConfig": {
-      "description": "The updater configuration for Windows.\n\nSee more: https://tauri.app/v1/api/config#updaterwindowsconfig",
+      "description": "The updater configuration for Windows.\n\nSee more: <https://tauri.app/v1/api/config#updaterwindowsconfig>",
       "type": "object",
       "properties": {
         "installMode": {
@@ -1856,7 +1856,7 @@
       ]
     },
     "SecurityConfig": {
-      "description": "Security configuration.\n\nSee more: https://tauri.app/v1/api/config#securityconfig",
+      "description": "Security configuration.\n\nSee more: <https://tauri.app/v1/api/config#securityconfig>",
       "type": "object",
       "properties": {
         "csp": {
@@ -2004,7 +2004,7 @@
       "additionalProperties": false
     },
     "AssetProtocolConfig": {
-      "description": "Config for the asset custom protocol.\n\nSee more: https://tauri.app/v1/api/config#assetprotocolconfig",
+      "description": "Config for the asset custom protocol.\n\nSee more: <https://tauri.app/v1/api/config#assetprotocolconfig>",
       "type": "object",
       "properties": {
         "scope": {
@@ -2066,7 +2066,7 @@
       ]
     },
     "TrayIconConfig": {
-      "description": "Configuration for application tray icon.\n\nSee more: https://tauri.app/v1/api/config#trayiconconfig",
+      "description": "Configuration for application tray icon.\n\nSee more: <https://tauri.app/v1/api/config#trayiconconfig>",
       "type": "object",
       "required": [
         "iconPath"
@@ -2104,7 +2104,7 @@
       "additionalProperties": false
     },
     "BuildConfig": {
-      "description": "The Build configuration object.\n\nSee more: https://tauri.app/v1/api/config#buildconfig",
+      "description": "The Build configuration object.\n\nSee more: <https://tauri.app/v1/api/config#buildconfig>",
       "type": "object",
       "properties": {
         "runner": {
@@ -2267,7 +2267,7 @@
       ]
     },
     "PluginConfig": {
-      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.\n\nSee more: https://tauri.app/v1/api/config#pluginconfig",
+      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.\n\nSee more: <https://tauri.app/v1/api/config#pluginconfig>",
       "type": "object",
       "additionalProperties": true
     }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -252,7 +252,7 @@ impl BundleTarget {
 
 /// Configuration for AppImage bundles.
 ///
-/// See more: https://tauri.app/v1/api/config#appimageconfig
+/// See more: <https://tauri.app/v1/api/config#appimageconfig>
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -265,7 +265,7 @@ pub struct AppImageConfig {
 
 /// Configuration for Debian (.deb) bundles.
 ///
-/// See more: https://tauri.app/v1/api/config#debconfig
+/// See more: <https://tauri.app/v1/api/config#debconfig>
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -295,7 +295,7 @@ where
 
 /// Configuration for the macOS bundles.
 ///
-/// See more: https://tauri.app/v1/api/config#macconfig
+/// See more: <https://tauri.app/v1/api/config#macconfig>
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -353,7 +353,7 @@ fn minimum_system_version() -> Option<String> {
 
 /// Configuration for a target language for the WiX build.
 ///
-/// See more: https://tauri.app/v1/api/config#wixlanguageconfig
+/// See more: <https://tauri.app/v1/api/config#wixlanguageconfig>
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -384,7 +384,7 @@ impl Default for WixLanguage {
 
 /// Configuration for the MSI bundle using WiX.
 ///
-/// See more: https://tauri.app/v1/api/config#wixconfig
+/// See more: <https://tauri.app/v1/api/config#wixconfig>
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -565,7 +565,7 @@ impl Default for WebviewInstallMode {
 
 /// Windows bundler configuration.
 ///
-/// See more: https://tauri.app/v1/api/config#windowsconfig
+/// See more: <https://tauri.app/v1/api/config#windowsconfig>
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -698,7 +698,7 @@ pub struct FileAssociation {
 
 /// The Updater configuration object.
 ///
-/// See more: https://tauri.app/v1/api/config#updaterconfig
+/// See more: <https://tauri.app/v1/api/config#updaterconfig>
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -757,7 +757,7 @@ impl Default for UpdaterConfig {
 
 /// Configuration for tauri-bundler.
 ///
-/// See more: https://tauri.app/v1/api/config#bundleconfig
+/// See more: <https://tauri.app/v1/api/config#bundleconfig>
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -862,7 +862,7 @@ pub struct WindowEffectsConfig {
 
 /// The window configuration object.
 ///
-/// See more: https://tauri.app/v1/api/config#windowconfig
+/// See more: <https://tauri.app/v1/api/config#windowconfig>
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1011,7 +1011,7 @@ pub struct WindowConfig {
   ///
   /// ## Platform-specific:
   ///
-  /// - **Windows**: If using decorations or shadows, you may want to try this workaround https://github.com/tauri-apps/tao/issues/72#issuecomment-975607891
+  /// - **Windows**: If using decorations or shadows, you may want to try this workaround <https://github.com/tauri-apps/tao/issues/72#issuecomment-975607891>
   /// - **Linux**: Unsupported
   #[serde(default, alias = "window-effects")]
   pub window_effects: Option<WindowEffectsConfig>,
@@ -1306,7 +1306,7 @@ impl FsScope {
 
 /// Config for the asset custom protocol.
 ///
-/// See more: https://tauri.app/v1/api/config#assetprotocolconfig
+/// See more: <https://tauri.app/v1/api/config#assetprotocolconfig>
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1321,7 +1321,7 @@ pub struct AssetProtocolConfig {
 
 /// Security configuration.
 ///
-/// See more: https://tauri.app/v1/api/config#securityconfig
+/// See more: <https://tauri.app/v1/api/config#securityconfig>
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1398,7 +1398,7 @@ impl Default for PatternKind {
 
 /// The Tauri configuration object.
 ///
-/// See more: https://tauri.app/v1/api/config#tauriconfig
+/// See more: <https://tauri.app/v1/api/config#tauriconfig>
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1539,7 +1539,7 @@ impl<'de> Deserialize<'de> for WindowsUpdateInstallMode {
 
 /// The updater configuration for Windows.
 ///
-/// See more: https://tauri.app/v1/api/config#updaterwindowsconfig
+/// See more: <https://tauri.app/v1/api/config#updaterwindowsconfig>
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1552,7 +1552,7 @@ pub struct UpdaterWindowsConfig {
 
 /// Configuration for application tray icon.
 ///
-/// See more: https://tauri.app/v1/api/config#trayiconconfig
+/// See more: <https://tauri.app/v1/api/config#trayiconconfig>
 #[skip_serializing_none]
 #[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1667,7 +1667,7 @@ pub enum HookCommand {
 
 /// The Build configuration object.
 ///
-/// See more: https://tauri.app/v1/api/config#buildconfig
+/// See more: <https://tauri.app/v1/api/config#buildconfig>
 #[skip_serializing_none]
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -1802,7 +1802,7 @@ impl<'d> serde::Deserialize<'d> for PackageVersion {
 
 /// The package configuration.
 ///
-/// See more: https://tauri.app/v1/api/config#packageconfig
+/// See more: <https://tauri.app/v1/api/config#packageconfig>
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -1926,7 +1926,7 @@ pub struct Config {
 
 /// The plugin configs holds a HashMap mapping a plugin name to its configuration object.
 ///
-/// See more: https://tauri.app/v1/api/config#pluginconfig
+/// See more: <https://tauri.app/v1/api/config#pluginconfig>
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 pub struct PluginConfig(pub HashMap<String, JsonValue>);

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -113,7 +113,7 @@
   "additionalProperties": false,
   "definitions": {
     "PackageConfig": {
-      "description": "The package configuration.\n\nSee more: https://tauri.app/v1/api/config#packageconfig",
+      "description": "The package configuration.\n\nSee more: <https://tauri.app/v1/api/config#packageconfig>",
       "type": "object",
       "properties": {
         "productName": {
@@ -136,7 +136,7 @@
       "additionalProperties": false
     },
     "TauriConfig": {
-      "description": "The Tauri configuration object.\n\nSee more: https://tauri.app/v1/api/config#tauriconfig",
+      "description": "The Tauri configuration object.\n\nSee more: <https://tauri.app/v1/api/config#tauriconfig>",
       "type": "object",
       "properties": {
         "pattern": {
@@ -291,7 +291,7 @@
       ]
     },
     "WindowConfig": {
-      "description": "The window configuration object.\n\nSee more: https://tauri.app/v1/api/config#windowconfig",
+      "description": "The window configuration object.\n\nSee more: <https://tauri.app/v1/api/config#windowconfig>",
       "type": "object",
       "properties": {
         "label": {
@@ -510,7 +510,7 @@
           "type": "boolean"
         },
         "windowEffects": {
-          "description": "Window effects.\n\nRequires the window to be transparent.\n\n## Platform-specific:\n\n- **Windows**: If using decorations or shadows, you may want to try this workaround https://github.com/tauri-apps/tao/issues/72#issuecomment-975607891 - **Linux**: Unsupported",
+          "description": "Window effects.\n\nRequires the window to be transparent.\n\n## Platform-specific:\n\n- **Windows**: If using decorations or shadows, you may want to try this workaround <https://github.com/tauri-apps/tao/issues/72#issuecomment-975607891> - **Linux**: Unsupported",
           "anyOf": [
             {
               "$ref": "#/definitions/WindowEffectsConfig"
@@ -867,7 +867,7 @@
       "minItems": 4
     },
     "BundleConfig": {
-      "description": "Configuration for tauri-bundler.\n\nSee more: https://tauri.app/v1/api/config#bundleconfig",
+      "description": "Configuration for tauri-bundler.\n\nSee more: <https://tauri.app/v1/api/config#bundleconfig>",
       "type": "object",
       "required": [
         "identifier"
@@ -1229,7 +1229,7 @@
       ]
     },
     "AppImageConfig": {
-      "description": "Configuration for AppImage bundles.\n\nSee more: https://tauri.app/v1/api/config#appimageconfig",
+      "description": "Configuration for AppImage bundles.\n\nSee more: <https://tauri.app/v1/api/config#appimageconfig>",
       "type": "object",
       "properties": {
         "bundleMediaFramework": {
@@ -1241,7 +1241,7 @@
       "additionalProperties": false
     },
     "DebConfig": {
-      "description": "Configuration for Debian (.deb) bundles.\n\nSee more: https://tauri.app/v1/api/config#debconfig",
+      "description": "Configuration for Debian (.deb) bundles.\n\nSee more: <https://tauri.app/v1/api/config#debconfig>",
       "type": "object",
       "properties": {
         "depends": {
@@ -1273,7 +1273,7 @@
       "additionalProperties": false
     },
     "MacConfig": {
-      "description": "Configuration for the macOS bundles.\n\nSee more: https://tauri.app/v1/api/config#macconfig",
+      "description": "Configuration for the macOS bundles.\n\nSee more: <https://tauri.app/v1/api/config#macconfig>",
       "type": "object",
       "properties": {
         "frameworks": {
@@ -1333,7 +1333,7 @@
       "additionalProperties": false
     },
     "WindowsConfig": {
-      "description": "Windows bundler configuration.\n\nSee more: https://tauri.app/v1/api/config#windowsconfig",
+      "description": "Windows bundler configuration.\n\nSee more: <https://tauri.app/v1/api/config#windowsconfig>",
       "type": "object",
       "properties": {
         "digestAlgorithm": {
@@ -1517,7 +1517,7 @@
       ]
     },
     "WixConfig": {
-      "description": "Configuration for the MSI bundle using WiX.\n\nSee more: https://tauri.app/v1/api/config#wixconfig",
+      "description": "Configuration for the MSI bundle using WiX.\n\nSee more: <https://tauri.app/v1/api/config#wixconfig>",
       "type": "object",
       "properties": {
         "language": {
@@ -1642,7 +1642,7 @@
       ]
     },
     "WixLanguageConfig": {
-      "description": "Configuration for a target language for the WiX build.\n\nSee more: https://tauri.app/v1/api/config#wixlanguageconfig",
+      "description": "Configuration for a target language for the WiX build.\n\nSee more: <https://tauri.app/v1/api/config#wixlanguageconfig>",
       "type": "object",
       "properties": {
         "localePath": {
@@ -1786,7 +1786,7 @@
       "additionalProperties": false
     },
     "UpdaterConfig": {
-      "description": "The Updater configuration object.\n\nSee more: https://tauri.app/v1/api/config#updaterconfig",
+      "description": "The Updater configuration object.\n\nSee more: <https://tauri.app/v1/api/config#updaterconfig>",
       "type": "object",
       "properties": {
         "active": {
@@ -1814,7 +1814,7 @@
       "additionalProperties": false
     },
     "UpdaterWindowsConfig": {
-      "description": "The updater configuration for Windows.\n\nSee more: https://tauri.app/v1/api/config#updaterwindowsconfig",
+      "description": "The updater configuration for Windows.\n\nSee more: <https://tauri.app/v1/api/config#updaterwindowsconfig>",
       "type": "object",
       "properties": {
         "installMode": {
@@ -1856,7 +1856,7 @@
       ]
     },
     "SecurityConfig": {
-      "description": "Security configuration.\n\nSee more: https://tauri.app/v1/api/config#securityconfig",
+      "description": "Security configuration.\n\nSee more: <https://tauri.app/v1/api/config#securityconfig>",
       "type": "object",
       "properties": {
         "csp": {
@@ -2004,7 +2004,7 @@
       "additionalProperties": false
     },
     "AssetProtocolConfig": {
-      "description": "Config for the asset custom protocol.\n\nSee more: https://tauri.app/v1/api/config#assetprotocolconfig",
+      "description": "Config for the asset custom protocol.\n\nSee more: <https://tauri.app/v1/api/config#assetprotocolconfig>",
       "type": "object",
       "properties": {
         "scope": {
@@ -2066,7 +2066,7 @@
       ]
     },
     "TrayIconConfig": {
-      "description": "Configuration for application tray icon.\n\nSee more: https://tauri.app/v1/api/config#trayiconconfig",
+      "description": "Configuration for application tray icon.\n\nSee more: <https://tauri.app/v1/api/config#trayiconconfig>",
       "type": "object",
       "required": [
         "iconPath"
@@ -2104,7 +2104,7 @@
       "additionalProperties": false
     },
     "BuildConfig": {
-      "description": "The Build configuration object.\n\nSee more: https://tauri.app/v1/api/config#buildconfig",
+      "description": "The Build configuration object.\n\nSee more: <https://tauri.app/v1/api/config#buildconfig>",
       "type": "object",
       "properties": {
         "runner": {
@@ -2267,7 +2267,7 @@
       ]
     },
     "PluginConfig": {
-      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.\n\nSee more: https://tauri.app/v1/api/config#pluginconfig",
+      "description": "The plugin configs holds a HashMap mapping a plugin name to its configuration object.\n\nSee more: <https://tauri.app/v1/api/config#pluginconfig>",
       "type": "object",
       "additionalProperties": true
     }


### PR DESCRIPTION
All changes are of this form.

```
warning: this URL is not a hyperlink
    --> core/tauri-utils/src/config.rs:1805:15
     |
1805 | /// See more: https://tauri.app/v1/api/config#packageconfig
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://tauri.app/v1/api/config#packageconfig>`
```

All alterations to .json files are auto generated ( triggered by running cargo doc. )

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
