### PR TITLE
fix(core): macos #5122 app.runtime panic in app.set_activation_policy

### DIFF
--- a/.changes/fix-set-activation-policy.md
+++ b/.changes/fix-set-activation-policy.md
@@ -1,0 +1,7 @@
+---
+"tauri": patch:bug
+"tauri-runtime": patch:bug
+"tauri-runtime-wry": patch:bug
+---
+
+Fix calling `set_activation_policy` when the event loop is running.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -26,9 +26,7 @@ use tauri_runtime::{
 };
 
 #[cfg(target_os = "macos")]
-use tao::platform::macos::EventLoopWindowTargetExtMacOS;
-#[cfg(target_os = "macos")]
-use tao::platform::macos::WindowBuilderExtMacOS;
+use tao::platform::macos::{EventLoopWindowTargetExtMacOS, WindowBuilderExtMacOS};
 #[cfg(target_os = "linux")]
 use tao::platform::unix::{WindowBuilderExtUnix, WindowExtUnix};
 #[cfg(windows)]
@@ -425,6 +423,16 @@ pub fn map_theme(theme: &TaoTheme) -> Theme {
     TaoTheme::Light => Theme::Light,
     TaoTheme::Dark => Theme::Dark,
     _ => Theme::Light,
+  }
+}
+
+#[cfg(target_os = "macos")]
+fn tao_activation_policy(activation_policy: ActivationPolicy) -> TaoActivationPolicy {
+  match activation_policy {
+    ActivationPolicy::Regular => TaoActivationPolicy::Regular,
+    ActivationPolicy::Accessory => TaoActivationPolicy::Accessory,
+    ActivationPolicy::Prohibited => TaoActivationPolicy::Prohibited,
+    _ => unimplemented!(),
   }
 }
 
@@ -1185,6 +1193,8 @@ pub type CreateWebviewClosure = Box<dyn FnOnce(&Window) -> Result<WebviewWrapper
 
 pub enum Message<T: 'static> {
   Task(Box<dyn FnOnce() + Send>),
+  #[cfg(target_os = "macos")]
+  SetActivationPolicy(ActivationPolicy),
   RequestExit(i32),
   #[cfg(target_os = "macos")]
   Application(ApplicationMessage),
@@ -1970,6 +1980,14 @@ impl<T: UserEvent> RuntimeHandle<T> for WryHandle<T> {
     EventProxy(self.context.proxy.clone())
   }
 
