### PR TITLE
fix(cli): use UTF-8 encoding for vswhere.exe output

### DIFF
--- a/.changes/cli-windows-build-tools-detect-utf8.md
+++ b/.changes/cli-windows-build-tools-detect-utf8.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+On Windows, fixed `tauri info` fails to detect the build tool when the system language is CJK.

--- a/tooling/cli/src/info/env_system.rs
+++ b/tooling/cli/src/info/env_system.rs
@@ -43,6 +43,7 @@ fn build_tools_version() -> crate::Result<Vec<String>> {
       "Microsoft.VisualStudio.Component.Windows10SDK.*",
       "-format",
       "json",
+      "-utf8",
     ])
     .output()?;
 
@@ -57,6 +58,7 @@ fn build_tools_version() -> crate::Result<Vec<String>> {
       "Microsoft.VisualStudio.Component.Windows11SDK.*",
       "-format",
       "json",
+      "-utf8",
     ])
     .output()?;
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
- The `description` property in the `vswhere.exe` output may contain non-UTF-8 encoding characters if the system language is set to CJK.
- `serde_json` fails to parse the output due to the inability to escape those non-UTF-8 characters.
- `vswhere.exe` provides an option to output with UTF-8 encoding and is recommended when outputting JSON.