### PR TITLE
refactor(core): exit() and restart() triggers ExitRequested and Exit

### DIFF
--- a/.changes/refactor-exit.md
+++ b/.changes/refactor-exit.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:breaking
+---
+
+`AppHandle::exit` and `AppHandle::restart` now go triggers `RunEvent::ExitRequested` and `RunEvent::Exit` and cannot be executed on the event loop handler.

--- a/.changes/request-exit.md
+++ b/.changes/request-exit.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime": patch:feat
+"tauri-runtime-wry": patch:feat
+---
+
+Added `RuntimeHandle::request_exit` function.

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -153,6 +153,8 @@ pub enum RunEvent<T: UserEvent> {
   Exit,
   /// Event loop is about to exit
   ExitRequested {
+    /// The exit code.
+    code: Option<i32>,
     tx: Sender<ExitRequestedEventAction>,
   },
   /// An event associated with a window.
@@ -203,6 +205,9 @@ pub trait RuntimeHandle<T: UserEvent>: Debug + Clone + Send + Sync + Sized + 'st
 
   /// Creates an `EventLoopProxy` that can be used to dispatch user events to the main event loop.
   fn create_proxy(&self) -> <Self::Runtime as Runtime<T>>::EventLoopProxy;
+
+  /// Requests an exit of the event loop.
+  fn request_exit(&self, code: i32) -> Result<()>;
 
   /// Create a new window.
   fn create_window<F: Fn(RawWindow) + Send + 'static>(

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -375,11 +375,6 @@ impl<R: Runtime> AppHandle<R> {
   }
 
   /// Exits the app by triggering [`RunEvent::ExitRequested`] and [`RunEvent::Exit`].
-  ///
-  /// # Panics
-  ///
-  /// - Panics if the event loop is not running yet, usually when called on the [`setup`](Builder#method.setup) closure.
-  /// - Panics when called on the main thread, usually on the [`run`](App#method.run) closure.
   pub fn exit(&self, exit_code: i32) {
     if let Err(e) = self.runtime_handle.request_exit(exit_code) {
       debug_eprintln!("failed to exit: {}", e);
@@ -389,11 +384,6 @@ impl<R: Runtime> AppHandle<R> {
   }
 
   /// Restarts the app by triggering [`RunEvent::ExitRequested`] with code [`RESTART_EXIT_CODE`] and [`RunEvent::Exit`]..
-  ///
-  /// # Panics
-  ///
-  /// - Panics if the event loop is not running yet, usually when called on the [`setup`](Builder#method.setup) closure.
-  /// - Panics when called on the main thread, usually on the [`run`](App#method.run) closure.
   pub fn restart(&self) {
     if self.runtime_handle.request_exit(RESTART_EXIT_CODE).is_err() {
       self.cleanup_before_exit();

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -77,7 +77,9 @@ pub const RESTART_EXIT_CODE: i32 = i32::MAX;
 pub struct ExitRequestApi(Sender<ExitRequestedEventAction>);
 
 impl ExitRequestApi {
-  /// Prevents the app from exiting
+  /// Prevents the app from exiting.
+  ///
+  /// **Note:** This is ignored when using [`AppHandle#method.restart`].
   pub fn prevent_exit(&self) {
     self.0.send(ExitRequestedEventAction::Prevent).unwrap();
   }

--- a/core/tauri/src/test/mock_runtime.rs
+++ b/core/tauri/src/test/mock_runtime.rs
@@ -118,6 +118,10 @@ impl<T: UserEvent> RuntimeHandle<T> for MockRuntimeHandle {
     EventProxy {}
   }
 
+  fn request_exit(&self, code: i32) -> Result<()> {
+    unimplemented!()
+  }
+
   /// Create a new webview window.
   fn create_window<F: Fn(RawWindow<'_>) + Send + 'static>(
     &self,
@@ -1008,7 +1012,7 @@ impl<T: UserEvent> Runtime<T> for MockRuntime {
               let is_empty = self.context.windows.borrow().is_empty();
               if is_empty {
                 let (tx, rx) = channel();
-                callback(RunEvent::ExitRequested { tx });
+                callback(RunEvent::ExitRequested { code: None, tx });
 
                 let recv = rx.try_recv();
                 let should_prevent = matches!(recv, Ok(ExitRequestedEventAction::Prevent));

--- a/core/tauri/src/window/mod.rs
+++ b/core/tauri/src/window/mod.rs
@@ -1569,12 +1569,6 @@ impl<R: Runtime> Window<R> {
   }
 
   /// Closes this window.
-  /// # Panics
-  ///
-  /// - Panics if the event loop is not running yet, usually when called on the [`setup`](crate::Builder#method.setup) closure.
-  /// - Panics when called on the main thread, usually on the [`run`](crate::App#method.run) closure.
-  ///
-  /// You can spawn a task to use the API using [`crate::async_runtime::spawn`] or [`std::thread::spawn`] to prevent the panic.
   pub fn close(&self) -> crate::Result<()> {
     self.window.dispatcher.close().map_err(Into::into)
   }

--- a/examples/api/src-tauri/src/lib.rs
+++ b/examples/api/src-tauri/src/lib.rs
@@ -153,10 +153,13 @@ pub fn run_app<R: Runtime, F: FnOnce(&App<R>) + Send + 'static>(
 
   app.run(move |_app_handle, _event| {
     #[cfg(all(desktop, not(test)))]
-    if let RunEvent::ExitRequested { api, .. } = &_event {
+    if let RunEvent::ExitRequested { api, code, .. } = &_event {
       // Keep the event loop running even if all windows are closed
       // This allow us to catch tray icon events when there is no window
-      api.prevent_exit();
+      // if we manually requested an exit (code is Some(_)) we will let it go through
+      if code.is_none() {
+        api.prevent_exit();
+      }
     }
   })
 }


### PR DESCRIPTION
This changes the AppHandle::exit and AppHandle::restart implementations to actually trigger RunEvent::ExitRequested and RunEvent::Exit instead of forcing exit with std::process::exit