### PR TITLE
fix(updater): Use escaped installer path when starting the updater msi

### DIFF
--- a/.changes/updater-msi-escaped-path.md
+++ b/.changes/updater-msi-escaped-path.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Escape path of the updater msi to avoid crashing on installers with spaces.

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -844,7 +844,7 @@ fn copy_files_and_run<R: Read + Seek>(
           "-ArgumentList",
         ])
         .arg("/i,")
-        .arg(msi_path_arg)
+        .arg(&msi_path_arg)
         .arg(format!(", {}, /promptrestart;", msiexec_args.join(", ")))
         .arg("Start-Process")
         .arg(current_exe_arg)

--- a/core/tauri/src/updater/core.rs
+++ b/core/tauri/src/updater/core.rs
@@ -858,7 +858,7 @@ fn copy_files_and_run<R: Read + Seek>(
         );
         let _ = Command::new(msiexec_path)
           .arg("/i")
-          .arg(found_path)
+          .arg(msi_path_arg)
           .args(msiexec_args)
           .arg("/promptrestart")
           .spawn();


### PR DESCRIPTION
Continuation of https://github.com/tauri-apps/tauri/pull/7956

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
