### PR TITLE
feat: enhance multiple capabilities file format & fix mixed permissions schema

### DIFF
--- a/.changes/build-schema-generation.md
+++ b/.changes/build-schema-generation.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch:bug
+---
+
+Fixed generation of capability schema for permissions field which previously disallowed mixed (strings and objects) permission definition.

--- a/.changes/utils-named-capability-file.md
+++ b/.changes/utils-named-capability-file.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": major:breaking
+---
+
+Changed `CapabiltyFile::List` enum variant to be a tuple-struct and added `CapabiltyFile::NamedList`. This allows more flexibility when parsing capabilties from JSON files. 

--- a/core/tauri-build/src/acl.rs
+++ b/core/tauri-build/src/acl.rs
@@ -168,8 +168,8 @@ fn capabilities_schema(acl_manifests: &BTreeMap<String, Manifest>) -> RootSchema
   if let Some(Schema::Object(obj)) = schema.definitions.get_mut("PermissionEntry") {
     let permission_entry_any_of_schemas = obj.subschemas().any_of.as_mut().unwrap();
 
-    if let Schema::Object(mut scope_extended_schema_obj) =
-      permission_entry_any_of_schemas.remove(permission_entry_any_of_schemas.len() - 1)
+    if let Schema::Object(scope_extended_schema_obj) =
+      permission_entry_any_of_schemas.last_mut().unwrap()
     {
       let mut global_scope_one_of = Vec::new();
 
@@ -246,8 +246,6 @@ fn capabilities_schema(acl_manifests: &BTreeMap<String, Manifest>) -> RootSchema
             one_of: Some(global_scope_one_of),
             ..Default::default()
           }));
-
-        permission_entry_any_of_schemas.push(scope_extended_schema_obj.into());
       };
     }
   }

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -425,7 +425,8 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
         CapabilityFile::Capability(c) => {
           capabilities.insert(c.identifier.clone(), c);
         }
-        CapabilityFile::List {
+        CapabilityFile::List(capabilities_list)
+        | CapabilityFile::NamedList {
           capabilities: capabilities_list,
         } => {
           capabilities.extend(

--- a/core/tauri-utils/src/acl/build.rs
+++ b/core/tauri-utils/src/acl/build.rs
@@ -136,7 +136,7 @@ pub fn parse_capabilities(
       CapabilityFile::Capability(capability) => {
         capabilities_map.insert(capability.identifier.clone(), capability);
       }
-      CapabilityFile::List { capabilities } => {
+      CapabilityFile::List(capabilities) | CapabilityFile::NamedList { capabilities } => {
         for capability in capabilities {
           capabilities_map.insert(capability.identifier.clone(), capability);
         }

--- a/core/tauri-utils/src/acl/capability.rs
+++ b/core/tauri-utils/src/acl/capability.rs
@@ -110,7 +110,9 @@ pub enum CapabilityFile {
   /// A single capability.
   Capability(Capability),
   /// A list of capabilities.
-  List {
+  List(Vec<Capability>),
+  /// A list of capabilities.
+  NamedList {
     /// The list of capabilities.
     capabilities: Vec<Capability>,
   },
@@ -135,11 +137,9 @@ impl FromStr for CapabilityFile {
   type Err = super::Error;
 
   fn from_str(s: &str) -> Result<Self, Self::Err> {
-    match s.chars().next() {
-      Some('[') => toml::from_str(s).map_err(Into::into),
-      Some('{') => serde_json::from_str(s).map_err(Into::into),
-      _ => Err(super::Error::UnknownCapabilityFormat(s.into())),
-    }
+    serde_json::from_str(s)
+      .or_else(|_| toml::from_str(s))
+      .map_err(Into::into)
   }
 }
 

--- a/core/tauri/src/ipc/authority.rs
+++ b/core/tauri/src/ipc/authority.rs
@@ -243,7 +243,9 @@ impl RuntimeAuthority {
       CapabilityFile::Capability(c) => {
         capabilities.insert(c.identifier.clone(), c);
       }
-      CapabilityFile::List {
+
+      CapabilityFile::List(capabilities_list)
+      | CapabilityFile::NamedList {
         capabilities: capabilities_list,
       } => {
         capabilities.extend(


### PR DESCRIPTION
This enhances the DX of defining multiple definitions in a single JSON file, previously the only way was:
```json
{
  "capabilities": [ {...}, {...} ] 
}
```
now we can also support 
```json
[
  {...},
  {...}
]
```

toml however can't take advantage of this due to the nature of toml but doesn't matter that much
```toml
[[capabilities]]
identifier = "id"

[[capabilities]]
identifier = "another-one"
```


