### PR TITLE
feat: add `libraries` flag to `MacConfig` (1.x)

### DIFF
--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1380,6 +1380,16 @@
             "string",
             "null"
           ]
+        },
+        "libraries": {
+          "description": "MacOS library files that need to be bundled with the app.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -331,6 +331,9 @@ pub struct MacConfig {
   pub provider_short_name: Option<String>,
   /// Path to the entitlements file.
   pub entitlements: Option<String>,
+  /// MacOS library files that need to be bundled with the app.
+  pub libraries: Option<HashMap<String, String>>,
+
 }
 
 impl Default for MacConfig {
@@ -343,6 +346,7 @@ impl Default for MacConfig {
       signing_identity: None,
       provider_short_name: None,
       entitlements: None,
+      libraries: None,
     }
   }
 }

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -219,6 +219,8 @@ pub struct MacOsSettings {
   pub entitlements: Option<String>,
   /// Path to the Info.plist file for the bundle.
   pub info_plist_path: Option<PathBuf>,
+  /// MacOS library files that need to be bundled with the app.
+  pub libraries: Option<HashMap<String, String>>,
 }
 
 /// Configuration for a target language for the WiX build.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1380,6 +1380,16 @@
             "string",
             "null"
           ]
+        },
+        "libraries": {
+          "description": "MacOS library files that need to be bundled with the app.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1116,6 +1116,7 @@ fn tauri_config_to_bundle_settings(
           None
         }
       },
+      libraries: config.macos.libraries,
     },
     windows: WindowsSettings {
       timestamp_url: config.windows.timestamp_url,


### PR DESCRIPTION
For macOS apps leveraging `SMAppService`, we need to place a codesigned `plist` under the app's `Contents/Library/LaunchDaemons` directory. This is outside of the `Contents/Resources` directory so we can't use the `resources` flag.

The PR as it stands adds a `libraries` flag to `MacConfig` to allow this