### PR TITLE
fix(cross): Fix docker image and cross setup

### DIFF
--- a/.docker/cross/aarch64.Dockerfile
+++ b/.docker/cross/aarch64.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY common.sh lib.sh /

--- a/examples/api/.setup-cross.sh
+++ b/examples/api/.setup-cross.sh
@@ -3,3 +3,4 @@
 export ICONS_VOLUME="$(realpath ../.icons)"
 export DIST_VOLUME="$(realpath dist)"
 export ISOLATION_VOLUME="$(realpath isolation-dist)"
+export WORKSPACE_VOLUME="$(realpath ../..)"

--- a/examples/api/src-tauri/Cross.toml
+++ b/examples/api/src-tauri/Cross.toml
@@ -1,10 +1,11 @@
 [build.env]
-# must set ICONS_VOLUME, DIST_VOLUME and ISOLATION_VOLUME environment variables
+# must set ICONS_VOLUME, DIST_VOLUME, ISOLATION_VOLUME and WORKSPACE_VOLUME environment variables
 # ICONS_VOLUME: absolute path to the .icons folder
 # DIST_VOLUME: absolute path to the dist folder
 # ISOLATION_VOLUME: absolute path to the isolation dist folder
+# WORKSPACE_VOLUME: absolute path to the workspace
 # this can be done running `$ . .setup-cross.sh` in the examples/api folder
-volumes = ["ICONS_VOLUME", "DIST_VOLUME", "ISOLATION_VOLUME"]
+volumes = ["ICONS_VOLUME", "DIST_VOLUME", "ISOLATION_VOLUME","WORKSPACE_VOLUME"]
 
 [target.aarch64-unknown-linux-gnu]
 image = "aarch64-unknown-linux-gnu:latest"


### PR DESCRIPTION
- Updating to Ubuntu 22.04 libwebkit2gtk-4.1-dev is not available for Ubuntu 18.04
- Adding a WORKSPACE_VOLUME to fix issue `failed to find a workspace root`
  Cf. https://github.com/cross-rs/cross/issues/1181

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
