### PR TITLE
feat: enable socks-proxy for bundler download (#8596)

### DIFF
--- a/.changes/bundler-socks-proxy.md
+++ b/.changes/bundler-socks-proxy.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:enhance
+---
+
+Support using socks proxy from environment when downloading files. 

--- a/tooling/bundler/Cargo.toml
+++ b/tooling/bundler/Cargo.toml
@@ -32,7 +32,7 @@ tempfile = "3.8.1"
 log = { version = "0.4.20", features = [ "kv_unstable" ] }
 dirs-next = "2.0"
 os_pipe = "1"
-ureq = { version = "2.9.1", default-features = false }
+ureq = { version = "2.9.1", default-features = false, features = [ "socks-proxy" ] }
 native-tls = { version = "0.2", optional = true }
 hex = "0.4"
 semver = "1"


### PR DESCRIPTION
port of https://github.com/tauri-apps/tauri/pull/8596 to 1.x