### PR TITLE
feat(bundler): add dmg settings, closes #4669

### DIFF
--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -37,6 +37,20 @@
           "deb": {
             "files": {}
           },
+          "dmg": {
+            "appPosition": {
+              "x": 180,
+              "y": 170
+            },
+            "applicationFolderPosition": {
+              "x": 480,
+              "y": 170
+            },
+            "windowSize": {
+              "height": 400,
+              "width": 660
+            }
+          },
           "iOS": {},
           "icon": [],
           "identifier": "",
@@ -170,6 +184,20 @@
             },
             "deb": {
               "files": {}
+            },
+            "dmg": {
+              "appPosition": {
+                "x": 180,
+                "y": 170
+              },
+              "applicationFolderPosition": {
+                "x": 480,
+                "y": 170
+              },
+              "windowSize": {
+                "height": 400,
+                "width": 660
+              }
             },
             "iOS": {},
             "icon": [],
@@ -976,6 +1004,28 @@
             }
           ]
         },
+        "dmg": {
+          "description": "DMG-specific settings.",
+          "default": {
+            "appPosition": {
+              "x": 180,
+              "y": 170
+            },
+            "applicationFolderPosition": {
+              "x": 480,
+              "y": 170
+            },
+            "windowSize": {
+              "height": 400,
+              "width": 660
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/DmgConfig"
+            }
+          ]
+        },
         "macOS": {
           "description": "Configuration for the macOS bundles.",
           "default": {
@@ -1268,6 +1318,113 @@
             "string",
             "null"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DmgConfig": {
+      "description": "Configuration for Apple Disk Image (.dmg) bundles.\n\nSee more: https://tauri.app/v1/api/config#dmgconfig",
+      "type": "object",
+      "properties": {
+        "background": {
+          "description": "Image to use as the background in dmg file. Accepted formats: `png`/`jpg`/`gif`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "windowPosition": {
+          "description": "Position of volume window on screen.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Position"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "windowSize": {
+          "description": "Size of volume window.",
+          "default": {
+            "height": 400,
+            "width": 660
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Size"
+            }
+          ]
+        },
+        "appPosition": {
+          "description": "Position of app file on window.",
+          "default": {
+            "x": 180,
+            "y": 170
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Position"
+            }
+          ]
+        },
+        "applicationFolderPosition": {
+          "description": "Position of application folder on window.",
+          "default": {
+            "x": 480,
+            "y": 170
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Position"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Position": {
+      "description": "Position coordinates struct.",
+      "type": "object",
+      "required": [
+        "x",
+        "y"
+      ],
+      "properties": {
+        "x": {
+          "description": "X coordinate.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "y": {
+          "description": "Y coordinate.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Size": {
+      "description": "Size of the window.",
+      "type": "object",
+      "required": [
+        "height",
+        "width"
+      ],
+      "properties": {
+        "width": {
+          "description": "Width of the window.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "height": {
+          "description": "Height of the window.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -282,6 +282,95 @@ pub struct DebConfig {
   pub desktop_template: Option<PathBuf>,
 }
 
+/// Position coordinates struct.
+#[derive(Default, Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Position {
+  /// X coordinate.
+  pub x: u32,
+  /// Y coordinate.
+  pub y: u32,
+}
+
+/// Size of the window.
+#[derive(Default, Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Size {
+  /// Width of the window.
+  pub width: u32,
+  /// Height of the window.
+  pub height: u32,
+}
+
+
+
+/// Configuration for Apple Disk Image (.dmg) bundles.
+///
+/// See more: https://tauri.app/v1/api/config#dmgconfig
+#[skip_serializing_none]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DmgConfig {
+  /// Image to use as the background in dmg file. Accepted formats: `png`/`jpg`/`gif`.
+  pub background: Option<PathBuf>,
+  /// Position of volume window on screen.
+  pub window_position: Option<Position>,
+  /// Size of volume window.
+  #[serde(
+    default = "window_size",
+    alias = "window-size"
+  )]
+  pub window_size: Size,
+  /// Position of app file on window.
+  #[serde(
+    default = "app_position",
+    alias = "app-position"
+  )]
+  pub app_position: Position,
+  /// Position of application folder on window.
+  #[serde(
+    default = "application_folder_position",
+    alias = "application-folder-position"
+  )]
+  pub application_folder_position: Position,
+}
+
+impl Default for DmgConfig {
+  fn default() -> Self {
+    Self {
+      background: None,
+      window_position: None,
+      window_size: window_size(),
+      app_position: app_position(),
+      application_folder_position: application_folder_position(),
+    }
+  }
+}
+
+fn window_size() -> Size {
+  Size {
+    width: 660,
+    height: 400,
+  }
+}
+
+fn app_position() -> Position {
+  Position {
+    x: 180,
+    y: 170,
+  }
+}
+
+fn application_folder_position() -> Position {
+  Position {
+    x: 480,
+    y: 170,
+  }
+}
+
 fn de_minimum_system_version<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
   D: Deserializer<'de>,
