### PR TITLE
ci: fix publish `@tauri-apps/api` to `latest` instead of `next` 

### DIFF
--- a/tooling/api/package.json
+++ b/tooling/api/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "rollup -c --configPlugin typescript",
     "npm-pack": "yarn build && cd ./dist && npm pack",
-    "npm-publish": "yarn build && cd ./dist && yarn publish --access public --loglevel silly --tag latest",
+    "npm-publish": "yarn build && cd ./dist && yarn publish --access public --loglevel silly",
     "ts:check": "tsc -noEmit",
     "lint": "eslint --ext ts \"./src/**/*.ts\"",
     "lint:fix": "eslint --fix --ext ts \"./src/**/*.ts\"",

--- a/tooling/api/package.json
+++ b/tooling/api/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "rollup -c --configPlugin typescript",
     "npm-pack": "yarn build && cd ./dist && npm pack",
-    "npm-publish": "yarn build && cd ./dist && yarn publish --access public --loglevel silly --tag next",
+    "npm-publish": "yarn build && cd ./dist && yarn publish --access public --loglevel silly --tag latest",
     "ts:check": "tsc -noEmit",
     "lint": "eslint --ext ts \"./src/**/*.ts\"",
     "lint:fix": "eslint --fix --ext ts \"./src/**/*.ts\"",


### PR DESCRIPTION
closes #8335

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
