### PR TITLE
fix(core): use event.code to check which key pressed

### DIFF
--- a/.changes/fix-devtool-hotkey-code.md
+++ b/.changes/fix-devtool-hotkey-code.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix toggling devtools by hotkey not works on MacOS.

--- a/.changes/fix-devtool-hotkey-code.md
+++ b/.changes/fix-devtool-hotkey-code.md
@@ -1,5 +1,0 @@
----
-"tauri": patch:bug
----
-
-Fix toggling devtools by hotkey not works on MacOS.

--- a/core/tauri/src/webview/scripts/toggle-devtools.js
+++ b/core/tauri/src/webview/scripts/toggle-devtools.js
@@ -8,8 +8,8 @@
 
     const isHotkey =
       osName === 'macos'
-        ? (event) => event.metaKey && event.altKey && event.key === 'I'
-        : (event) => event.ctrlKey && event.shiftKey && event.key === 'I'
+        ? (event) => event.metaKey && event.altKey && event.code === 'KeyI'
+        : (event) => event.ctrlKey && event.shiftKey && event.code === 'KeyI'
 
     document.addEventListener('keydown', (event) => {
       if (isHotkey(event)) {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Hitting `CMD + ALT + I`, `event.key` may be `^, Dead, i, I` depends on which modified key was hit at last.
However, `event.code` will always give you `KeyI` and I think this is more suitable for the use case.