### PR TITLE
fix(bundler/nsis): remove empty resources folders on uninstall

### DIFF
--- a/.changes/nsis-leftover-dirs.md
+++ b/.changes/nsis-leftover-dirs.md
@@ -1,0 +1,7 @@
+---
+"@tauri-apps/cli": patch:bug
+"tauri-cli": patch:bug
+"tauri-bundler": patch:bug
+---
+
+Fixes an issue in the NSIS installer which caused the uninstallation to leave empty folders on the system if the `resources` feature was used.

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -303,6 +303,17 @@ fn build_nsis_app_installer(
   let resources = generate_resource_data(settings)?;
   let resources_dirs =
     std::collections::HashSet::<PathBuf>::from_iter(resources.values().map(|r| r.0.to_owned()));
+
+  let mut resources_ancestors = resources_dirs
+    .iter()
+    .flat_map(|r| r.ancestors())
+    .collect::<Vec<_>>();
+  resources_ancestors.sort_unstable();
+  resources_ancestors.dedup();
+  resources_ancestors.sort_by(|a, b| b.components().count().cmp(&a.components().count()));
+  resources_ancestors.pop(); // Last one is always ""
+
+  data.insert("resources_ancestors", to_json(resources_ancestors));
   data.insert("resources_dirs", to_json(resources_dirs));
   data.insert("resources", to_json(&resources));
 

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -306,11 +306,11 @@ fn build_nsis_app_installer(
 
   let mut resources_ancestors = resources_dirs
     .iter()
-    .flat_map(|r| r.ancestors())
+    .flat_map(|p| p.ancestors())
     .collect::<Vec<_>>();
   resources_ancestors.sort_unstable();
   resources_ancestors.dedup();
-  resources_ancestors.sort_by(|a, b| b.components().count().cmp(&a.components().count()));
+  resources_ancestors.sort_by_key(|p| std::cmp::Reverse(p.components().count()));
   resources_ancestors.pop(); // Last one is always ""
 
   data.insert("resources_ancestors", to_json(resources_ancestors));

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -533,7 +533,6 @@ Section Install
 
   ; Copy resources
   {{#each resources_dirs}}
-    ; `\\` is not a typo.
     CreateDirectory "$INSTDIR\\{{this}}"
   {{/each}}
   {{#each resources}}
@@ -623,7 +622,6 @@ Section Uninstall
   ; Delete resources
   {{#each resources}}
     Delete "$INSTDIR\\{{this.[1]}}"
-    RMDir "$INSTDIR\\{{this.[0]}}"
   {{/each}}
 
   ; Delete external binaries
@@ -634,7 +632,14 @@ Section Uninstall
   ; Delete uninstaller
   Delete "$INSTDIR\uninstall.exe"
 
-  RMDir "$INSTDIR"
+  ${If} $DeleteAppDataCheckboxState == 1
+    RMDir /R /REBOOTOK "$INSTDIR"
+  ${Else}
+    {{#each resources_ancestors}}
+    RMDir /REBOOTOK "$INSTDIR\\{{this}}"
+    {{/each}}
+    RMDir "$INSTDIR"
+  ${EndIf}
 
   ; Remove start menu shortcut
   !insertmacro MUI_STARTMENU_GETFOLDER Application $AppStartMenuFolder


### PR DESCRIPTION
This is a follow up of https://github.com/tauri-apps/tauri/pull/8233, so please read that PR description for context.

Currently the uninstaller only deletes the top-level resources folders. NSIS' rmdir function has a `/R` flag for recursive deletion but i thought that it has to follow the "Delete application data" checkbox, even if the installdir is not the data dirs we expose with the bundle id. This makes it quite a bit more ~~complicated~~ spammy since now we have to delete each folder level seperately...

If we prefer to use the /R over a much bigger uninstaller then i'll be happy to adapt this PR, this is just how i understood it was meant to work :)

p.s. The uninstaller now recursively deletes the installdir too _if the checkbox is ticked_, just in case the dev added files in there too.