### PR TITLE
fix(cli): expand globs in workspace member paths

### DIFF
--- a/.changes/dev-watcher-glob.md
+++ b/.changes/dev-watcher-glob.md
@@ -3,4 +3,4 @@
 '@tauri-apps/cli': 'patch:bug'
 ---
 
-Expand glob patterns in workspace member paths.
+Expand glob patterns in workspace member paths so the CLI would watch all matching pathhs.

--- a/.changes/dev-watcher-glob.md
+++ b/.changes/dev-watcher-glob.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Expand glob patterns in workspace member paths.

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -3448,6 +3448,7 @@ dependencies = [
  "ctrlc",
  "dialoguer",
  "env_logger",
+ "glob",
  "handlebars",
  "heck",
  "html5ever",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -82,6 +82,7 @@ tokio = { version = "1", features = [ "macros", "sync" ] }
 common-path = "1"
 serde-value = "0.7.0"
 itertools = "0.11"
+glob = "0.3"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = [ "handleapi", "processenv", "winbase", "wincon", "winnt" ] }

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -434,14 +434,14 @@ impl Rust {
     };
 
     let watch_folders = watch_folders
-      .iter()
+      .into_iter()
       .flat_map(|p| {
-        match expand_member_path(p) {
+        match expand_member_path(&p) {
           Ok(p) => p,
           Err(err) => {
             // If this fails cargo itself should fail too. But we still try to keep going with the unexpanded path.
             error!("Error watching {}: {}", p.display(), err.to_string());
-            vec![p.to_owned()]
+            vec![p]
           }
         }
       })

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -338,7 +338,7 @@ fn lookup<F: FnMut(FileType, PathBuf)>(dir: &Path, mut f: F) {
 // Copied from https://github.com/rust-lang/cargo/blob/69255bb10de7f74511b5cef900a9d102247b6029/src/cargo/core/workspace.rs#L665
 fn expand_member_path(path: &Path) -> crate::Result<Vec<PathBuf>> {
   let Some(path) = path.to_str() else {
-    return Ok(Vec::new());
+    return Err(anyhow::anyhow!("path is not UTF-8 compatible"));
   };
   let res = glob(path).with_context(|| format!("could not parse pattern `{}`", &path))?;
   let res = res

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -22,7 +22,6 @@ use anyhow::Context;
 use glob::glob;
 use heck::ToKebabCase;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use itertools::Itertools;
 use log::{debug, error, info};
 use notify::RecursiveMode;
 use notify_debouncer_mini::new_debouncer;


### PR DESCRIPTION
fixes #8403

Edit: Alternatively we could also re-use the output of cargo metadata but i didn't want to bother trying to parse `"my-package 0.1.0 (path+file:///path/to/my-package)"` unless you think it'd be better than trying to be cargo again.