### PR TITLE
fix(core): deadlock on window destroy

### DIFF
--- a/.changes/fix-window-destroy-deadlock.md
+++ b/.changes/fix-window-destroy-deadlock.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes a deadlock when the window is destroyed.

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -528,7 +528,8 @@ impl<R: Runtime> AppManager<R> {
   }
 
   pub(crate) fn on_window_close(&self, label: &str) {
-    if let Some(window) = self.window.windows_lock().remove(label) {
+    let window = self.window.windows_lock().remove(label);
+    if let Some(window) = window {
       for webview in window.webviews() {
         self.webview.webviews_lock().remove(webview.label());
       }

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -979,6 +979,10 @@ impl<R: Runtime> Webview<R> {
       .expect("could not locate webview parent window")
   }
 
+  pub(crate) fn window_label(&self) -> String {
+    self.window_label.lock().unwrap().clone()
+  }
+
   /// Executes a closure, providing it with the webview handle that is specific to the current platform.
   ///
   /// The closure is executed on the main thread.

--- a/core/tauri/src/window/mod.rs
+++ b/core/tauri/src/window/mod.rs
@@ -988,7 +988,7 @@ impl<R: Runtime> Window<R> {
       .webview
       .webviews_lock()
       .values()
-      .filter(|w| &w.window() == self)
+      .filter(|w| w.window_label() == self.label())
       .cloned()
       .collect()
   }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
