### PR TITLE
fix(core/window): set window_effects from config

### DIFF
--- a/core/tauri/src/window/mod.rs
+++ b/core/tauri/src/window/mod.rs
@@ -241,6 +241,7 @@ async fn reopen_window(app: tauri::AppHandle) {
     Self {
       manager,
       label: config.label.clone(),
+      window_effects: config.window_effects.clone(),
       window_builder:
         <R::WindowDispatcher as WindowDispatch<EventLoopMessage>>::WindowBuilder::with_config(
           config,
@@ -249,7 +250,6 @@ async fn reopen_window(app: tauri::AppHandle) {
       menu: None,
       #[cfg(desktop)]
       on_menu_event: None,
-      window_effects: None,
     }
   }
 


### PR DESCRIPTION
The #8280 pull request cannot set window effects when use the config `windowEffects.effects`.

`window_effects` is always `None`, and the if judgment on line 410 will only be false.
```rust
    if let Some(effects) = self.window_effects {
      crate::vibrancy::set_window_effects(&window, Some(effects))?;
    }
```
Advance the `window_effects` because the `config` was moved at `window_builder`.

