### PR TITLE
feat(ipc): improve error message when plugin command is not allowed

### DIFF
--- a/core/tauri-utils/src/acl/mod.rs
+++ b/core/tauri-utils/src/acl/mod.rs
@@ -200,24 +200,11 @@ pub enum ExecutionContext {
 mod build_ {
   use std::convert::identity;
 
-  use crate::tokens::*;
+  use crate::{literal_struct, tokens::*};
 
   use super::*;
   use proc_macro2::TokenStream;
   use quote::{quote, ToTokens, TokenStreamExt};
-
-  /// Write a `TokenStream` of the `$struct`'s fields to the `$tokens`.
-  ///
-  /// All fields must represent a binding of the same name that implements `ToTokens`.
-  macro_rules! literal_struct {
-    ($tokens:ident, $struct:ident, $($field:ident),+) => {
-      $tokens.append_all(quote! {
-        ::tauri::utils::acl::$struct {
-          $($field: #$field),+
-        }
-      })
-    };
-  }
 
   impl ToTokens for ExecutionContext {
     fn to_tokens(&self, tokens: &mut TokenStream) {
@@ -239,7 +226,7 @@ mod build_ {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let allow = vec_lit(&self.allow, str_lit);
       let deny = vec_lit(&self.deny, str_lit);
-      literal_struct!(tokens, Commands, allow, deny)
+      literal_struct!(tokens, ::tauri::utils::acl::Commands, allow, deny)
     }
   }
 
@@ -247,7 +234,7 @@ mod build_ {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let allow = opt_vec_lit(self.allow.as_ref(), identity);
       let deny = opt_vec_lit(self.deny.as_ref(), identity);
-      literal_struct!(tokens, Scopes, allow, deny)
+      literal_struct!(tokens, ::tauri::utils::acl::Scopes, allow, deny)
     }
   }
 
@@ -263,7 +250,7 @@ mod build_ {
       let scope = &self.scope;
       literal_struct!(
         tokens,
-        Permission,
+        ::tauri::utils::acl::Permission,
         version,
         identifier,
         description,
@@ -278,7 +265,13 @@ mod build_ {
       let identifier = str_lit(&self.identifier);
       let description = str_lit(&self.description);
       let permissions = vec_lit(&self.permissions, str_lit);
-      literal_struct!(tokens, PermissionSet, identifier, description, permissions)
+      literal_struct!(
+        tokens,
+        ::tauri::utils::acl::PermissionSet,
+        identifier,
+        description,
+        permissions
+      )
     }
   }
 }

--- a/core/tauri-utils/src/acl/plugin.rs
+++ b/core/tauri-utils/src/acl/plugin.rs
@@ -109,20 +109,7 @@ mod build {
   use std::convert::identity;
 
   use super::*;
-  use crate::tokens::*;
-
-  /// Write a `TokenStream` of the `$struct`'s fields to the `$tokens`.
-  ///
-  /// All fields must represent a binding of the same name that implements `ToTokens`.
-  macro_rules! literal_struct {
-    ($tokens:ident, $struct:ident, $($field:ident),+) => {
-      $tokens.append_all(quote! {
-        ::tauri::utils::acl::plugin::$struct {
-          $($field: #$field),+
-        }
-      })
-    };
-  }
+  use crate::{literal_struct, tokens::*};
 
   impl ToTokens for DefaultPermission {
     fn to_tokens(&self, tokens: &mut TokenStream) {
@@ -132,7 +119,13 @@ mod build {
       }));
       let description = opt_str_lit(self.description.as_ref());
       let permissions = vec_lit(&self.permissions, str_lit);
-      literal_struct!(tokens, DefaultPermission, version, description, permissions)
+      literal_struct!(
+        tokens,
+        ::tauri::utils::acl::plugin::DefaultPermission,
+        version,
+        description,
+        permissions
+      )
     }
   }
 
@@ -156,7 +149,7 @@ mod build {
 
       literal_struct!(
         tokens,
-        Manifest,
+        ::tauri::utils::acl::plugin::Manifest,
         default_permission,
         permissions,
         permission_sets

--- a/core/tauri-utils/src/acl/resolved.rs
+++ b/core/tauri-utils/src/acl/resolved.rs
@@ -403,26 +403,18 @@ mod build {
   use std::convert::identity;
 
   use super::*;
-  use crate::tokens::*;
-
-  /// Write a `TokenStream` of the `$struct`'s fields to the `$tokens`.
-  ///
-  /// All fields must represent a binding of the same name that implements `ToTokens`.
-  macro_rules! literal_struct {
-    ($tokens:ident, $struct:ident, $($field:ident),+) => {
-      $tokens.append_all(quote! {
-        ::tauri::utils::acl::resolved::$struct {
-          $($field: #$field),+
-        }
-      })
-    };
-  }
+  use crate::{literal_struct, tokens::*};
 
   impl ToTokens for CommandKey {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let name = str_lit(&self.name);
       let context = &self.context;
-      literal_struct!(tokens, CommandKey, name, context)
+      literal_struct!(
+        tokens,
+        ::tauri::utils::acl::resolved::CommandKey,
+        name,
+        context
+      )
     }
   }
 
@@ -431,7 +423,12 @@ mod build {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let capability = str_lit(&self.capability);
       let permission = str_lit(&self.permission);
-      literal_struct!(tokens, ResolvedCommandReference, capability, permission)
+      literal_struct!(
+        tokens,
+        ::tauri::utils::acl::resolved::ResolvedCommandReference,
+        capability,
+        permission
+      )
     }
   }
 
@@ -448,10 +445,21 @@ mod build {
 
       #[cfg(debug_assertions)]
       {
-        literal_struct!(tokens, ResolvedCommand, referenced_by, windows, scope)
+        literal_struct!(
+          tokens,
+          ::tauri::utils::acl::resolved::ResolvedCommand,
+          referenced_by,
+          windows,
+          scope
+        )
       }
       #[cfg(not(debug_assertions))]
-      literal_struct!(tokens, ResolvedCommand, windows, scope)
+      literal_struct!(
+        tokens,
+        ::tauri::utils::acl::resolved::ResolvedCommand,
+        windows,
+        scope
+      )
     }
   }
 
@@ -459,7 +467,12 @@ mod build {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let allow = vec_lit(&self.allow, identity);
       let deny = vec_lit(&self.deny, identity);
-      literal_struct!(tokens, ResolvedScope, allow, deny)
+      literal_struct!(
+        tokens,
+        ::tauri::utils::acl::resolved::ResolvedScope,
+        allow,
+        deny
+      )
     }
   }
 
@@ -505,7 +518,7 @@ mod build {
       {
         literal_struct!(
           tokens,
-          Resolved,
+          ::tauri::utils::acl::resolved::Resolved,
           acl,
           allowed_commands,
           denied_commands,
@@ -516,7 +529,7 @@ mod build {
       #[cfg(not(debug_assertions))]
       literal_struct!(
         tokens,
-        Resolved,
+        ::tauri::utils::acl::resolved::Resolved,
         allowed_commands,
         denied_commands,
         command_scope,

--- a/core/tauri-utils/src/acl/resolved.rs
+++ b/core/tauri-utils/src/acl/resolved.rs
@@ -6,6 +6,7 @@
 
 use std::{
   collections::{hash_map::DefaultHasher, BTreeMap, HashSet},
+  fmt,
   hash::{Hash, Hasher},
 };
 
@@ -22,13 +23,35 @@ use super::{
 /// A key for a scope, used to link a [`ResolvedCommand#structfield.scope`] to the store [`Resolved#structfield.scopes`].
 pub type ScopeKey = usize;
 
+/// Metadata for what referenced a [`ResolvedCommand`].
+#[cfg(debug_assertions)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct ResolvedCommandReference {
+  /// Identifier of the capability.
+  pub capability: String,
+  /// Identifier of the permission.
+  pub permission: String,
+}
+
 /// A resolved command permission.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Clone, PartialEq, Eq)]
 pub struct ResolvedCommand {
-  /// The list of window label patterns that is allowed to run this command.
+  /// The list of capability/permission that referenced this command.
+  #[cfg(debug_assertions)]
+  pub referenced_by: Vec<ResolvedCommandReference>,
+  /// The list of window label patterns that was resolved for this command.
   pub windows: Vec<glob::Pattern>,
   /// The reference of the scope that is associated with this command. See [`Resolved#structfield.scopes`].
   pub scope: Option<ScopeKey>,
+}
+
+impl fmt::Debug for ResolvedCommand {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("ResolvedCommand")
+      .field("windows", &self.windows)
+      .field("scope", &self.scope)
+      .finish()
+  }
 }
 
 /// A resolved scope. Merges all scopes defined for a single command.
@@ -51,8 +74,11 @@ pub struct CommandKey {
 }
 
 /// Resolved access control list.
-#[derive(Debug)]
+#[derive(Default)]
 pub struct Resolved {
+  /// ACL plugin manifests.
+  #[cfg(debug_assertions)]
+  pub acl: BTreeMap<String, Manifest>,
   /// The commands that are allowed. Map each command with its context to a [`ResolvedCommand`].
   pub allowed_commands: BTreeMap<CommandKey, ResolvedCommand>,
   /// The commands that are denied. Map each command with its context to a [`ResolvedCommand`].
@@ -61,6 +87,17 @@ pub struct Resolved {
   pub command_scope: BTreeMap<ScopeKey, ResolvedScope>,
   /// The global scope.
   pub global_scope: BTreeMap<String, ResolvedScope>,
+}
+
+impl fmt::Debug for Resolved {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("Resolved")
+      .field("allowed_commands", &self.allowed_commands)
+      .field("denied_commands", &self.denied_commands)
+      .field("command_scope", &self.command_scope)
+      .field("global_scope", &self.global_scope)
+      .finish()
+  }
 }
 
 impl Resolved {
@@ -139,6 +176,8 @@ impl Resolved {
                   format!("plugin:{plugin_name}|{allowed_command}"),
                   capability,
                   scope_id,
+                  #[cfg(debug_assertions)]
+                  permission,
                 );
               }
 
@@ -148,6 +187,8 @@ impl Resolved {
                   format!("plugin:{plugin_name}|{denied_command}"),
                   capability,
                   scope_id,
+                  #[cfg(debug_assertions)]
+                  permission,
                 );
               }
             }
@@ -205,12 +246,16 @@ impl Resolved {
       .collect();
 
     let resolved = Self {
+      #[cfg(debug_assertions)]
+      acl,
       allowed_commands: allowed_commands
         .into_iter()
         .map(|(key, cmd)| {
           Ok((
             key,
             ResolvedCommand {
+              #[cfg(debug_assertions)]
+              referenced_by: cmd.referenced_by,
               windows: parse_window_patterns(cmd.windows)?,
               scope: cmd.resolved_scope_key,
             },
@@ -223,6 +268,8 @@ impl Resolved {
           Ok((
             key,
             ResolvedCommand {
+              #[cfg(debug_assertions)]
+              referenced_by: cmd.referenced_by,
               windows: parse_window_patterns(cmd.windows)?,
               scope: cmd.resolved_scope_key,
             },
@@ -247,6 +294,8 @@ fn parse_window_patterns(windows: HashSet<String>) -> Result<Vec<glob::Pattern>,
 
 #[derive(Debug, Default)]
 struct ResolvedCommandTemp {
+  #[cfg(debug_assertions)]
+  pub referenced_by: Vec<ResolvedCommandReference>,
   pub windows: HashSet<String>,
   pub scope: Vec<usize>,
   pub resolved_scope_key: Option<usize>,
@@ -257,6 +306,7 @@ fn resolve_command(
   command: String,
   capability: &Capability,
   scope_id: Option<usize>,
+  #[cfg(debug_assertions)] permission: &Permission,
 ) {
   let contexts = match &capability.context {
     CapabilityContext::Local => {
@@ -278,6 +328,12 @@ fn resolve_command(
         context,
       })
       .or_default();
+
+    #[cfg(debug_assertions)]
+    resolved.referenced_by.push(ResolvedCommandReference {
+      capability: capability.identifier.clone(),
+      permission: permission.identifier.clone(),
+    });
 
     resolved.windows.extend(capability.windows.clone());
     if let Some(id) = scope_id {
@@ -370,13 +426,31 @@ mod build {
     }
   }
 
+  #[cfg(debug_assertions)]
+  impl ToTokens for ResolvedCommandReference {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+      let capability = str_lit(&self.capability);
+      let permission = str_lit(&self.permission);
+      literal_struct!(tokens, ResolvedCommandReference, capability, permission)
+    }
+  }
+
   impl ToTokens for ResolvedCommand {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+      #[cfg(debug_assertions)]
+      let referenced_by = vec_lit(&self.referenced_by, identity);
+
       let windows = vec_lit(&self.windows, |window| {
         let w = window.as_str();
         quote!(#w.parse().unwrap())
       });
       let scope = opt_lit(self.scope.as_ref());
+
+      #[cfg(debug_assertions)]
+      {
+        literal_struct!(tokens, ResolvedCommand, referenced_by, windows, scope)
+      }
+      #[cfg(not(debug_assertions))]
       literal_struct!(tokens, ResolvedCommand, windows, scope)
     }
   }
@@ -391,6 +465,14 @@ mod build {
 
   impl ToTokens for Resolved {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+      #[cfg(debug_assertions)]
+      let acl = map_lit(
+        quote! { ::std::collections::BTreeMap },
+        &self.acl,
+        str_lit,
+        identity,
+      );
+
       let allowed_commands = map_lit(
         quote! { ::std::collections::BTreeMap },
         &self.allowed_commands,
@@ -419,6 +501,19 @@ mod build {
         identity,
       );
 
+      #[cfg(debug_assertions)]
+      {
+        literal_struct!(
+          tokens,
+          Resolved,
+          acl,
+          allowed_commands,
+          denied_commands,
+          command_scope,
+          global_scope
+        )
+      }
+      #[cfg(not(debug_assertions))]
       literal_struct!(
         tokens,
         Resolved,

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -2127,23 +2127,10 @@ fn default_build() -> BuildConfig {
 #[cfg(feature = "build")]
 mod build {
   use super::*;
-  use crate::tokens::*;
+  use crate::{literal_struct, tokens::*};
   use proc_macro2::TokenStream;
   use quote::{quote, ToTokens, TokenStreamExt};
   use std::convert::identity;
-
-  /// Write a `TokenStream` of the `$struct`'s fields to the `$tokens`.
-  ///
-  /// All fields must represent a binding of the same name that implements `ToTokens`.
-  macro_rules! literal_struct {
-    ($tokens:ident, $struct:ident, $($field:ident),+) => {
-      $tokens.append_all(quote! {
-        ::tauri::utils::config::$struct {
-          $($field: #$field),+
-        }
-      })
-    };
-  }
 
   impl ToTokens for WebviewUrl {
     fn to_tokens(&self, tokens: &mut TokenStream) {
@@ -2186,7 +2173,14 @@ mod build {
       let radius = opt_lit(self.radius.as_ref());
       let color = opt_lit(self.color.as_ref());
 
-      literal_struct!(tokens, WindowEffectsConfig, effects, state, radius, color)
+      literal_struct!(
+        tokens,
+        ::tauri::utils::config::WindowEffectsConfig,
+        effects,
+        state,
+        radius,
+        color
+      )
     }
   }
 
@@ -2295,7 +2289,7 @@ mod build {
 
       literal_struct!(
         tokens,
-        WindowConfig,
+        ::tauri::utils::config::WindowConfig,
         label,
         url,
         user_agent,
@@ -2401,7 +2395,13 @@ mod build {
       let pubkey = str_lit(&self.pubkey);
       let windows = &self.windows;
 
-      literal_struct!(tokens, UpdaterConfig, active, pubkey, windows);
+      literal_struct!(
+        tokens,
+        ::tauri::utils::config::UpdaterConfig,
+        active,
+        pubkey,
+        windows
+      );
     }
   }
 
@@ -2431,7 +2431,7 @@ mod build {
 
       literal_struct!(
         tokens,
-        BundleConfig,
+        ::tauri::utils::config::BundleConfig,
         active,
         identifier,
         publisher,
@@ -2486,7 +2486,7 @@ mod build {
 
       literal_struct!(
         tokens,
-        BuildConfig,
+        ::tauri::utils::config::BuildConfig,
         runner,
         dev_path,
         dist_dir,
@@ -2514,7 +2514,11 @@ mod build {
   impl ToTokens for UpdaterWindowsConfig {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let install_mode = &self.install_mode;
-      literal_struct!(tokens, UpdaterWindowsConfig, install_mode);
+      literal_struct!(
+        tokens,
+        ::tauri::utils::config::UpdaterWindowsConfig,
+        install_mode
+      );
     }
   }
 
@@ -2582,7 +2586,7 @@ mod build {
 
       literal_struct!(
         tokens,
-        RemoteDomainAccessScope,
+        ::tauri::utils::config::RemoteDomainAccessScope,
         scheme,
         domain,
         windows,
@@ -2601,7 +2605,7 @@ mod build {
 
       literal_struct!(
         tokens,
-        SecurityConfig,
+        ::tauri::utils::config::SecurityConfig,
         csp,
         dev_csp,
         freeze_prototype,
@@ -2621,7 +2625,7 @@ mod build {
       let tooltip = opt_str_lit(self.tooltip.as_ref());
       literal_struct!(
         tokens,
-        TrayIconConfig,
+        ::tauri::utils::config::TrayIconConfig,
         id,
         icon_path,
         icon_as_template,
@@ -2669,7 +2673,7 @@ mod build {
 
       literal_struct!(
         tokens,
-        TauriConfig,
+        ::tauri::utils::config::TauriConfig,
         pattern,
         windows,
         bundle,
@@ -2697,7 +2701,12 @@ mod build {
       let product_name = opt_str_lit(self.product_name.as_ref());
       let version = opt_str_lit(self.version.as_ref());
 
-      literal_struct!(tokens, PackageConfig, product_name, version);
+      literal_struct!(
+        tokens,
+        ::tauri::utils::config::PackageConfig,
+        product_name,
+        version
+      );
     }
   }
 
@@ -2709,7 +2718,15 @@ mod build {
       let build = &self.build;
       let plugins = &self.plugins;
 
-      literal_struct!(tokens, Config, schema, package, tauri, build, plugins);
+      literal_struct!(
+        tokens,
+        ::tauri::utils::config::Config,
+        schema,
+        package,
+        tauri,
+        build,
+        plugins
+      );
     }
   }
 }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -2423,7 +2423,7 @@ mod build {
       let rpm = quote!(Default::default());
       let dmg = quote!(Default::default());
       let macos = quote!(Default::default());
-      let external_bin = opt_vec_str_lit(self.external_bin.as_ref());
+      let external_bin = opt_vec_lit(self.external_bin.as_ref(), str_lit);
       let windows = &self.windows;
       let ios = quote!(Default::default());
       let android = quote!(Default::default());

--- a/core/tauri-utils/src/tokens.rs
+++ b/core/tauri-utils/src/tokens.rs
@@ -28,14 +28,28 @@ pub fn opt_lit(item: Option<&impl ToTokens>) -> TokenStream {
   }
 }
 
+/// Create an `Option` constructor `TokenStream` over an owned [`ToTokens`] impl type.
+pub fn opt_lit_owned(item: Option<impl ToTokens>) -> TokenStream {
+  match item {
+    None => quote! { ::core::option::Option::None },
+    Some(item) => quote! { ::core::option::Option::Some(#item) },
+  }
+}
+
 /// Helper function to combine an `opt_lit` with `str_lit`.
 pub fn opt_str_lit(item: Option<impl AsRef<str>>) -> TokenStream {
   opt_lit(item.map(str_lit).as_ref())
 }
 
 /// Helper function to combine an `opt_lit` with a list of `str_lit`
-pub fn opt_vec_str_lit(item: Option<impl IntoIterator<Item = impl AsRef<str>>>) -> TokenStream {
-  opt_lit(item.map(|list| vec_lit(list, str_lit)).as_ref())
+pub fn opt_vec_lit<Raw, Tokens>(
+  item: Option<impl IntoIterator<Item = Raw>>,
+  map: impl Fn(Raw) -> Tokens,
+) -> TokenStream
+where
+  Tokens: ToTokens,
+{
+  opt_lit(item.map(|list| vec_lit(list, map)).as_ref())
 }
 
 /// Create a `Vec` constructor, mapping items with a function that spits out `TokenStream`s.

--- a/core/tauri-utils/src/tokens.rs
+++ b/core/tauri-utils/src/tokens.rs
@@ -11,6 +11,20 @@ use quote::{quote, ToTokens};
 use serde_json::Value as JsonValue;
 use url::Url;
 
+/// Write a `TokenStream` of the `$struct`'s fields to the `$tokens`.
+///
+/// All fields must represent a binding of the same name that implements `ToTokens`.
+#[macro_export]
+macro_rules! literal_struct {
+  ($tokens:ident, $struct:path, $($field:ident),+) => {
+    $tokens.append_all(quote! {
+      $struct {
+        $($field: #$field),+
+      }
+    })
+  };
+}
+
 /// Create a `String` constructor `TokenStream`.
 ///
 /// e.g. `"Hello World" -> String::from("Hello World").

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -125,6 +125,8 @@ pub fn mock_context<A: Assets>(assets: A) -> crate::Context<A> {
     _info_plist: (),
     pattern: Pattern::Brownfield(std::marker::PhantomData),
     resolved_acl: Resolved {
+      #[cfg(debug_assertions)]
+      acl: Default::default(),
       allowed_commands: Default::default(),
       denied_commands: Default::default(),
       command_scope: Default::default(),

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -1093,22 +1093,19 @@ fn main() {
       request.headers,
     );
 
+    let acl_origin = if is_local {
+      Origin::Local
+    } else {
+      Origin::Remote {
+        domain: current_url
+          .domain()
+          .map(|d| d.to_string())
+          .unwrap_or_default(),
+      }
+    };
     let resolved_acl = manager
       .runtime_authority
-      .resolve_access(
-        &request.cmd,
-        &message.webview.webview.label,
-        if is_local {
-          Origin::Local
-        } else {
-          Origin::Remote {
-            domain: current_url
-              .domain()
-              .map(|d| d.to_string())
-              .unwrap_or_default(),
-          }
-        },
-      )
+      .resolve_access(&request.cmd, &message.webview.webview.label, &acl_origin)
       .cloned();
 
     let mut invoke = Invoke {
@@ -1117,20 +1114,33 @@ fn main() {
       acl: resolved_acl,
     };
 
-    if request.cmd.starts_with("plugin:") {
+    if let Some((plugin, command_name)) = request.cmd.strip_prefix("plugin:").map(|raw_command| {
+      let mut tokens = raw_command.split('|');
+      // safe to unwrap: split always has a least one item
+      let plugin = tokens.next().unwrap();
+      let command = tokens.next().map(|c| c.to_string()).unwrap_or_default();
+      (plugin, command)
+    }) {
       if request.cmd != crate::ipc::channel::FETCH_CHANNEL_DATA_COMMAND && invoke.acl.is_none() {
-        invoke.resolver.reject("NOT ALLOWED");
+        #[cfg(debug_assertions)]
+        {
+          invoke
+            .resolver
+            .reject(manager.runtime_authority.resolve_access_message(
+              plugin,
+              &command_name,
+              &invoke.message.webview.webview.label,
+              &acl_origin,
+            ));
+        }
+        #[cfg(not(debug_assertions))]
+        invoke
+          .resolver
+          .reject(format!("Command {} not allowed by ACL", request.cmd));
         return;
       }
 
-      let command = invoke.message.command.replace("plugin:", "");
-      let mut tokens = command.split('|');
-      // safe to unwrap: split always has a least one item
-      let plugin = tokens.next().unwrap();
-      invoke.message.command = tokens
-        .next()
-        .map(|c| c.to_string())
-        .unwrap_or_else(String::new);
+      invoke.message.command = command_name;
 
       let command = invoke.message.command.clone();
 


### PR DESCRIPTION
On debug, we'll give more information to the app developer on why the IPC call was rejected:
- what permissions he can use to enable the command
- if the command is enabled but for a different window, we present that info
- if the command is enabled but for a different remote, we also display that info
- if the command was denied by one of the capabilities, we tell that to the user too