### PR TITLE
fix(core): clear window surface for transparent windows

### DIFF
--- a/.changes/tauri-decorated-transparent.md
+++ b/.changes/tauri-decorated-transparent.md
@@ -1,0 +1,6 @@
+---
+'tauri': 'patch:bug'
+'tauri-runtime-wry': 'patch'
+---
+
+On Windows, fix decorated window not transparent initially until resized.

--- a/core/tauri-runtime-wry/Cargo.toml
+++ b/core/tauri-runtime-wry/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 wry = { version = "0.35.2", default-features = false, features = [ "file-drop", "protocol", "os-webview" ] }
-tao = { version = "0.24", default-features = false, features = [ "rwh_05" ] }
+tao = { version = "0.24", default-features = false, features = [ "rwh_05", "rwh_06" ] }
 tauri-runtime = { version = "1.0.0-alpha.8", path = "../tauri-runtime" }
 tauri-utils = { version = "2.0.0-alpha.13", path = "../tauri-utils" }
 raw-window-handle = "0.5"
@@ -23,6 +23,7 @@ tracing = { version = "0.1", optional = true }
 
 [target."cfg(windows)".dependencies]
 webview2-com = "0.28"
+softbuffer = "0.4"
 
   [target."cfg(windows)".dependencies.windows]
   version = "0.52"

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2479,6 +2479,7 @@ fn handle_user_message<T: UserEvent>(
         webview_id_map.insert(window.id(), window_id);
 
         let window = Arc::new(window);
+
         #[cfg(windows)]
         let surface = if is_window_transparent {
           if let Ok(context) = softbuffer::Context::new(window.clone()) {
@@ -2502,6 +2503,7 @@ fn handle_user_message<T: UserEvent>(
             inner: Some(WindowHandle::Window(window.clone())),
             window_event_listeners: Default::default(),
             is_window_transparent,
+            #[cfg(windows)]
             surface,
           },
         );

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -1678,6 +1678,9 @@ pub struct WindowWrapper {
   label: String,
   inner: Option<WindowHandle>,
   window_event_listeners: WindowEventListeners,
+  is_window_transparent: bool,
+  #[cfg(windows)]
+  surface: Option<softbuffer::Surface<Arc<Window>, Arc<Window>>>,
 }
 
 impl fmt::Debug for WindowWrapper {
@@ -1685,6 +1688,7 @@ impl fmt::Debug for WindowWrapper {
     f.debug_struct("WindowWrapper")
       .field("label", &self.label)
       .field("inner", &self.inner)
+      .field("is_window_transparent", &self.is_window_transparent)
       .finish()
   }
 }
@@ -2470,20 +2474,38 @@ fn handle_user_message<T: UserEvent>(
     },
     Message::CreateWindow(window_id, handler, sender) => {
       let (label, builder) = handler();
+      let is_window_transparent = builder.window.transparent;
       if let Ok(window) = builder.build(event_loop) {
         webview_id_map.insert(window.id(), window_id);
 
-        let w = Arc::new(window);
+        let window = Arc::new(window);
+        #[cfg(windows)]
+        let surface = if is_window_transparent {
+          if let Ok(context) = softbuffer::Context::new(window.clone()) {
+            if let Ok(mut surface) = softbuffer::Surface::new(&context, window.clone()) {
+              clear_window_surface(&window, &mut surface);
+              Some(surface)
+            } else {
+              None
+            }
+          } else {
+            None
+          }
+        } else {
+          None
+        };
 
         windows.borrow_mut().insert(
           window_id,
           WindowWrapper {
             label,
-            inner: Some(WindowHandle::Window(w.clone())),
+            inner: Some(WindowHandle::Window(window.clone())),
             window_event_listeners: Default::default(),
+            is_window_transparent,
+            surface,
           },
         );
-        sender.send(Ok(Arc::downgrade(&w))).unwrap();
+        sender.send(Ok(Arc::downgrade(&window))).unwrap();
       } else {
         sender.send(Err(Error::CreateWindow)).unwrap();
       }
@@ -2533,8 +2555,23 @@ fn handle_event_loop<T: UserEvent>(
       callback(RunEvent::Exit);
     }
 
-    #[cfg(feature = "tracing")]
+    #[cfg(any(feature = "tracing", windows))]
     Event::RedrawRequested(id) => {
+      #[cfg(windows)]
+      if let Some(window_id) = webview_id_map.get(&id) {
+        let mut windows_ref = windows.borrow_mut();
+        if let Some(window) = windows_ref.get_mut(&window_id) {
+          if window.is_window_transparent {
+            if let Some(surface) = &mut window.surface {
+              if let Some(window) = &window.inner {
+                clear_window_surface(&window, surface)
+              }
+            }
+          }
+        }
+      }
+
+      #[cfg(feature = "tracing")]
       active_tracing_spans.remove_window_draw(id);
     }
 
@@ -2685,6 +2722,8 @@ fn on_close_requested<'a, T: UserEvent>(
 fn on_window_close(window_id: WebviewId, windows: Rc<RefCell<HashMap<WebviewId, WindowWrapper>>>) {
   if let Some(window_wrapper) = windows.borrow_mut().get_mut(&window_id) {
     window_wrapper.inner = None;
+    #[cfg(windows)]
+    window_wrapper.surface.take();
   }
 }
 
@@ -3021,10 +3060,27 @@ fn create_webview<T: UserEvent, F: Fn(RawWindow) + Send + 'static>(
     .unwrap();
   }
 
+  let window = Arc::new(window);
+  #[cfg(windows)]
+  let surface = if is_window_transparent {
+    if let Ok(context) = softbuffer::Context::new(window.clone()) {
+      if let Ok(mut surface) = softbuffer::Surface::new(&context, window.clone()) {
+        clear_window_surface(&window, &mut surface);
+        Some(surface)
+      } else {
+        None
+      }
+    } else {
+      None
+    }
+  } else {
+    None
+  };
+
   Ok(WindowWrapper {
     label,
     inner: Some(WindowHandle::Webview {
-      window: Arc::new(window),
+      window,
       inner: Rc::new(webview),
       context_store: web_context_store.clone(),
       context_key: if automation_enabled {
@@ -3034,6 +3090,9 @@ fn create_webview<T: UserEvent, F: Fn(RawWindow) + Send + 'static>(
       },
     }),
     window_event_listeners,
+    is_window_transparent,
+    #[cfg(windows)]
+    surface,
   })
 }
 
@@ -3056,4 +3115,21 @@ fn create_ipc_handler<T: UserEvent>(
       request,
     );
   })
+}
+
+#[cfg(windows)]
+fn clear_window_surface(
+  window: &Window,
+  surface: &mut softbuffer::Surface<Arc<Window>, Arc<Window>>,
+) {
+  let size = window.inner_size();
+  if let (Some(width), Some(height)) = (
+    std::num::NonZeroU32::new(size.width),
+    std::num::NonZeroU32::new(size.height),
+  ) {
+    surface.resize(width, height).unwrap();
+    let mut buffer = surface.buffer_mut().unwrap();
+    buffer.fill(0);
+    let _ = buffer.present();
+  }
 }


### PR DESCRIPTION
closes #8632

this may conflict with `tauri-egui` rendering to the surface so we may need to add an option to disable internal rendering

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
