### PR TITLE
fix(macos): fix notraytool's apple-id option name, close #7917

### DIFF
--- a/.changes/fix-notarytool-args-apple-id.md
+++ b/.changes/fix-notarytool-args-apple-id.md
@@ -1,5 +1,6 @@
 ---
 'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
 ---
 
 On macOS, fix the `apple-id` option name when using `notarytools submit`.

--- a/.changes/fix-notarytool-args-apple-id.md
+++ b/.changes/fix-notarytool-args-apple-id.md
@@ -1,5 +1,5 @@
 ---
-'tauri-cli': 'patch-bug'
+'tauri-cli': 'patch:bug'
 ---
 
 On macOS, fix the `apple-id` option name when using `notarytools submit`.

--- a/.changes/fix-notarytool-args-apple-id.md
+++ b/.changes/fix-notarytool-args-apple-id.md
@@ -1,0 +1,5 @@
+---
+'tauri-cli': 'patch-bug'
+---
+
+On macOS, fix the `apple-id` option name when using `notarytools submit`.

--- a/tooling/bundler/src/bundle/macos/sign.rs
+++ b/tooling/bundler/src/bundle/macos/sign.rs
@@ -358,7 +358,7 @@ impl NotarytoolCmdExt for Command {
         team_id,
       } => {
         self
-          .arg("--username")
+          .arg("--apple-id")
           .arg(apple_id)
           .arg("--password")
           .arg(password);


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Issue: #7917 

```
OVERVIEW: Submit an archive to the Notary service

USAGE: notarytool submit [<options>] <file-path>

ARGUMENTS:
  <file-path>             Path to the archive

OPTIONS:
  -v, --verbose
  -k, --key <key>         App Store Connect API key. File system path to the private key.
  -d, --key-id <key-id>   App Store Connect API Key ID. Usually 10 alphanumeric characters.
  -i, --issuer <issuer>   App Store Connect API Issuer ID. UUID format.
  --apple-id <apple-id>   Developer Apple ID.
  --password <password>   App-specific password for your Apple ID. You will be given a secure prompt on the command line if Apple ID and Team ID are provided and '--password' option is
                          not specified.
  --team-id <team-id>     Developer Team ID.
  -p, --keychain-profile <keychain-profile>
                          Authenticate with credentials stored in the Keychain. Use the profile name you provided in the "store-credentials" command.
  --keychain <keychain>   Pass the path to a keychain file to use for reading the keychain item. If the specified keychain is locked, you'll be prompted to unlock it.
  -f, --output-format <output-format>
                          Desired output format. Note that 'json' and 'plist' are incompatible with '--progress'; a single update will be output at the end of the operation. Choices:
                          ["normal", "json", "plist"] (default: normal)
  --progress/--no-progress
                          Display progress indicators. Only compatible with normal output format (default) and will be otherwise suppressed. (default: true)
  --webhook <webhook>     Designate a public webhook URL to receive HTTP notifications on.
  --wait/--no-wait        Wait until processing is complete. Optionally set a '--timeout' if waiting. (default: false)
  --timeout <duration>    Optional time limit for 'wait'. notarytool will exit after polling for <duration>. The Notary service will continue processing even if the timeout is reached.
        'duration' is an integer followed by an optional suffix: seconds 's' (default), minutes 'm', hours 'h'. Examples: '3600', '60m', '1h'
  --s3-acceleration/--no-s3-acceleration
                          Use S3 Transfer Acceleration for uploads. (default: true)
  --force                 Upload the file even if pre-flight validation or other problems are encountered.
  --version               Show the version.
  -h, --help              Show help information.
  ```

Not seeing the `--username` option in the notarytool's manual, I guess it might be a typo?
After changing it back to `--apple-id`, it signed successfully. 
