### PR TITLE
refactor(core): delete the command module

### DIFF
--- a/.changes/move-command-module.md
+++ b/.changes/move-command-module.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:breaking
+---
+
+Moved the `command` module items to the `ipc` module so its import name does not clash with the `command` macro.

--- a/core/tauri-macros/src/command/wrapper.rs
+++ b/core/tauri-macros/src/command/wrapper.rs
@@ -264,7 +264,7 @@ pub fn wrapper(attributes: TokenStream, item: TokenStream) -> TokenStream {
         // double braces because the item is expected to be a block expression
         ($path:path, $invoke:ident) => {{
           #[allow(unused_imports)]
-          use #root::command::private::*;
+          use #root::ipc::private::*;
           // prevent warnings when the body is a `compile_error!` or if the command has no arguments
           #[allow(unused_variables)]
           let #root::ipc::Invoke { message: #message, resolver: #resolver, acl: #acl } = $invoke;
@@ -442,8 +442,8 @@ fn parse_arg(
 
   let root = &attributes.root;
 
-  Ok(quote!(#root::command::CommandArg::from_command(
-    #root::command::CommandItem {
+  Ok(quote!(#root::ipc::CommandArg::from_command(
+    #root::ipc::CommandItem {
       plugin: #plugin_name,
       name: stringify!(#command),
       key: #key,

--- a/core/tauri/permissions/app/schemas/schema.json
+++ b/core/tauri/permissions/app/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -163,70 +55,37 @@
         }
       }
     },
-    "Scopes": {
-      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
       "type": "object",
+      "required": [
+        "permissions"
+      ],
       "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
+        "description": {
+          "description": "Human-readable description of what the permission does.",
           "type": [
-            "array",
+            "string",
             "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
           ]
         },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
+        "permissions": {
+          "description": "All permissions this set contains.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Value"
+            "type": "string"
           }
         },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         }
-      ]
+      }
     },
     "Number": {
       "description": "A valid ACL number.",
@@ -242,6 +101,56 @@
           "format": "double"
         }
       ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
     },
     "PermissionKind": {
       "type": "string",
@@ -322,6 +231,97 @@
           "enum": [
             "default"
           ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
         }
       ]
     }

--- a/core/tauri/permissions/event/schemas/schema.json
+++ b/core/tauri/permissions/event/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -159,6 +51,183 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "allow-emit -> Enables the emit command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "allow-emit"
+          ]
+        },
+        {
+          "description": "deny-emit -> Denies the emit command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "deny-emit"
+          ]
+        },
+        {
+          "description": "allow-listen -> Enables the listen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "allow-listen"
+          ]
+        },
+        {
+          "description": "deny-listen -> Denies the listen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "deny-listen"
+          ]
+        },
+        {
+          "description": "allow-unlisten -> Enables the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "allow-unlisten"
+          ]
+        },
+        {
+          "description": "deny-unlisten -> Denies the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "deny-unlisten"
+          ]
+        },
+        {
+          "description": "default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
           }
         }
       }
@@ -225,75 +294,6 @@
           "additionalProperties": {
             "$ref": "#/definitions/Value"
           }
-        }
-      ]
-    },
-    "Number": {
-      "description": "A valid ACL number.",
-      "anyOf": [
-        {
-          "description": "Represents an [`i64`].",
-          "type": "integer",
-          "format": "int64"
-        },
-        {
-          "description": "Represents a [`f64`].",
-          "type": "number",
-          "format": "double"
-        }
-      ]
-    },
-    "PermissionKind": {
-      "type": "string",
-      "oneOf": [
-        {
-          "description": "allow-emit -> Enables the emit command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "allow-emit"
-          ]
-        },
-        {
-          "description": "deny-emit -> Denies the emit command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "deny-emit"
-          ]
-        },
-        {
-          "description": "allow-listen -> Enables the listen command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "allow-listen"
-          ]
-        },
-        {
-          "description": "deny-listen -> Denies the listen command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "deny-listen"
-          ]
-        },
-        {
-          "description": "allow-unlisten -> Enables the unlisten command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "allow-unlisten"
-          ]
-        },
-        {
-          "description": "deny-unlisten -> Denies the unlisten command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "deny-unlisten"
-          ]
-        },
-        {
-          "description": "default -> Default permissions for the plugin.",
-          "type": "string",
-          "enum": [
-            "default"
-          ]
         }
       ]
     }

