### PR TITLE
fix(Linux): Fix non-standard permission bug (fix #7992)

### DIFF
--- a/.changes/fix-non-standard-permission-bug.md
+++ b/.changes/fix-non-standard-permission-bug.md
@@ -1,5 +1,5 @@
 ---
-'tauri': 'patch:bug'
+'tauri-bundler': 'patch:bug'
 ---
 
 

--- a/.changes/fix-non-standard-permission-bug.md
+++ b/.changes/fix-non-standard-permission-bug.md
@@ -1,0 +1,6 @@
+---
+'tauri': 'patch:bug'
+---
+
+
+Fix the `non-standard-file-perm` and `non-standard-dir-perm` issue in Debian packages

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1320,6 +1320,20 @@
             "string",
             "null"
           ]
+        },
+        "section": {
+          "description": "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1334,6 +1334,13 @@
             "string",
             "null"
           ]
+        },
+        "changelog": {
+          "description": "Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -285,6 +285,9 @@ pub struct DebConfig {
   /// Change the priority of the Debian Package. By default, it is set to optional.
   /// Recognized Priorities as of now are :  required, important, standard, optional, extra
   pub priority: Option<String>,
+  /// Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See 
+  /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+  pub changelog: Option<PathBuf>,
 }
 
 fn de_minimum_system_version<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -280,6 +280,11 @@ pub struct DebConfig {
   ///
   /// Available variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.
   pub desktop_template: Option<PathBuf>,
+  /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+  pub section: Option<String>,
+  /// Change the priority of the Debian Package. By default, it is set to optional.
+  /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+  pub priority: Option<String>,
 }
 
 fn de_minimum_system_version<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -134,8 +134,29 @@ pub fn generate_data(
   let icons =
     generate_icon_files(settings, &data_dir).with_context(|| "Failed to create icon files")?;
   generate_desktop_file(settings, &data_dir).with_context(|| "Failed to create desktop file")?;
+  generate_changelog_file(settings, &data_dir).with_context(|| "Failed to create changelog.gz file")?;
 
   Ok((data_dir, icons))
+}
+
+/// Generate the Changelog file, to be stored at /usr/share/doc/package-name. See 
+/// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+fn generate_changelog_file(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
+  if let Some(changelog_src_path) = &settings.deb().changelog {
+    let mut src_file = File::open(changelog_src_path)?;
+
+    let bin_name = settings.main_binary_name();
+    let dest_path = data_dir
+      .join(format!("usr/share/doc/{}/changelog.gz", bin_name));
+
+    let changelog_file = common::create_file(&dest_path)?;
+    let mut gzip_encoder = gzip::Encoder::new(changelog_file)?;
+    io::copy(&mut src_file, &mut gzip_encoder)?;
+    
+    let mut changelog_file = gzip_encoder.finish().into_result()?;
+    changelog_file.flush()?;
+  }
+  Ok(())
 }
 
 /// Generate the application desktop file and store it under the `data_dir`.

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -369,19 +369,19 @@ fn create_tar_from_dir<P: AsRef<Path>, W: Write>(src_dir: P, dest_file: W) -> cr
     if entry.file_type().is_dir() {
       let stat = fs::metadata(src_path)?;
       let mut header = tar::Header::new_gnu();
+      header.set_mode(0o755);
       header.set_metadata(&stat);
       header.set_uid(0);
       header.set_gid(0);
-      header.set_mode(0o755);
       tar_builder.append_data(&mut header, dest_path, &mut io::empty())?;
     } else {
       let mut src_file = fs::File::open(src_path)?;
       let stat = src_file.metadata()?;
       let mut header = tar::Header::new_gnu();
+      header.set_mode(0o644);
       header.set_metadata(&stat);
       header.set_uid(0);
       header.set_gid(0);
-      header.set_mode(0o644);
       tar_builder.append_data(&mut header, dest_path, &mut src_file)?;
     }
   }

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -210,6 +210,14 @@ fn generate_control_file(
   writeln!(file, "Installed-Size: {}", total_dir_size(data_dir)? / 1024)?;
   let authors = settings.authors_comma_separated().unwrap_or_default();
   writeln!(file, "Maintainer: {}", authors)?;
+  if let Some(section) = &settings.deb().section {
+    writeln!(file, "Section: {}", section)?;
+  }
+  if let Some(priority) = &settings.deb().priority {
+    writeln!(file, "Priority: {}", priority)?;
+  } else {
+    writeln!(file, "Priority: optional")?;
+  }
   if !settings.homepage_url().is_empty() {
     writeln!(file, "Homepage: {}", settings.homepage_url())?;
   }
@@ -234,7 +242,6 @@ fn generate_control_file(
       writeln!(file, " {}", line)?;
     }
   }
-  writeln!(file, "Priority: optional")?;
   file.flush()?;
   Ok(())
 }
@@ -384,9 +391,9 @@ fn create_tar_from_dir<P: AsRef<Path>, W: Write>(src_dir: P, dest_file: W) -> cr
       header.set_gid(0);
 
       // It extracts the MSB in octal permissions.
