### PR TITLE
fix(core): scope checks on Android

### DIFF
--- a/.changes/fix-android-scope.md
+++ b/.changes/fix-android-scope.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes file scope checks on Android.

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -79,55 +79,54 @@ fn push_pattern<P: AsRef<Path>, F: Fn(&str) -> Result<Pattern, glob::PatternErro
 ) -> crate::Result<()> {
   let path: PathBuf = pattern.as_ref().components().collect();
   list.insert(f(&path.to_string_lossy())?);
-  #[cfg(any(windows, target_os = "android"))]
-  {
-    let mut path = path;
-    let mut checked_path = None;
 
-    // attempt to canonicalize parents in case we have a path like `/data/user/0/appid/**`
-    // where `**` obviously does not exist but we need to canonicalize the parent
-    //
-    // example: given the `/data/user/0/appid/assets/*` path,
-    // it's a glob pattern so it won't exist (canonicalize() fails);
-    //
-    // the second iteration needs to check `/data/user/0/appid/assets` and save the `*` component to append later.
-    //
-    // if it also does not exist, a third iteration is required to check `/data/user/0/appid`
-    // with `assets/*` as the cached value (`checked_path` variable)
-    // on Android that gets canonicalized to `/data/data/appid` so the final value will be `/data/data/appid/assets/*`
-    // which is the value we want to check when we execute the `is_allowed` function
-    let canonicalized = loop {
-      if let Ok(path) = path.canonicalize() {
-        break Some(if let Some(p) = checked_path {
-          path.join(p)
-        } else {
-          path
-        });
-      }
+  let mut path = path;
+  let mut checked_path = None;
 
-      // get the last component of the path as an OsStr
-      let last = path.iter().next_back().map(PathBuf::from);
-      if let Some(mut p) = last {
-        // remove the last component of the path
-        // so the next iteration checks its parent
-        path.pop();
-        // append the already checked path to the last component
-        if let Some(checked_path) = &checked_path {
-          p.push(checked_path);
-        }
-        // replace the checked path with the current value
-        checked_path.replace(p);
+  // attempt to canonicalize parents in case we have a path like `/data/user/0/appid/**`
+  // where `**` obviously does not exist but we need to canonicalize the parent
+  //
+  // example: given the `/data/user/0/appid/assets/*` path,
+  // it's a glob pattern so it won't exist (canonicalize() fails);
+  //
+  // the second iteration needs to check `/data/user/0/appid/assets` and save the `*` component to append later.
+  //
+  // if it also does not exist, a third iteration is required to check `/data/user/0/appid`
+  // with `assets/*` as the cached value (`checked_path` variable)
+  // on Android that gets canonicalized to `/data/data/appid` so the final value will be `/data/data/appid/assets/*`
+  // which is the value we want to check when we execute the `is_allowed` function
+  let canonicalized = loop {
+    if let Ok(path) = path.canonicalize() {
+      break Some(if let Some(p) = checked_path {
+        path.join(p)
       } else {
-        break None;
-      }
-    };
-
-    if let Some(p) = canonicalized {
-      list.insert(f(&p.to_string_lossy())?);
-    } else if cfg!(windows) {
-      list.insert(f(&format!("\\\\?\\{}", path.display()))?);
+        path
+      });
     }
+
+    // get the last component of the path as an OsStr
+    let last = path.iter().next_back().map(PathBuf::from);
+    if let Some(mut p) = last {
+      // remove the last component of the path
+      // so the next iteration checks its parent
+      path.pop();
+      // append the already checked path to the last component
+      if let Some(checked_path) = &checked_path {
+        p.push(checked_path);
+      }
+      // replace the checked path with the current value
+      checked_path.replace(p);
+    } else {
+      break None;
+    }
+  };
+
+  if let Some(p) = canonicalized {
+    list.insert(f(&p.to_string_lossy())?);
+  } else if cfg!(windows) {
+    list.insert(f(&format!("\\\\?\\{}", path.display()))?);
   }
+
   Ok(())
 }
 

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -79,11 +79,33 @@ fn push_pattern<P: AsRef<Path>, F: Fn(&str) -> Result<Pattern, glob::PatternErro
 ) -> crate::Result<()> {
   let path: PathBuf = pattern.as_ref().components().collect();
   list.insert(f(&path.to_string_lossy())?);
-  #[cfg(windows)]
+  #[cfg(any(windows, target_os = "android"))]
   {
-    if let Ok(p) = std::fs::canonicalize(&path) {
+    let mut path = path;
+    let mut buf = None;
+
+    // attempt to canonicalize parents in case we have a path like `/data/user/0/appid/**`
+    // where `**` obviously does not exist but we need to canonicalize the parent
+    let canonicalized = loop {
+      if let Ok(p) = path.canonicalize() {
+        break Some(if let Some(buf) = buf { p.join(buf) } else { p });
+      }
+
+      let last = path.iter().rev().next().map(PathBuf::from);
+      if let Some(mut p) = last {
+        path.pop();
+        if let Some(buf) = &buf {
+          p.push(buf);
+        }
+        buf.replace(p);
+      } else {
+        break None;
+      }
+    };
+
+    if let Some(p) = canonicalized {
       list.insert(f(&p.to_string_lossy())?);
-    } else {
+    } else if cfg!(windows) {
       list.insert(f(&format!("\\\\?\\{}", path.display()))?);
     }
   }


### PR DESCRIPTION


<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

On Android, when we call canonicalize() on "/data/user/0/appid" (which is the data dir), the result is a "/data/data/appid" path, so we need to adjust our scope for that.