### PR TITLE
feat(core): dynamic runtime capability

### DIFF
--- a/.changes/runtime-capability-dynamic.md
+++ b/.changes/runtime-capability-dynamic.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+`Manager::add_capability` now allows adding a dynamically defined capability instead of only relying on static strings.

--- a/core/tauri/src/ipc/authority.rs
+++ b/core/tauri/src/ipc/authority.rs
@@ -164,34 +164,31 @@ impl CapabilityBuilder {
       .try_into()
       .unwrap_or_else(|_| panic!("invalid permission identifier '{permission}'"));
 
+    let allowed_scope = allowed
+      .into_iter()
+      .map(|a| {
+        serde_json::to_value(a)
+          .expect("failed to serialize scope")
+          .into()
+      })
+      .collect();
+    let denied_scope = denied
+      .into_iter()
+      .map(|a| {
+        serde_json::to_value(a)
+          .expect("failed to serialize scope")
+          .into()
+      })
+      .collect();
+    let scope = Scopes {
+      allow: Some(allowed_scope),
+      deny: Some(denied_scope),
+    };
+
     self
       .0
       .permissions
-      .push(PermissionEntry::ExtendedPermission {
-        identifier,
-        scope: Scopes {
-          allow: Some(
-            allowed
-              .into_iter()
-              .map(|a| {
-                serde_json::to_value(a)
-                  .expect("failed to serialize scope")
-                  .into()
-              })
-              .collect(),
-          ),
-          deny: Some(
-            denied
-              .into_iter()
-              .map(|a| {
-                serde_json::to_value(a)
-                  .expect("failed to serialize scope")
-                  .into()
-              })
-              .collect(),
-          ),
-        },
-      });
+      .push(PermissionEntry::ExtendedPermission { identifier, scope });
     self
   }
 }

--- a/core/tauri/src/ipc/authority.rs
+++ b/core/tauri/src/ipc/authority.rs
@@ -7,15 +7,18 @@ use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use state::TypeMap;
 
-use tauri_utils::acl::capability::CapabilityFile;
-use tauri_utils::acl::manifest::Manifest;
+use tauri_utils::acl::{
+  capability::{Capability, CapabilityFile, PermissionEntry},
+  manifest::Manifest,
+  Value, APP_ACL_KEY,
+};
 use tauri_utils::acl::{
   resolved::{CommandKey, Resolved, ResolvedCommand, ResolvedScope, ScopeKey},
-  ExecutionContext,
+  ExecutionContext, Scopes,
 };
-use tauri_utils::acl::{Value, APP_ACL_KEY};
 
 use crate::{ipc::InvokeError, sealed::ManagerBase, Runtime};
 use crate::{AppHandle, Manager};
@@ -62,6 +65,128 @@ impl Origin {
   }
 }
 
