### PR TITLE
fix(cli): migration for http plugin ACL

### DIFF
--- a/.changes/fix-cli-migration-http-acl.md
+++ b/.changes/fix-cli-migration-http-acl.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix `tauri migrate` for http plugin ACL.

--- a/tooling/cli/src/migrate/config.rs
+++ b/tooling/cli/src/migrate/config.rs
@@ -14,7 +14,7 @@ use tauri_utils::{
 };
 
 use std::{
-  collections::HashSet,
+  collections::{BTreeMap, HashSet},
   fs::{create_dir_all, write},
   path::Path,
 };
@@ -443,7 +443,11 @@ fn allowlist_to_permissions(
       .scope
       .0
       .into_iter()
-      .map(|p| AclValue::String(p.to_string()))
+      .map(|p| {
+        let mut map = BTreeMap::new();
+        map.insert("url".to_string(), AclValue::String(p.to_string()));
+        AclValue::Map(map)
+      })
       .collect::<Vec<_>>();
 
     permissions.push(PermissionEntry::ExtendedPermission {


### PR DESCRIPTION
`tauri migrate` creates an array of strings but http plugin expects an array of objects with a key of `url` and a string value.