### PR TITLE
fix(event): let once event return `EventId`, close #8912

### DIFF
--- a/.changes/core-once-event-return-event-id.md
+++ b/.changes/core-once-event-return-event-id.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:enhance'
+---
+
+Let once event listener return the event id.

--- a/.changes/core-once-event-return-event-id.md
+++ b/.changes/core-once-event-return-event-id.md
@@ -2,4 +2,4 @@
 'tauri': 'patch:enhance'
 ---
 
-Let once event listener return the event id.
+Return an id when using from `Manager::once_any`, `App::once`, `Window::once`, `Webview::once`, `WebviewWindow::once` and `fs::Scope::once`.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -845,7 +845,7 @@ macro_rules! shared_app_impl {
       /// Listen to an event on this app only once.
       ///
       /// See [`Self::listen`] for more information.
-      pub fn once<F>(&self, event: impl Into<String>, handler: F)
+      pub fn once<F>(&self, event: impl Into<String>, handler: F) -> EventId
       where
         F: FnOnce(Event) + Send + 'static,
       {

--- a/core/tauri/src/event/listener.rs
+++ b/core/tauri/src/event/listener.rs
@@ -159,7 +159,7 @@ impl Listeners {
     event: String,
     target: EventTarget,
     handler: F,
-  ) {
+  ) -> EventId {
     let self_ = self.clone();
     let handler = Cell::new(Some(handler));
 
@@ -170,7 +170,7 @@ impl Listeners {
         .expect("attempted to call handler more than once");
       handler(event);
       self_.unlisten(id);
-    });
+    })
   }
 
   /// Removes an event listener.

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -655,7 +655,7 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
   /// Listens once to an emitted event to any [target](EventTarget) .
   ///
   /// See [`Self::listen_any`] for more information.
-  fn once_any<F>(&self, event: impl Into<String>, handler: F)
+  fn once_any<F>(&self, event: impl Into<String>, handler: F) -> EventId
   where
     F: FnOnce(Event) + Send + 'static,
   {

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -469,7 +469,7 @@ impl<R: Runtime> AppManager<R> {
     event: String,
     target: EventTarget,
     handler: F,
-  ) {
+  ) -> EventId {
     assert_event_name_is_valid(&event);
     self.listeners().once(event, target, handler)
   }

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -201,7 +201,7 @@ impl Scope {
   }
 
   /// Listen to an event on this scope and immediately unlisten.
-  pub fn once<F: FnOnce(&Event) + Send + 'static>(&self, f: F) {
+  pub fn once<F: FnOnce(&Event) + Send + 'static>(&self, f: F) -> ScopeEventId {
     let listerners = self.event_listeners.clone();
     let handler = std::cell::Cell::new(Some(f));
     let id = self.next_event_id();
@@ -212,6 +212,7 @@ impl Scope {
         .expect("attempted to call handler more than once");
       handler(event)
     });
+    id
   }
 
   /// Removes an event listener on this scope.

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -1460,7 +1460,7 @@ tauri::Builder::default()
   /// Listen to an event on this webview only once.
   ///
   /// See [`Self::listen`] for more information.
-  pub fn once<F>(&self, event: impl Into<String>, handler: F)
+  pub fn once<F>(&self, event: impl Into<String>, handler: F) -> EventId
   where
     F: FnOnce(Event) + Send + 'static,
   {

--- a/core/tauri/src/webview/webview_window.rs
+++ b/core/tauri/src/webview/webview_window.rs
@@ -1766,7 +1766,7 @@ tauri::Builder::default()
   /// Listen to an event on this window webview only once.
   ///
   /// See [`Self::listen`] for more information.
-  pub fn once<F>(&self, event: impl Into<String>, handler: F)
+  pub fn once<F>(&self, event: impl Into<String>, handler: F) -> EventId
   where
     F: FnOnce(Event) + Send + 'static,
   {

--- a/core/tauri/src/window/mod.rs
+++ b/core/tauri/src/window/mod.rs
@@ -1992,7 +1992,7 @@ tauri::Builder::default()
   /// Listen to an event on this window only once.
   ///
   /// See [`Self::listen`] for more information.
-  pub fn once<F>(&self, event: impl Into<String>, handler: F)
+  pub fn once<F>(&self, event: impl Into<String>, handler: F) -> EventId
   where
     F: FnOnce(Event) + Send + 'static,
   {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Issue: https://github.com/tauri-apps/tauri/issues/8912

It allows users to unlisten `once` event manually.