### PR TITLE
Fixed channel deserialisation in iOS

### DIFF
--- a/.changes/fix-ios-channel.md
+++ b/.changes/fix-ios-channel.md
@@ -1,0 +1,5 @@
+---
+"tauri": 'patch:enhance'
+---
+
+Fixed the deserialisation of a `Channel` in iOS. 

--- a/core/tauri/mobile/ios-api/Sources/Tauri/Channel.swift
+++ b/core/tauri/mobile/ios-api/Sources/Tauri/Channel.swift
@@ -9,7 +9,7 @@ let channelDataKey = CodingUserInfoKey(rawValue: "sendChannelData")!
 
 public class Channel: Decodable {
   public let id: UInt64
-  let handler: (String) -> Void
+  let handler: (UInt64, String) -> Void
 
   public required init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
@@ -30,7 +30,7 @@ public class Channel: Decodable {
       )
     }
 
-    guard let handler = decoder.userInfo[channelDataKey] as? (String) -> Void else {
+    guard let handler = decoder.userInfo[channelDataKey] as? (UInt64, String) -> Void else {
       throw DecodingError.dataCorruptedError(
         in: container,
         debugDescription: "missing userInfo for Channel handler. This is a Tauri issue"
@@ -54,12 +54,12 @@ public class Channel: Decodable {
   }
 
   public func send(_ data: JsonValue) {
-    handler(serialize(data))
+    handler(id, serialize(data))
   }
 
   public func send<T: Encodable>(_ data: T) throws {
     let json = try JSONEncoder().encode(data)
-    handler(String(decoding: json, as: UTF8.self))
+    handler(id, String(decoding: json, as: UTF8.self))
   }
 
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Without this, a `registerListener` command would fail with the following error: `missing userInfo for Channel handler. This is a Tauri issue`.

I think I've done everything required to make this PR, let me know if I'm missing something.