--- a/core/tauri/permissions/menu/schemas/schema.json
+++ b/core/tauri/permissions/menu/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -163,70 +55,37 @@
         }
       }
     },
-    "Scopes": {
-      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
       "type": "object",
+      "required": [
+        "permissions"
+      ],
       "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
+        "description": {
+          "description": "Human-readable description of what the permission does.",
           "type": [
-            "array",
+            "string",
             "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
           ]
         },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
+        "permissions": {
+          "description": "All permissions this set contains.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Value"
+            "type": "string"
           }
         },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         }
-      ]
+      }
     },
     "Number": {
       "description": "A valid ACL number.",
@@ -242,6 +101,56 @@
           "format": "double"
         }
       ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
     },
     "PermissionKind": {
       "type": "string",
@@ -560,6 +469,97 @@
           "enum": [
             "default"
           ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
         }
       ]
     }

--- a/core/tauri/permissions/path/schemas/schema.json
+++ b/core/tauri/permissions/path/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -163,70 +55,37 @@
         }
       }
     },
-    "Scopes": {
-      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
       "type": "object",
+      "required": [
+        "permissions"
+      ],
       "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
+        "description": {
+          "description": "Human-readable description of what the permission does.",
           "type": [
-            "array",
+            "string",
             "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
           ]
         },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
+        "permissions": {
+          "description": "All permissions this set contains.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Value"
+            "type": "string"
           }
         },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         }
-      ]
+      }
     },
     "Number": {
       "description": "A valid ACL number.",
@@ -242,6 +101,56 @@
           "format": "double"
         }
       ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
     },
     "PermissionKind": {
       "type": "string",
@@ -364,6 +273,97 @@
           "enum": [
             "default"
           ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
         }
       ]
     }

--- a/core/tauri/permissions/resources/schemas/schema.json
+++ b/core/tauri/permissions/resources/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -159,6 +51,155 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
+      "type": "object",
+      "required": [
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
+    },
+    "PermissionKind": {
+      "type": "string",
+      "oneOf": [
+        {
+          "description": "allow-close -> Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "allow-close"
+          ]
+        },
+        {
+          "description": "deny-close -> Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "deny-close"
+          ]
+        },
+        {
+          "description": "default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
           }
         }
       }
@@ -225,47 +266,6 @@
           "additionalProperties": {
             "$ref": "#/definitions/Value"
           }
-        }
-      ]
-    },
-    "Number": {
-      "description": "A valid ACL number.",
-      "anyOf": [
-        {
-          "description": "Represents an [`i64`].",
-          "type": "integer",
-          "format": "int64"
-        },
-        {
-          "description": "Represents a [`f64`].",
-          "type": "number",
-          "format": "double"
-        }
-      ]
-    },
-    "PermissionKind": {
-      "type": "string",
-      "oneOf": [
-        {
-          "description": "allow-close -> Enables the close command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "allow-close"
-          ]
-        },
-        {
-          "description": "deny-close -> Denies the close command without any pre-configured scope.",
-          "type": "string",
-          "enum": [
-            "deny-close"
-          ]
-        },
-        {
-          "description": "default -> Default permissions for the plugin.",
-          "type": "string",
-          "enum": [
-            "default"
-          ]
         }
       ]
     }

--- a/core/tauri/permissions/tray/schemas/schema.json
+++ b/core/tauri/permissions/tray/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -163,70 +55,37 @@
         }
       }
     },
-    "Scopes": {
-      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
       "type": "object",
+      "required": [
+        "permissions"
+      ],
       "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
+        "description": {
+          "description": "Human-readable description of what the permission does.",
           "type": [
-            "array",
+            "string",
             "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
           ]
         },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
+        "permissions": {
+          "description": "All permissions this set contains.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Value"
+            "type": "string"
           }
         },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         }
-      ]
+      }
     },
     "Number": {
       "description": "A valid ACL number.",
@@ -242,6 +101,56 @@
           "format": "double"
         }
       ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
     },
     "PermissionKind": {
       "type": "string",
@@ -378,6 +287,97 @@
           "enum": [
             "default"
           ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
         }
       ]
     }

--- a/core/tauri/permissions/webview/schemas/schema.json
+++ b/core/tauri/permissions/webview/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -163,70 +55,37 @@
         }
       }
     },
