### PR TITLE
rename appimage.sh => build_appimage.sh in error

### DIFF
--- a/tooling/bundler/src/bundle/linux/appimage.rs
+++ b/tooling/bundler/src/bundle/linux/appimage.rs
@@ -108,7 +108,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   Command::new(&sh_file)
     .current_dir(output_path)
     .output_ok()
-    .context("error running appimage.sh")?;
+    .context("error running build_appimage.sh")?;
 
   remove_dir_all(&package_dir)?;
   Ok(vec![appimage_path])


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] `Kinda` Bugfix 
- [x] Insignificant change

### Does this PR introduce a breaking change?

- [x] No

### Other information

the `.sh` app image build filename was not good on error, leading to miss understanding of the error
