### PR TITLE
fix(cli): add MaybeWorkspace to license field

### DIFF
--- a/.changes/cli-license-field-workspace.md
+++ b/.changes/cli-license-field-workspace.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Allow license field in Cargo.toml to be `{ workspace = true }`

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -612,6 +612,7 @@ struct WorkspacePackageSettings {
   description: Option<String>,
   homepage: Option<String>,
   version: Option<String>,
+  license: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -930,7 +931,18 @@ impl RustAppSettings {
           })
           .unwrap()
       }),
-      license: cargo_package_settings.license.clone(),
+      license: cargo_package_settings.license.clone().map(|license| {
+        license
+          .resolve("license", || {
+            ws_package_settings
+              .as_ref()
+              .and_then(|v| v.license.clone())
+              .ok_or_else(|| {
+                anyhow::anyhow!("Couldn't inherit value for `license` from workspace")
+              })
+          })
+          .unwrap()
+      }),
       default_run: cargo_package_settings.default_run.clone(),
     };
 

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -635,7 +635,7 @@ pub struct CargoPackageSettings {
   /// the package's authors.
   pub authors: Option<MaybeWorkspace<Vec<String>>>,
   /// the package's license.
-  pub license: Option<String>,
+  pub license: Option<MaybeWorkspace<String>>,
   /// the default binary to run.
   pub default_run: Option<String>,
 }

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -937,9 +937,7 @@ impl RustAppSettings {
             ws_package_settings
               .as_ref()
               .and_then(|v| v.license.clone())
-              .ok_or_else(|| {
-                anyhow::anyhow!("Couldn't inherit value for `license` from workspace")
-              })
+              .ok_or_else(|| anyhow::anyhow!("Couldn't inherit value for `license` from workspace"))
           })
           .unwrap()
       }),


### PR DESCRIPTION
Got the bug in a project after updating to latest v2-alpha.
And got this error:
```
> pnpm tauri dev

       Error failed to load cargo settings: failed to parse Cargo.toml: TOML parse error at line 6, column 11
  |
6 | license = { workspace = true }
  |           ^^^^^^^^^^^^^^^^^^^^
invalid type: map, expected a string

 ELIFECYCLE  Command failed with exit code 1.
```

From what I saw in a code, license field was expected to be either String or None, but not workspace. Made it same as other fields (_by copy-pasting code from them_).

I think that it should work with any other case, but at least it fixes my issue. Let me know if I made something wrong. Will try to be fast with responses.

### Checks
- `cargo test` passes
- `cargo clippy` passes
- `cargo fmt` _locally_ passes
- if cli installed with `cargo install` and used via `cargo tauri dev` with a license field like `license = { workspace = true }`, exception is not being thrown