### PR TITLE
fix(core): allow canceling `data-tauri-drag-region` maximization on macOS, closes #8306

### DIFF
--- a/.changes/tauri-data-drag-region-macos-maximize.md
+++ b/.changes/tauri-data-drag-region-macos-maximize.md
@@ -1,5 +1,5 @@
 ---
-'tauri': 'patch'
+'tauri': 'patch:bug'
 ---
 
 On macOS, `data-tauri-drag-region` will now maximize when mouse doublick is up instead of when down, to allow cancelling it by moving it outside the drag element to match macOS native behavior.

--- a/.changes/tauri-data-drag-region-macos-maximize.md
+++ b/.changes/tauri-data-drag-region-macos-maximize.md
@@ -2,4 +2,4 @@
 'tauri': 'patch:bug'
 ---
 
-On macOS, `data-tauri-drag-region` will now maximize when mouse doublick is up instead of when down, to allow cancelling it by moving it outside the drag element to match macOS native behavior.
+On macOS, allow cancelling maximization when doubleclick happens on `data-tauri-drag-region` by simply keeping the left moust button pressed and then moving the mouse away of the starting position of the click, which is consistent with the native behavior of macOS. 

--- a/.changes/tauri-data-drag-region-macos-maximize.md
+++ b/.changes/tauri-data-drag-region-macos-maximize.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch'
+---
+
+On macOS, `data-tauri-drag-region` will now maximize when mouse doublick is up instead of when down, to allow cancelling it by moving it outside the drag element to match macOS native behavior.

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -144,10 +144,13 @@
 
   //-----------------------//
   // data-tauri-drag-region
+  //
+  // drag on mousedown and maximize on double click on Windows and Linux
+  // while macOS macos maximization should be on mouseup and if the mouse
+  // moves after the double click, it should be cancelled
   //-----------------------//
   const TAURI_DRAG_REGION_ATTR = 'data-tauri-drag-region';
-  //drag on mousedown and maximize on double click on Windows and Linux
-  // while macOS macos maximization is on mouseup below
+  let x = 0, y = 0;
   document.addEventListener('mousedown', (e) => {
     if (
       // element has the magic data attribute
@@ -155,15 +158,24 @@
       // and was left mouse button
       e.button === 0 &&
       // and was normal click to drag or double click to maximize
-      (e.detail === 1 || e.detail === 2) &&
-      // and was on Windows or Linux or was on macOS and we drag only (macos maximization is on mouseup below)
-      (osName !== 'macos' || (osName === 'macos' && e.detail === 1))
-    ) {
+      (e.detail === 1 || e.detail === 2)
+      ) {
+
+      // macOS maximization happens on `mouseup`,
+      // so we save needed state and early return
+      if (osName === 'macos' && e.detail == 2) {
+        x = e.clientX
+        y = e.clientY
+        return
+      }
+
       // prevents text cursor
       e.preventDefault()
+
       // fix #2549: double click on drag region edge causes content to maximize without window sizing change
       // https://github.com/tauri-apps/tauri/issues/2549#issuecomment-1250036908
       e.stopImmediatePropagation()
+
       window.__TAURI_INVOKE__('tauri', {
         __tauriModule: 'Window',
         message: {
@@ -187,7 +199,9 @@
         // and was left mouse button
         e.button === 0 &&
         // and was double click
-        e.detail === 2
+        e.detail === 2 &&
+        // and the cursor hasn't moved from initial mousedown
+        e.clientX === x && e.clientY === y
       ) {
         window.__TAURI_INVOKE__('tauri', {
           __tauriModule: 'Window',

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -147,7 +147,7 @@
   //
   // drag on mousedown and maximize on double click on Windows and Linux
   // while macOS macos maximization should be on mouseup and if the mouse
-  // moves after the double click, it should be cancelled
+  // moves after the double click, it should be cancelled (see https://github.com/tauri-apps/tauri/issues/8306)
   //-----------------------//
   const TAURI_DRAG_REGION_ATTR = 'data-tauri-drag-region';
   let x = 0, y = 0;

--- a/core/tauri/scripts/core.js
+++ b/core/tauri/scripts/core.js
@@ -157,7 +157,7 @@
       // and was normal click to drag or double click to maximize
       (e.detail === 1 || e.detail === 2) &&
       // and was on Windows or Linux or was on macOS and we drag only (macos maximization is on mouseup below)
-      (osName !== 'macos' || (osName === 'macOS' && e.detail === 1))
+      (osName !== 'macos' || (osName === 'macos' && e.detail === 1))
     ) {
       // prevents text cursor
       e.preventDefault()


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
