### PR TITLE
refactor(core): allow scope deserialization to run setup code

### DIFF
--- a/core/tauri/src/command/authority.rs
+++ b/core/tauri/src/command/authority.rs
@@ -216,7 +216,7 @@ pub struct ScopeManager {
   global_scope_cache: TypeMap![Send + Sync],
 }
 
-/// Marks a type as an scope object.
+/// Marks a type as a scope object.
 ///
 /// Usually you will just rely on [`serde::de::DeserializeOwned`] instead of implementing it manually,
 /// though this is useful if you need to do some initialization logic on the type itself.

--- a/core/tauri/src/command/mod.rs
+++ b/core/tauri/src/command/mod.rs
@@ -18,7 +18,7 @@ use serde::{
 
 mod authority;
 
-pub use authority::{CommandScope, GlobalScope, Origin, RuntimeAuthority, ScopeValue};
+pub use authority::{CommandScope, GlobalScope, Origin, RuntimeAuthority, ScopeObject, ScopeValue};
 use tauri_utils::acl::resolved::ResolvedCommand;
 
 /// Represents a custom command.

--- a/core/tauri/src/error.rs
+++ b/core/tauri/src/error.rs
@@ -145,6 +145,9 @@ pub enum Error {
   /// API requires the unstable feature flag.
   #[error("this feature requires the `unstable` flag on Cargo.toml")]
   UnstableFeatureNotSupported,
+  /// Failed to deserialize scope object.
+  #[error("error deserializing scope: {0}")]
+  CannotDeserializeScope(Box<dyn std::error::Error>),
 }
 
 /// `Result<T, ::tauri::Error>`

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -6,7 +6,7 @@
 
 use crate::{
   app::UriSchemeResponder,
-  command::ScopeValue,
+  command::{ScopeObject, ScopeValue},
   ipc::{Invoke, InvokeHandler},
   manager::webview::UriSchemeProtocol,
   utils::config::PluginConfig,
@@ -140,15 +140,13 @@ impl<R: Runtime, C: DeserializeOwned> PluginApi<R, C> {
   }
 
   /// Gets the global scope defined on the permissions that are part of the app ACL.
-  pub fn scope<T: Debug + DeserializeOwned + Send + Sync + 'static>(
-    &self,
-  ) -> crate::Result<&ScopeValue<T>> {
+  pub fn scope<T: ScopeObject>(&self) -> crate::Result<&ScopeValue<T>> {
     self
       .handle
       .manager
       .runtime_authority
       .scope_manager
-      .get_global_scope_typed(self.name)
+      .get_global_scope_typed(&self.handle, self.name)
   }
 }
 


### PR DESCRIPTION
Some plugins runs some checks and processing on the scope type (like the fs plugin replacing variables on the paths in a scope). This changes the scope value to a simple `T: DeserializeOwned` to a custom struct the plugin writer can implement.