### PR TITLE
docs: adding 'desktop only' pill to menu module

### DIFF
--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -98,6 +98,7 @@ pub mod image;
 #[cfg(target_os = "ios")]
 mod ios;
 #[cfg(desktop)]
+#[cfg_attr(docsrs, doc(cfg(desktop)))]
 pub mod menu;
 /// Path APIs.
 pub mod path;


### PR DESCRIPTION
It's a silly change but I've noticed that menu module is missing 'desktop only' pill. Tray module has this pill and it's confusing that menu doesn't. 