### PR TITLE
Fix strict mode: arguments -> args

### DIFF
--- a/.changes/js-strict.md
+++ b/.changes/js-strict.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/cli": 'patch:bug'
+---
+
+Fix running `bun --bun run tauri dev` in JS environments in strict mode.

--- a/.changes/js-strict.md
+++ b/.changes/js-strict.md
@@ -2,4 +2,4 @@
 "@tauri-apps/cli": 'patch:bug'
 ---
 
-Fix running `bun --bun run tauri dev` in JS environments in strict mode.
+Fix running `@tauri-apps/cli` in JS environments in strict mode.

--- a/tooling/cli/node/tauri.js
+++ b/tooling/cli/node/tauri.js
@@ -7,7 +7,7 @@
 const cli = require('./main')
 const path = require('path')
 
-const [bin, script, ...arguments] = process.argv
+const [bin, script, ...args] = process.argv
 const binStem = path.parse(bin).name.toLowerCase()
 
 // We want to make a helpful binary name for the underlying CLI helper, if we
@@ -48,10 +48,10 @@ else if (binStem.match(/(nodejs|node)\-?([0-9]*)*$/g)) {
   }
 } else {
   // We don't know what started it, assume it's already stripped.
-  arguments.unshift(bin)
+  args.unshift(bin)
 }
 
-cli.run(arguments, binName).catch((err) => {
+cli.run(args, binName).catch((err) => {
   cli.logError(err.message)
   process.exit(1)
 })


### PR DESCRIPTION
Currently, the cli breaks when running in strict mode, because a variable is named `arguments` which is a reserved word. I've renamed it to args. A similar change was recently applied to the create-tauri-app [here](https://github.com/tauri-apps/create-tauri-app/pull/478). A user hitting this issue with the `bun` runtime can be found [here](https://github.com/oven-sh/bun/issues/3237#issuecomment-1734476373).

- [X] Bugfix

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [X] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [X] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [X] I have added a convincing reason for adding this feature, if necessary

### Other information
