### PR TITLE
fix(api): do nothing in clearMocks if __TAURI_INTERNALS__ is not defined

### DIFF
--- a/.changes/fix-clearmocks.md
+++ b/.changes/fix-clearmocks.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/api": 'patch:bug'
+---
+
+No longer crashing in tests without mocks when `clearMocks` is defined in `afterEach` hook.

--- a/tooling/api/src/mocks.ts
+++ b/tooling/api/src/mocks.ts
@@ -152,11 +152,12 @@ export function mockWindows(
  *
  * @since 1.6.0
  */
-export function mockConvertFileSrc(
-  osName: string
-): void {
+export function mockConvertFileSrc(osName: string): void {
   window.__TAURI_INTERNALS__ = window.__TAURI_INTERNALS__ ?? {}
-  window.__TAURI_INTERNALS__.convertFileSrc = function (filePath, protocol = 'asset') {
+  window.__TAURI_INTERNALS__.convertFileSrc = function (
+    filePath,
+    protocol = 'asset'
+  ) {
     const path = encodeURIComponent(filePath)
     return osName === 'windows'
       ? `http://${protocol}.localhost/${path}`
@@ -191,6 +192,10 @@ export function mockConvertFileSrc(
  * @since 1.0.0
  */
 export function clearMocks(): void {
+  if (typeof window.__TAURI_INTERNALS__ !== 'object') {
+    return
+  }
+
   // @ts-expect-error "The operand of a 'delete' operator must be optional' does not matter in this case
   delete window.__TAURI_INTERNALS__.convertFileSrc
   // @ts-expect-error "The operand of a 'delete' operator must be optional' does not matter in this case


### PR DESCRIPTION


<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Prevents tests that didn't define any mocks from failing in `afterEach` test hook.