### PR TITLE
fix(cli): disable global gitignore during tauri.conf.* lookup

### DIFF
--- a/.changes/cli-global-gitignore.md
+++ b/.changes/cli-global-gitignore.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Ignore global `.gitignore` when searching for tauri directory.

--- a/tooling/cli/src/helpers/app_paths.rs
+++ b/tooling/cli/src/helpers/app_paths.rs
@@ -31,6 +31,7 @@ pub fn walk_builder(path: &Path) -> WalkBuilder {
 
   let mut builder = WalkBuilder::new(path);
   builder.add_custom_ignore_filename(".taurignore");
+  builder.git_global(false);
   let _ = builder.add_ignore(default_gitignore);
   builder
 }


### PR DESCRIPTION
There are cases when people use git to manage their dotfiles in the home directory. When a tauri projects uses other name than `src-tauri` for the rust source code, the lookup may fail if there's a global gitignore.

This PR aims to fix that.