### PR TITLE
fix(bundler): In .deb packages, set uid=0 for all files

### DIFF
--- a/.changes/bundler-deb-fix-owner.md
+++ b/.changes/bundler-deb-fix-owner.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:bug'
+---
+
+In Debian packages, set `root` the owner of control files and package files.


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This solves one of the issues reported in #7074:

`lintian` (the Debian package linter) reported these errors:
```
E: tauri-app: control-file-has-bad-owner 1000/1000 != root/root (or 0/0) [md5sums]
...
E: tauri-app: wrong-file-owner-uid-or-gid 1000/1000 [usr/]
E: tauri-app: wrong-file-owner-uid-or-gid 1000/1000 [usr/bin/]
E: tauri-app: wrong-file-owner-uid-or-gid 1000/1000 [usr/bin/tauri-app]
...
```

The Debian package file contains two archive files (`control.tar.gz` and `data.tar.gz`) which are created with file metadata copied from the build filesystem: mode, time, uid, gid, etc.

That caused the package to use the uid of the build user (typically an unprivileged user with `uid` 1000) instead of the `root` user as required.

With this commit, the metadata are still copied, except for `uid` and `gid`, which are overridden and set to `0` (=`root`).