### PR TITLE
fix: fix incorrect predefined menu item for Close Window

### DIFF
--- a/.changes/tauri-menu-predefined-close-wiwndow.md
+++ b/.changes/tauri-menu-predefined-close-wiwndow.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+Fix incorrect menu item for `PredefinedMenuItem::close_window`

--- a/core/tauri/src/menu/predefined.rs
+++ b/core/tauri/src/menu/predefined.rs
@@ -212,7 +212,7 @@ impl<R: Runtime> PredefinedMenuItem<R> {
   ///
   /// - **Linux:** Unsupported.
   pub fn close_window<M: Manager<R>>(manager: &M, text: Option<&str>) -> Self {
-    let inner = muda::PredefinedMenuItem::show_all(text);
+    let inner = muda::PredefinedMenuItem::close_window(text);
     Self {
       id: inner.id().clone(),
       inner,


### PR DESCRIPTION

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

I can see that the Show All menu item appears when I tried to add Close Window instead.