### PR TITLE
fix(core): resolve symlink on fs scope check

### DIFF
--- a/.changes/fix-fs-scope-check-symlink.md
+++ b/.changes/fix-fs-scope-check-symlink.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Resolve symlinks on the filesystem scope check.

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -298,6 +298,14 @@ impl Scope {
   /// Determines if the given path is allowed on this scope.
   pub fn is_allowed<P: AsRef<Path>>(&self, path: P) -> bool {
     let path = path.as_ref();
+    let path = if path.is_symlink() {
+      match std::fs::read_link(path) {
+        Ok(p) => p,
+        Err(_) => return false,
+      }
+    } else {
+      path.to_path_buf()
+    };
     let path = if !path.exists() {
       crate::Result::Ok(path.to_path_buf())
     } else {


### PR DESCRIPTION
Resolving the symlink enhances the check by verifying the developer/user granted access to the resolved path instead of the symlink itself, which is the path that will be accessed in the end.