### PR TITLE
docs: change `icon` help output to ask for 1024px source icons, closes #7886

### DIFF
--- a/tooling/cli/src/icon.rs
+++ b/tooling/cli/src/icon.rs
@@ -47,8 +47,7 @@ impl PngTarget {
 #[derive(Debug, Parser)]
 #[clap(about = "Generates various icons for all major platforms")]
 pub struct Options {
-  // TODO: Confirm 1240px
-  /// Path to the source icon (png, 1240x1240px with transparency).
+  /// Path to the source icon (png, 1024x1024px with transparency).
   #[clap(default_value = "./app-icon.png")]
   input: PathBuf,
   /// Output directory.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix - not really a bug fix, we just weren't sure back then.
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
closes #7886