### PR TITLE
fix(cli): Ignore query parameter in dev server

### DIFF
--- a/.changes/cli-devserver-queryparam.md
+++ b/.changes/cli-devserver-queryparam.md
@@ -3,4 +3,4 @@
 "@tauri-apps/cli": patch:bug
 ---
 
-The built-in dev watcher now ignores the `?` query part of URLs.
+Fix the built-in dev server failing to serve files when URL had queries `?` and other url components.

--- a/.changes/cli-devserver-queryparam.md
+++ b/.changes/cli-devserver-queryparam.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+The built-in dev watcher now ignores the `?` query part of URLs.

--- a/tooling/cli/src/helpers/web_dev_server.rs
+++ b/tooling/cli/src/helpers/web_dev_server.rs
@@ -123,11 +123,13 @@ pub fn start_dev_server<P: AsRef<Path>>(path: P, port: Option<u16>) -> crate::Re
 }
 
 async fn handler(uri: axum::http::Uri, state: Arc<State>) -> impl IntoResponse {
-  let uri = uri.to_string();
+  // Frontend files should not contain query parameters. This seems to be how vite handles it.
+  let uri = uri.path();
+
   let uri = if uri == "/" {
-    &uri
+    uri
   } else {
-    uri.strip_prefix('/').unwrap_or(&uri)
+    uri.strip_prefix('/').unwrap_or(uri)
   };
 
   let file = std::fs::read(state.serve_dir.join(uri))


### PR DESCRIPTION
fixes #8148
additional ref: https://discord.com/channels/616186924390023171/1201199918379974766

imho query parameters have no business being in frontend file names (same for `#` but the browser doesn't send that part to the server so doesn't matter here).

This should now also match the behavior after `tauri build`.

The asset protocol should be able to handle it fine due to the url encoding, so devs can still load files with weird filenames that aren't part of the frontend.