### PR TITLE
feat(cli): expose CLI signer flags as environment variables

### DIFF
--- a/.changes/cli-signer-env-vars.md
+++ b/.changes/cli-signer-env-vars.md
@@ -1,0 +1,9 @@
+---
+'tauri-cli': 'patch:enhance'
+---
+
+Added the following env vars to the `tauri signer sign` command to allow you to use in CI.
+
+- `TAURI_PRIVATE_KEY`
+- `TAURI_PRIVATE_KEY_PASSWORD`
+- `TAURI_PRIVATE_KEY_PATH`

--- a/.changes/cli-signer-env-vars.md
+++ b/.changes/cli-signer-env-vars.md
@@ -2,7 +2,7 @@
 'tauri-cli': 'patch:enhance'
 ---
 
-Added the following env vars to the `tauri signer sign` command to allow you to use in CI.
+Read the following env vars when using the `tauri signer sign` command to make it easier to use in CI.
 
 - `TAURI_PRIVATE_KEY`
 - `TAURI_PRIVATE_KEY_PASSWORD`

--- a/tooling/cli/src/signer/sign.rs
+++ b/tooling/cli/src/signer/sign.rs
@@ -17,13 +17,23 @@ use tauri_utils::display_path;
 #[clap(about = "Sign a file")]
 pub struct Options {
   /// Load the private key from a string
-  #[clap(short = 'k', long, conflicts_with("private_key_path"))]
+  #[clap(
+    short = 'k',
+    long,
+    conflicts_with("private_key_path"),
+    env = "TAURI_PRIVATE_KEY"
+  )]
   private_key: Option<String>,
   /// Load the private key from a file
-  #[clap(short = 'f', long, conflicts_with("private_key"))]
+  #[clap(
+    short = 'f',
+    long,
+    conflicts_with("private_key"),
+    env = "TAURI_PRIVATE_KEY_PATH"
+  )]
   private_key_path: Option<PathBuf>,
   /// Set private key password when signing
-  #[clap(short, long)]
+  #[clap(short, long, env = "TAURI_PRIVATE_KEY_PASSWORD")]
   password: Option<String>,
   /// Sign the specified file
   file: PathBuf,


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

Expose `TAURI_PRIVATE_KEY_PASSWORD`, `TAURI_PRIVATE_KEY_PASSWORD`, and `TAURI_PRIVATE_KEY` to make it easier to use the CLI in a CI environment.

In theory we can then call this with all the vars set to create a signature.
```
tauri signer sign *.exe
```

Although I saw that this renames the vars https://github.com/tauri-apps/tauri/blob/dev/.changes/cli-env-vars.md

I'm assuming that's a v2 breaking change and I'm not sure if I should adopt those values for this PR.

Guidance from the core team is extremely appreciated. thanks! 

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