-    "Scopes": {
-      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
       "type": "object",
+      "required": [
+        "permissions"
+      ],
       "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
+        "description": {
+          "description": "Human-readable description of what the permission does.",
           "type": [
-            "array",
+            "string",
             "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
           ]
         },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
+        "permissions": {
+          "description": "All permissions this set contains.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Value"
+            "type": "string"
           }
         },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         }
-      ]
+      }
     },
     "Number": {
       "description": "A valid ACL number.",
@@ -242,6 +101,56 @@
           "format": "double"
         }
       ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
     },
     "PermissionKind": {
       "type": "string",
@@ -392,6 +301,97 @@
           "enum": [
             "default"
           ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
         }
       ]
     }

--- a/core/tauri/permissions/window/schemas/schema.json
+++ b/core/tauri/permissions/window/schemas/schema.json
@@ -15,14 +15,6 @@
         }
       ]
     },
-    "set": {
-      "description": "A list of permissions sets defined",
-      "default": [],
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/PermissionSet"
-      }
-    },
     "permission": {
       "description": "A list of inlined permissions",
       "default": [],
@@ -30,117 +22,17 @@
       "items": {
         "$ref": "#/definitions/Permission"
       }
+    },
+    "set": {
+      "description": "A list of permissions sets defined",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PermissionSet"
+      }
     }
   },
   "definitions": {
-    "DefaultPermission": {
-      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
-      "type": "object",
-      "required": [
-        "permissions"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PermissionSet": {
-      "description": "A set of direct permissions grouped together under a new name.",
-      "type": "object",
-      "required": [
-        "description",
-        "identifier",
-        "permissions"
-      ],
-      "properties": {
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": "string"
-        },
-        "permissions": {
-          "description": "All permissions this set contains.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/PermissionKind"
-          }
-        }
-      }
-    },
-    "Permission": {
-      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
-      "type": "object",
-      "required": [
-        "identifier"
-      ],
-      "properties": {
-        "version": {
-          "description": "The version of the permission.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 1.0
-        },
-        "identifier": {
-          "description": "A unique identifier for the permission.",
-          "type": "string"
-        },
-        "description": {
-          "description": "Human-readable description of what the permission does.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "commands": {
-          "description": "Allowed or denied commands when using this permission.",
-          "default": {
-            "allow": [],
-            "deny": []
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Commands"
-            }
-          ]
-        },
-        "scope": {
-          "description": "Allowed or denied scoped when using this permission.",
-          "default": {},
-          "allOf": [
-            {
-              "$ref": "#/definitions/Scopes"
-            }
-          ]
-        }
-      }
-    },
     "Commands": {
       "description": "Allowed and denied commands inside a permission.\n\nIf two commands clash inside of `allow` and `deny`, it should be denied by default.",
       "type": "object",
@@ -163,70 +55,37 @@
         }
       }
     },
-    "Scopes": {
-      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+    "DefaultPermission": {
+      "description": "The default permission set of the plugin.\n\nWorks similarly to a permission with the \"default\" identifier.",
       "type": "object",
+      "required": [
+        "permissions"
+      ],
       "properties": {
-        "allow": {
-          "description": "Data that defines what is allowed by the scope.",
+        "description": {
+          "description": "Human-readable description of what the permission does.",
           "type": [
-            "array",
+            "string",
             "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        },
-        "deny": {
-          "description": "Data that defines what is denied by the scope.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/definitions/Value"
-          }
-        }
-      }
-    },
-    "Value": {
-      "description": "All supported ACL values.",
-      "anyOf": [
-        {
-          "description": "Represents a null JSON value.",
-          "type": "null"
-        },
-        {
-          "description": "Represents a [`bool`].",
-          "type": "boolean"
-        },
-        {
-          "description": "Represents a valid ACL [`Number`].",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Number"
-            }
           ]
         },
-        {
-          "description": "Represents a [`String`].",
-          "type": "string"
-        },
-        {
-          "description": "Represents a list of other [`Value`]s.",
+        "permissions": {
+          "description": "All permissions this set contains.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Value"
+            "type": "string"
           }
         },
-        {
-          "description": "Represents a map of [`String`] keys to [`Value`]s.",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/Value"
-          }
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
         }
-      ]
+      }
     },
     "Number": {
       "description": "A valid ACL number.",
@@ -242,6 +101,56 @@
           "format": "double"
         }
       ]
