### PR TITLE
fix(cli): Fixes errors on command output, closes #8110

### DIFF
--- a/.changes/fix-cmd-output-error.md
+++ b/.changes/fix-cmd-output-error.md
@@ -1,0 +1,7 @@
+---
+"@tauri-apps/cli": patch:bug
+"tauri-cli": patch:bug
+"tauri-bundler": patch:bug
+---
+
+Fixes errors on command output, occuring when the output stream contains an invalid UTF-8 character, or ends with a multi-bytes UTF-8 character.

--- a/tooling/bundler/src/bundle/common.rs
+++ b/tooling/bundler/src/bundle/common.rs
@@ -169,11 +169,14 @@ impl CommandExt for Command {
       let mut lines = stdout_lines_.lock().unwrap();
       loop {
         line.clear();
-        if let Ok(0) = stdout.read_line(&mut line) {
-          break;
+        match stdout.read_line(&mut line) {
+          Ok(0) => break,
+          Ok(_) => {
+            debug!(action = "stdout"; "{}", line.trim_end());
+            lines.extend(line.as_bytes().to_vec());
+          }
+          Err(_) => (),
         }
-        debug!(action = "stdout"; "{}", &line[0..line.len() - 1]);
-        lines.extend(line.as_bytes().to_vec());
       }
     });
 
@@ -185,11 +188,14 @@ impl CommandExt for Command {
       let mut lines = stderr_lines_.lock().unwrap();
       loop {
         line.clear();
-        if let Ok(0) = stderr.read_line(&mut line) {
-          break;
+        match stderr.read_line(&mut line) {
+          Ok(0) => break,
+          Ok(_) => {
+            debug!(action = "stderr"; "{}", line.trim_end());
+            lines.extend(line.as_bytes().to_vec());
+          }
+          Err(_) => (),
         }
-        debug!(action = "stderr"; "{}", &line[0..line.len() - 1]);
-        lines.extend(line.as_bytes().to_vec());
       }
     });
 

--- a/tooling/cli/src/lib.rs
+++ b/tooling/cli/src/lib.rs
@@ -231,11 +231,14 @@ impl CommandExt for Command {
       let mut lines = stdout_lines_.lock().unwrap();
       loop {
         line.clear();
-        if let Ok(0) = stdout.read_line(&mut line) {
-          break;
+        match stdout.read_line(&mut line) {
+          Ok(0) => break,
+          Ok(_) => {
+            debug!(action = "stdout"; "{}", line.trim_end());
+            lines.extend(line.as_bytes().to_vec());
+          }
+          Err(_) => (),
         }
-        debug!(action = "stdout"; "{}", &line[0..line.len() - 1]);
-        lines.extend(line.as_bytes().to_vec());
       }
     });
 
@@ -247,11 +250,14 @@ impl CommandExt for Command {
       let mut lines = stderr_lines_.lock().unwrap();
       loop {
         line.clear();
-        if let Ok(0) = stderr.read_line(&mut line) {
-          break;
+        match stderr.read_line(&mut line) {
+          Ok(0) => break,
+          Ok(_) => {
+            debug!(action = "stderr"; "{}", line.trim_end());
+            lines.extend(line.as_bytes().to_vec());
+          }
+          Err(_) => (),
         }
-        debug!(action = "stderr"; "{}", &line[0..line.len() - 1]);
-        lines.extend(line.as_bytes().to_vec());
       }
     });
 


### PR DESCRIPTION
Command output was fixed in #8042; however it also created two issues:

https://github.com/tauri-apps/tauri/blob/ae75004cee126c4bac332643c49869d2cfe38ad1/tooling/bundler/src/bundle/common.rs#L183-L194

- If `read_line` returns `Err` (which happens if the stream contains an invalid UTF-8 character), `line` is empty and `&line[0..line.len() - 1]` fails (`attempt to subtract with overflow`)
  That happens on macos with `bundle_dmg.sh` when the product name contains a Chinese character or an emoji (cf #8110).
- If the stream ends with no linebreak (just EOF), `line` does not end with `\n`. Therefore, the last byte of the stream is removed. If this is e.g. an ASCII character, it's just one character missing in the output. If the last character is multi-bytes, it throws an error (`byte index xxx is not a char boundary; it is inside xxx`)

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Fixes #8110
