### PR TITLE
fix(build): move capability schema definitions to root

### DIFF
--- a/.changes/fix-capability-schema-definitions.md
+++ b/.changes/fix-capability-schema-definitions.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch:bug
+---
+
+Fixes the capability schema not resolving inner definitions.


### PR DESCRIPTION
This ensures each plugin scope schema definitions are added to the root JSON schema so they can be discovered.