### PR TITLE
docs: Update doc comment from `normalize` function in `path` plugin to match definition

### DIFF
--- a/tooling/api/src/path.ts
+++ b/tooling/api/src/path.ts
@@ -581,7 +581,7 @@ async function resolve(...paths: string[]): Promise<string> {
  * ```typescript
  * import { normalize, appDataDir } from '@tauri-apps/api/path';
  * const appDataDirPath = await appDataDir();
- * const path = await normalize(appDataDirPath, '..', 'users', 'tauri', 'avatar.png');
+ * const path = await normalize(`${appDataDirPath}/../users/tauri/avatar.png`);
  * ```
  *
  * @since 1.0.0


### PR DESCRIPTION
The doc comment from the normalize function in the path plugin was not matching the actual definition.

Rust definition: https://github.com/tauri-apps/tauri/blob/0cb0a15ce22af3d649cf219ac04188c14c5f4905/core/tauri/src/path/plugin.rs#L18

Typescript definition: https://github.com/tauri-apps/tauri/blob/0cb0a15ce22af3d649cf219ac04188c14c5f4905/tooling/api/src/path.ts#L589

Yet, the doc comment was passing the different segments from the path as arguments:

```ts
const path = await normalize(appDataDirPath, '..', 'users', 'tauri', 'avatar.png');
```

I suggest this, although I wonder if there is a better way (perhaps with the `join` function? I don't know, perhaps the extra call isn't worth, feel free to suggest other ways!):

```ts
const path = await normalize(`${appDataDirPath}/../users/tauri/avatar.png`);
```
