### PR TITLE
feat: add webdriver options for windows

### DIFF
--- a/.changes/webdriver-webview-options.md
+++ b/.changes/webdriver-webview-options.md
@@ -1,0 +1,5 @@
+---
+"tauri-driver": patch:feat
+---
+
+Added `webviewOptions` object to the `tauri:options` capability to configure the [Edge webview options](https://learn.microsoft.com/en-us/microsoft-edge/webdriver-chromium/capabilities-edge-options#webviewoptions-object) on Windows.

--- a/tooling/webdriver/src/server.rs
+++ b/tooling/webdriver/src/server.rs
@@ -24,6 +24,9 @@ struct TauriOptions {
   application: PathBuf,
   #[serde(default)]
   args: Vec<String>,
+  #[cfg(target_os = "windows")]
+  #[serde(default)]
+  webview_options: Option<Value>
 }
 
 impl TauriOptions {
@@ -44,7 +47,7 @@ impl TauriOptions {
     map.insert("browserName".into(), json!("webview2"));
     map.insert(
       "ms:edgeOptions".into(),
-      json!({"binary": self.application, "args": self.args}),
+      json!({"binary": self.application, "args": self.args, "webviewOptions": self.webview_options}),
     );
     map
   }

--- a/tooling/webdriver/src/server.rs
+++ b/tooling/webdriver/src/server.rs
@@ -20,13 +20,14 @@ type HttpClient = Client<hyper::client::HttpConnector>;
 const TAURI_OPTIONS: &str = "tauri:options";
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct TauriOptions {
   application: PathBuf,
   #[serde(default)]
   args: Vec<String>,
   #[cfg(target_os = "windows")]
   #[serde(default)]
-  webview_options: Option<Value>
+  webview_options: Option<Value>,
 }
 
 impl TauriOptions {


### PR DESCRIPTION
Add option to pass `webviewOptions` into tauri [web driver](https://github.com/tauri-apps/tauri/tree/dev/tooling/webdriver), 
As per [capabilities-edge-options#webviewoptions-object](https://learn.microsoft.com/en-us/microsoft-edge/webdriver-chromium/capabilities-edge-options#webviewoptions-object)

When testing with webdriver, I needed to use the default data directory of my app for authentication,
and the only way to pass it with webview2 is using `webviewOptions`.

Usage example:
```js
const capabilities = new Capabilities();
capabilities.set("tauri:options", {
    application,
    args: [], // passed to EdgeOptions
    webview_options: {
	    additionalBrowserArguments: ["--user-data-dir=C:\Users\User\AppData\Local\AppName\EBWebView"],
    },
});
capabilities.setBrowserName("wry");

// start the webdriver client
driver = await new Builder()
  .withCapabilities(capabilities)
  .usingServer("http://127.0.0.1:4444/")
  .build();
```