### PR TITLE
fix #8442: OUT_DIR not set (windows) 

### DIFF
--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -448,6 +448,9 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
   println!("cargo:rustc-env=TAURI_ENV_TARGET_TRIPLE={target_triple}");
 
   let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+
+  println!("cargo:rustc-env=OUT_DIR={}", out_dir.to_str().unwrap());
+
   // TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/5457>
   let target_dir = out_dir
     .parent()

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -448,9 +448,7 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
   println!("cargo:rustc-env=TAURI_ENV_TARGET_TRIPLE={target_triple}");
 
   let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-
   println!("cargo:rustc-env=OUT_DIR={}", out_dir.to_str().unwrap());
-
   // TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/5457>
   let target_dir = out_dir
     .parent()

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -369,7 +369,7 @@ impl Attributes {
 /// If any of the build time helpers fail, they will [`std::panic!`] with the related error message.
 /// This is typically desirable when running inside a build script; see [`try_build`] for no panics.
 pub fn build() {
-   if let Err(error) = try_build(Attributes::default()) {
+  if let Err(error) = try_build(Attributes::default()) {
     let error = format!("{error:#}");
     println!("{error}");
     if error.starts_with("unknown field") {

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -369,7 +369,7 @@ impl Attributes {
 /// If any of the build time helpers fail, they will [`std::panic!`] with the related error message.
 /// This is typically desirable when running inside a build script; see [`try_build`] for no panics.
 pub fn build() {
-  if let Err(error) = try_build(Attributes::default()) {
+   if let Err(error) = try_build(Attributes::default()) {
     let error = format!("{error:#}");
     println!("{error}");
     if error.starts_with("unknown field") {
@@ -448,6 +448,9 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
   println!("cargo:rustc-env=TAURI_ENV_TARGET_TRIPLE={target_triple}");
 
   let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+
+  println!("cargo:rustc-env=OUT_DIR={}", out_dir.to_str().unwrap());
+
   // TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/5457>
   let target_dir = out_dir
     .parent()


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
It seems that the OUT_DIR environment variable isn't exposed to the rust environment variables during the build process. This should clear the error message that the OUT_DIR isn't set.
![image](https://github.com/tauri-apps/tauri/assets/77780263/c40e95dc-3910-43b5-af70-32e30b4aeeeb)
This closes #8442 
