### PR TITLE
fix(bundler/nsis): calculate estimated size on build system

### DIFF
--- a/.changes/nsis-slow-resources-installation.md
+++ b/.changes/nsis-slow-resources-installation.md
@@ -1,0 +1,7 @@
+---
+"@tauri-apps/cli": patch:bug
+"tauri-cli": patch:bug
+"tauri-bundler": patch:bug
+---
+
+Fixes an issue in the NSIS installer which caused the installation to take much longer than expected when many `resources` were added to the bundle.

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -303,6 +303,9 @@ fn build_nsis_app_installer(
   data.insert("out_file", to_json(out_file));
 
   let resources = generate_resource_data(settings)?;
+  let resources_dirs =
+    std::collections::HashSet::<PathBuf>::from_iter(resources.values().map(|r| r.0.to_owned()));
+  data.insert("resources_dirs", to_json(resources_dirs));
   data.insert("resources", to_json(resources));
 
   let binaries = generate_binaries_data(settings)?;

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -565,17 +565,17 @@ fn generate_estimated_size(
 
   let mut size = 0;
 
-  size = size + metadata(main)?.len();
+  size += metadata(main)?.len();
 
-  for (k, _) in binaries {
-    size = size + metadata(k)?.len();
+  for k in binaries.keys() {
+    size += metadata(k)?.len();
   }
 
-  for (k, _) in resources {
-    size = size + metadata(k)?.len();
+  for k in resources.keys() {
+    size += metadata(k)?.len();
   }
 
-  size = size / 1000;
+  size /= 1000;
 
   Ok(format!("{size:#08x}"))
 }

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -563,15 +563,9 @@ fn generate_estimated_size(
 ) -> crate::Result<String> {
   use std::fs::metadata;
 
-  let mut size = 0;
+  let mut size = metadata(main)?.len();
 
-  size += metadata(main)?.len();
-
-  for k in binaries.keys() {
-    size += metadata(k)?.len();
-  }
-
-  for k in resources.keys() {
+  for k in binaries.keys().chain(resources.keys()) {
     size += metadata(k)?.len();
   }
 

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -535,8 +535,10 @@ Section Install
   IntOp $AppSize $AppSize + $0
 
   ; Copy resources
+  {{#each resources_dirs}}
+    CreateDirectory "$INSTDIR\{{this}}"
+  {{/each}}
   {{#each resources}}
-    CreateDirectory "$INSTDIR\\{{this.[0]}}"
     File /a "/oname={{this.[1]}}" "{{@key}}"
     ${GetSize} "$INSTDIR\{{this.[1]}}" "/S=0B" $0 $1 $2
     IntOp $AppSize $AppSize + $0

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -40,6 +40,7 @@ ${StrLoc}
 !define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
 !define MANUPRODUCTKEY "Software\${MANUFACTURER}\${PRODUCTNAME}"
 !define UNINSTALLERSIGNCOMMAND "{{uninstaller_sign_cmd}}"
+!define ESTIMATEDSIZE "{{estimated_size}}"
 
 Name "${PRODUCTNAME}"
 BrandingText "${COPYRIGHT}"
@@ -522,33 +523,26 @@ SectionEnd
   app_check_done:
 !macroend
 
-Var AppSize
 Section Install
   SetOutPath $INSTDIR
-  StrCpy $AppSize 0
 
   !insertmacro CheckIfAppIsRunning
 
   ; Copy main executable
   File "${MAINBINARYSRCPATH}"
-  ${GetSize} "$INSTDIR\${MAINBINARYNAME}.exe" "/S=0B" $0 $1 $2
-  IntOp $AppSize $AppSize + $0
 
   ; Copy resources
   {{#each resources_dirs}}
-    CreateDirectory "$INSTDIR\{{this}}"
+    ; `\\` is not a typo.
+    CreateDirectory "$INSTDIR\\{{this}}"
   {{/each}}
   {{#each resources}}
     File /a "/oname={{this.[1]}}" "{{@key}}"
-    ${GetSize} "$INSTDIR\{{this.[1]}}" "/S=0B" $0 $1 $2
-    IntOp $AppSize $AppSize + $0
   {{/each}}
 
   ; Copy external binaries
   {{#each binaries}}
     File /a "/oname={{this}}" "{{@key}}"
-    ${GetSize} "$INSTDIR\{{this}}" "/S=0B" $0 $1 $2
-    IntOp $AppSize $AppSize + $0
   {{/each}}
 
   ; Create uninstaller
@@ -572,9 +566,7 @@ Section Install
   WriteRegStr SHCTX "${UNINSTKEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
   WriteRegDWORD SHCTX "${UNINSTKEY}" "NoModify" "1"
   WriteRegDWORD SHCTX "${UNINSTKEY}" "NoRepair" "1"
-  IntOp $AppSize $AppSize / 1000
-  IntFmt $AppSize "0x%08X" $AppSize
-  WriteRegDWORD SHCTX "${UNINSTKEY}" "EstimatedSize" "$AppSize"
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "EstimatedSize" "${ESTIMATEDSIZE}"
 
   ; Create start menu shortcut (GUI)
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -531,21 +531,21 @@ Section Install
 
   ; Copy main executable
   File "${MAINBINARYSRCPATH}"
-  ${GetSize} "$INSTDIR" "/M=${MAINBINARYNAME}.exe /S=0B" $0 $1 $2
+  ${GetSize} "$INSTDIR\${MAINBINARYNAME}.exe" "/S=0B" $0 $1 $2
   IntOp $AppSize $AppSize + $0
 
   ; Copy resources
   {{#each resources}}
     CreateDirectory "$INSTDIR\\{{this.[0]}}"
     File /a "/oname={{this.[1]}}" "{{@key}}"
-    ${GetSize} "$INSTDIR" "/M={{this.[1]}} /S=0B" $0 $1 $2
+    ${GetSize} "$INSTDIR\{{this.[1]}}" "/S=0B" $0 $1 $2
     IntOp $AppSize $AppSize + $0
   {{/each}}
 
   ; Copy external binaries
   {{#each binaries}}
     File /a "/oname={{this}}" "{{@key}}"
-    ${GetSize} "$INSTDIR" "/M={{this}} /S=0B" $0 $1 $2
+    ${GetSize} "$INSTDIR\{{this}}" "/S=0B" $0 $1 $2
     IntOp $AppSize $AppSize + $0
   {{/each}}
 


### PR DESCRIPTION
So the project from the devs that reported this issues includes 200+ folders and 1000+ files via the resources config. In this case it's a node_modules folder (intentionally) and putting aside whether or not one should bundle a node_modules folder this can also easily happen in non-nodejs contexts.

Anyway, said app took ~8 minutes to install on my machine. Btw, the files are ~20mb total.

1st commit: Pointing the GetSize call directly at the file instead of the whole folder with a mask reduces that to ~12 seconds - btw the GetSize docs are super confusing, i also thought it can only point to a folder so i looked at other things before i tried this first...

2nd commit: This i'm a bit unsure about whether we can add it to v1 or only to v2 which is why i split it up into another commit. Basically the folder structure is now calculated upfront on the build system, sorted and deduplicated and in the installer the dir creation and file extraction are now 2 steps to not create the same dir again and again. This reduced the install time to ~10 seconds.

### Further "improvements"

- SetCompress off reduces it to ~3 to 4 seconds so that _may_ be something worth to add as a config.
- If we don't check the install size it can be basically instant (without compression) so my initial idea was to calculate file sizes on the build system and use them for the progress report. That _may_ lead to slightly inaccurate progress bars but i don't think that matters (we can just set it too 100% at the end i guess). Buuut that's a slightly bigger change i didn't want to implement without talking about it and this PR is basically a hotfix for the devs that reached out.