### PR TITLE
feat: re-export `Url`

### DIFF
--- a/.changes/export-url.md
+++ b/.changes/export-url.md
@@ -1,5 +1,5 @@
 ---
-'tauri': 'patch'
+'tauri': 'patch:feat'
 ---
 
 Re-export `Url` type.

--- a/.changes/export-url.md
+++ b/.changes/export-url.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch'
+---
+
+Re-export `Url` type.

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -176,6 +176,8 @@ pub use error::Error;
 pub use regex;
 pub use tauri_macros::{command, generate_handler};
 
+pub use url::Url;
+
 pub mod api;
 pub(crate) mod app;
 pub mod async_runtime;


### PR DESCRIPTION
`Url` is used/returned from public API, we should re-export it