-      let user_permission = (stat.mode()%512)/64;
+      let user_permission = (stat.mode()%512) / 64;
       // Check if file is executable, and set permissions accordingly.
-      if user_permission%2 == 1{
+      if user_permission % 2 == 1{
         header.set_mode(0o755);
       } else {
         header.set_mode(0o644);

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -33,6 +33,7 @@ use libflate::gzip;
 use log::info;
 use serde::Serialize;
 use walkdir::WalkDir;
+use tar::HeaderMode;
 
 use std::{
   collections::BTreeSet,
@@ -374,31 +375,16 @@ fn create_tar_from_dir<P: AsRef<Path>, W: Write>(src_dir: P, dest_file: W) -> cr
       continue;
     }
     let dest_path = src_path.strip_prefix(src_dir)?;
+    
+    let stat = fs::metadata(src_path)?;
+    let mut header = tar::Header::new_gnu();
+    header.set_metadata_in_mode(&stat, HeaderMode::Deterministic);
+    header.set_mtime(stat.mtime() as u64);
+    
     if entry.file_type().is_dir() {
-      let stat = fs::metadata(src_path)?;
-      let mut header = tar::Header::new_gnu();
-      header.set_metadata(&stat);
-      header.set_uid(0);
-      header.set_gid(0);
-      header.set_mode(0o755);
       tar_builder.append_data(&mut header, dest_path, &mut io::empty())?;
     } else {
       let mut src_file = fs::File::open(src_path)?;
-      let stat = src_file.metadata()?;
-      let mut header = tar::Header::new_gnu();
-      header.set_metadata(&stat);
-      header.set_uid(0);
-      header.set_gid(0);
-
-      // It extracts the MSB in octal permissions.
-      let user_permission = (stat.mode()%512) / 64;
-      // Check if file is executable, and set permissions accordingly.
-      if user_permission % 2 == 1{
-        header.set_mode(0o755);
-      } else {
-        header.set_mode(0o644);
-      }
-
       tar_builder.append_data(&mut header, dest_path, &mut src_file)?;
     }
   }

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -372,6 +372,7 @@ fn create_tar_from_dir<P: AsRef<Path>, W: Write>(src_dir: P, dest_file: W) -> cr
       header.set_metadata(&stat);
       header.set_uid(0);
       header.set_gid(0);
+      header.set_mode(0o755);
       tar_builder.append_data(&mut header, dest_path, &mut io::empty())?;
     } else {
       let mut src_file = fs::File::open(src_path)?;
@@ -380,6 +381,7 @@ fn create_tar_from_dir<P: AsRef<Path>, W: Write>(src_dir: P, dest_file: W) -> cr
       header.set_metadata(&stat);
       header.set_uid(0);
       header.set_gid(0);
+      header.set_mode(0o644);
       tar_builder.append_data(&mut header, dest_path, &mut src_file)?;
     }
   }

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -190,6 +190,9 @@ pub struct DebianSettings {
   /// Change the priority of the Debian Package. By default, it is set to optional.
   /// Recognized Priorities as of now are :  required, important, standard, optional, extra
   pub priority: Option<String>,
+  /// Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See 
+  /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+  pub changelog: Option<PathBuf>,
 }
 
 /// The macOS bundle settings.

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -185,6 +185,11 @@ pub struct DebianSettings {
   #[doc = include_str!("./linux/templates/main.desktop")]
   /// ```
   pub desktop_template: Option<PathBuf>,
+  /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+  pub section: Option<String>,
+  /// Change the priority of the Debian Package. By default, it is set to optional.
+  /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+  pub priority: Option<String>,
 }
 
 /// The macOS bundle settings.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1320,6 +1320,20 @@
             "string",
             "null"
           ]
+        },
+        "section": {
+          "description": "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1334,6 +1334,13 @@
             "string",
             "null"
           ]
+        },
+        "changelog": {
+          "description": "Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1101,6 +1101,8 @@ fn tauri_config_to_bundle_settings(
       },
       files: config.deb.files,
       desktop_template: config.deb.desktop_template,
+      section: config.deb.section,
+      priority: config.deb.priority,
     },
     macos: MacOsSettings {
       frameworks: config.macos.frameworks,

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1103,6 +1103,7 @@ fn tauri_config_to_bundle_settings(
       desktop_template: config.deb.desktop_template,
       section: config.deb.section,
       priority: config.deb.priority,
+      changelog: config.deb.changelog,
     },
     macos: MacOsSettings {
       frameworks: config.macos.frameworks,


### PR DESCRIPTION
# Fix non-standard permission bug

- Closes #7992 , as the permissions are set correctly now.
- Closes #7074 as well

Rest of the warnings mentioned in #7074 must be solved at user end itself, for example, by adding Copyright file, ChangeLogs, Maintainer, Categories etc. , and are not concerned as issues with Tauri itself.

So, yeah, both of the issues should be closed now!