### PR TITLE
chore(deps): replace deprecated  rollup-plugin-terser with @rollup/plugin-terser

### DIFF
--- a/tooling/cli/templates/plugin/package.json
+++ b/tooling/cli/templates/plugin/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "13.3.0",
     "@rollup/plugin-typescript": "8.3.3",
+    "@rollup/plugin-terser": "0.4.4",
     "rollup": "2.75.6",
-    "rollup-plugin-terser": "7.0.2",
     "typescript": "4.7.3"
   },
   "dependencies": {

--- a/tooling/cli/templates/plugin/webview-src/rollup.config.js
+++ b/tooling/cli/templates/plugin/webview-src/rollup.config.js
@@ -1,6 +1,6 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve'
-import { terser } from 'rollup-plugin-terser'
 import typescript from '@rollup/plugin-typescript'
+import  terser from '@rollup/plugin-terser'
 
 export default {
   input: './webview-src/index.ts',


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Update the plugin template

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
The package 'rollup-plugin-terser@7.0.2' is deprecated. This PR replaces it with the latest "@rollup/plugin-terser" according to the package manager's warning.

WARNING from `pnpm`
>  WARN  deprecated rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser

WARNING from `Yarn`
> warning rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
