### PR TITLE
refactor!: changed `Env.args` to `Env.args_os` and use `OsString` instead of `String`

### DIFF
--- a/.changes/tauri-env-args.md
+++ b/.changes/tauri-env-args.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'major:breaking'
+---
+
+Changed `Env.args` to `Env.args_os` and now uses `OsString` instead of `String`

--- a/core/tauri-utils/src/lib.rs
+++ b/core/tauri-utils/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::deprecated_semver)]
 
 use std::{
+  ffi::OsString,
   fmt::Display,
   path::{Path, PathBuf},
 };
@@ -275,13 +276,13 @@ pub struct Env {
   #[cfg(target_os = "linux")]
   pub appdir: Option<std::ffi::OsString>,
   /// The command line arguments of the current process.
-  pub args: Vec<String>,
+  pub args_os: Vec<OsString>,
 }
 
 #[allow(clippy::derivable_impls)]
 impl Default for Env {
   fn default() -> Self {
-    let args = std::env::args().skip(1).collect();
+    let args_os = std::env::args_os().skip(1).collect();
     #[cfg(target_os = "linux")]
     {
       let env = Self {
@@ -289,7 +290,7 @@ impl Default for Env {
         appimage: std::env::var_os("APPIMAGE"),
         #[cfg(target_os = "linux")]
         appdir: std::env::var_os("APPDIR"),
-        args,
+        args_os,
       };
       if env.appimage.is_some() || env.appdir.is_some() {
         // validate that we're actually running on an AppImage
@@ -312,7 +313,7 @@ impl Default for Env {
     }
     #[cfg(not(target_os = "linux"))]
     {
-      Self { args }
+      Self { args_os }
     }
   }
 }

--- a/core/tauri/src/process.rs
+++ b/core/tauri/src/process.rs
@@ -76,7 +76,7 @@ pub fn restart(env: &Env) {
 
   if let Ok(path) = current_binary(env) {
     Command::new(path)
-      .args(&env.args)
+      .args(&env.args_os)
       .spawn()
       .expect("application failed to start");
   }

--- a/core/tests/restart/src/main.rs
+++ b/core/tests/restart/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
   match argv.nth(1).as_deref() {
     Some("restart") => {
       let mut env = Env::default();
-      env.args.clear();
+      env.args_os.clear();
       tauri::process::restart(&env)
     }
     Some(invalid) => panic!("only argument `restart` is allowed, {invalid} is invalid"),


### PR DESCRIPTION
ref: https://github.com/tauri-apps/tauri/issues/7756

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
