### PR TITLE
fix(cli): IDE failing to read CLI options on `build --open` commands

### DIFF
--- a/.changes/fix-ide-build-run.md
+++ b/.changes/fix-ide-build-run.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fixes `android build --open` and `ios build --open` IDE failing to read CLI options.

--- a/tooling/cli/src/mobile/android/build.rs
+++ b/tooling/cli/src/mobile/android/build.rs
@@ -4,7 +4,7 @@
 
 use super::{
   configure_cargo, delete_codegen_vars, ensure_init, env, get_app, get_config, inject_assets,
-  log_finished, open_and_wait, MobileTarget,
+  log_finished, open_and_wait, MobileTarget, OptionsHandle,
 };
 use crate::{
   build::Options as BuildOptions,
@@ -131,7 +131,7 @@ pub fn command(mut options: Options, noise_level: NoiseLevel) -> Result<()> {
   )?;
 
   let open = options.open;
-  run_build(
+  let _handle = run_build(
     options,
     tauri_config,
     profile,
@@ -154,7 +154,7 @@ fn run_build(
   config: &AndroidConfig,
   env: &mut Env,
   noise_level: NoiseLevel,
-) -> Result<()> {
+) -> Result<OptionsHandle> {
   if !(options.apk || options.aab) {
     // if the user didn't specify the format to build, we'll do both
     options.apk = true;
@@ -192,7 +192,7 @@ fn run_build(
     noise_level,
     vars: Default::default(),
   };
-  let _handle = write_options(
+  let handle = write_options(
     &tauri_config
       .lock()
       .unwrap()
@@ -240,7 +240,7 @@ fn run_build(
   log_finished(apk_outputs, "APK");
   log_finished(aab_outputs, "AAB");
 
-  Ok(())
+  Ok(handle)
 }
 
 fn get_targets_or_all<'a>(targets: Vec<String>) -> Result<Vec<&'a Target<'a>>> {

--- a/tooling/cli/src/mobile/android/mod.rs
+++ b/tooling/cli/src/mobile/android/mod.rs
@@ -29,7 +29,7 @@ use sublime_fuzzy::best_match;
 use super::{
   ensure_init, get_app,
   init::{command as init_command, configure_cargo},
-  log_finished, read_options, setup_dev_config, CliOptions, Target as MobileTarget,
+  log_finished, read_options, setup_dev_config, CliOptions, OptionsHandle, Target as MobileTarget,
   MIN_DEVICE_MATCH_SCORE,
 };
 use crate::{helpers::config::Config as TauriConfig, Result};

--- a/tooling/cli/src/mobile/ios/build.rs
+++ b/tooling/cli/src/mobile/ios/build.rs
@@ -4,7 +4,7 @@
 
 use super::{
   configure_cargo, detect_target_ok, ensure_init, env, get_app, get_config, inject_assets,
-  log_finished, open_and_wait, MobileTarget,
+  log_finished, open_and_wait, MobileTarget, OptionsHandle,
 };
 use crate::{
   build::Options as BuildOptions,
@@ -103,7 +103,7 @@ pub fn command(mut options: Options, noise_level: NoiseLevel) -> Result<()> {
   configure_cargo(&app, None)?;
 
   let open = options.open;
-  run_build(options, tauri_config, &config, &mut env, noise_level)?;
+  let _handle = run_build(options, tauri_config, &config, &mut env, noise_level)?;
 
   if open {
     open_and_wait(&config, &env);
@@ -118,7 +118,7 @@ fn run_build(
   config: &AppleConfig,
   env: &mut Env,
   noise_level: NoiseLevel,
-) -> Result<()> {
+) -> Result<OptionsHandle> {
   let profile = if options.debug {
     Profile::Debug
   } else {
@@ -151,7 +151,7 @@ fn run_build(
     noise_level,
     vars: Default::default(),
   };
-  let _handle = write_options(
+  let handle = write_options(
     &tauri_config
       .lock()
       .unwrap()
@@ -199,5 +199,5 @@ fn run_build(
 
   log_finished(out_files, "IPA");
 
-  Ok(())
+  Ok(handle)
 }

--- a/tooling/cli/src/mobile/ios/mod.rs
+++ b/tooling/cli/src/mobile/ios/mod.rs
@@ -24,7 +24,7 @@ use sublime_fuzzy::best_match;
 use super::{
   ensure_init, env, get_app,
   init::{command as init_command, configure_cargo},
-  log_finished, read_options, setup_dev_config, CliOptions, Target as MobileTarget,
+  log_finished, read_options, setup_dev_config, CliOptions, OptionsHandle, Target as MobileTarget,
   MIN_DEVICE_MATCH_SCORE,
 };
 use crate::{helpers::config::Config as TauriConfig, Result};

--- a/tooling/cli/src/mobile/mod.rs
+++ b/tooling/cli/src/mobile/mod.rs
@@ -217,11 +217,10 @@ fn env() -> Result<Env, EnvError> {
   Ok(env)
 }
 
+pub struct OptionsHandle(Runtime, ServerHandle);
+
 /// Writes CLI options to be used later on the Xcode and Android Studio build commands
-pub fn write_options(
-  identifier: &str,
-  mut options: CliOptions,
-) -> crate::Result<(Runtime, ServerHandle)> {
+pub fn write_options(identifier: &str, mut options: CliOptions) -> crate::Result<OptionsHandle> {
   options.vars.extend(env_vars());
 
   let runtime = Runtime::new().unwrap();
@@ -243,7 +242,7 @@ pub fn write_options(
     addr.to_string(),
   )?;
 
-  Ok((runtime, handle))
+  Ok(OptionsHandle(runtime, handle))
 }
 
 fn read_options(identifier: &str) -> CliOptions {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

We need to keep the websocket server alive to share the options with the CLI process started by the IDE.