### PR TITLE
feat: Add Section, Priority and Changelog options

### DIFF
--- a/.changes/add-section-priority-changelog.md
+++ b/.changes/add-section-priority-changelog.md
@@ -1,0 +1,7 @@
+---
+"tauri-bundler": patch:feat
+---
+
+Add `priority`, `section` and `changelog` options in Debian config. 
+
+

--- a/.changes/add-section-priority-changelog.md
+++ b/.changes/add-section-priority-changelog.md
@@ -3,5 +3,3 @@
 ---
 
 Add `priority`, `section` and `changelog` options in Debian config. 
-
-

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1320,6 +1320,27 @@
             "string",
             "null"
           ]
+        },
+        "section": {
+          "description": "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "changelog": {
+          "description": "Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1336,7 +1336,7 @@
           ]
         },
         "changelog": {
-          "description": "Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+          "description": "Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
           "type": [
             "string",
             "null"

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1329,7 +1329,7 @@
           ]
         },
         "priority": {
-          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "description": "Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`",
           "type": [
             "string",
             "null"

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -282,8 +282,8 @@ pub struct DebConfig {
   pub desktop_template: Option<PathBuf>,
   /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
   pub section: Option<String>,
-  /// Change the priority of the Debian Package. By default, it is set to optional.
-  /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+  /// Change the priority of the Debian Package. By default, it is set to `optional`.
+  /// Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`
   pub priority: Option<String>,
   /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
   /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -285,7 +285,7 @@ pub struct DebConfig {
   /// Change the priority of the Debian Package. By default, it is set to optional.
   /// Recognized Priorities as of now are :  required, important, standard, optional, extra
   pub priority: Option<String>,
-  /// Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
+  /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
   /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
   pub changelog: Option<PathBuf>,
 }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -280,6 +280,14 @@ pub struct DebConfig {
   ///
   /// Available variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.
   pub desktop_template: Option<PathBuf>,
+  /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+  pub section: Option<String>,
+  /// Change the priority of the Debian Package. By default, it is set to optional.
+  /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+  pub priority: Option<String>,
+  /// Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
+  /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+  pub changelog: Option<PathBuf>,
 }
 
 fn de_minimum_system_version<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -135,7 +135,8 @@ pub fn generate_data(
   let icons =
     generate_icon_files(settings, &data_dir).with_context(|| "Failed to create icon files")?;
   generate_desktop_file(settings, &data_dir).with_context(|| "Failed to create desktop file")?;
-  generate_changelog_file(settings, &data_dir).with_context(|| "Failed to create changelog.gz file")?;
+  generate_changelog_file(settings, &data_dir)
+    .with_context(|| "Failed to create changelog.gz file")?;
 
   Ok((data_dir, icons))
 }
@@ -146,8 +147,7 @@ fn generate_changelog_file(settings: &Settings, data_dir: &Path) -> crate::Resul
   if let Some(changelog_src_path) = &settings.deb().changelog {
     let mut src_file = File::open(changelog_src_path)?;
     let bin_name = settings.main_binary_name();
-    let dest_path = data_dir
-      .join(format!("usr/share/doc/{}/changelog.gz", bin_name));
+    let dest_path = data_dir.join(format!("usr/share/doc/{}/changelog.gz", bin_name));
 
     let changelog_file = common::create_file(&dest_path)?;
     let mut gzip_encoder = GzEncoder::new(changelog_file, Compression::new(9));

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -135,8 +135,28 @@ pub fn generate_data(
   let icons =
     generate_icon_files(settings, &data_dir).with_context(|| "Failed to create icon files")?;
   generate_desktop_file(settings, &data_dir).with_context(|| "Failed to create desktop file")?;
+  generate_changelog_file(settings, &data_dir).with_context(|| "Failed to create changelog.gz file")?;
 
   Ok((data_dir, icons))
+}
+
+/// Generate the Changelog file by compressing, to be stored at /usr/share/doc/package-name/changelog.gz. See
+/// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+fn generate_changelog_file(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
+  if let Some(changelog_src_path) = &settings.deb().changelog {
+    let mut src_file = File::open(changelog_src_path)?;
+    let bin_name = settings.main_binary_name();
+    let dest_path = data_dir
+      .join(format!("usr/share/doc/{}/changelog.gz", bin_name));
+
+    let changelog_file = common::create_file(&dest_path)?;
+    let gzip_encoder = GzEncoder::new(dest_file, Compression::new(9));
+    io::copy(&mut src_file, &mut gzip_encoder)?;
+
+    let mut changelog_file = gzip_encoder.finish()?;
+    changelog_file.flush()?;
+  }
+  Ok(())
 }
 
 /// Generate the application desktop file and store it under the `data_dir`.
@@ -212,6 +232,14 @@ fn generate_control_file(
   writeln!(file, "Installed-Size: {}", total_dir_size(data_dir)? / 1024)?;
   let authors = settings.authors_comma_separated().unwrap_or_default();
   writeln!(file, "Maintainer: {}", authors)?;
+  if let Some(section) = &settings.deb().section {
+    writeln!(file, "Section: {}", section)?;
+  }
+  if let Some(priority) = &settings.deb().priority {
+    writeln!(file, "Priority: {}", priority)?;
+  } else {
+    writeln!(file, "Priority: optional")?;
+  }
   if !settings.homepage_url().is_empty() {
     writeln!(file, "Homepage: {}", settings.homepage_url())?;
   }
@@ -236,7 +264,6 @@ fn generate_control_file(
       writeln!(file, " {}", line)?;
     }
   }
-  writeln!(file, "Priority: optional")?;
   file.flush()?;
   Ok(())
 }

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -150,7 +150,7 @@ fn generate_changelog_file(settings: &Settings, data_dir: &Path) -> crate::Resul
       .join(format!("usr/share/doc/{}/changelog.gz", bin_name));
 
     let changelog_file = common::create_file(&dest_path)?;
-    let gzip_encoder = GzEncoder::new(dest_file, Compression::new(9));
+    let mut gzip_encoder = GzEncoder::new(changelog_file, Compression::new(9));
     io::copy(&mut src_file, &mut gzip_encoder)?;
 
     let mut changelog_file = gzip_encoder.finish()?;

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -187,8 +187,8 @@ pub struct DebianSettings {
   pub desktop_template: Option<PathBuf>,
   /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
   pub section: Option<String>,
-  /// Change the priority of the Debian Package. By default, it is set to optional.
-  /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+  /// Change the priority of the Debian Package. By default, it is set to `optional`.
+  /// Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`
   pub priority: Option<String>,
   /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
   /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -185,6 +185,15 @@ pub struct DebianSettings {
   #[doc = include_str!("./linux/templates/main.desktop")]
   /// ```
   pub desktop_template: Option<PathBuf>,
+    /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+    pub section: Option<String>,
+    /// Change the priority of the Debian Package. By default, it is set to optional.
+    /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+    pub priority: Option<String>,
+    /// Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
+    /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+    pub changelog: Option<PathBuf>,
+  
 }
 
 /// The macOS bundle settings.

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -190,7 +190,7 @@ pub struct DebianSettings {
     /// Change the priority of the Debian Package. By default, it is set to optional.
     /// Recognized Priorities as of now are :  required, important, standard, optional, extra
     pub priority: Option<String>,
-    /// Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
+    /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
     /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
     pub changelog: Option<PathBuf>,
   

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -185,15 +185,14 @@ pub struct DebianSettings {
   #[doc = include_str!("./linux/templates/main.desktop")]
   /// ```
   pub desktop_template: Option<PathBuf>,
-    /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
-    pub section: Option<String>,
-    /// Change the priority of the Debian Package. By default, it is set to optional.
-    /// Recognized Priorities as of now are :  required, important, standard, optional, extra
-    pub priority: Option<String>,
-    /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
-    /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
-    pub changelog: Option<PathBuf>,
-  
+  /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+  pub section: Option<String>,
+  /// Change the priority of the Debian Package. By default, it is set to optional.
+  /// Recognized Priorities as of now are :  required, important, standard, optional, extra
+  pub priority: Option<String>,
+  /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
+  /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+  pub changelog: Option<PathBuf>,
 }
 
 /// The macOS bundle settings.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1320,6 +1320,27 @@
             "string",
             "null"
           ]
+        },
+        "section": {
+          "description": "Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "changelog": {
+          "description": "Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1336,7 +1336,7 @@
           ]
         },
         "changelog": {
-          "description": "Path to the Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
+          "description": "Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes",
           "type": [
             "string",
             "null"

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1329,7 +1329,7 @@
           ]
         },
         "priority": {
-          "description": "Change the priority of the Debian Package. By default, it is set to optional. Recognized Priorities as of now are :  required, important, standard, optional, extra",
+          "description": "Change the priority of the Debian Package. By default, it is set to `optional`. Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`",
           "type": [
             "string",
             "null"

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1101,6 +1101,9 @@ fn tauri_config_to_bundle_settings(
       },
       files: config.deb.files,
       desktop_template: config.deb.desktop_template,
+      section: config.deb.section,
+      priority: config.deb.priority,
+      changelog: config.deb.changelog,
     },
     macos: MacOsSettings {
       frameworks: config.macos.frameworks,


### PR DESCRIPTION
Add `priority`, `section` and `changelog` options in Debian config in Tauri Bundler. Hence, users can now make fully Debian Compliant Packages with ease.

- Closes https://github.com/tauri-apps/tauri/issues/7074

**Thank You**