### PR TITLE
fix: creation of schemas

### DIFF
--- a/core/tauri-config-schema/build.rs
+++ b/core/tauri-config-schema/build.rs
@@ -18,7 +18,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     crate_dir.join("../../tooling/cli/schema.json"),
   ] {
     let mut schema_file = BufWriter::new(File::create(file)?);
-    write!(schema_file, "{schema_str}")?;
+    write!(schema_file, "{}", schema_str)?;
   }
 
   Ok(())


### PR DESCRIPTION
currently, tauri generates schemas like this:
```json
{schema_str}
```

rust seems to treat the value like a string literal, not a format statement.

this commit should fix this error.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