+    },
+    "Permission": {
+      "description": "Descriptions of explicit privileges of commands.\n\nIt can enable commands to be accessible in the frontend of the application.\n\nIf the scope is defined it can be used to fine grain control the access of individual or multiple commands.",
+      "type": "object",
+      "required": [
+        "identifier"
+      ],
+      "properties": {
+        "commands": {
+          "description": "Allowed or denied commands when using this permission.",
+          "default": {
+            "allow": [],
+            "deny": []
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Commands"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "scope": {
+          "description": "Allowed or denied scoped when using this permission.",
+          "default": {},
+          "allOf": [
+            {
+              "$ref": "#/definitions/Scopes"
+            }
+          ]
+        },
+        "version": {
+          "description": "The version of the permission.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 1.0
+        }
+      }
     },
     "PermissionKind": {
       "type": "string",
@@ -1092,6 +1001,97 @@
           "enum": [
             "default"
           ]
+        }
+      ]
+    },
+    "PermissionSet": {
+      "description": "A set of direct permissions grouped together under a new name.",
+      "type": "object",
+      "required": [
+        "description",
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable description of what the permission does.",
+          "type": "string"
+        },
+        "identifier": {
+          "description": "A unique identifier for the permission.",
+          "type": "string"
+        },
+        "permissions": {
+          "description": "All permissions this set contains.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionKind"
+          }
+        }
+      }
+    },
+    "Scopes": {
+      "description": "A restriction of the command/endpoint functionality.\n\nIt can be of any serde serializable type and is used for allowing or preventing certain actions inside a Tauri command.\n\nThe scope is passed to the command and handled/enforced by the command itself.",
+      "type": "object",
+      "properties": {
+        "allow": {
+          "description": "Data that defines what is allowed by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        "deny": {
+          "description": "Data that defines what is denied by the scope.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      }
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
         }
       ]
     }

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-  command::{CommandArg, CommandItem},
   ipc::{
-    channel::ChannelDataIpcQueue, CallbackFn, Invoke, InvokeError, InvokeHandler, InvokeResponder,
-    InvokeResponse,
+    channel::ChannelDataIpcQueue, CallbackFn, CommandArg, CommandItem, Invoke, InvokeError,
+    InvokeHandler, InvokeResponder, InvokeResponse,
   },
   manager::{
     webview::{UriSchemeProtocol, WebviewLabelDef},

--- a/core/tauri/src/ipc/authority.rs
+++ b/core/tauri/src/ipc/authority.rs
@@ -456,7 +456,7 @@ mod tests {
     ExecutionContext,
   };
 
-  use crate::command::Origin;
+  use crate::ipc::Origin;
 
   use super::RuntimeAuthority;
 

--- a/core/tauri/src/ipc/channel.rs
+++ b/core/tauri/src/ipc/channel.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
   command,
-  command::{CommandArg, CommandItem},
+  ipc::{CommandArg, CommandItem},
   plugin::{Builder as PluginBuilder, TauriPlugin},
   Manager, Runtime, State, Webview,
 };

--- a/core/tauri/src/ipc/command.rs
+++ b/core/tauri/src/ipc/command.rs
@@ -16,9 +16,6 @@ use serde::{
   Deserialize, Deserializer,
 };
 
-mod authority;
-
-pub use authority::{CommandScope, GlobalScope, Origin, RuntimeAuthority, ScopeObject, ScopeValue};
 use tauri_utils::acl::resolved::ResolvedCommand;
 
 /// Represents a custom command.

--- a/core/tauri/src/ipc/mod.rs
+++ b/core/tauri/src/ipc/mod.rs
@@ -16,18 +16,18 @@ pub use serialize_to_javascript::Options as SerializeOptions;
 use tauri_macros::default_runtime;
 use tauri_utils::acl::resolved::ResolvedCommand;
 
-use crate::{
-  command::{CommandArg, CommandItem},
-  webview::Webview,
-  Runtime, StateManager,
-};
+use crate::{webview::Webview, Runtime, StateManager};
 
+mod authority;
 pub(crate) mod channel;
+mod command;
 #[cfg(any(target_os = "macos", target_os = "ios", not(ipc_custom_protocol)))]
 pub(crate) mod format_callback;
 pub(crate) mod protocol;
 
+pub use authority::{CommandScope, GlobalScope, Origin, RuntimeAuthority, ScopeObject, ScopeValue};
 pub use channel::{Channel, JavaScriptChannelId};
