### PR TITLE
fix: truncate file when not appending in `writeFile`, closes #7973

### DIFF
--- a/.changes/fix-incomplete-writeFile.md
+++ b/.changes/fix-incomplete-writeFile.md
@@ -1,0 +1,5 @@
+---
+"tauri": 'patch:bug'
+---
+
+Set the correct `truncate` option on `OpenOptions` so that `write_file` can completely overwrite existing files.

--- a/core/tauri/src/endpoints/file_system.rs
+++ b/core/tauri/src/endpoints/file_system.rs
@@ -188,6 +188,7 @@ impl Cmd {
       .append(append)
       .write(true)
       .create(true)
+      .truncate(true)
       .open(&resolved_path)
       .with_context(|| format!("path: {}", resolved_path.display()))
       .map_err(Into::into)

--- a/core/tauri/src/endpoints/file_system.rs
+++ b/core/tauri/src/endpoints/file_system.rs
@@ -188,7 +188,7 @@ impl Cmd {
       .append(append)
       .write(true)
       .create(true)
-      .truncate(true)
+      .truncate(!append)
       .open(&resolved_path)
       .with_context(|| format!("path: {}", resolved_path.display()))
       .map_err(Into::into)


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Original issue: https://github.com/tauri-apps/tauri/issues/7973