### PR TITLE
feat(core): allow the `MockRuntime` to call a command and get a return value  + fix doctest

### DIFF
--- a/.changes/get-ipc-response-test.md
+++ b/.changes/get-ipc-response-test.md
@@ -2,4 +2,4 @@
 "tauri": patch:enhance
 ---
 
-Added `test::get_ipc_response` and `test::get_ipc_response_raw`.
+Added `test::get_ipc_response`.

--- a/.changes/get-ipc-response-test.md
+++ b/.changes/get-ipc-response-test.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Added `test::get_ipc_response` and `test::get_ipc_response_raw`.

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -11,47 +11,38 @@
 //! # Examples
 //!
 //! ```rust
-//! #[tauri::command]
-//! fn my_cmd() {}
+//! use tauri::test::{mock_builder, mock_context, noop_assets};
 //!
-//! fn create_app<R: tauri::Runtime>(mut builder: tauri::Builder<R>) -> tauri::App<R> {
-//!   builder
-//!     .setup(|app| {
-//!       // do something
-//!       Ok(())
-//!     })
-//!     .invoke_handler(tauri::generate_handler![my_cmd])
-//!     // remove the string argument on your app
-//!     .build(tauri::generate_context!("test/fixture/src-tauri/tauri.conf.json"))
-//!     .expect("failed to build app")
+//! #[tauri::command]
+//! fn ping() -> &'static str {
+//!     "pong"
+//! }
+//!
+//! fn create_app<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::App<R> {
+//!     builder
+//!         .invoke_handler(tauri::generate_handler![ping])
+//!         // remove the string argument to use your app's config file
+//!         .build(tauri::generate_context!("test/fixture/src-tauri/tauri.conf.json"))
+//!         .expect("failed to build app")
 //! }
 //!
 //! fn main() {
-//!   // let app = create_app(tauri::Builder::default());
-//!   // app.run(|_handle, _event| {});
-//! }
+//!     let app = create_app(mock_builder());
+//!     let window = tauri::WindowBuilder::new(&app, "main", Default::default())
+//!         .build()
+//!         .unwrap();
 //!
-//! //#[cfg(test)]
-//! mod tests {
-//!   use tauri::Manager;
-//!   //#[cfg(test)]
-//!   fn something() {
-//!     let app = super::create_app(tauri::test::mock_builder());
-//!     let window = app.get_window("main").unwrap();
-//!     // do something with the app and window
-//!     // in this case we'll run the my_cmd command with no arguments
-//!     tauri::test::assert_ipc_response(
-//!       &window,
-//!       tauri::window::InvokeRequest {
-//!         cmd: "my_cmd".into(),
-//!         callback: tauri::ipc::CallbackFn(0),
-//!         error: tauri::ipc::CallbackFn(1),
-//!         body: serde_json::Value::Null.into(),
-//!         headers: Default::default(),
-//!       },
-//!       Ok(())
+//!     // run the `ping` command and assert it returns `pong`
+//!     let res = tauri::test::get_ipc_response::<String>(
+//!         &window,
+//!         tauri::window::InvokeRequest {
+//!             cmd: "ping".into(),
+//!             callback: tauri::ipc::CallbackFn(0),
+//!             error: tauri::ipc::CallbackFn(1),
+//!             body: tauri::ipc::InvokeBody::default(),
+//!             headers: Default::default(),
+//!         },
 //!     );
-//!   }
 //! }
 //! ```
 
