### PR TITLE
fix(iOS): Update .gitignore of template to exclude *.xcodeproj/ for iOS projects

### DIFF
--- a/tooling/cli/templates/mobile/ios/.gitignore
+++ b/tooling/cli/templates/mobile/ios/.gitignore
@@ -1,3 +1,4 @@
 xcuserdata/
 build/
 Externals/
+*.xcodeproj/


### PR DESCRIPTION
We don't need to track `xcodeproj` in git because it is generated using xcodegen