### PR TITLE
fix(cli): fix code output of `tauri plugin android init`

### DIFF
--- a/.changes/cli-plugin-android-init.md
+++ b/.changes/cli-plugin-android-init.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix `tauri plugin android init` printing invalid code that has a missing closing `"`.

--- a/tooling/cli/src/plugin/android.rs
+++ b/tooling/cli/src/plugin/android.rs
@@ -114,7 +114,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {{
   Builder::new("{name}")
     .setup(|app, api| {{
       #[cfg(target_os = "android")]
-      let handle = api.register_android_plugin("{identifier}, "ExamplePlugin")?;
+      let handle = api.register_android_plugin("{identifier}", "ExamplePlugin")?;
       Ok(())
     }})
     .build()


### PR DESCRIPTION
double quotes `"` wasn't matching in plugin android init command

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
