### PR TITLE
add option to force v1 postMessage ipc protocol

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -128,6 +128,7 @@ http-range = "0.1.5"
 [features]
 default = [ "wry", "compression", "objc-exception", "common-controls-v6" ]
 unstable = [ ]
+force-ipc-v1-protocol = [ ]
 common-controls-v6 = [ "tray-icon?/common-controls-v6", "muda/common-controls-v6" ]
 tray-icon = [ "dep:tray-icon" ]
 tracing = [

--- a/core/tauri/build.rs
+++ b/core/tauri/build.rs
@@ -216,7 +216,9 @@ fn main() {
 
   alias(
     "ipc_custom_protocol",
-    target_os != "android" && (target_os != "linux" || has_feature("linux-ipc-protocol")),
+    target_os != "android" && 
+    (target_os != "linux" || has_feature("linux-ipc-protocol")) && 
+    !has_feature("force-ipc-v1-protocol"),
   );
 
   let out_dir = PathBuf::from(var("OUT_DIR").unwrap());

--- a/core/tauri/scripts/ipc-protocol.js
+++ b/core/tauri/scripts/ipc-protocol.js
@@ -7,6 +7,7 @@
   const osName = __TEMPLATE_os_name__
   const fetchChannelDataCommand = __TEMPLATE_fetch_channel_data_command__
   const useCustomProtocol = __TEMPLATE_use_custom_protocol__
+  const forceUseV1Protocol = __TEMPLATE_force_v1_protocol__
 
   Object.defineProperty(window.__TAURI_INTERNALS__, 'postMessage', {
     value: (message) => {
@@ -25,7 +26,8 @@
         !(
           (osName === 'macos' || osName === 'ios') &&
           location.protocol === 'https:'
-        )
+        ) &&
+        !forceUseV1Protocol
       ) {
         const { contentType, data } = processIpcMessage(payload)
         fetch(window.__TAURI_INTERNALS__.convertFileSrc(cmd, 'ipc'), {

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1085,6 +1085,7 @@ struct InvokeInitializationScript<'a> {
   os_name: &'a str,
   fetch_channel_data_command: &'a str,
   use_custom_protocol: bool,
+  force_v1_protocol: bool
 }
 
 /// Make `Wry` the default `Runtime` for `Builder`
@@ -1118,6 +1119,7 @@ impl<R: Runtime> Builder<R> {
         os_name: std::env::consts::OS,
         fetch_channel_data_command: crate::ipc::channel::FETCH_CHANNEL_DATA_COMMAND,
         use_custom_protocol: cfg!(ipc_custom_protocol),
+        force_v1_protocol: cfg!(feature = "force-ipc-v1-protocol")
       }
       .render_default(&Default::default())
       .unwrap()

--- a/core/tauri/src/ipc/protocol.rs
+++ b/core/tauri/src/ipc/protocol.rs
@@ -283,6 +283,7 @@ fn handle_ipc_message<R: Runtime>(message: String, manager: &AppManager<R>, labe
             // the channel data command is the only command that uses a custom protocol on Linux
             if webview.manager().webview.invoke_responder.is_none()
               && cmd != crate::ipc::channel::FETCH_CHANNEL_DATA_COMMAND
+              || cfg!(feature = "force-ipc-v1-protocol")
             {
               fn responder_eval<R: Runtime>(
                 webview: &crate::Webview<R>,
@@ -314,6 +315,7 @@ fn handle_ipc_message<R: Runtime>(message: String, manager: &AppManager<R>, labe
               match &response {
                 InvokeResponse::Ok(InvokeBody::Json(v)) => {
                   if !(cfg!(target_os = "macos") || cfg!(target_os = "ios"))
+                    && cmd != crate::ipc::channel::FETCH_CHANNEL_DATA_COMMAND
                     && matches!(v, JsonValue::Object(_) | JsonValue::Array(_))
                   {
                     let _ = Channel::from_callback_fn(webview, callback).send(v);


### PR DESCRIPTION
It's important to have the ability to control whether to use the old IPC protocol or the newer one. For instance, because the new method uses fetch, we have issues like https://github.com/tauri-apps/tauri/issues/8476.

So, I added the ability to force using the v1 `postMessage` `IPC` protocol by activating the `force-ipc-v1-protocol` feature in the Tauri dependency.

I tested it on `MacOS` / `Windows` both when activated and not, and it works.
Also it solved for me the `CSP` issues in windows.

https://discord.com/channels/616186924390023171/1201542436040757248

## Update
Looks like it doesn't work on `Windows` when returning JSON value from rust, checking it. (it works with strings)

## Update1 
Solved in second commit. need review