### PR TITLE
fix(cli): Handle target triples with 4 components

### DIFF
--- a/.changes/cli-hook-env-vars.md
+++ b/.changes/cli-hook-env-vars.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Prevent `Invalid target triple` warnings and correctly set `TAURI_ENV_` vars when target triple contains 4 components.

--- a/.changes/cli-hook-env-vars.md
+++ b/.changes/cli-hook-env-vars.md
@@ -3,4 +3,4 @@
 '@tauri-apps/cli': 'patch:bug'
 ---
 
-Prevent `Invalid target triple` warnings and correctly set `TAURI_ENV_` vars when target triple contains 4 components.
+Prevent `Invalid target triple` warnings and correctly set `TAURI_ENV_` vars when target triple contains 4 components. `darwin` and `androideabi` are no longer replaced with `macos` and `android` in `TAURI_ENV_PLATFORM`.

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -249,16 +249,8 @@ impl Interface for Rust {
         a => a.into(),
       },
     );
-    env.insert(
-      "TAURI_ENV_PLATFORM",
-      match (host, host_env) {
-        // keeps compatibility with old `std::env::consts::OS` implementation
-        ("darwin", _) => "macos".into(),
-        ("ios", Some("sim")) => "ios".into(),
-        ("androideabi", _) => "android".into(),
-        (h, _) => h.into(),
-      },
-    );
+
+    env.insert("TAURI_ENV_PLATFORM", host.into());
 
     env.insert(
       "TAURI_ENV_FAMILY",

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -230,7 +230,7 @@ impl Interface for Rust {
 
     let target_triple = &self.app_settings.target_triple;
     let target_components: Vec<&str> = target_triple.split('-').collect();
-    let (arch, host, host_env) = match target_components.as_slice() {
+    let (arch, host, _host_env) = match target_components.as_slice() {
       // 3 components like aarch64-apple-darwin
       [arch, _, host] => (*arch, *host, None),
       // 4 components like x86_64-pc-windows-msvc and aarch64-apple-ios-sim


### PR DESCRIPTION
Follow up of #8321 which broke the `TAURI_ENV_` vars for linux, windows and ios-sim

p.s. there are 2 targets, fuchsia and wasi that only have 2 components but ig we don't need to care about those for now.