+  #[cfg(target_os = "macos")]
+  fn set_activation_policy(&self, activation_policy: ActivationPolicy) -> Result<()> {
+    send_user_message(
+      &self.context,
+      Message::SetActivationPolicy(activation_policy),
+    )
+  }
+
   fn request_exit(&self, code: i32) -> Result<()> {
     // NOTE: request_exit cannot use the `send_user_message` function because it accesses the event loop callback
     self
@@ -2271,12 +2289,7 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
   fn set_activation_policy(&mut self, activation_policy: ActivationPolicy) {
     self
       .event_loop
-      .set_activation_policy(match activation_policy {
-        ActivationPolicy::Regular => TaoActivationPolicy::Regular,
-        ActivationPolicy::Accessory => TaoActivationPolicy::Accessory,
-        ActivationPolicy::Prohibited => TaoActivationPolicy::Prohibited,
-        _ => unimplemented!(),
-      });
+      .set_activation_policy(tao_activation_policy(activation_policy));
   }
 
   #[cfg(target_os = "macos")]
@@ -2421,6 +2434,10 @@ fn handle_user_message<T: UserEvent>(
   } = context;
   match message {
     Message::Task(task) => task(),
+    #[cfg(target_os = "macos")]
+    Message::SetActivationPolicy(activation_policy) => {
+      event_loop.set_activation_policy_at_runtime(tao_activation_policy(activation_policy))
+    }
     Message::RequestExit(_code) => panic!("cannot handle RequestExit on the main thread"),
     #[cfg(target_os = "macos")]
     Message::Application(application_message) => match application_message {

--- a/core/tauri-runtime/src/lib.rs
+++ b/core/tauri-runtime/src/lib.rs
@@ -206,6 +206,11 @@ pub trait RuntimeHandle<T: UserEvent>: Debug + Clone + Send + Sync + Sized + 'st
   /// Creates an `EventLoopProxy` that can be used to dispatch user events to the main event loop.
   fn create_proxy(&self) -> <Self::Runtime as Runtime<T>>::EventLoopProxy;
 
+  /// Sets the activation policy for the application.
+  #[cfg(target_os = "macos")]
+  #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+  fn set_activation_policy(&self, activation_policy: ActivationPolicy) -> Result<()>;
+
   /// Requests an exit of the event loop.
   fn request_exit(&self, code: i32) -> Result<()>;
 
@@ -311,7 +316,7 @@ pub trait Runtime<T: UserEvent>: Debug + Sized + 'static {
   fn primary_monitor(&self) -> Option<Monitor>;
   fn available_monitors(&self) -> Vec<Monitor>;
 
-  /// Sets the activation policy for the application. It is set to `NSApplicationActivationPolicyRegular` by default.
+  /// Sets the activation policy for the application.
   #[cfg(target_os = "macos")]
   #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
   fn set_activation_policy(&mut self, activation_policy: ActivationPolicy);

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -818,11 +818,9 @@ impl<R: Runtime> App<R> {
   #[cfg(target_os = "macos")]
   #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
   pub fn set_activation_policy(&mut self, activation_policy: ActivationPolicy) {
-    self
-      .runtime
-      .as_mut()
-      .unwrap()
-      .set_activation_policy(activation_policy);
+    if let Some(runtime) = self.runtime.as_mut() {
+      runtime.set_activation_policy(activation_policy);
+    }
   }
 
   /// Change the device event filter mode.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -820,6 +820,11 @@ impl<R: Runtime> App<R> {
   pub fn set_activation_policy(&mut self, activation_policy: ActivationPolicy) {
     if let Some(runtime) = self.runtime.as_mut() {
       runtime.set_activation_policy(activation_policy);
+    } else {
+      let _ = self
+        .app_handle()
+        .runtime_handle
+        .set_activation_policy(activation_policy);
     }
   }
 

--- a/core/tauri/src/test/mock_runtime.rs
+++ b/core/tauri/src/test/mock_runtime.rs
@@ -118,6 +118,15 @@ impl<T: UserEvent> RuntimeHandle<T> for MockRuntimeHandle {
     EventProxy {}
   }
 
+  #[cfg(target_os = "macos")]
+  #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
+  fn set_activation_policy(
+    &self,
+    activation_policy: tauri_runtime::ActivationPolicy,
+  ) -> Result<()> {
+    Ok(())
+  }
+
   fn request_exit(&self, code: i32) -> Result<()> {
     unimplemented!()
   }


### PR DESCRIPTION
1. fix #5122
2. the problem:

```rust
pub fn run() {
    let mut app = tauri::Builder::default()
        .setup(|app| {
            // c
            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
            Ok(())
        })
        .build(tauri::tauri_build_context!())
        .unwrap();
    // a
    app.set_activation_policy(tauri::ActivationPolicy::Regular);
    // b
    app.run(move |_app_handle, _event| {})
}
```

`a`: this line runs first
`b`: app.run will take the app.runtime as in https://github.com/tauri-apps/tauri/blob/00e1567584721644797b587205187f9cbe4e5cd1/core/tauri/src/app.rs#L875
`c`: the `set_activation_policy` will try to get `app.runtime` and `unwrap`, but now, the `app.runtime` is None and the program panic.

I add an `if let` to `set_activation_policy`. This will cause `c` ignored silently, maybe we need a better approach. 

And it seems the bug is not related to `window.show()` in the original issue, whether before or after the multi web view refactor c77b40324ea9bf580871fc11aed69ba0c9b6b8cf.
