### PR TITLE
feat(cli): merge user-defined plist with the iOS plist file

### DIFF
--- a/.changes/merge-ios-plist.md
+++ b/.changes/merge-ios-plist.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:feat
+"@tauri-apps/cli": patch:feat
+---
+
+Merge `src-tauri/Info.plist` and `src-tauri/Info.ios.plist` with the iOS project plist file.

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.16.3"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
+checksum = "6ca592ad99e6a0fd4b95153406138b997cc26ccd3cd0aecdfd4fbdbf1519bd77"
 dependencies = [
  "serde",
  "toml 0.8.2",

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -4099,6 +4099,7 @@ dependencies = [
  "once_cell",
  "os_info",
  "os_pipe",
+ "plist",
  "regex",
  "resvg",
  "semver",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -102,6 +102,9 @@ cc = "1"
 [target."cfg(unix)".dependencies]
 libc = "0.2"
 
+[target."cfg(target_os = \"macos\")".dependencies]
+plist = "1"
+
 [features]
 default = [ "rustls" ]
 native-tls = [

--- a/tooling/cli/src/mobile/ios/build.rs
+++ b/tooling/cli/src/mobile/ios/build.rs
@@ -94,11 +94,22 @@ pub fn command(mut options: Options, noise_level: NoiseLevel) -> Result<()> {
   };
 
   let tauri_path = tauri_dir();
-  set_current_dir(tauri_path).with_context(|| "failed to change current working directory")?;
+  set_current_dir(&tauri_path).with_context(|| "failed to change current working directory")?;
 
   ensure_init(config.project_dir(), MobileTarget::Ios)?;
   inject_assets(&config)?;
-  merge_plist(&config)?;
+
+  let info_plist_path = config
+    .project_dir()
+    .join(config.scheme())
+    .join("Info.plist");
+  merge_plist(
+    &[
+      tauri_path.join("Info.plist"),
+      tauri_path.join("Info.ios.plist"),
+    ],
+    &info_plist_path,
+  )?;
 
   let mut env = env()?;
   configure_cargo(&app, None)?;

--- a/tooling/cli/src/mobile/ios/build.rs
+++ b/tooling/cli/src/mobile/ios/build.rs
@@ -4,7 +4,7 @@
 
 use super::{
   configure_cargo, detect_target_ok, ensure_init, env, get_app, get_config, inject_assets,
-  log_finished, open_and_wait, MobileTarget,
+  log_finished, merge_plist, open_and_wait, MobileTarget,
 };
 use crate::{
   build::Options as BuildOptions,
@@ -98,6 +98,7 @@ pub fn command(mut options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   ensure_init(config.project_dir(), MobileTarget::Ios)?;
   inject_assets(&config)?;
+  merge_plist(&config)?;
 
   let mut env = env()?;
   configure_cargo(&app, None)?;

--- a/tooling/cli/src/mobile/ios/dev.rs
+++ b/tooling/cli/src/mobile/ios/dev.rs
@@ -145,11 +145,23 @@ fn run_command(mut options: Options, noise_level: NoiseLevel) -> Result<()> {
   };
 
   let tauri_path = tauri_dir();
-  set_current_dir(tauri_path).with_context(|| "failed to change current working directory")?;
+  set_current_dir(&tauri_path).with_context(|| "failed to change current working directory")?;
 
   ensure_init(config.project_dir(), MobileTarget::Ios)?;
   inject_assets(&config)?;
-  merge_plist(&config)?;
+
+  let info_plist_path = config
+    .project_dir()
+    .join(config.scheme())
+    .join("Info.plist");
+  merge_plist(
+    &[
+      tauri_path.join("Info.plist"),
+      tauri_path.join("Info.ios.plist"),
+    ],
+    &info_plist_path,
+  )?;
+
   run_dev(options, tauri_config, &app, &config, noise_level)
 }
 

--- a/tooling/cli/src/mobile/ios/dev.rs
+++ b/tooling/cli/src/mobile/ios/dev.rs
@@ -4,7 +4,7 @@
 
 use super::{
   configure_cargo, device_prompt, ensure_init, env, get_app, get_config, inject_assets,
-  open_and_wait, setup_dev_config, MobileTarget, APPLE_DEVELOPMENT_TEAM_ENV_VAR_NAME,
+  merge_plist, open_and_wait, setup_dev_config, MobileTarget, APPLE_DEVELOPMENT_TEAM_ENV_VAR_NAME,
 };
 use crate::{
   dev::Options as DevOptions,
@@ -149,6 +149,7 @@ fn run_command(mut options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   ensure_init(config.project_dir(), MobileTarget::Ios)?;
   inject_assets(&config)?;
+  merge_plist(&config)?;
   run_dev(options, tauri_config, &app, &config, noise_level)
 }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Merge the src-tauri/Info.plist and src-tauri/Info.ios.plist files with the iOS project Info.plist file to allow extending the IPA configuration, similar to the macOS implementation.