### PR TITLE
fix(deps): Downgrade minisign to 0.7.3 again

### DIFF
--- a/.changes/cli-downgrade-rust-minisign.md
+++ b/.changes/cli-downgrade-rust-minisign.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Downgraded `rust-minisign` to `0.7.3` to fix signing updater bundles with empty passwords.

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -1764,9 +1764,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign"
-version = "0.7.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b6f58413c6cee060115673578e47271838f3c87cb9322c61a3bcd6d740b7d2"
+checksum = "b23ef13ff1d745b1e52397daaa247e333c607f3cff96d4df2b798dc252db974b"
 dependencies = [
  "getrandom 0.2.10",
  "rpassword",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -57,7 +57,7 @@ toml = "0.8"
 jsonschema = "0.17"
 handlebars = "4.4"
 include_dir = "0.7"
-minisign = "=0.7.5"
+minisign = "=0.7.3"
 base64 = "0.21.4"
 ureq = { version = "2.8", default-features = false, features = [ "gzip" ] }
 os_info = "3"


### PR DESCRIPTION
rust-minisign was upgraded to 0.7.5 in the last patch release via https://github.com/tauri-apps/tauri/pull/7641 even though it was pinned. It was downgraded because 0.7.5 breaks the update bundle signer if an empty password is provided, see https://github.com/FabianLars/mw-toolbox/pull/550 (pr that made me notice the change) and https://github.com/jedisct1/rust-minisign/issues/26 (upstream issue i opened) and https://github.com/tauri-apps/tauri/pull/7197 (the last time i downgraded it)

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
