### PR TITLE
fix(bundler): escape potentially problematic strings in an XML

### DIFF
--- a/.changes/escape-paths-wix.md
+++ b/.changes/escape-paths-wix.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:bug
+---
+
+On Windows, fix building WiX installer when resources contains an XML charcter that should be escaped.

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -16,7 +16,7 @@ use crate::bundle::{
   },
 };
 use anyhow::{bail, Context};
-use handlebars::{to_json, Handlebars};
+use handlebars::{html_escape, to_json, Handlebars};
 use log::info;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -122,7 +122,7 @@ impl ResourceDirectory {
           r#"<Component Id="{id}" Guid="{guid}" Win64="$(var.Win64)" KeyPath="yes"><File Id="PathFile_{id}" Source="{path}" /></Component>"#,
           id = file.id,
           guid = file.guid,
-          path = file.path.display()
+          path = html_escape(&file.path.display().to_string())
         ).as_str()
       );
     }
@@ -140,7 +140,7 @@ impl ResourceDirectory {
       format!(
         r#"<Directory Id="I{id}" Name="{name}">{files}{directories}</Directory>"#,
         id = Uuid::new_v4().as_simple(),
-        name = self.name,
+        name = html_escape(&self.name),
         files = files,
         directories = directories,
       )


### PR DESCRIPTION
- replace characters invalid in XML with their escaped form to properly bundle resources with such characters in their pathnames.

closes #9030 