### PR TITLE
chore(cli/help): mention the need for a second `--` in `tauri dev`

### DIFF
--- a/tooling/cli/src/build.rs
+++ b/tooling/cli/src/build.rs
@@ -53,7 +53,7 @@ pub struct Options {
   /// JSON string or path to JSON file to merge with tauri.conf.json
   #[clap(short, long)]
   pub config: Option<String>,
-  /// Command line arguments passed to the runner
+  /// Command line arguments passed to the runner. Use `--` to explicitly mark the start of the arguments.
   pub args: Vec<String>,
   /// Skip prompting for values
   #[clap(long)]

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -57,7 +57,8 @@ pub struct Options {
   #[clap(long = "release")]
   pub release_mode: bool,
   /// Command line arguments passed to the runner.
-  /// Use `--` to explicitly mark the start of the arguments, arguments after the second `--` are passed to the application.
+  /// Use `--` to explicitly mark the start of the arguments. Arguments after a second `--` are passed to the application
+  /// e.g. `tauri dev -- [runnerArgs] -- [appArgs]`.
   pub args: Vec<String>,
   /// Disable the file watcher
   #[clap(long)]

--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -56,7 +56,8 @@ pub struct Options {
   /// Run the code in release mode
   #[clap(long = "release")]
   pub release_mode: bool,
-  /// Command line arguments passed to the runner. Arguments after `--` are passed to the application.
+  /// Command line arguments passed to the runner.
+  /// Use `--` to explicitly mark the start of the arguments, arguments after the second `--` are passed to the application.
   pub args: Vec<String>,
   /// Disable the file watcher
   #[clap(long)]


### PR DESCRIPTION
ref: https://github.com/tauri-apps/tauri/issues/8382#issuecomment-1854016310

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
