### PR TITLE
fix(bundler): modify version in output file name when bundling wix

### DIFF
--- a/.changes/fix-wix-output-filename-version.md
+++ b/.changes/fix-wix-output-filename-version.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": 'patch:bug'
+---
+
+Modify version in output file name when bundling wix (original: 0.0.0-0 -> 0.0.0.0, fix: 0.0.0-0 -> 0.0.0-0)

--- a/.changes/fix-wix-output-filename-version.md
+++ b/.changes/fix-wix-output-filename-version.md
@@ -2,4 +2,4 @@
 "tauri-bundler": 'patch:bug'
 ---
 
-Modify version in output file name when bundling wix (original: 0.0.0-0 -> 0.0.0.0, fix: 0.0.0-0 -> 0.0.0-0)
+Use original version string on WiX output file name.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -807,7 +807,8 @@ pub fn build_wix_app_installer(
       "*.wixobj".into(),
     ];
     let msi_output_path = output_path.join("output.msi");
-    let msi_path = app_installer_output_path(settings, &language, &app_version, updater)?;
+    let msi_path =
+      app_installer_output_path(settings, &language, settings.version_string(), updater)?;
     create_dir_all(msi_path.parent().unwrap())?;
 
     info!(action = "Running"; "light to produce {}", display_path(&msi_path));


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
When wix bundling a project whose current version is `0.0.0-0`, the file name appears as `0.0.0.0`. This is not identical to other files. In addition, GitHub Action searches for `0.0.0-0` files, so only related msi files cannot be uploaded together.