### PR TITLE
Yes no cancel dialogbuttons, closes #7855

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -88,11 +88,11 @@ encoding_rs = "0.8.31"
 sys-locale = { version = "0.2.3", optional = true }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
-rfd = { version = "0.10", optional = true, features = [ "gtk3", "common-controls-v6" ] }
+rfd = { version = "0.12", optional = true, features = [ "gtk3", "common-controls-v6" ] }
 notify-rust = { version = "4.5", optional = true }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
-gtk = { version = "0.15", features = [ "v3_20" ] }
+gtk = { version = "0.18.1", features = [ "v3_20" ] }
 glib = "0.15"
 webkit2gtk = { version = "0.18.2", features = [ "v2_22" ] }
 

--- a/core/tauri/src/api/dialog.rs
+++ b/core/tauri/src/api/dialog.rs
@@ -183,6 +183,10 @@ pub enum MessageDialogButtons {
   OkWithLabel(String),
   /// Ok and Cancel buttons with customized text.
   OkCancelWithLabels(String, String),
+  /// Yes, No, and Cancel Buttons
+  YesNoCancel,
+  /// Yes, No, and Cancel buttons with customized text.
+  YesNoCancelWithLabels(String, String, String),
 }
 
 impl From<MessageDialogButtons> for rfd::MessageButtons {
@@ -194,6 +198,10 @@ impl From<MessageDialogButtons> for rfd::MessageButtons {
       MessageDialogButtons::OkWithLabel(ok_text) => Self::OkCustom(ok_text),
       MessageDialogButtons::OkCancelWithLabels(ok_text, cancel_text) => {
         Self::OkCancelCustom(ok_text, cancel_text)
+      }
+      MessageDialogButtons::YesNoCancel => Self::YesNoCancel,
+      MessageDialogButtons::YesNoCancelWithLabels(yes_text, no_text, cancel_text) => {
+        Self::YesNoCancelCustom(yes_text, no_text, cancel_text)
       }
     }
   }

--- a/core/tauri/src/endpoints/dialog.rs
+++ b/core/tauri/src/endpoints/dialog.rs
@@ -162,6 +162,15 @@ pub enum Cmd {
     #[serde(rename = "buttonLabels")]
     button_labels: Option<(String, String)>,
   },
+  #[cmd(dialod_ask_or_cancel, "dialog > askOrCancel")]
+  AskOrCancelDialog {
+    title: Option<String>,
+    message: String,
+    #[serde(rename = "type")]
+    level: Option<MessageDialogType>,
+    #[serde(rename = "buttonLabels")]
+    button_labels: Option<(String, String, String)>,
+  },
 }
 
 impl Cmd {
@@ -292,6 +301,19 @@ impl Cmd {
           crate::api::dialog::MessageDialogButtons::OkCancelWithLabels(ok, cancel)
         })
         .unwrap_or(crate::api::dialog::MessageDialogButtons::OkCancel)
+    }
+  );
+
+  message_dialog!(
+    ask_or_cancel_dialog,
+    dialod_ask_or_cancel,
+    Option<(String, String, String)>,
+    |labels: Option<(String, String, String)>| {
+      labels
+        .map(|(yes, no, cancel)| {
+          crate::api::dialog::MessageDialogButtons::YesNoCancelWithLabels(yes, no, cancel)
+        })
+        .unwrap_or(crate::api::dialog::MessageDialogButtons::YesNoCancel)
     }
   );
 }

--- a/tooling/api/src/dialog.ts
+++ b/tooling/api/src/dialog.ts
@@ -112,6 +112,19 @@ interface ConfirmDialogOptions {
   cancelLabel?: string
 }
 
+interface AskOrCancelDialogOptions {
+  /** The title of the dialog. Defaults to the app name. */
+  title?: string
+  /** The type of the dialog. Defaults to `info`. */
+  type?: 'info' | 'warning' | 'error'
+  /** The label of the yes button. */
+  yesLabel?: string
+  /** The label of the no button. */
+  noLabel?: string
+  /** The label of the cancel button. */
+  cancelLabel?: string
+}
+
 /**
  * Open a file/directory selection dialog.
  *
@@ -318,6 +331,27 @@ async function confirm(
       type: opts?.type,
       buttonLabels: [
         opts?.okLabel?.toString() ?? 'Ok',
+        opts?.cancelLabel?.toString() ?? 'Cancel'
+      ]
+    }
+  })
+}
+
+async function askOrCancel(
+  message: string,
+  options?: string | AskOrCancelDialogOptions
+): Promise<boolean | null> {
+  const opts = typeof options === 'string' ? { title: options } : options
+  return invokeTauriCommand({
+    __tauriModule: 'Dialog',
+    message: {
+      cmd: 'confirmOrCancelDialog',
+      message: message.toString(),
+      title: opts?.title?.toString(),
+      type: opts?.type,
+      buttonLabels: [
+        opts?.yesLabel?.toString() ?? 'Yes',
+        opts?.noLabel?.toString() ?? 'No',
         opts?.cancelLabel?.toString() ?? 'Cancel'
       ]
     }


### PR DESCRIPTION
Adds YesNoCancel option for Dialogs so that things like exiting the software and asking if a user want's to "save, don't save, or cancel" can be implemented.

Issue: #7855

Also requires this PR to be completed first:
https://github.com/tauri-apps/webkit2gtk-rs/pull/149

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [X] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [X] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
