### PR TITLE
fix(core): wrong ACL validation on multiwebview contexts

### DIFF
--- a/.changes/fix-acl-webview-check.md
+++ b/.changes/fix-acl-webview-check.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes capability webview label check.

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -1153,8 +1153,8 @@ fn main() {
       .unwrap()
       .resolve_access(
         &request.cmd,
-        message.webview.label(),
         message.webview.window().label(),
+        message.webview.label(),
         &acl_origin,
       )
       .cloned();


### PR DESCRIPTION
The function call is not sending the window/webview labels in the right order.