### PR TITLE
fix(windows): fix data url html encoding issue 

### DIFF
--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -3365,10 +3365,20 @@ fn create_webview<T: UserEvent>(
     }
   };
 
-  let mut webview_builder = builder
+  // use with_html method if html content can be extracted from url.
+  // else defaults to with_url method
+  let mut webview_builder = if let Some(html_string) = tauri_utils::html::extract_html_content(&url) {
+    builder
+      .with_html(html_string)
+      .map_err(|e| Error::CreateWebview(Box::new(e)))?
+  } else {
+    builder
+      .with_url(&url)
+      .map_err(|e| Error::CreateWebview(Box::new(e)))?
+  };
+
+  webview_builder = webview_builder
     .with_focused(window.is_focused())
-    .with_url(&url)
-    .unwrap() // safe to unwrap because we validate the URL beforehand
     .with_transparent(webview_attributes.transparent)
     .with_accept_first_mouse(webview_attributes.accept_first_mouse);
 

--- a/core/tauri-utils/Cargo.toml
+++ b/core/tauri-utils/Cargo.toml
@@ -40,6 +40,7 @@ infer = "0.15"
 dunce = "1"
 log = "0.4.20"
 cargo_metadata = { version = "0.18", optional = true }
+data-url = { version = "0.3", optional = true }
 
 [target."cfg(target_os = \"linux\")".dependencies]
 heck = "0.4"
@@ -62,3 +63,4 @@ process-relaunch-dangerous-allow-symlink-macos = [ ]
 config-json5 = [ "json5" ]
 config-toml = [ ]
 resources = [ "walkdir" ]
+webview-data-url = [ "data-url" ]

--- a/core/tauri-utils/src/html.rs
+++ b/core/tauri-utils/src/html.rs
@@ -286,6 +286,20 @@ pub fn inline_isolation(document: &NodeRef, dir: &Path) {
   }
 }
 
+/// Temporary naive method to check if a string is a html
+pub fn is_html(data_string: &str) -> bool {
+  data_string.contains('<') && data_string.contains('>')
+}
+
+/// Temporary naive method to extract data from html data string
+pub fn extract_html_content(input: &str) -> Option<&str> {
+  if input.starts_with("data:text/html,") {
+      Some(&input[15..])
+  } else {
+      None
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use kuchiki::traits::*;

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -152,7 +152,7 @@ macos-private-api = [
   "tauri-runtime/macos-private-api",
   "tauri-runtime-wry/macos-private-api"
 ]
-webview-data-url = [ "data-url" ]
+webview-data-url = [ "tauri-utils/webview-data-url", "data-url" ]
 protocol-asset = [ "http-range" ]
 config-json5 = [ "tauri-macros/config-json5" ]
 config-toml = [ "tauri-macros/config-toml" ]

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -423,9 +423,10 @@ impl<R: Runtime> WebviewManager<R> {
         }
         url
       }
-
       WebviewUrl::CustomProtocol(url) => url.clone(),
-      _ => unimplemented!(),
+      #[cfg(feature = "webview-data-url")]
+      WebviewUrl::DataUrl(url) => url.clone(),
+      _ => unimplemented!()
     };
 
     #[cfg(not(feature = "webview-data-url"))]
@@ -435,23 +436,46 @@ impl<R: Runtime> WebviewManager<R> {
       ));
     }
 
-    #[cfg(feature = "webview-data-url")]
-    if let Some(csp) = app_manager.csp() {
-      if url.scheme() == "data" {
-        if let Ok(data_url) = data_url::DataUrl::process(url.as_str()) {
-          let (body, _) = data_url.decode_to_vec().unwrap();
-          let html = String::from_utf8_lossy(&body).into_owned();
-          // naive way to check if it's an html
-          if html.contains('<') && html.contains('>') {
-            let document = tauri_utils::html::parse(html);
-            tauri_utils::html::inject_csp(&document, &csp.to_string());
-            url.set_path(&format!("{},{}", mime::TEXT_HTML, document.to_string()));
-          }
+    match (
+      url.scheme(),
+      tauri_utils::html::extract_html_content(url.as_str()),
+    ) {
+      #[cfg(feature = "webview-data-url")]
+      ("data", Some(html_string)) => {
+        // There is an issue with the external DataUrl where HTML containing special characters
+        // are not correctly processed. A workaround is to first percent encode the html string,
+        // before it processed by DataUrl.
+        let encoded_string = percent_encoding::utf8_percent_encode(html_string, percent_encoding::NON_ALPHANUMERIC).to_string();
+        let url = data_url::DataUrl::process(&format!("data:text/html,{}", encoded_string))
+          .map_err(|_| crate::Error::InvalidWebviewUrl("Failed to process data url"))
+          .and_then(|data_url| {
+            data_url
+              .decode_to_vec()
+              .map_err(|_| crate::Error::InvalidWebviewUrl("Failed to decode processed data url"))
+          })
+          .and_then(|(body, _)| {
+            let html = String::from_utf8_lossy(&body).into_owned();
+            let mut document = tauri_utils::html::parse(html);
+            if let Some(csp) = app_manager.csp() {
+              tauri_utils::html::inject_csp(&mut document, &csp.to_string());
+            }
+            // decode back to raw html, as the content should be fully decoded
+            // when passing to wry / tauri-runtime-wry, which will be responsible
+            // for handling the encoding based on the OS.
+            let encoded_html = document.to_string();
+            Ok(
+              percent_encoding::percent_decode_str(encoded_html.as_str())
+                .decode_utf8_lossy()
+                .to_string(),
+            )
+          })
+          .unwrap_or(html_string.to_string());
+          pending.url = format!("data:text/html,{}", url);
         }
-      }
-    }
-
-    pending.url = url.to_string();
+        _ => {
+          pending.url = url.to_string();
+        }
+      };
 
     #[cfg(target_os = "android")]
     {


### PR DESCRIPTION
closes #8760 

Goal here 
- Introduce DataUrl as a new WebViewUrl variant. This is because while data url strings work with existing variants, it does not really belong to any of it. 
- Change `url` field of PendingWebview from String to Url, as the method to build a webview differ depending on the kind of URL.
- Pass the html string in a raw format to WRY, and let WRY handle the encoding instead.

WIP 
- Right now it requires users to pass in encoded strings to properly work. Perform that operation in tauri directly
- Able to clean up the html helper functions, and perhaps separate html from url, similar to what WRY is doing

Tested on windows:
![image](https://github.com/tauri-apps/tauri/assets/68838289/0826f8a9-e1d0-40a5-8044-85b6bee6c717)

