### PR TITLE
feat: enable socks-proxy for bundler download

### DIFF
--- a/.changes/bundler-socks-proxy.md
+++ b/.changes/bundler-socks-proxy.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:enhance
+---
+
+Support using socks proxy from environment when downloading files. 

--- a/tooling/bundler/Cargo.toml
+++ b/tooling/bundler/Cargo.toml
@@ -32,7 +32,7 @@ tempfile = "3.8.1"
 log = { version = "0.4.20", features = [ "kv_unstable" ] }
 dirs-next = "2.0"
 os_pipe = "1"
-ureq = { version = "2.8", default-features = false }
+ureq = { version = "2.8", default-features = false, features = [ "socks-proxy" ] }
 native-tls = { version = "0.2", optional = true }
 hex = "0.4"
 semver = "1"


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

description: I encountered the error message `tauri Connection Failed: Connect error: SOCKS feature disabled.` when I want to bundle the tauri app, and I realized that my socks proxy is not supported defaultly by ureq. The socks proxy is widely used in Mainland China and Russia to bypass the Great Firewall, and I think the cost of enable socks-proxy feature is much lower than the benefit for developers that rely on proxy toolchains to work.

related issue: https://github.com/tauri-apps/tauri/issues/7338  #7338 

