### PR TITLE
refactor: replace `once_cell` with `std::sync::OnceLock`

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -49,7 +49,6 @@ uuid = { version = "1", features = [ "v4" ], optional = true }
 url = { version = "2.4" }
 anyhow = "1.0"
 thiserror = "1.0"
-once_cell = "1"
 tauri-runtime = { version = "1.0.0-alpha.5", path = "../tauri-runtime" }
 tauri-macros = { version = "2.0.0-alpha.11", path = "../tauri-macros" }
 tauri-utils = { version = "2.0.0-alpha.11", features = [ "resources" ], path = "../tauri-utils" }
@@ -109,7 +108,6 @@ swift-rs = "1.0.6"
 
 [build-dependencies]
 heck = "0.4"
-once_cell = "1"
 tauri-build = { path = "../tauri-build/", version = "2.0.0-alpha.12" }
 
 [dev-dependencies]

--- a/core/tauri/build.rs
+++ b/core/tauri/build.rs
@@ -4,8 +4,6 @@
 
 use heck::AsShoutySnakeCase;
 
-use once_cell::sync::OnceCell;
-
 use std::env::var_os;
 use std::fs::read_dir;
 use std::fs::read_to_string;
@@ -13,10 +11,10 @@ use std::fs::write;
 use std::{
   env::var,
   path::{Path, PathBuf},
-  sync::Mutex,
+  sync::{Mutex, OnceLock},
 };
 
