### PR TITLE
fix(core): Retain order of map keys in ipc, fixes #7922

### DIFF
--- a/.changes/fix-formbody-order.md
+++ b/.changes/fix-formbody-order.md
@@ -2,4 +2,4 @@
 'tauri': 'patch:bug'
 ---
 
-The IPC will now preserve the order of JS map keys. This fixes issues with servers that required a specific order of FormBody contents.
+Preserve the order of JS object/map keys in IPC calls. This also fixes issues with the JS `http` module when calling to servers that required a specific order of `FormBody` contents.

--- a/.changes/fix-formbody-order.md
+++ b/.changes/fix-formbody-order.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+The IPC will now preserve the order of JS map keys. This fixes issues with servers that required a specific order of FormBody contents.

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -157,7 +157,7 @@ updater = [
   "dialog-ask",
   "fs-extract-api"
 ]
-http-api = [ "reqwest", "bytes" ]
+http-api = [ "reqwest", "bytes", "indexmap" ]
 http-multipart = [ "reqwest/multipart" ]
 os-api = [ "sys-locale" ]
 shell-open-api = [ "open", "regex", "tauri-macros/shell-scope" ]
@@ -229,7 +229,7 @@ fs-rename-file = [ ]
 fs-write-file = [ ]
 global-shortcut-all = [ "global-shortcut" ]
 http-all = [ "http-request" ]
-http-request = [ "http-api", "dep:indexmap" ]
+http-request = [ "http-api" ]
 notification-all = [ "notification", "dialog-ask" ]
 os-all = [ "os_info", "os-api" ]
 path-all = [ ]

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -49,7 +49,7 @@ targets = [
 normal = [ "reqwest" ]
 
 [dependencies]
-serde_json = { version = "1.0", features = [ "raw_value" ] }
+serde_json = { version = "1.0", features = [ "raw_value", "preserve_order" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 tokio = { version = "1", features = [ "rt", "rt-multi-thread", "sync", "fs", "io-util" ] }
 futures-util = "0.3"
@@ -95,6 +95,7 @@ ico = { version = "0.2.0", optional = true }
 encoding_rs = "0.8.31"
 sys-locale = { version = "0.2.3", optional = true }
 tracing = { version = "0.1", optional = true }
+indexmap = { version = "1", features = [ "std", "serde" ], optional = true }
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 rfd = { version = "0.10", optional = true, features = [ "gtk3", "common-controls-v6" ] }
@@ -228,7 +229,7 @@ fs-rename-file = [ ]
 fs-write-file = [ ]
 global-shortcut-all = [ "global-shortcut" ]
 http-all = [ "http-request" ]
-http-request = [ "http-api" ]
+http-request = [ "http-api", "dep:indexmap" ]
 notification-all = [ "notification", "dialog-ask" ]
 os-all = [ "os_info", "os-api" ]
 path-all = [ ]

--- a/core/tauri/src/api/http.rs
+++ b/core/tauri/src/api/http.rs
@@ -250,11 +250,16 @@ pub enum FormPart {
 
 /// Form body definition.
 #[derive(Debug, Deserialize)]
-pub struct FormBody(pub(crate) HashMap<String, FormPart>);
+pub struct FormBody(pub(crate) indexmap::IndexMap<String, FormPart>);
 
 impl FormBody {
   /// Creates a new form body.
   pub fn new(data: HashMap<String, FormPart>) -> Self {
+    Self(indexmap::IndexMap::from_iter(data))
+  }
+
+  /// Creates a new form body with pre-ordered keys. Useful if the api requires a specific order.
+  pub fn new_ordered(data: indexmap::IndexMap<String, FormPart>) -> Self {
     Self(data)
   }
 }

--- a/tooling/bundler/Cargo.toml
+++ b/tooling/bundler/Cargo.toml
@@ -32,7 +32,7 @@ tempfile = "3.8.1"
 log = { version = "0.4.20", features = [ "kv_unstable" ] }
 dirs-next = "2.0"
 os_pipe = "1"
-ureq = { version = "2.8", default-features = false }
+ureq = { version = "2.9.1", default-features = false }
 native-tls = { version = "0.2", optional = true }
 hex = "0.4"
 semver = "1"

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -59,7 +59,7 @@ handlebars = "4.4"
 include_dir = "0.7"
 minisign = "=0.7.3"
 base64 = "0.21.5"
-ureq = { version = "2.8", default-features = false, features = [ "gzip" ] }
+ureq = { version = "2.9.1", default-features = false, features = [ "gzip" ] }
 os_info = "3"
 semver = "1.0"
 regex = "1.10.2"


### PR DESCRIPTION
fixes #7922

This should not have a major effect on ipc performance though there weren't that many benchmarks so a bit hard to say.