### PR TITLE
feat(utils): generate table markdown of permissions

### DIFF
--- a/.changes/permission-table.md
+++ b/.changes/permission-table.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:enhance
+---
+
+Changed plugin markdown docs generation to table format.

--- a/core/tauri-utils/src/acl/build.rs
+++ b/core/tauri-utils/src/acl/build.rs
@@ -233,12 +233,12 @@ pub fn generate_schema<P: AsRef<Path>>(
 
 /// Generate a markdown documentation page containing the list of permissions of the plugin.
 pub fn generate_docs(permissions: &[PermissionFile], out_dir: &Path) -> Result<(), Error> {
-  let mut docs = "# Permissions\n\n".to_string();
+  let mut docs = "| Permission | Description |\n|------|-----|\n".to_string();
 
   fn docs_from(id: &str, description: Option<&str>) -> String {
-    let mut docs = format!("## {id}");
+    let mut docs = format!("|`{id}`");
     if let Some(d) = description {
-      docs.push_str(&format!("\n\n{d}"));
+      docs.push_str(&format!("|{d}|"));
     }
     docs
   }
@@ -246,12 +246,12 @@ pub fn generate_docs(permissions: &[PermissionFile], out_dir: &Path) -> Result<(
   for permission in permissions {
     for set in &permission.set {
       docs.push_str(&docs_from(&set.identifier, Some(&set.description)));
-      docs.push_str("\n\n");
+      docs.push('\n');
     }
 
     if let Some(default) = &permission.default {
       docs.push_str(&docs_from("default", default.description.as_deref()));
-      docs.push_str("\n\n");
+      docs.push('\n');
     }
 
     for permission in &permission.permission {
@@ -259,7 +259,7 @@ pub fn generate_docs(permissions: &[PermissionFile], out_dir: &Path) -> Result<(
         &permission.identifier,
         permission.description.as_deref(),
       ));
-      docs.push_str("\n\n");
+      docs.push('\n');
     }
   }
 


### PR DESCRIPTION
This PR changes the markdown generation from a list to a table, preview:

![image](https://github.com/tauri-apps/tauri/assets/61759797/d2ae589c-77c2-4231-9e8c-e664ab52931d)

GitHub markdown preview:
https://github.com/vasfvitor/tauri-docs/blob/ci-hist/permission.md
![image](https://github.com/tauri-apps/tauri/assets/61759797/3c296ba7-5e3c-40d0-a4a5-c5f88f6ff3e3)

- [x] Ensure `cargo test` and `cargo clippy` passes.

