### PR TITLE
perf: skip large `Window` and `AppHandle` fields on traces

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -115,6 +115,9 @@ jobs:
           cargo update -p bstr --precise 1.6.2
           cargo update -p backtrace --precise 0.3.68
           cargo update -p blocking --precise 1.4.1
+          cargo update -p ignore --precise 0.4.18
+          cargo update -p regex --precise 1.9.6
+          cargo update -p globset --precise 0.4.13
 
       - name: test
         run: cargo test --target ${{ matrix.platform.target }} ${{ matrix.features.args }}

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -664,7 +664,7 @@ impl<R: Runtime> PluginStore<R> {
   }
 }
 
-#[cfg_attr(feature = "tracing", tracing::instrument(name = "plugin::hooks::initialize", skip(plugin), fields(name = plugin.name())))]
+#[cfg_attr(feature = "tracing", tracing::instrument(name = "plugin::hooks::initialize", skip(plugin, app), fields(name = plugin.name())))]
 fn initialize<R: Runtime>(
   plugin: &mut Box<dyn Plugin<R>>,
   app: &AppHandle<R>,

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -1804,7 +1804,7 @@ impl<R: Runtime> Window<R> {
 
   #[cfg_attr(feature = "tracing", tracing::instrument(
     "window::emit::eval",
-    skip(emit_args),
+    skip(self, emit_args),
     fields(
       event = emit_args.event,
       source_window = emit_args.source_window_label,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: performance

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

These contain large fields like image buffers, causing spans/events to be very large when serialized.

Especially the `window::emit::eval` one which is in a hot code path.