### PR TITLE
refactor!: remove `GlobalWindowEvent` type

### DIFF
--- a/.changes/tauri-remove-global-window-event-type.md
+++ b/.changes/tauri-remove-global-window-event-type.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'major:breaking'
+---
+
+Removed `GlobalWindowEvent` struct, and unpacked its field to be passed directly to `tauri::Builder::on_window_event`.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -63,7 +63,7 @@ pub(crate) type GlobalMenuEventListener<T> = Box<dyn Fn(&T, crate::menu::MenuEve
 #[cfg(all(desktop, feature = "tray-icon"))]
 pub(crate) type GlobalTrayIconEventListener<T> =
   Box<dyn Fn(&T, crate::tray::TrayIconEvent) + Send + Sync>;
-pub(crate) type GlobalWindowEventListener<R> = Box<dyn Fn(Window<R>, WindowEvent) + Send + Sync>;
+pub(crate) type GlobalWindowEventListener<R> = Box<dyn Fn(&Window<R>, &WindowEvent) + Send + Sync>;
 /// A closure that is run when the Tauri application is setting up.
 pub type SetupHook<R> =
   Box<dyn FnOnce(&mut App<R>) -> Result<(), Box<dyn std::error::Error>> + Send>;
@@ -1295,7 +1295,7 @@ impl<R: Runtime> Builder<R> {
   ///   });
   /// ```
   #[must_use]
-  pub fn on_window_event<F: Fn(Window<R>, WindowEvent) + Send + Sync + 'static>(
+  pub fn on_window_event<F: Fn(&Window<R>, &WindowEvent) + Send + Sync + 'static>(
     mut self,
     handler: F,
   ) -> Self {

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -197,10 +197,7 @@ pub use self::utils::TitleBarStyle;
 
 pub use self::event::{Event, EventId};
 pub use {
-  self::app::{
-    App, AppHandle, AssetResolver, Builder, CloseRequestApi, GlobalWindowEvent, RunEvent,
-    WindowEvent,
-  },
+  self::app::{App, AppHandle, AssetResolver, Builder, CloseRequestApi, RunEvent, WindowEvent},
   self::manager::Asset,
   self::runtime::{
     webview::WebviewAttributes,

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -573,7 +573,7 @@ impl<R: Runtime> WindowManager<R> {
     window.on_window_event(move |event| {
       let _ = on_window_event(&window_, &manager, event);
       for handler in window_event_listeners.iter() {
-        handler(window_.clone(), event.clone());
+        handler(&window_, event);
       }
     });
 

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -28,8 +28,7 @@ use crate::{
   ipc::{InvokeHandler, InvokeResponder},
   pattern::PatternJavascript,
   window::PageLoadPayload,
-  AppHandle, EventLoopMessage, GlobalWindowEvent, Icon, Manager, Runtime, Scopes, Window,
-  WindowEvent,
+  AppHandle, EventLoopMessage, Icon, Manager, Runtime, Scopes, Window, WindowEvent,
 };
 
 use super::AppManager;
@@ -574,10 +573,7 @@ impl<R: Runtime> WindowManager<R> {
     window.on_window_event(move |event| {
       let _ = on_window_event(&window_, &manager, event);
       for handler in window_event_listeners.iter() {
-        handler(GlobalWindowEvent {
-          window: window_.clone(),
-          event: event.clone(),
-        });
+        handler(window_.clone(), event.clone());
       }
     });
 


### PR DESCRIPTION
This type was useless IMO and wasn't consistent with other callbacks. By unpacking its fields to be passed directly we make it consistent with other callbacks like `on_page_load`