@@ -806,6 +895,9 @@ pub struct BundleConfig {
   /// Configuration for the Debian bundle.
   #[serde(default)]
   pub deb: DebConfig,
+  /// DMG-specific settings.
+  #[serde(default)]
+  pub dmg: DmgConfig,
   /// Configuration for the macOS bundles.
   #[serde(rename = "macOS", default)]
   pub macos: MacConfig,
@@ -2378,6 +2470,7 @@ mod build {
       let long_description = quote!(None);
       let appimage = quote!(Default::default());
       let deb = quote!(Default::default());
+      let dmg = quote!(Default::default());
       let macos = quote!(Default::default());
       let external_bin = opt_vec_str_lit(self.external_bin.as_ref());
       let windows = &self.windows;
@@ -2401,6 +2494,7 @@ mod build {
         long_description,
         appimage,
         deb,
+        dmg,
         macos,
         external_bin,
         windows,
@@ -2707,6 +2801,7 @@ mod test {
         long_description: None,
         appimage: Default::default(),
         deb: Default::default(),
+        dmg: Default::default(),
         macos: Default::default(),
         external_bin: None,
         windows: Default::default(),

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -20,8 +20,8 @@ use tauri_utils::display_path;
 pub use self::{
   category::AppCategory,
   settings::{
-    BundleBinary, BundleSettings, DebianSettings, MacOsSettings, PackageSettings, PackageType,
-    Settings, SettingsBuilder, UpdaterSettings,
+    BundleBinary, BundleSettings, DebianSettings, DmgSettings, MacOsSettings, PackageSettings, PackageType,
+    Settings, SettingsBuilder, UpdaterSettings, Position, Size
   },
 };
 #[cfg(target_os = "macos")]

--- a/tooling/bundler/src/bundle/macos/dmg.rs
+++ b/tooling/bundler/src/bundle/macos/dmg.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use anyhow::Context;
-use log::{info};
+use log::info;
 
 use std::{
   env,
@@ -126,8 +126,8 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
     &bundle_file_name,
   ];
 
-  let window_position = dmg_settings.window_position.as_ref().map_or(None, |position| {
-    Some((position.x.to_string(), position.y.to_string()))
+  let window_position = dmg_settings.window_position.as_ref().map(|position| {
+    (position.x.to_string(), position.y.to_string())
   });
 
   if let Some(window_position) = &window_position {

--- a/tooling/bundler/src/bundle/macos/dmg.rs
+++ b/tooling/bundler/src/bundle/macos/dmg.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use anyhow::Context;
-use log::info;
+use log::{info};
 
 use std::{
   env,
@@ -96,22 +96,61 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
     .output()
     .expect("Failed to chmod script");
 
+  let dmg_settings = settings.dmg();
+
+  let app_position = &dmg_settings.app_position;
+  let application_folder_position = &dmg_settings.application_folder_position;
+  let window_size = &dmg_settings.window_size;
+
+  let app_position_x = app_position.x.to_string();
+  let app_position_y = app_position.y.to_string();
+  let application_folder_position_x = application_folder_position.x.to_string();
+  let application_folder_position_y = application_folder_position.y.to_string();
+  let window_size_width = window_size.width.to_string();
+  let window_size_height = window_size.height.to_string();
+
   let mut args = vec![
     "--volname",
     product_name,
     "--icon",
     &bundle_file_name,
-    "180",
-    "170",
+    &app_position_x,
+    &app_position_y,
     "--app-drop-link",
-    "480",
-    "170",
+    &application_folder_position_x,
+    &application_folder_position_y,
     "--window-size",
-    "660",
-    "400",
+    &window_size_width,
+    &window_size_height,
     "--hide-extension",
     &bundle_file_name,
   ];
+
+  let window_position = dmg_settings.window_position.as_ref().map_or(None, |position| {
+    Some((position.x.to_string(), position.y.to_string()))
+  });
+
+  if let Some(window_position) = &window_position {
+    args.push("--window-pos");
+    args.push(&window_position.0);
+    args.push(&window_position.1);
+  }
+
+  let background_path_string = if let Some(background_path) = &dmg_settings.background {
+    Some(
+      env::current_dir()?
+        .join(background_path)
+        .to_string_lossy()
+        .to_string(),
+    )
+  } else {
+    None
+  };
+
+  if let Some(background_path_string) = &background_path_string {
+    args.push("--background");
+    args.push(background_path_string);
+  }
 
   let icns_icon_path =
     create_icns_file(&output_path, settings)?.map(|path| path.to_string_lossy().to_string());
@@ -120,15 +159,20 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
     args.push(icon);
   }
 
-  #[allow(unused_assignments)]
-  let mut license_path_ref = "".to_string();
-  if let Some(license_path) = &settings.macos().license {
+  let license_path_string = if let Some(license_path) = &settings.macos().license {
+    Some(
+      env::current_dir()?
+        .join(license_path)
+        .to_string_lossy()
+        .to_string(),
+    )
+  } else {
+    None
+  };
+
+  if let Some(license_path) = &license_path_string {
     args.push("--eula");
-    license_path_ref = env::current_dir()?
-      .join(license_path)
-      .to_string_lossy()
-      .to_string();
-    args.push(&license_path_ref);
+    args.push(license_path);
   }
 
   // Issue #592 - Building MacOS dmg files on CI

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -163,6 +163,39 @@ pub struct DebianSettings {
   pub desktop_template: Option<PathBuf>,
 }
 
+/// Position coordinates struct.
+#[derive(Clone, Debug, Default)]
+pub struct Position {
+  /// X coordinate.
+  pub x: u32,
+  /// Y coordinate.
+  pub y: u32,
+}
+
+/// Size of the window.
+#[derive(Clone, Debug, Default)]
+pub struct Size {
+  /// Width of the window.
+  pub width: u32,
+  /// Height of the window.
+  pub height: u32,
+}
+
+/// The DMG bundle settings.
+#[derive(Clone, Debug, Default)]
+pub struct DmgSettings {
+  /// Image to use as the background in dmg file. Accepted formats: `png`/`jpg`/`gif`.
+  pub background: Option<PathBuf>,
+  /// Position of volume window on screen.
+  pub window_position: Option<Position>,
+  /// Size of volume window.
+  pub window_size: Size,
+  /// Position of app file on window.
+  pub app_position: Position,
+  /// Position of application folder on window.
+  pub application_folder_position: Position,
+}
+
 /// The macOS bundle settings.
 #[derive(Clone, Debug, Default)]
 pub struct MacOsSettings {
@@ -388,6 +421,8 @@ pub struct BundleSettings {
   pub external_bin: Option<Vec<String>>,
   /// Debian-specific settings.
   pub deb: DebianSettings,
+  /// DMG-specific settings.
+  pub dmg: DmgSettings,
   /// MacOS-specific settings.
   pub macos: MacOsSettings,
   /// Updater configuration.
@@ -810,6 +845,11 @@ impl Settings {
   /// Returns the debian settings.
   pub fn deb(&self) -> &DebianSettings {
     &self.bundle_settings.deb
+  }
+
+  /// Returns the DMG settings.
+  pub fn dmg(&self) -> &DmgSettings {
+    &self.bundle_settings.dmg
   }
 
   /// Returns the MacOS settings.

--- a/tooling/bundler/src/error.rs
+++ b/tooling/bundler/src/error.rs
@@ -67,6 +67,9 @@ pub enum Error {
   /// Couldn't find icons.
   #[error("Could not find Icon paths.  Please make sure they exist in the tauri config JSON file")]
   IconPathError,
+  /// Couldn't find background file.
+  #[error("Could not find background file. Make sure it exists in the tauri config JSON file and extension is png/jpg/gif")]
+  BackgroundPathError,
   /// Error on path util operation.
   #[error("Path Error:`{0}`")]
   PathUtilError(String),

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -37,6 +37,20 @@
           "deb": {
             "files": {}
           },
+          "dmg": {
+            "appPosition": {
+              "x": 180,
+              "y": 170
+            },
+            "applicationFolderPosition": {
+              "x": 480,
+              "y": 170
+            },
+            "windowSize": {
+              "height": 400,
+              "width": 660
+            }
+          },
           "iOS": {},
           "icon": [],
           "identifier": "",
@@ -170,6 +184,20 @@
             },
             "deb": {
               "files": {}
+            },
+            "dmg": {
+              "appPosition": {
+                "x": 180,
+                "y": 170
+              },
+              "applicationFolderPosition": {
+                "x": 480,
+                "y": 170
+              },
+              "windowSize": {
+                "height": 400,
+                "width": 660
+              }
             },
             "iOS": {},
             "icon": [],
@@ -976,6 +1004,28 @@
             }
           ]
         },
+        "dmg": {
+          "description": "DMG-specific settings.",
+          "default": {
+            "appPosition": {
+              "x": 180,
+              "y": 170
+            },
+            "applicationFolderPosition": {
+              "x": 480,
+              "y": 170
+            },
+            "windowSize": {
+              "height": 400,
+              "width": 660
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/DmgConfig"
+            }
+          ]
+        },
         "macOS": {
           "description": "Configuration for the macOS bundles.",
           "default": {
@@ -1268,6 +1318,113 @@
             "string",
             "null"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DmgConfig": {
+      "description": "Configuration for Apple Disk Image (.dmg) bundles.\n\nSee more: https://tauri.app/v1/api/config#dmgconfig",
+      "type": "object",
+      "properties": {
+        "background": {
+          "description": "Image to use as the background in dmg file. Accepted formats: `png`/`jpg`/`gif`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "windowPosition": {
+          "description": "Position of volume window on screen.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Position"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "windowSize": {
+          "description": "Size of volume window.",
+          "default": {
+            "height": 400,
+            "width": 660
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Size"
+            }
+          ]
+        },
+        "appPosition": {
+          "description": "Position of app file on window.",
+          "default": {
+            "x": 180,
+            "y": 170
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Position"
+            }
+          ]
+        },
+        "applicationFolderPosition": {
+          "description": "Position of application folder on window.",
+          "default": {
+            "x": 480,
+            "y": 170
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Position"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Position": {
+      "description": "Position coordinates struct.",
+      "type": "object",
+      "required": [
+        "x",
+        "y"
+      ],
+      "properties": {
+        "x": {
+          "description": "X coordinate.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "y": {
+          "description": "Y coordinate.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Size": {
+      "description": "Size of the window.",
+      "type": "object",
+      "required": [
+        "height",
+        "width"
+      ],
+      "properties": {
+        "width": {
+          "description": "Width of the window.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "height": {
+          "description": "Height of the window.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -22,8 +22,8 @@ use notify::RecursiveMode;
 use notify_debouncer_mini::new_debouncer;
 use serde::Deserialize;
 use tauri_bundler::{
-  AppCategory, BundleBinary, BundleSettings, DebianSettings, MacOsSettings, PackageSettings,
-  UpdaterSettings, WindowsSettings,
+  AppCategory, BundleBinary, BundleSettings, DebianSettings, DmgSettings, MacOsSettings, PackageSettings,
+  UpdaterSettings, WindowsSettings, Position, Size
 };
 use tauri_utils::config::parse::is_configuration_file;
 
@@ -1166,6 +1166,28 @@ fn tauri_config_to_bundle_settings(
       },
       files: config.deb.files,
       desktop_template: config.deb.desktop_template,
+    },
+    dmg: DmgSettings {
+      background: config.dmg.background,
+      window_position: match config.dmg.window_position {
+        Some(window_position) => Some(Position {
+          x: window_position.x,
+          y: window_position.y,
+        }),
+        None => None,
+      },
+      window_size: Size {
+          width: config.dmg.window_size.width,
+          height: config.dmg.window_size.height,
+      },
+      app_position: Position {
+        x: config.dmg.app_position.x,
+        y: config.dmg.app_position.y,
+      },
+      application_folder_position: Position {
+        x: config.dmg.application_folder_position.x,
+        y: config.dmg.application_folder_position.y,
+      },
     },
     macos: MacOsSettings {
       frameworks: config.macos.frameworks,


### PR DESCRIPTION
Added new "dmg" param to tauri.conf.json. It provides more settings to "create-dmg" cli and allows to customise DMG files with:
- background image
- Installer window size
- Installer window position
- Application position
- Application folder position

DMG view before:
![image](https://github.com/tauri-apps/tauri/assets/20759487/7e69f90c-ac88-40ec-bbfe-29c401b9e969)

DMG view after:
![image](https://github.com/tauri-apps/tauri/assets/20759487/51ce4024-5b41-4cb9-bff4-3b1e1abaa1dd)

New part of tauri.conf.json looks like this:
```json
{
  "tauri": {
    "bundle": {
      "dmg": {
        "background": "images/background.png",
        "appPosition": {
          "x": 180,
          "y": 170
        },
        "applicationFolderPosition": {
          "x": 480,
          "y": 170
        },
        "windowSize": {
          "height": 400,
          "width": 660
        },
        "windowPosition": {
          "x": 200,
          "y": 180
        }
      }
    }
  }
}
```


Resolves #4669 

### What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Small note. I've never used commit signing, but saw that it's required after creating PR (after first commit). So I have only 1 out of 2 commit signed, I hope it's not a big deal 🙂