-static CHECKED_FEATURES: OnceCell<Mutex<Vec<String>>> = OnceCell::new();
+static CHECKED_FEATURES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 
 // checks if the given Cargo feature is enabled.
 fn has_feature(feature: &str) -> bool {

--- a/core/tauri/src/async_runtime.rs
+++ b/core/tauri/src/async_runtime.rs
@@ -22,8 +22,8 @@ pub use tokio::{
 use std::{
   future::Future,
   pin::Pin,
-  task::{Context, Poll},
   sync::OnceLock,
+  task::{Context, Poll},
 };
 
 static RUNTIME: OnceLock<GlobalRuntime> = OnceLock::new();

--- a/core/tauri/src/async_runtime.rs
+++ b/core/tauri/src/async_runtime.rs
@@ -10,7 +10,6 @@
 //! one you need isn't here, you could use types in [`tokio`] directly.
 //! For custom command handlers, it's recommended to use a plain `async fn` command.
 
-use once_cell::sync::OnceCell;
 pub use tokio::{
   runtime::{Handle as TokioHandle, Runtime as TokioRuntime},
   sync::{
@@ -24,9 +23,10 @@ use std::{
   future::Future,
   pin::Pin,
   task::{Context, Poll},
+  sync::OnceLock,
 };
 
-static RUNTIME: OnceCell<GlobalRuntime> = OnceCell::new();
+static RUNTIME: OnceLock<GlobalRuntime> = OnceLock::new();
 
 struct GlobalRuntime {
   runtime: Option<Runtime>,

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -887,10 +887,9 @@ pub mod test;
 #[cfg(test)]
 mod tests {
   use cargo_toml::Manifest;
-  use once_cell::sync::OnceCell;
-  use std::{env::var, fs::read_to_string, path::PathBuf};
+  use std::{env::var, fs::read_to_string, path::PathBuf, sync::OnceLock};
 
-  static MANIFEST: OnceCell<Manifest> = OnceCell::new();
+  static MANIFEST: OnceLock<Manifest> = OnceLock::new();
   const CHECKED_FEATURES: &str = include_str!(concat!(env!("OUT_DIR"), "/checked_features"));
 
   fn get_manifest() -> &'static Manifest {

--- a/core/tauri/src/plugin/mobile.rs
+++ b/core/tauri/src/plugin/mobile.rs
@@ -29,7 +29,7 @@ type PendingPluginCallHandler = Box<dyn FnOnce(PluginResponse) + Send + 'static>
 #[cfg(mobile)]
 static PENDING_PLUGIN_CALLS_ID: AtomicI32 = AtomicI32::new(0);
 static PENDING_PLUGIN_CALLS: OnceLock<Mutex<HashMap<i32, PendingPluginCallHandler>>> =
-OnceLock::new();
+  OnceLock::new();
 static CHANNELS: OnceLock<Mutex<HashMap<u32, Channel>>> = OnceLock::new();
 
 /// Possible errors when invoking a plugin.

--- a/core/tauri/src/plugin/mobile.rs
+++ b/core/tauri/src/plugin/mobile.rs
@@ -14,13 +14,12 @@ use crate::{
 #[cfg(mobile)]
 use std::sync::atomic::{AtomicI32, Ordering};
 
-use once_cell::sync::OnceCell;
 use serde::{de::DeserializeOwned, Serialize};
 
 use std::{
   collections::HashMap,
   fmt,
-  sync::{mpsc::channel, Mutex},
+  sync::{mpsc::channel, Mutex, OnceLock},
 };
 
 type PluginResponse = Result<serde_json::Value, serde_json::Value>;
@@ -29,9 +28,9 @@ type PendingPluginCallHandler = Box<dyn FnOnce(PluginResponse) + Send + 'static>
 
 #[cfg(mobile)]
 static PENDING_PLUGIN_CALLS_ID: AtomicI32 = AtomicI32::new(0);
-static PENDING_PLUGIN_CALLS: OnceCell<Mutex<HashMap<i32, PendingPluginCallHandler>>> =
-  OnceCell::new();
-static CHANNELS: OnceCell<Mutex<HashMap<u32, Channel>>> = OnceCell::new();
+static PENDING_PLUGIN_CALLS: OnceLock<Mutex<HashMap<i32, PendingPluginCallHandler>>> =
+OnceLock::new();
+static CHANNELS: OnceLock<Mutex<HashMap<u32, Channel>>> = OnceLock::new();
 
 /// Possible errors when invoking a plugin.
 #[derive(Debug, thiserror::Error)]

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -4092,7 +4092,6 @@ dependencies = [
  "minisign",
  "notify",
  "notify-debouncer-mini",
- "once_cell",
  "os_info",
  "os_pipe",
  "plist",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -51,7 +51,6 @@ clap = { version = "4.4", features = [ "derive", "env" ] }
 anyhow = "1.0"
 tauri-bundler = { version = "2.0.0-alpha.12", default-features = false, path = "../bundler" }
 colored = "2.0"
-once_cell = "1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 notify = "6.1"

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -16,7 +16,6 @@ use crate::{
 use anyhow::{bail, Context};
 use clap::{ArgAction, Parser};
 use log::{error, info, warn};
-use once_cell::sync::OnceCell;
 use shared_child::SharedChild;
 use tauri_utils::platform::Target;
 
@@ -26,12 +25,12 @@ use std::{
   process::{exit, Command, Stdio},
   sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
+    Arc, Mutex, OnceLock,
   },
 };
 
-static BEFORE_DEV: OnceCell<Mutex<Arc<SharedChild>>> = OnceCell::new();
-static KILL_BEFORE_DEV_FLAG: OnceCell<AtomicBool> = OnceCell::new();
+static BEFORE_DEV: OnceLock<Mutex<Arc<SharedChild>>> = OnceLock::new();
+static KILL_BEFORE_DEV_FLAG: OnceLock<AtomicBool> = OnceLock::new();
 
 #[cfg(unix)]
 const KILL_CHILDREN_SCRIPT: &[u8] = include_bytes!("../scripts/kill-children.sh");
@@ -107,7 +106,7 @@ fn command_internal(mut options: Options) -> Result<()> {
 }
 
 pub fn local_ip_address(force: bool) -> &'static IpAddr {
-  static LOCAL_IP: OnceCell<IpAddr> = OnceCell::new();
+  static LOCAL_IP: OnceLock<IpAddr> = OnceLock::new();
   LOCAL_IP.get_or_init(|| {
     let prompt_for_ip = || {
       let addresses: Vec<IpAddr> = local_ip_address::list_afinet_netifas()

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -17,8 +17,6 @@ use tauri_utils::{
   platform::Target,
 };
 
-static APP_DIR: OnceLock<PathBuf> = OnceLock::new();
-
 const TAURI_GITIGNORE: &[u8] = include_bytes!("../../tauri.gitignore");
 
 pub fn walk_builder(path: &Path) -> WalkBuilder {
@@ -116,6 +114,8 @@ fn get_app_dir() -> Option<PathBuf> {
 }
 
 pub fn app_dir() -> &'static PathBuf {
+  static APP_DIR: OnceLock<PathBuf> = OnceLock::new();
+
   APP_DIR.get_or_init(|| {
     get_app_dir().unwrap_or_else(|| get_tauri_dir().parent().unwrap().to_path_buf())
   })

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -116,9 +116,9 @@ fn get_app_dir() -> Option<PathBuf> {
 }
 
 pub fn app_dir() -> &'static PathBuf {
-  &APP_DIR.get_or_init(|| {
+  APP_DIR.get_or_init(|| {
     get_app_dir().unwrap_or_else(|| get_tauri_dir().parent().unwrap().to_path_buf())
-  });
+  })
 }
 
 pub fn tauri_dir() -> PathBuf {

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -7,15 +7,17 @@ use std::{
   env::current_dir,
   ffi::OsStr,
   path::{Path, PathBuf},
+  sync::OnceLock,
 };
 
 use ignore::WalkBuilder;
-use once_cell::sync::Lazy;
 
 use tauri_utils::{
   config::parse::{folder_has_configuration_file, is_configuration_file, ConfigFormat},
   platform::Target,
 };
+
+static APP_DIR: OnceLock<PathBuf> = OnceLock::new();
 
 const TAURI_GITIGNORE: &[u8] = include_bytes!("../../tauri.gitignore");
 
@@ -114,9 +116,7 @@ fn get_app_dir() -> Option<PathBuf> {
 }
 
 pub fn app_dir() -> &'static PathBuf {
-  static APP_DIR: Lazy<PathBuf> =
-    Lazy::new(|| get_app_dir().unwrap_or_else(|| get_tauri_dir().parent().unwrap().to_path_buf()));
-  &APP_DIR
+  &APP_DIR.get_or_init(|| get_app_dir().unwrap_or_else(|| get_tauri_dir().parent().unwrap().to_path_buf()));
 }
 
 pub fn tauri_dir() -> PathBuf {

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -116,7 +116,9 @@ fn get_app_dir() -> Option<PathBuf> {
 }
 
 pub fn app_dir() -> &'static PathBuf {
-  &APP_DIR.get_or_init(|| get_app_dir().unwrap_or_else(|| get_tauri_dir().parent().unwrap().to_path_buf()));
+  &APP_DIR.get_or_init(|| {
+    get_app_dir().unwrap_or_else(|| get_tauri_dir().parent().unwrap().to_path_buf())
+  });
 }
 
 pub fn tauri_dir() -> PathBuf {

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -115,7 +115,6 @@ fn get_app_dir() -> Option<PathBuf> {
 
 pub fn app_dir() -> &'static PathBuf {
   static APP_DIR: OnceLock<PathBuf> = OnceLock::new();
-
   APP_DIR.get_or_init(|| {
     get_app_dir().unwrap_or_else(|| get_tauri_dir().parent().unwrap().to_path_buf())
   })

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -5,7 +5,6 @@
 use anyhow::Context;
 use json_patch::merge;
 use log::error;
-use once_cell::sync::Lazy;
 use serde_json::Value as JsonValue;
 
 pub use tauri_utils::{config::*, platform::Target};
@@ -15,8 +14,10 @@ use std::{
   env::{current_dir, set_current_dir, set_var, var_os},
   ffi::OsStr,
   process::exit,
-  sync::{Arc, Mutex},
+  sync::{Arc, Mutex, OnceLock},
 };
+
+static CONFING_HANDLE: OnceLock<ConfigHandle> = OnceLock::new(Default::default());
 
 pub const MERGE_CONFIG_EXTENSION_NAME: &str = "--config";
 
@@ -115,7 +116,6 @@ pub fn nsis_settings(config: NsisConfig) -> tauri_bundler::NsisSettings {
 }
 
 fn config_handle() -> &'static ConfigHandle {
-  static CONFING_HANDLE: Lazy<ConfigHandle> = Lazy::new(Default::default);
   &CONFING_HANDLE
 }
 

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -115,7 +115,6 @@ pub fn nsis_settings(config: NsisConfig) -> tauri_bundler::NsisSettings {
 
 fn config_handle() -> &'static ConfigHandle {
   static CONFIG_HANDLE: OnceLock<ConfigHandle> = OnceLock::new();
-
   CONFIG_HANDLE.get_or_init(Default::default)
 }
 

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -17,8 +17,6 @@ use std::{
   sync::{Arc, Mutex, OnceLock},
 };
 
-static CONFING_HANDLE: OnceLock<ConfigHandle> = OnceLock::new();
-
 pub const MERGE_CONFIG_EXTENSION_NAME: &str = "--config";
 
 pub struct ConfigMetadata {
@@ -116,7 +114,9 @@ pub fn nsis_settings(config: NsisConfig) -> tauri_bundler::NsisSettings {
 }
 
 fn config_handle() -> &'static ConfigHandle {
-  CONFING_HANDLE.get_or_init(Default::default)
+  static CONFIG_HANDLE: OnceLock<ConfigHandle> = OnceLock::new();
+
+  CONFIG_HANDLE.get_or_init(Default::default)
 }
 
 /// Gets the static parsed config from `tauri.conf.json`.

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -17,7 +17,7 @@ use std::{
   sync::{Arc, Mutex, OnceLock},
 };
 
-static CONFING_HANDLE: OnceLock<ConfigHandle> = OnceLock::new(Default::default());
+static CONFING_HANDLE: OnceLock<ConfigHandle> = OnceLock::new();
 
 pub const MERGE_CONFIG_EXTENSION_NAME: &str = "--config";
 
@@ -116,7 +116,7 @@ pub fn nsis_settings(config: NsisConfig) -> tauri_bundler::NsisSettings {
 }
 
 fn config_handle() -> &'static ConfigHandle {
-  &CONFING_HANDLE
+  CONFING_HANDLE.get_or_init(Default::default)
 }
 
 /// Gets the static parsed config from `tauri.conf.json`.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Since Rust 1.70, [once_cell::sync::OnceCell](https://docs.rs/once_cell/latest/once_cell/sync/struct.OnceCell.html), from the `once_cell` crate got integrated into the standard library as [std::sync::OnceLock](https://doc.rust-lang.org/std/sync/struct.OnceLock.html).