### PR TITLE
fix(runtime-wry): avoid panic during clipboard initialization on wayland

### DIFF
--- a/.changes/clipboard-wayland.md
+++ b/.changes/clipboard-wayland.md
@@ -1,0 +1,5 @@
+---
+'tauri-runtime-wry': 'patch'
+---
+
+Fix panic during intialization on wayland when using `clipboard` feature, instead propagate the error during API usage.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2019,7 +2019,7 @@ impl<T: UserEvent> Wry<T> {
     #[cfg(feature = "clipboard")]
     #[allow(clippy::redundant_clone)]
     let clipboard_manager_handle = ClipboardManagerWrapper {
-      clipboard: Arc::new(Mutex::new(Clipboard::new().unwrap())),
+      clipboard: Arc::new(Mutex::new(Clipboard::new())),
     };
 
     Ok(Self {


### PR DESCRIPTION
closes #8964
