### PR TITLE
Revert "feat(core): use a strict CSP on the isolation iframe"

### DIFF
--- a/.changes/strict-isolation-csp.md
+++ b/.changes/strict-isolation-csp.md
@@ -1,5 +1,0 @@
----
-"tauri": patch:enhance
----
-
-Use a strict content security policy on the isolation pattern HTML.

--- a/core/tauri/src/protocol/isolation.rs
+++ b/core/tauri/src/protocol/isolation.rs
@@ -10,8 +10,6 @@ use std::sync::Arc;
 
 use crate::{manager::webview::PROCESS_IPC_MESSAGE_FN, webview::UriSchemeProtocolHandler};
 
-const CSP: &str = "default-src: 'none'";
-
 pub fn get(assets: Arc<EmbeddedAssets>, aes_gcm_key: [u8; 32]) -> UriSchemeProtocolHandler {
   Box::new(move |request, responder| {
     let response = match request_to_path(&request).as_str() {
@@ -25,7 +23,6 @@ pub fn get(assets: Arc<EmbeddedAssets>, aes_gcm_key: [u8; 32]) -> UriSchemeProto
           match template.render(asset.as_ref(), &Default::default()) {
             Ok(asset) => http::Response::builder()
               .header(CONTENT_TYPE, mime::TEXT_HTML.as_ref())
-              .header("Content-Security-Policy", CSP)
               .body(asset.into_string().as_bytes().to_vec()),
             Err(_) => http::Response::builder()
               .status(http::StatusCode::INTERNAL_SERVER_ERROR)

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -3302,7 +3302,6 @@ dependencies = [
  "gtk",
  "http",
  "jni",
- "log",
  "percent-encoding",
  "raw-window-handle 0.6.0",
  "softbuffer",


### PR DESCRIPTION
Reverts tauri-apps/tauri#9075

it's not working on macOS, needs more work