### PR TITLE
fix: target specific window for window events

### DIFF
--- a/.changes/tauri-close-requested-target-specific.md
+++ b/.changes/tauri-close-requested-target-specific.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Fix JS `onCloseRequested` catching close event from other windows.

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -713,21 +713,23 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
     #[cfg(feature = "tracing")]
     tracing::Span::current().record("target", format!("{target:?}"));
 
-    self.manager().emit_filter(event, payload, |s| match s {
-      t @ EventTarget::Window { label }
-      | t @ EventTarget::Webview { label }
-      | t @ EventTarget::WebviewWindow { label } => {
-        if let EventTarget::AnyLabel {
-          label: target_label,
-        } = &target
-        {
-          label == target_label
-        } else {
-          t == &target
-        }
-      }
-      t => t == &target,
-    })
+    match target {
+      // if targeting all, emit to all using emit without filter
+      EventTarget::Any => self.manager().emit(event, payload),
+
+      // if targeting any label, emit using emit_filter and filter labels
+      EventTarget::AnyLabel {
+        label: target_label,
+      } => self.manager().emit_filter(event, payload, |t| match t {
+        EventTarget::Window { label }
+        | EventTarget::Webview { label }
+        | EventTarget::WebviewWindow { label } => label == &target_label,
+        _ => false,
+      }),
+
+      // otherwise match same target
+      _ => self.manager().emit_filter(event, payload, |t| t == &target),
+    }
   }
 
   /// Emits an event to all [targets](EventTarget) based on the given filter.

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -130,6 +130,25 @@ impl<R: Runtime> WindowManager<R> {
   }
 }
 
+impl<R: Runtime> Window<R> {
+  fn emit_self<S: Serialize + Clone>(&self, event: &str, payload: S) -> crate::Result<()> {
+    let window_label = self.label();
+    self.emit_filter(event, payload, |target| match target {
+      EventTarget::Window { label } | EventTarget::WebviewWindow { label } => label == window_label,
+      _ => false,
+    })
+  }
+
+  fn has_js_listener(&self, event: &str) -> bool {
+    let window_label = self.label();
+    let listeners = self.manager().listeners();
+    listeners.has_js_listener(event, |target| match target {
+      EventTarget::Window { label } | EventTarget::WebviewWindow { label } => label == window_label,
+      _ => false,
+    })
+  }
+}
+
 #[derive(Serialize, Clone)]
 struct FileDropPayload<'a> {
   paths: &'a Vec<PathBuf>,
