### PR TITLE
fix: remove mut self from set_native_icon signature

### DIFF
--- a/.changes/set_native_icon_signature.md
+++ b/.changes/set_native_icon_signature.md
@@ -1,0 +1,5 @@
+---
+"tauri": 'patch:enhance'
+---
+
+remove mut self from set_native_icon signature

--- a/.changes/set_native_icon_signature.md
+++ b/.changes/set_native_icon_signature.md
@@ -1,5 +1,5 @@
 ---
-"tauri": 'patch:enhance'
+"tauri": 'patch:bug'
 ---
 
-remove mut self from set_native_icon signature
+Changed `IconMenuItem::set_native_icon` signature to take `&self` instead of `&mut self` to fix compilation error on macos.

--- a/core/tauri/src/menu/icon.rs
+++ b/core/tauri/src/menu/icon.rs
@@ -207,7 +207,7 @@ impl<R: Runtime> IconMenuItem<R> {
   /// - **Windows / Linux**: Unsupported.
   pub fn set_native_icon(&self, _icon: Option<NativeIcon>) -> crate::Result<()> {
     #[cfg(target_os = "macos")]
-    return run_main_thread!(mut self, |self_: Self| self_
+    return run_main_thread!(self, |self_: Self| self_
       .inner
       .set_native_icon(_icon.map(Into::into)));
     #[allow(unreachable_code)]

--- a/core/tauri/src/menu/icon.rs
+++ b/core/tauri/src/menu/icon.rs
@@ -205,7 +205,7 @@ impl<R: Runtime> IconMenuItem<R> {
   /// ## Platform-specific:
   ///
   /// - **Windows / Linux**: Unsupported.
-  pub fn set_native_icon(&mut self, _icon: Option<NativeIcon>) -> crate::Result<()> {
+  pub fn set_native_icon(&self, _icon: Option<NativeIcon>) -> crate::Result<()> {
     #[cfg(target_os = "macos")]
     return run_main_thread!(mut self, |self_: Self| self_
       .inner

--- a/core/tauri/src/menu/icon.rs
+++ b/core/tauri/src/menu/icon.rs
@@ -207,7 +207,7 @@ impl<R: Runtime> IconMenuItem<R> {
   /// - **Windows / Linux**: Unsupported.
   pub fn set_native_icon(&mut self, _icon: Option<NativeIcon>) -> crate::Result<()> {
     #[cfg(target_os = "macos")]
-    return run_main_thread!(self, |self_: Self| self_
+    return run_main_thread!(mut self, |self_: Self| self_
       .inner
       .set_native_icon(_icon.map(Into::into)));
     #[allow(unreachable_code)]


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
I'm getting a compile error in the latest alpha release.  The error can be reproduced with this [repo](https://github.com/logankeenan/native-app/) by running `cargo tauri dev`. It looks like the bug was introduced [here](https://github.com/tauri-apps/tauri/pull/7754/files#diff-41ef79e158d69fe78154d145fa88e594ef8a3daf35e727db8ad9fa73cc23a663R210).

```
error[E0596]: cannot borrow `self_.inner` as mutable, as `self_` is not declared as mutable
   --> /Users/logankeenan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.0.0-alpha.14/src/menu/icon.rs:210:49
    |
210 |       return run_main_thread!(self, |self_: Self| self_
    |  _________________________________________________^
211 | |       .inner
212 | |       .set_native_icon(_icon.map(Into::into)));
    | |_____________________________________________^ cannot borrow as mutable
    |
help: consider changing this to be mutable
    |
210 |     return run_main_thread!(self, |mut self_: Self| self_
    |                                    +++

For more information about this error, try `rustc --explain E0596`.
error: could not compile `tauri` (lib) due to previous error

```

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
