### PR TITLE
refactor(core): allow configuring both local and remote URLs on capability

### DIFF
--- a/.changes/capability-context-refactor.md
+++ b/.changes/capability-context-refactor.md
@@ -1,0 +1,7 @@
+---
+"tauri-utils": patch:breaking
+"tauri-cli": patch:breaking
+"@tauri-apps/cli": patch:breaking
+---
+
+Changed the capability format to allow configuring both `remote: { urls: Vec<String> }` and `local: bool (default: true)` instead of choosing one on the `context` field.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1085,14 +1085,21 @@
           "default": "",
           "type": "string"
         },
-        "context": {
-          "description": "Execution context of the capability.\n\nAt runtime, Tauri filters the IPC command together with the context to determine whether it is allowed or not and its scope.",
-          "default": "local",
-          "allOf": [
+        "remote": {
+          "description": "Configure remote URLs that can use the capability permissions.",
+          "anyOf": [
             {
-              "$ref": "#/definitions/CapabilityContext"
+              "$ref": "#/definitions/CapabilityRemote"
+            },
+            {
+              "type": "null"
             }
           ]
+        },
+        "local": {
+          "description": "Whether this capability is enabled for local app URLs or not. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
         },
         "windows": {
           "description": "List of windows that uses this capability. Can be a glob pattern.\n\nOn multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.",
@@ -1131,42 +1138,21 @@
         }
       }
     },
-    "CapabilityContext": {
-      "description": "Context of the capability.",
-      "oneOf": [
-        {
-          "description": "Capability refers to local URL usage.",
-          "type": "string",
-          "enum": [
-            "local"
-          ]
-        },
-        {
-          "description": "Capability refers to remote usage.",
-          "type": "object",
-          "required": [
-            "remote"
-          ],
-          "properties": {
-            "remote": {
-              "type": "object",
-              "required": [
-                "urls"
-              ],
-              "properties": {
-                "urls": {
-                  "description": "Remote domains this capability refers to. Can use glob patterns.",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "additionalProperties": false
+    "CapabilityRemote": {
+      "description": "Configuration for remote URLs that are associated with the capability.",
+      "type": "object",
+      "required": [
+        "urls"
+      ],
+      "properties": {
+        "urls": {
+          "description": "Remote domains this capability refers to. Can use glob patterns.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
-      ]
+      }
     },
     "PermissionEntry": {
       "description": "An entry for a permission value in a [`Capability`] can be either a raw permission [`Identifier`] or an object that references a permission and extends its scope.",

--- a/core/tauri-utils/src/acl/resolved.rs
+++ b/core/tauri-utils/src/acl/resolved.rs
@@ -15,7 +15,7 @@ use glob::Pattern;
 use crate::platform::Target;
 
 use super::{
-  capability::{Capability, CapabilityContext, PermissionEntry},
+  capability::{Capability, PermissionEntry},
   plugin::Manifest,
   Commands, Error, ExecutionContext, Permission, PermissionSet, Scopes, Value,
 };
@@ -346,18 +346,18 @@ fn resolve_command(
   scope_id: Option<ScopeKey>,
   #[cfg(debug_assertions)] referenced_by_permission_identifier: String,
 ) {
-  let contexts = match &capability.context {
-    CapabilityContext::Local => {
-      vec![ExecutionContext::Local]
-    }
-    CapabilityContext::Remote { urls } => urls
-      .iter()
-      .map(|url| ExecutionContext::Remote {
+  let mut contexts = Vec::new();
+  if capability.local {
+    contexts.push(ExecutionContext::Local);
+  }
+  if let Some(remote) = &capability.remote {
+    contexts.extend(remote.urls.iter().map(|url| {
+      ExecutionContext::Remote {
         url: Pattern::new(url)
           .unwrap_or_else(|e| panic!("invalid glob pattern for remote URL {url}: {e}")),
-      })
-      .collect(),
-  };
+      }
+    }));
+  }
 
   for context in contexts {
     let resolved = commands

--- a/core/tests/acl/fixtures/capabilities/file-explorer-remote/cap.toml
+++ b/core/tests/acl/fixtures/capabilities/file-explorer-remote/cap.toml
@@ -2,5 +2,6 @@ identifier = "run-app"
 description = "app capability"
 windows = ["main"]
 permissions = ["fs:read", "fs:allow-app"]
-[context.remote]
+local = false
+[remote]
 urls = ["https://tauri.app"]

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1085,14 +1085,21 @@
           "default": "",
           "type": "string"
         },
-        "context": {
-          "description": "Execution context of the capability.\n\nAt runtime, Tauri filters the IPC command together with the context to determine whether it is allowed or not and its scope.",
-          "default": "local",
-          "allOf": [
+        "remote": {
+          "description": "Configure remote URLs that can use the capability permissions.",
+          "anyOf": [
             {
-              "$ref": "#/definitions/CapabilityContext"
+              "$ref": "#/definitions/CapabilityRemote"
+            },
+            {
+              "type": "null"
             }
           ]
+        },
+        "local": {
+          "description": "Whether this capability is enabled for local app URLs or not. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
         },
         "windows": {
           "description": "List of windows that uses this capability. Can be a glob pattern.\n\nOn multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.",
@@ -1131,42 +1138,21 @@
         }
       }
     },
-    "CapabilityContext": {
-      "description": "Context of the capability.",
-      "oneOf": [
-        {
-          "description": "Capability refers to local URL usage.",
-          "type": "string",
-          "enum": [
-            "local"
-          ]
-        },
-        {
-          "description": "Capability refers to remote usage.",
-          "type": "object",
-          "required": [
-            "remote"
-          ],
-          "properties": {
-            "remote": {
-              "type": "object",
-              "required": [
-                "urls"
-              ],
-              "properties": {
-                "urls": {
-                  "description": "Remote domains this capability refers to. Can use glob patterns.",
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "additionalProperties": false
+    "CapabilityRemote": {
+      "description": "Configuration for remote URLs that are associated with the capability.",
+      "type": "object",
+      "required": [
+        "urls"
+      ],
+      "properties": {
+        "urls": {
+          "description": "Remote domains this capability refers to. Can use glob patterns.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
-      ]
+      }
     },
     "PermissionEntry": {
       "description": "An entry for a permission value in a [`Capability`] can be either a raw permission [`Identifier`] or an object that references a permission and extends its scope.",

--- a/tooling/cli/src/migrate/config.rs
+++ b/tooling/cli/src/migrate/config.rs
@@ -7,7 +7,7 @@ use crate::Result;
 use serde_json::{Map, Value};
 use tauri_utils::{
   acl::{
-    capability::{Capability, CapabilityContext, PermissionEntry},
+    capability::{Capability, PermissionEntry},
     Scopes, Value as AclValue,
   },
   platform::Target,
@@ -59,7 +59,8 @@ pub fn migrate(tauri_dir: &Path) -> Result<()> {
       serde_json::to_string_pretty(&Capability {
         identifier: "migrated".to_string(),
         description: "permissions that were migrated from v1".into(),
-        context: CapabilityContext::Local,
+        local: true,
+        remote: None,
         windows: vec!["main".into()],
         webviews: vec![],
         permissions,


### PR DESCRIPTION
The current capability format allows you to configure **either** a capability that applies to local URLs **or** to a list of remote URLs. This forces users to have to define two identical capability files if they choose to enable a set of permissions both locally and to remote URLs.
This PR changes the model from `context: local | { remote: { urls: string[] } }` to `remote: { urls: string[] }, local: bool`