### PR TITLE
fix(bundler/deb): use lintian-compliant permissions , closes #7992

### DIFF
--- a/.changes/fix-non-standard-permission-bug.md
+++ b/.changes/fix-non-standard-permission-bug.md
@@ -1,0 +1,6 @@
+---
+'tauri-bundler': 'patch:bug'
+---
+
+
+Fix the `non-standard-file-perm` and `non-standard-dir-perm` issue in Debian packages


### PR DESCRIPTION

This Pull Request
- Closes https://github.com/tauri-apps/tauri/issues/7992 , Default Permissions are set to each file.
- Remove the Redundant code and uses Rust Standard Library Functions


**Thank You**
