### PR TITLE
fix(examples): multiwindow example README.md

### DIFF
--- a/examples/multiwindow/README.md
+++ b/examples/multiwindow/README.md
@@ -2,4 +2,4 @@
 
 An example Tauri Multi-Window Application.
 
-To execute run the following on the root directory of the repository: `cargo run --example multiwindow --features window-create`.
+To execute run the following on the root directory of the repository: `cargo run --example multiwindow`.


### PR DESCRIPTION
It seems the `window-create` feature is removed as shown in 

https://github.com/tauri-apps/tauri/blob/95da1a27476e01e06f6ce0335df8535b662dd9c4/core/tauri/Cargo.toml#L181-L184

but the `README.md` didn't reflect that.