+/// A capability that can be added at runtime.
+pub trait RuntimeCapability {
+  /// Creates the capability file.
+  fn build(self) -> CapabilityFile;
+}
+
+impl<T: AsRef<str>> RuntimeCapability for T {
+  fn build(self) -> CapabilityFile {
+    self.as_ref().parse().expect("invalid capability")
+  }
+}
+
+/// A builder for a [`Capability`].
+pub struct CapabilityBuilder(Capability);
+
+impl CapabilityBuilder {
+  /// Creates a new capability builder with a unique identifier.
+  pub fn new(identifier: impl Into<String>) -> Self {
+    Self(Capability {
+      identifier: identifier.into(),
+      description: "".into(),
+      remote: None,
+      local: true,
+      windows: Vec::new(),
+      webviews: Vec::new(),
+      permissions: Vec::new(),
+      platforms: Vec::new(),
+    })
+  }
+
+  /// Allows this capability to be used by a remote URL.
+  pub fn remote(mut self, url: String) -> Self {
+    self
+      .0
+      .remote
+      .get_or_insert_with(Default::default)
+      .urls
+      .push(url);
+    self
+  }
+
+  /// Do not apply this capability on local app URLs.
+  pub fn skip_local(mut self) -> Self {
+    self.0.local = false;
+    self
+  }
+
+  /// Link this capability to the given window label.
+  pub fn window(mut self, window: impl Into<String>) -> Self {
+    self.0.windows.push(window.into());
+    self
+  }
+
+  /// Link this capability to the given webview label.
+  pub fn webview(mut self, webview: impl Into<String>) -> Self {
+    self.0.webviews.push(webview.into());
+    self
+  }
+
+  /// Add a new permission to this capability.
+  pub fn permission(mut self, permission: impl Into<String>) -> Self {
+    let permission = permission.into();
+    self.0.permissions.push(PermissionEntry::PermissionRef(
+      permission
+        .clone()
+        .try_into()
+        .unwrap_or_else(|_| panic!("invalid permission identifier '{permission}'")),
+    ));
+    self
+  }
+
+  /// Add a new scoped permission to this capability.
+  pub fn permission_scoped<T: Serialize>(
+    mut self,
+    permission: impl Into<String>,
+    allowed: Vec<T>,
+    denied: Vec<T>,
+  ) -> Self {
+    let permission = permission.into();
+    let identifier = permission
+      .clone()
+      .try_into()
+      .unwrap_or_else(|_| panic!("invalid permission identifier '{permission}'"));
+
+    self
+      .0
+      .permissions
+      .push(PermissionEntry::ExtendedPermission {
+        identifier,
+        scope: Scopes {
+          allow: Some(
+            allowed
+              .into_iter()
+              .map(|a| {
+                serde_json::to_value(a)
+                  .expect("failed to serialize scope")
+                  .into()
+              })
+              .collect(),
+          ),
+          deny: Some(
+            denied
+              .into_iter()
+              .map(|a| {
+                serde_json::to_value(a)
+                  .expect("failed to serialize scope")
+                  .into()
+              })
+              .collect(),
+          ),
+        },
+      });
+    self
+  }
+}
+
+impl RuntimeCapability for CapabilityBuilder {
+  fn build(self) -> CapabilityFile {
+    CapabilityFile::Capability(self.0)
+  }
+}
+
 impl RuntimeAuthority {
   #[doc(hidden)]
   pub fn new(acl: BTreeMap<String, Manifest>, resolved_acl: Resolved) -> Self {
@@ -102,9 +227,9 @@ impl RuntimeAuthority {
   }
 
   /// Adds the given capability to the runtime authority.
-  pub fn add_capability(&mut self, capability: CapabilityFile) -> crate::Result<()> {
+  pub fn add_capability(&mut self, capability: impl RuntimeCapability) -> crate::Result<()> {
     let mut capabilities = BTreeMap::new();
-    match capability {
+    match capability.build() {
       CapabilityFile::Capability(c) => {
         capabilities.insert(c.identifier.clone(), c);
       }

--- a/core/tauri/src/ipc/authority.rs
+++ b/core/tauri/src/ipc/authority.rs
@@ -106,9 +106,9 @@ impl CapabilityBuilder {
     self
   }
 
-  /// Do not apply this capability on local app URLs.
-  pub fn skip_local(mut self) -> Self {
-    self.0.local = false;
+  /// Whether this capability is applied on local app URLs or not. Defaults to `true`.
+  pub fn local(mut self, local: bool) -> Self {
+    self.0.local = local;
     self
   }
 
@@ -118,9 +118,24 @@ impl CapabilityBuilder {
     self
   }
 
+  /// Link this capability to the a list of window labels.
+  pub fn windows(mut self, windows: impl IntoIterator<Item = impl Into<String>>) -> Self {
+    self.0.windows.extend(windows.into_iter().map(|w| w.into()));
+    self
+  }
+
   /// Link this capability to the given webview label.
   pub fn webview(mut self, webview: impl Into<String>) -> Self {
     self.0.webviews.push(webview.into());
+    self
+  }
+
+  /// Link this capability to the a list of window labels.
+  pub fn webviews(mut self, webviews: impl IntoIterator<Item = impl Into<String>>) -> Self {
+    self
+      .0
+      .webviews
+      .extend(webviews.into_iter().map(|w| w.into()));
     self
   }
 

--- a/core/tauri/src/ipc/mod.rs
+++ b/core/tauri/src/ipc/mod.rs
@@ -25,7 +25,10 @@ mod command;
 pub(crate) mod format_callback;
 pub(crate) mod protocol;
 
-pub use authority::{CommandScope, GlobalScope, Origin, RuntimeAuthority, ScopeObject, ScopeValue};
+pub use authority::{
+  CapabilityBuilder, CommandScope, GlobalScope, Origin, RuntimeAuthority, RuntimeCapability,
+  ScopeObject, ScopeValue,
+};
 pub use channel::{Channel, JavaScriptChannelId};
 pub use command::{private, CommandArg, CommandItem};
 

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -69,7 +69,7 @@ pub use cocoa;
 #[doc(hidden)]
 pub use embed_plist;
 pub use error::{Error, Result};
-use ipc::RuntimeAuthority;
+use ipc::{RuntimeAuthority, RuntimeCapability};
 pub use resources::{Resource, ResourceId, ResourceTable};
 #[cfg(target_os = "ios")]
 #[doc(hidden)]
@@ -888,13 +888,13 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
   ///     Ok(())
   ///   });
   /// ```
-  fn add_capability(&self, capability: &'static str) -> Result<()> {
+  fn add_capability(&self, capability: impl RuntimeCapability) -> Result<()> {
     self
       .manager()
       .runtime_authority
       .lock()
       .unwrap()
-      .add_capability(capability.parse().expect("invalid capability"))
+      .add_capability(capability)
   }
 }
 

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -22,10 +22,7 @@ use tauri_runtime::{
   window::dpi::{PhysicalPosition, PhysicalSize, Position, Size},
   WindowDispatch,
 };
-use tauri_utils::{
-  acl::APP_ACL_KEY,
-  config::{WebviewUrl, WindowConfig},
-};
+use tauri_utils::config::{WebviewUrl, WindowConfig};
 pub use url::Url;
 
 use crate::{
@@ -1192,7 +1189,7 @@ fn main() {
       {
         let (key, command_name) = plugin_command
           .clone()
-          .unwrap_or_else(|| (APP_ACL_KEY, request.cmd.clone()));
+          .unwrap_or_else(|| (tauri_utils::acl::APP_ACL_KEY, request.cmd.clone()));
         invoke.resolver.reject(
           manager
             .runtime_authority

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -3151,7 +3151,7 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tauri"
-version = "2.0.0-beta.7"
+version = "2.0.0-beta.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "base64",
  "brotli",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "anyhow",
  "glob",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "gtk",
  "http",
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "cocoa",
  "gtk",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.6"
 dependencies = [
  "aes-gcm",
  "brotli",


### PR DESCRIPTION
Some capabilities must be dynamic (e.g. allow a dynamically started localhost server, runtime-defined remote URLs, fine-grained permissions that depend on user configuration like access token scopes..). This can be done already by creating a string at runtime and leaking it so it becomes a &'static str, but it's not ideal so we now support both runtime strings and added a new capability builder aswell so you can either `include_str!()` a static capability file or create/modify one at runtime.