@@ -175,48 +166,39 @@ pub fn mock_app() -> App<MockRuntime> {
 /// # Examples
 ///
 /// ```rust
+/// use tauri::test::{mock_builder, mock_context, noop_assets};
+///
 /// #[tauri::command]
 /// fn ping() -> &'static str {
-///   "pong"
+///     "pong"
 /// }
 ///
-/// fn create_app<R: tauri::Runtime>(mut builder: tauri::Builder<R>) -> tauri::App<R> {
-///   builder
-///     .invoke_handler(tauri::generate_handler![ping])
-///     // remove the string argument on your app
-///     .build(tauri::generate_context!("test/fixture/src-tauri/tauri.conf.json"))
-///     .expect("failed to build app")
+/// fn create_app<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::App<R> {
+///     builder
+///         .invoke_handler(tauri::generate_handler![ping])
+///         // remove the string argument to use your app's config file
+///         .build(tauri::generate_context!("test/fixture/src-tauri/tauri.conf.json"))
+///         .expect("failed to build app")
 /// }
 ///
 /// fn main() {
-///   // let app = create_app(tauri::Builder::default());
-///   // app.run(|_handle, _event| {});}
-/// }
-///
-/// //#[cfg(test)]
-/// mod tests {
-///   use tauri::Manager;
-///
-///   //#[cfg(test)]
-///   fn something() {
-///     let app = super::create_app(tauri::test::mock_builder());
-///     let window = app.get_window("main").unwrap();
+///     let app = create_app(mock_builder());
+///     let window = tauri::WindowBuilder::new(&app, "main", Default::default())
+///         .build()
+///         .unwrap();
 ///
 ///     // run the `ping` command and assert it returns `pong`
 ///     tauri::test::assert_ipc_response(
-///       &window,
-///       tauri::window::InvokeRequest {
-///         cmd: "ping".into(),
-///         callback: tauri::ipc::CallbackFn(0),
-///         error: tauri::ipc::CallbackFn(1),
-///         body: serde_json::Value::Null.into(),
-///         headers: Default::default(),
-///       },
-///       // the expected response is a success with the "pong" payload
-///       // we could also use Err("error message") here to ensure the command failed
+///         &window,
+///         tauri::window::InvokeRequest {
+///             cmd: "ping".into(),
+///             callback: tauri::ipc::CallbackFn(0),
+///             error: tauri::ipc::CallbackFn(1),
+///             body: tauri::ipc::InvokeBody::default(),
+///             headers: Default::default(),
+///         },
 ///       Ok("pong")
 ///     );
-///   }
 /// }
 /// ```
 pub fn assert_ipc_response<T: Serialize + Debug + Send + Sync + 'static>(
@@ -260,7 +242,8 @@ pub fn assert_ipc_response<T: Serialize + Debug + Send + Sync + 'static>(
 /// fn create_app<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::App<R> {
 ///     builder
 ///         .invoke_handler(tauri::generate_handler![ping])
-///         .build(mock_context(noop_assets()))
+///         // remove the string argument to use your app's config file
+///         .build(tauri::generate_context!("test/fixture/src-tauri/tauri.conf.json"))
 ///         .expect("failed to build app")
 /// }
 ///

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -33,7 +33,7 @@
 //!         .unwrap();
 //!
 //!     // run the `ping` command and assert it returns `pong`
-//!     let res = tauri::test::get_ipc_response::<String>(
+//!     let res = tauri::test::get_ipc_response(
 //!         &window,
 //!         tauri::window::InvokeRequest {
 //!             cmd: "ping".into(),
@@ -42,7 +42,7 @@
 //!             body: tauri::ipc::InvokeBody::default(),
 //!             headers: Default::default(),
 //!         },
-//!     );
+//!     ).map(|b| b.deserialize::<String>().unwrap());
 //! }
 //! ```
 
@@ -50,7 +50,7 @@
 
 mod mock_runtime;
 pub use mock_runtime::*;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 
 use std::{borrow::Cow, fmt::Debug};
 
@@ -189,7 +189,8 @@ pub fn assert_ipc_response<T: Serialize + Debug + Send + Sync + 'static>(
   request: InvokeRequest,
   expected: Result<T, T>,
 ) {
-  let response = get_ipc_response::<serde_json::Value>(window, request);
+  let response =
+    get_ipc_response(window, request).map(|b| b.deserialize::<serde_json::Value>().unwrap());
   assert_eq!(
     response,
     expected
@@ -225,7 +226,7 @@ pub fn assert_ipc_response<T: Serialize + Debug + Send + Sync + 'static>(
 ///         .unwrap();
 ///
 ///     // run the `ping` command and assert it returns `pong`
-///     let res = tauri::test::get_ipc_response::<String>(
+///     let res = tauri::test::get_ipc_response(
 ///         &window,
 ///         tauri::window::InvokeRequest {
 ///             cmd: "ping".into(),
@@ -236,16 +237,13 @@ pub fn assert_ipc_response<T: Serialize + Debug + Send + Sync + 'static>(
 ///         },
 ///     );
 ///     assert!(res.is_ok());
-///     assert_eq!(res.unwrap(), String::from("pong"));
+///     assert_eq!(res.unwrap().deserialize::<String>().unwrap(), String::from("pong"));
 /// }
 ///```
-pub fn get_ipc_response<T>(
+pub fn get_ipc_response(
   window: &Window<MockRuntime>,
   request: InvokeRequest,
-) -> Result<T, serde_json::Value>
-where
-  T: DeserializeOwned + Debug,
-{
+) -> Result<InvokeBody, serde_json::Value> {
   let (tx, rx) = std::sync::mpsc::sync_channel(1);
   window.clone().on_message(
     request,
@@ -256,73 +254,8 @@ where
 
   let res = rx.recv().expect("Failed to receive result from command");
   match res {
-    InvokeResponse::Ok(InvokeBody::Json(v)) => Ok(serde_json::from_value(v).unwrap()),
-    InvokeResponse::Ok(InvokeBody::Raw(v)) => Ok(serde_json::from_slice(&v).unwrap()),
+    InvokeResponse::Ok(b) => Ok(b),
     InvokeResponse::Err(InvokeError(v)) => Err(v),
-  }
-}
-
-/// Executes the given IPC message and get the return value as a raw buffer.
-///
-/// # Examples
-///
-/// ```rust
-/// use tauri::ipc::Response;
-/// use tauri::test::{get_ipc_response_raw, mock_builder, mock_context, noop_assets};
-///
-/// #[tauri::command]
-/// fn ping() -> Response {
-///     Response::new("pong".as_bytes().to_vec())
-/// }
-///
-/// fn create_app<R: tauri::Runtime>(builder: tauri::Builder<R>) -> tauri::App<R> {
-///     builder
-///         .invoke_handler(tauri::generate_handler![ping])
-///         // remove the string argument on your app
-///         .build(mock_context(noop_assets()))
-///         .expect("failed to build app")
-/// }
-///
-/// fn main() {
-///     let app = create_app(mock_builder());
-///     let window = tauri::WindowBuilder::new(&app, "main", Default::default())
-///         .build()
-///         .unwrap();
-///
-///     // run the `ping` command and assert it returns `pong`
-///     let res = get_ipc_response_raw(
-///         &window,
-///         tauri::window::InvokeRequest {
-///             cmd: "ping".into(),
-///             callback: tauri::ipc::CallbackFn(0),
-///             error: tauri::ipc::CallbackFn(1),
-///             body: tauri::ipc::InvokeBody::default(),
-///             headers: Default::default(),
-///         },
-///     );
-///     assert!(res.is_ok());
-///     assert_eq!(res.unwrap(), "pong".as_bytes().to_vec());
-/// }
-///```
-pub fn get_ipc_response_raw(
-  window: &Window<MockRuntime>,
-  request: InvokeRequest,
-) -> Result<Vec<u8>, String> {
-  let (tx, rx) = std::sync::mpsc::sync_channel(1);
-  window.clone().on_message(
-    request,
-    Box::new(move |_window, _cmd, response, _callback, _error| {
-      tx.send(response).unwrap();
-    }),
-  );
-
-  let res = rx.recv().expect("Failed to receive result from command");
-  match res {
-    InvokeResponse::Ok(InvokeBody::Json(v)) => {
-      Ok(serde_json::to_string(&v).unwrap().as_bytes().to_vec())
-    }
-    InvokeResponse::Ok(InvokeBody::Raw(v)) => Ok(v),
-    InvokeResponse::Err(InvokeError(v)) => Err(v.to_string()),
   }
 }
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Similar to #8228  but for dev branch.
This PR improves on the current `MockRuntime` by giving it a function to call a Tauri command and get back the command result. 
The end goal is to use these changes to facilitate fuzzing Tauri applications.

This PR changes:
- Add 2 functions to the `MockRuntime`
- Fix the doctests of the `tauri::test` module
- No breaking changes

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
