### PR TITLE
refactor(core/plugin)!: inline result type alias

### DIFF
--- a/.changes/tauri-extranous-result-types-removal.md
+++ b/.changes/tauri-extranous-result-types-removal.md
@@ -3,4 +3,4 @@
 ---
 
 - Removed `tauri::path::Error` and added its variants to `tauri::Error`
-- Removed `tauri::path::Result` and `tauri::plugin::Result` aliases, you should use `tauri::Result` or your own `Result` tye.
+- Removed `tauri::path::Result` and `tauri::plugin::Result` aliases, you should use `tauri::Result` or your own `Result` type.

--- a/.changes/tauri-extranous-result-types-removal.md
+++ b/.changes/tauri-extranous-result-types-removal.md
@@ -2,4 +2,5 @@
 'tauri': 'major:breaking'
 ---
 
-Removed `tauri::path::Error` and added its variants to `tauri::Error`.
+- Removed `tauri::path::Error` and added its variants to `tauri::Error`
+- Removed `tauri::path::Result` and `tauri::plugin::Result` aliases, you should use `tauri::Result` or your own `Result` tye.


### PR DESCRIPTION
avoid multiple result aliases when a user searches on docs.rs

continuation of #7875

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