@@ -142,24 +161,16 @@ fn on_window_event<R: Runtime>(
   event: &WindowEvent,
 ) -> crate::Result<()> {
   match event {
-    WindowEvent::Resized(size) => window.emit(WINDOW_RESIZED_EVENT, size)?,
-    WindowEvent::Moved(position) => window.emit(WINDOW_MOVED_EVENT, position)?,
+    WindowEvent::Resized(size) => window.emit_self(WINDOW_RESIZED_EVENT, size)?,
+    WindowEvent::Moved(position) => window.emit_self(WINDOW_MOVED_EVENT, position)?,
     WindowEvent::CloseRequested { api } => {
-      let match_label = |target: &EventTarget| match target {
-        EventTarget::Window { label } | EventTarget::WebviewWindow { label } => {
-          label == window.label()
-        }
-        _ => false,
-      };
-      let listeners = window.manager().listeners();
-      let has_js_listener = listeners.has_js_listener(WINDOW_CLOSE_REQUESTED_EVENT, match_label);
-      if has_js_listener {
+      if window.has_js_listener(WINDOW_CLOSE_REQUESTED_EVENT) {
         api.prevent_close();
       }
-      manager.emit_filter(WINDOW_CLOSE_REQUESTED_EVENT, (), match_label)?;
+      window.emit_self(WINDOW_CLOSE_REQUESTED_EVENT, ())?;
     }
     WindowEvent::Destroyed => {
-      window.emit(WINDOW_DESTROYED_EVENT, ())?;
+      window.emit_self(WINDOW_DESTROYED_EVENT, ())?;
       let label = window.label();
       let webviews_map = manager.webview.webviews_lock();
       let webviews = webviews_map.values();
@@ -169,7 +180,7 @@ fn on_window_event<R: Runtime>(
         ))?;
       }
     }
-    WindowEvent::Focused(focused) => window.emit(
+    WindowEvent::Focused(focused) => window.emit_self(
       if *focused {
         WINDOW_FOCUS_EVENT
       } else {
@@ -181,7 +192,7 @@ fn on_window_event<R: Runtime>(
       scale_factor,
       new_inner_size,
       ..
-    } => window.emit(
+    } => window.emit_self(
       WINDOW_SCALE_FACTOR_CHANGED_EVENT,
       ScaleFactorChanged {
         scale_factor: *scale_factor,
@@ -191,7 +202,7 @@ fn on_window_event<R: Runtime>(
     WindowEvent::FileDrop(event) => match event {
       FileDropEvent::Hovered { paths, position } => {
         let payload = FileDropPayload { paths, position };
-        window.emit(WINDOW_FILE_DROP_HOVER_EVENT, payload)?
+        window.emit_self(WINDOW_FILE_DROP_HOVER_EVENT, payload)?
       }
       FileDropEvent::Dropped { paths, position } => {
         let scopes = window.state::<Scopes>();
@@ -203,12 +214,14 @@ fn on_window_event<R: Runtime>(
           }
         }
         let payload = FileDropPayload { paths, position };
-        window.emit(WINDOW_FILE_DROP_EVENT, payload)?
+        window.emit_self(WINDOW_FILE_DROP_EVENT, payload)?
       }
-      FileDropEvent::Cancelled => window.emit(WINDOW_FILE_DROP_CANCELLED_EVENT, ())?,
+      FileDropEvent::Cancelled => window.emit_self(WINDOW_FILE_DROP_CANCELLED_EVENT, ())?,
       _ => unimplemented!(),
     },
-    WindowEvent::ThemeChanged(theme) => window.emit(WINDOW_THEME_CHANGED, theme.to_string())?,
+    WindowEvent::ThemeChanged(theme) => {
+      window.emit_self(WINDOW_THEME_CHANGED, theme.to_string())?
+    }
   }
   Ok(())
 }

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -155,8 +155,8 @@ fn on_window_event<R: Runtime>(
       let has_js_listener = listeners.has_js_listener(WINDOW_CLOSE_REQUESTED_EVENT, match_label);
       if has_js_listener {
         api.prevent_close();
-        manager.emit_filter(WINDOW_CLOSE_REQUESTED_EVENT, (), match_label)?;
       }
+      manager.emit_filter(WINDOW_CLOSE_REQUESTED_EVENT, (), match_label)?;
     }
     WindowEvent::Destroyed => {
       window.emit(WINDOW_DESTROYED_EVENT, ())?;

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -156,7 +156,7 @@ fn on_window_event<R: Runtime>(
       if has_js_listener {
         api.prevent_close();
       }
-      window.emit(WINDOW_CLOSE_REQUESTED_EVENT, ())?;
+      window.emit_to(window.label(), WINDOW_CLOSE_REQUESTED_EVENT, ())?;
     }
     WindowEvent::Destroyed => {
       window.emit(WINDOW_DESTROYED_EVENT, ())?;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

When using the [onCloseRequested JS Api](https://github.com/tauri-apps/tauri/blob/cf3e40cc473dd0bb77f759fd59c1594af263429b/tooling/api/src/window.ts#L1689C29-L1689C39), the event was triggered even when closing other windows, not just the one of interest.

I believe it would be more logical for this event to be dispatched exclusively for the current window's close requests.

Before:

https://github.com/tauri-apps/tauri/assets/65032978/81220baa-6c0e-4677-bb65-e6cc797e0a8a

After:

https://github.com/tauri-apps/tauri/assets/65032978/d557beec-2c18-46cc-9643-fc9202c4f2de


