### PR TITLE
refactor(core): merge scope and commands resolving permission sets

### DIFF
--- a/core/tests/acl/fixtures/capabilities/scope-extended/cap.json
+++ b/core/tests/acl/fixtures/capabilities/scope-extended/cap.json
@@ -35,6 +35,7 @@
           "path": "$APP/*.db"
         }
       ]
-    }
+    },
+    "fs:read-download-dir"
   ]
 }

--- a/core/tests/acl/fixtures/capabilities/scope/cap.toml
+++ b/core/tests/acl/fixtures/capabilities/scope/cap.toml
@@ -7,4 +7,5 @@ permissions = [
   "fs:deny-home",
   "fs:allow-read-resources",
   "fs:allow-move-temp",
+  "fs:read-download-dir"
 ]

--- a/core/tests/acl/fixtures/plugins/fs/read-download-dir.toml
+++ b/core/tests/acl/fixtures/plugins/fs/read-download-dir.toml
@@ -1,0 +1,4 @@
+[[set]]
+identifier = "read-download-dir"
+description = "allows all read the $DOWNLOAD dir"
+permissions = ["allow-read-dir", "allow-download-dir"]

--- a/core/tests/acl/fixtures/plugins/fs/scope.toml
+++ b/core/tests/acl/fixtures/plugins/fs/scope.toml
@@ -1,6 +1,14 @@
-
 [[permission]]
 identifier = "allow-app"
 description = "Allows accessing the $APP path."
 [[permission.scope.allow]]
 path = "$APP"
+
+
+[[permission]]
+identifier = "allow-download-dir"
+description = "Allows accessing the $DOWNLOAD directory."
+[[permission.scope.allow]]
+path = "$DOWNLOAD"
+[[permission.scope.allow]]
+path = "$DOWNLOAD/**"

--- a/core/tests/acl/fixtures/snapshots/acl_tests__tests__scope-extended.snap
+++ b/core/tests/acl/fixtures/snapshots/acl_tests__tests__scope-extended.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/acl/src/lib.rs
-assertion_line: 59
 expression: resolved
 ---
 Resolved {
@@ -30,7 +29,7 @@ Resolved {
                 },
             ],
             scope: Some(
-                792017965103506125,
+                9188997750422900590,
             ),
         },
         CommandKey {
@@ -58,7 +57,7 @@ Resolved {
                 },
             ],
             scope: Some(
-                5856262838373339618,
+                1349364295896631601,
             ),
         },
         CommandKey {
@@ -86,13 +85,95 @@ Resolved {
                 },
             ],
             scope: Some(
-                10252531491715478446,
+                8031926490300119127,
             ),
         },
     },
     denied_commands: {},
     command_scope: {
-        792017965103506125: ResolvedScope {
+        1349364295896631601: ResolvedScope {
+            allow: [
+                Map(
+                    {
+                        "path": String(
+                            "$HOME/.config/**",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE/**",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$DOWNLOAD",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$DOWNLOAD/**",
+                        ),
+                    },
+                ),
+            ],
+            deny: [
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE/**/*.key",
+                        ),
+                    },
+                ),
+            ],
+        },
+        8031926490300119127: ResolvedScope {
+            allow: [
+                Map(
+                    {
+                        "path": String(
+                            "$HOME/.config/**",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE/**",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE",
+                        ),
+                    },
+                ),
+            ],
+            deny: [
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE/**/*.key",
+                        ),
+                    },
+                ),
+            ],
+        },
+        9188997750422900590: ResolvedScope {
             allow: [
                 Map(
                     {
@@ -104,74 +185,6 @@ Resolved {
             ],
             deny: [],
         },
-        5856262838373339618: ResolvedScope {
-            allow: [
-                Map(
-                    {
-                        "path": String(
-                            "$HOME/.config/**",
-                        ),
-                    },
-                ),
-                Map(
-                    {
-                        "path": String(
-                            "$RESOURCE/**",
-                        ),
-                    },
-                ),
-                Map(
-                    {
-                        "path": String(
-                            "$RESOURCE",
-                        ),
-                    },
-                ),
-            ],
-            deny: [
-                Map(
-                    {
-                        "path": String(
-                            "$RESOURCE/**/*.key",
-                        ),
-                    },
-                ),
-            ],
-        },
-        10252531491715478446: ResolvedScope {
-            allow: [
-                Map(
-                    {
-                        "path": String(
-                            "$HOME/.config/**",
-                        ),
-                    },
-                ),
-                Map(
-                    {
-                        "path": String(
-                            "$RESOURCE/**",
-                        ),
-                    },
-                ),
-                Map(
-                    {
-                        "path": String(
-                            "$RESOURCE",
-                        ),
-                    },
-                ),
-            ],
-            deny: [
-                Map(
-                    {
-                        "path": String(
-                            "$RESOURCE/**/*.key",
-                        ),
-                    },
-                ),
-            ],
-        },
     },
     global_scope: {
         "fs": ResolvedScope {
@@ -179,14 +192,14 @@ Resolved {
                 Map(
                     {
                         "path": String(
-                            "$APP",
+                            "$APP/**",
                         ),
                     },
                 ),
                 Map(
                     {
                         "path": String(
-                            "$APP/**",
+                            "$APP",
                         ),
                     },
                 ),

--- a/core/tests/acl/fixtures/snapshots/acl_tests__tests__scope.snap
+++ b/core/tests/acl/fixtures/snapshots/acl_tests__tests__scope.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/acl/src/lib.rs
-assertion_line: 59
 expression: resolved
 ---
 Resolved {
@@ -58,7 +57,7 @@ Resolved {
                 },
             ],
             scope: Some(
-                7912899488978770657,
+                5856262838373339618,
             ),
         },
         CommandKey {
@@ -92,6 +91,39 @@ Resolved {
     },
     denied_commands: {},
     command_scope: {
+        5856262838373339618: ResolvedScope {
+            allow: [
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE/**",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$RESOURCE",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$DOWNLOAD",
+                        ),
+                    },
+                ),
+                Map(
+                    {
+                        "path": String(
+                            "$DOWNLOAD/**",
+                        ),
+                    },
+                ),
+            ],
+            deny: [],
+        },
         7912899488978770657: ResolvedScope {
             allow: [
                 Map(


### PR DESCRIPTION
Given the following permissions:

```toml
# $APP global scope
[[permission]]
identifier = "scope-app"
description = "This scope permits access to all files and list content of top level directories in the `$APP`folder."

[[permission.scope.allow]]
path = "$APP/*"

# read_dir command
[[permission]]
identifier = "allow-read-dir"
description = "Enables the read_dir command without any pre-configured scope."
commands.allow = ["read_dir"]

# read $APP dir set
[[set]]
identifier = "allow-app-read"
description = "This allows non-recursive read access to the `$APP` folder."
permissions = [
    "allow-read-dir",
    "scope-app"
]
```

The current ACL resolution implementation resolves the `allow-app-read` set permissions individually:
- adds the $APP/* entry to the global scope
- allows the read_dir command without any command-specific scope

---------

I believe the logical approach would be that this set enables the read_dir command **with $APP/* as command-specific scope**, leaving the global scope untouched. Current approach leaks the scope.