### PR TITLE
fix(multiwebview): remove webview from store on close

### DIFF
--- a/.changes/fix-webview-close.md
+++ b/.changes/fix-webview-close.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+When using the multiwebview mode, properly remove the webview from memory on `Webview::close`.

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -543,6 +543,10 @@ impl<R: Runtime> AppManager<R> {
     }
   }
 
+  pub(crate) fn on_webview_close(&self, label: &str) {
+    self.webview.webviews_lock().remove(label);
+  }
+
   pub fn windows(&self) -> HashMap<String, Window<R>> {
     self.window.windows_lock().clone()
   }

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -878,7 +878,9 @@ impl<R: Runtime> Webview<R> {
     if self.window.webview_window {
       self.window.close()
     } else {
-      self.webview.dispatcher.close().map_err(Into::into)
+      self.webview.dispatcher.close()?;
+      self.manager().on_webview_close(self.label());
+      Ok(())
     }
   }
 


### PR DESCRIPTION
Kinda hacky? should we think about implementing event loop events for webviews instead?