### PR TITLE
fix(build): always invoke resource compiler on windows, fixes #8164

### DIFF
--- a/.changes/tauri-build-resource-compiler.md
+++ b/.changes/tauri-build-resource-compiler.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": 'patch:bug'
+---
+
+Fixed an issue that caused the resource compiler to not run on Windows when `package.version` was not set in `tauri.conf.json` preventing the app from starting.

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -534,45 +534,43 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
       .window_icon_path
       .unwrap_or_else(|| find_icon(&config, |i| i.ends_with(".ico"), "icons/icon.ico"));
 
-    if target_triple.contains("windows") {
-      if window_icon_path.exists() {
-        let mut res = WindowsResource::new();
+    if window_icon_path.exists() {
+      let mut res = WindowsResource::new();
 
-        if let Some(manifest) = attributes.windows_attributes.app_manifest {
-          res.set_manifest(&manifest);
-        } else {
-          res.set_manifest(include_str!("window-app-manifest.xml"));
-        }
-
-        if let Some(version_str) = &config.package.version {
-          if let Ok(v) = Version::parse(version_str) {
-            let version = v.major << 48 | v.minor << 32 | v.patch << 16;
-            res.set_version_info(VersionInfo::FILEVERSION, version);
-            res.set_version_info(VersionInfo::PRODUCTVERSION, version);
-          }
-          if let Some(product_name) = &config.package.product_name {
-            res.set("ProductName", product_name);
-          }
-          if let Some(short_description) = &config.tauri.bundle.short_description {
-            res.set("FileDescription", short_description);
-          }
-          if let Some(copyright) = &config.tauri.bundle.copyright {
-            res.set("LegalCopyright", copyright);
-          }
-          res.set_icon_with_id(&window_icon_path.display().to_string(), "32512");
-          res.compile().with_context(|| {
-            format!(
-              "failed to compile `{}` into a Windows Resource file during tauri-build",
-              window_icon_path.display()
-            )
-          })?;
-        }
+      if let Some(manifest) = attributes.windows_attributes.app_manifest {
+        res.set_manifest(&manifest);
       } else {
-        return Err(anyhow!(format!(
-          "`{}` not found; required for generating a Windows Resource file during tauri-build",
-          window_icon_path.display()
-        )));
+        res.set_manifest(include_str!("window-app-manifest.xml"));
       }
+
+      if let Some(version_str) = &config.package.version {
+        if let Ok(v) = Version::parse(version_str) {
+          let version = v.major << 48 | v.minor << 32 | v.patch << 16;
+          res.set_version_info(VersionInfo::FILEVERSION, version);
+          res.set_version_info(VersionInfo::PRODUCTVERSION, version);
+        }
+        if let Some(product_name) = &config.package.product_name {
+          res.set("ProductName", product_name);
+        }
+        if let Some(short_description) = &config.tauri.bundle.short_description {
+          res.set("FileDescription", short_description);
+        }
+        if let Some(copyright) = &config.tauri.bundle.copyright {
+          res.set("LegalCopyright", copyright);
+        }
+      }
+      res.set_icon_with_id(&window_icon_path.display().to_string(), "32512");
+      res.compile().with_context(|| {
+        format!(
+          "failed to compile `{}` into a Windows Resource file during tauri-build",
+          window_icon_path.display()
+        )
+      })?;
+    } else {
+      return Err(anyhow!(format!(
+        "`{}` not found; required for generating a Windows Resource file during tauri-build",
+        window_icon_path.display()
+      )));
     }
 
     let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -534,44 +534,49 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
       .window_icon_path
       .unwrap_or_else(|| find_icon(&config, |i| i.ends_with(".ico"), "icons/icon.ico"));
 
+    let mut res = WindowsResource::new();
+
+    if let Some(manifest) = attributes.windows_attributes.app_manifest {
+      res.set_manifest(&manifest);
+    } else {
+      res.set_manifest(include_str!("window-app-manifest.xml"));
+    }
+
+    if let Some(version_str) = &config.package.version {
+      if let Ok(v) = Version::parse(version_str) {
+        let version = v.major << 48 | v.minor << 32 | v.patch << 16;
+        res.set_version_info(VersionInfo::FILEVERSION, version);
+        res.set_version_info(VersionInfo::PRODUCTVERSION, version);
+      }
+    }
+
+    if let Some(product_name) = &config.package.product_name {
+      res.set("ProductName", product_name);
+    }
+
+    if let Some(short_description) = &config.tauri.bundle.short_description {
+      res.set("FileDescription", short_description);
+    }
+
+    if let Some(copyright) = &config.tauri.bundle.copyright {
+      res.set("LegalCopyright", copyright);
+    }
+
     if window_icon_path.exists() {
-      let mut res = WindowsResource::new();
-
-      if let Some(manifest) = attributes.windows_attributes.app_manifest {
-        res.set_manifest(&manifest);
-      } else {
-        res.set_manifest(include_str!("window-app-manifest.xml"));
-      }
-
-      if let Some(version_str) = &config.package.version {
-        if let Ok(v) = Version::parse(version_str) {
-          let version = v.major << 48 | v.minor << 32 | v.patch << 16;
-          res.set_version_info(VersionInfo::FILEVERSION, version);
-          res.set_version_info(VersionInfo::PRODUCTVERSION, version);
-        }
-      }
-      if let Some(product_name) = &config.package.product_name {
-        res.set("ProductName", product_name);
-      }
-      if let Some(short_description) = &config.tauri.bundle.short_description {
-        res.set("FileDescription", short_description);
-      }
-      if let Some(copyright) = &config.tauri.bundle.copyright {
-        res.set("LegalCopyright", copyright);
-      }
       res.set_icon_with_id(&window_icon_path.display().to_string(), "32512");
-      res.compile().with_context(|| {
-        format!(
-          "failed to compile `{}` into a Windows Resource file during tauri-build",
-          window_icon_path.display()
-        )
-      })?;
     } else {
       return Err(anyhow!(format!(
         "`{}` not found; required for generating a Windows Resource file during tauri-build",
         window_icon_path.display()
       )));
     }
+
+    res.compile().with_context(|| {
+      format!(
+        "failed to compile `{}` into a Windows Resource file during tauri-build",
+        window_icon_path.display()
+      )
+    })?;
 
     let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
     match target_env.as_str() {

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -549,15 +549,15 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
           res.set_version_info(VersionInfo::FILEVERSION, version);
           res.set_version_info(VersionInfo::PRODUCTVERSION, version);
         }
-        if let Some(product_name) = &config.package.product_name {
-          res.set("ProductName", product_name);
-        }
-        if let Some(short_description) = &config.tauri.bundle.short_description {
-          res.set("FileDescription", short_description);
-        }
-        if let Some(copyright) = &config.tauri.bundle.copyright {
-          res.set("LegalCopyright", copyright);
-        }
+      }
+      if let Some(product_name) = &config.package.product_name {
+        res.set("ProductName", product_name);
+      }
+      if let Some(short_description) = &config.tauri.bundle.short_description {
+        res.set("FileDescription", short_description);
+      }
+      if let Some(copyright) = &config.tauri.bundle.copyright {
+        res.set("LegalCopyright", copyright);
       }
       res.set_icon_with_id(&window_icon_path.display().to_string(), "32512");
       res.compile().with_context(|| {


### PR DESCRIPTION
This fixes a simple v1 merge error that caused winres/embed-resource to only be compiled if package.version was set in tauri.conf.json.
While i was at it i also removed the duplicate `if windows` check.

We may want to remove the icon path check to (== check for it only when setting the icon) so that the resource compiler still runs even if no icon is provided - may as well wait for a usecase for that though 🤷 
Edit: Changed the `if` location to only wrap the set_icon call to make that change a tiny bit easier.

fixes #8164 