### PR TITLE
fix: correct invoke command for toggling devtools by hotkey, closes #8771

### DIFF
--- a/.changes/fix-invoke-devtools-by-hotkey.md
+++ b/.changes/fix-invoke-devtools-by-hotkey.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix invoking toggle devtools by hotkey.

--- a/core/tauri/src/webview/scripts/toggle-devtools.js
+++ b/core/tauri/src/webview/scripts/toggle-devtools.js
@@ -14,7 +14,7 @@
     document.addEventListener('keydown', (event) => {
       if (isHotkey(event)) {
         window.__TAURI_INTERNALS__.invoke(
-          'plugin:window|internal_toggle_devtools'
+          'plugin:webview|internal_toggle_devtools'
         )
       }
     })


### PR DESCRIPTION
Issue: [tauri#8771](https://github.com/tauri-apps/tauri/issues/8771)

The scope used by webview toggle_devtools script was set to `window`, it should be `webview` now.
