### PR TITLE
feat(cli): migrate tauri-build version

### DIFF
--- a/.changes/migrate-tauri-build-version.md
+++ b/.changes/migrate-tauri-build-version.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:feat
+"@tauri-apps/cli": patch:feat
+---
+
+Include tauri-build on the migration script.

--- a/tooling/cli/src/interface/mod.rs
+++ b/tooling/cli/src/interface/mod.rs
@@ -13,7 +13,7 @@ use std::{
 use crate::helpers::config::Config;
 use tauri_bundler::bundle::{PackageType, Settings, SettingsBuilder};
 
-pub use rust::{manifest, MobileOptions, Options, Rust as AppInterface};
+pub use rust::{MobileOptions, Options, Rust as AppInterface};
 
 pub trait DevProcess {
   fn kill(&self) -> std::io::Result<()>;


### PR DESCRIPTION
This changes the migrate command to also migrate the tauri-build dependency to v2, previously it only updated the tauri dependency.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