+pub use command::{private, CommandArg, CommandItem};
 
 /// A closure that is run every time Tauri receives a message it doesn't explicitly handle.
 pub type InvokeHandler<R> = dyn Fn(Invoke<R>) -> bool + Send + Sync + 'static;

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -78,7 +78,6 @@ pub use tauri_macros::{command, generate_handler};
 
 pub(crate) mod app;
 pub mod async_runtime;
-pub mod command;
 mod error;
 mod event;
 pub mod ipc;

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -22,9 +22,8 @@ use tauri_utils::{
 
 use crate::{
   app::{AppHandle, GlobalWindowEventListener, OnPageLoad},
-  command::RuntimeAuthority,
   event::{assert_event_name_is_valid, Event, EventId, EventSource, Listeners},
-  ipc::{Invoke, InvokeHandler, InvokeResponder},
+  ipc::{Invoke, InvokeHandler, InvokeResponder, RuntimeAuthority},
   plugin::PluginStore,
   utils::{
     assets::Assets,

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -6,8 +6,7 @@
 
 use crate::{
   app::UriSchemeResponder,
-  command::{ScopeObject, ScopeValue},
-  ipc::{Invoke, InvokeHandler},
+  ipc::{Invoke, InvokeHandler, ScopeObject, ScopeValue},
   manager::webview::UriSchemeProtocol,
   utils::config::PluginConfig,
   webview::PageLoadPayload,

--- a/core/tauri/src/state.rs
+++ b/core/tauri/src/state.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-  command::{CommandArg, CommandItem},
-  ipc::InvokeError,
+  ipc::{CommandArg, CommandItem, InvokeError},
   Runtime,
 };
 use state::TypeMap;

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -27,11 +27,10 @@ pub use url::Url;
 
 use crate::{
   app::UriSchemeResponder,
-  command::{CommandArg, CommandItem, Origin},
   event::{EmitArgs, EventSource},
   ipc::{
-    CallbackFn, Invoke, InvokeBody, InvokeError, InvokeMessage, InvokeResolver,
-    OwnedInvokeResponder,
+    CallbackFn, CommandArg, CommandItem, Invoke, InvokeBody, InvokeError, InvokeMessage,
+    InvokeResolver, Origin, OwnedInvokeResponder,
   },
   manager::{webview::WebviewLabelDef, AppManager},
   sealed::{ManagerBase, RuntimeOrDispatch},

--- a/core/tauri/src/webview/webview_window.rs
+++ b/core/tauri/src/webview/webview_window.rs
@@ -27,8 +27,7 @@ use tauri_utils::config::{WebviewUrl, WindowConfig};
 use url::Url;
 
 use crate::{
-  command::{CommandArg, CommandItem},
-  ipc::{InvokeError, OwnedInvokeResponder},
+  ipc::{CommandArg, CommandItem, InvokeError, OwnedInvokeResponder},
   manager::{webview::WebviewLabelDef, AppManager},
   sealed::{ManagerBase, RuntimeOrDispatch},
   webview::PageLoadPayload,

--- a/core/tauri/src/window/mod.rs
+++ b/core/tauri/src/window/mod.rs
@@ -14,9 +14,8 @@ pub use tauri_utils::{config::Color, WindowEffect as Effect, WindowEffectState a
 
 use crate::{
   app::AppHandle,
-  command::{CommandArg, CommandItem},
   event::{Event, EventId, EventSource},
-  ipc::InvokeError,
+  ipc::{CommandArg, CommandItem, InvokeError},
   manager::{webview::WebviewLabelDef, AppManager},
   runtime::{
     monitor::Monitor as RuntimeMonitor,

--- a/examples/api/src-tauri/tauri-plugin-sample/src/lib.rs
+++ b/examples/api/src-tauri/tauri-plugin-sample/src/lib.rs
@@ -53,8 +53,8 @@ struct SampleScope {
 fn ping<R: tauri::Runtime>(
   app: tauri::AppHandle<R>,
   value: Option<String>,
-  scope: tauri::command::CommandScope<PingScope>,
-  global_scope: tauri::command::GlobalScope<SampleScope>,
+  scope: tauri::ipc::CommandScope<PingScope>,
+  global_scope: tauri::ipc::GlobalScope<SampleScope>,
 ) -> std::result::Result<PingResponse, String> {
   println!("local scope {:?}", scope);
   println!("global scope {:?}", global_scope);


### PR DESCRIPTION
The `command` module name clashes with the `command` macro so it's unintuitive for the user when he has to import both. Let's move the public APIs to the ipc module instead.