### PR TITLE
fix(windows): relax `UpdaterWindowsConfig` to not deny unknowns fields

### DIFF
--- a/.changes/cli-updater-unkown-fields.md
+++ b/.changes/cli-updater-unkown-fields.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix bundling when `plugins > updater > windows > installerArgs` are set in `tauri.conf.json`

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -776,7 +776,7 @@ impl WindowsUpdateInstallMode {
 }
 
 #[derive(Default, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdaterWindowsConfig {
   #[serde(default, alias = "install-mode")]
   pub install_mode: WindowsUpdateInstallMode,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix updater plugin `installerArgs` config not working in tauri config files

References:

- https://github.com/tauri-apps/plugins-workspace/issues/1015
- https://github.com/tauri-apps/plugins-workspace/pull/1051
