### PR TITLE
fix(acl): inconsistencies on urlpattern usage for remote domain URL

### DIFF
--- a/.changes/fix-remote-domain-url.md
+++ b/.changes/fix-remote-domain-url.md
@@ -2,4 +2,4 @@
 "tauri": patch:bug
 ---
 
-Fixes capability remote domain now allowing subpaths, query parameters and hash when those values are empty.
+Fixes capability remote domain not allowing subpaths, query parameters and hash when those values are empty.

--- a/.changes/fix-remote-domain-url.md
+++ b/.changes/fix-remote-domain-url.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes capability remote domain now allowing subpaths, query parameters and hash when those values are empty.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1141,7 +1141,7 @@
       ],
       "properties": {
         "urls": {
-          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).",
+          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).\n\n# Examples\n\n- \"https://*.mydomain.dev\": allows subdomains of mydomain.dev - \"https://mydomain.dev/api/*\": allows any subpath of mydomain.dev/api",
           "type": "array",
           "items": {
             "type": "string"

--- a/core/tauri-utils/src/acl/capability.rs
+++ b/core/tauri-utils/src/acl/capability.rs
@@ -90,6 +90,11 @@ fn default_capability_local() -> bool {
 #[serde(rename_all = "camelCase")]
 pub struct CapabilityRemote {
   /// Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).
+  ///
+  /// # Examples
+  ///
+  /// - "https://*.mydomain.dev": allows subdomains of mydomain.dev
+  /// - "https://mydomain.dev/api/*": allows any subpath of mydomain.dev/api
   pub urls: Vec<String>,
 }
 

--- a/core/tauri-utils/src/acl/mod.rs
+++ b/core/tauri-utils/src/acl/mod.rs
@@ -217,7 +217,6 @@ impl FromStr for RemoteUrlPattern {
     {
       init.pathname.replace("*".to_string());
     }
-    println!("{:?}", init);
     let pattern = urlpattern::UrlPattern::parse(init)?;
     Ok(Self(Arc::new(pattern), s.to_string()))
   }

--- a/core/tests/acl/fixtures/snapshots/acl_tests__tests__file-explorer-remote.snap
+++ b/core/tests/acl/fixtures/snapshots/acl_tests__tests__file-explorer-remote.snap
@@ -90,50 +90,59 @@ Resolved {
                                 },
                             },
                             pathname: Component {
-                                pattern_string: "/",
+                                pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "^/$",
+                                        "^(.*)$",
                                     ),
                                 ),
-                                group_name_list: [],
+                                group_name_list: [
+                                    "0",
+                                ],
                                 matcher: Matcher {
                                     prefix: "",
                                     suffix: "",
-                                    inner: Literal {
-                                        literal: "/",
+                                    inner: SingleCapture {
+                                        filter: None,
+                                        allow_empty: true,
                                     },
                                 },
                             },
                             search: Component {
-                                pattern_string: "",
+                                pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "^$",
+                                        "^(.*)$",
                                     ),
                                 ),
-                                group_name_list: [],
+                                group_name_list: [
+                                    "0",
+                                ],
                                 matcher: Matcher {
                                     prefix: "",
                                     suffix: "",
-                                    inner: Literal {
-                                        literal: "",
+                                    inner: SingleCapture {
+                                        filter: None,
+                                        allow_empty: true,
                                     },
                                 },
                             },
                             hash: Component {
-                                pattern_string: "",
+                                pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "^$",
+                                        "^(.*)$",
                                     ),
                                 ),
-                                group_name_list: [],
+                                group_name_list: [
+                                    "0",
+                                ],
                                 matcher: Matcher {
                                     prefix: "",
                                     suffix: "",
-                                    inner: Literal {
-                                        literal: "",
+                                    inner: SingleCapture {
+                                        filter: None,
+                                        allow_empty: true,
                                     },
                                 },
                             },
@@ -251,50 +260,59 @@ Resolved {
                                 },
                             },
                             pathname: Component {
-                                pattern_string: "/",
+                                pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "^/$",
+                                        "^(.*)$",
                                     ),
                                 ),
-                                group_name_list: [],
+                                group_name_list: [
+                                    "0",
+                                ],
                                 matcher: Matcher {
                                     prefix: "",
                                     suffix: "",
-                                    inner: Literal {
-                                        literal: "/",
+                                    inner: SingleCapture {
+                                        filter: None,
+                                        allow_empty: true,
                                     },
                                 },
                             },
                             search: Component {
-                                pattern_string: "",
+                                pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "^$",
+                                        "^(.*)$",
                                     ),
                                 ),
-                                group_name_list: [],
+                                group_name_list: [
+                                    "0",
+                                ],
                                 matcher: Matcher {
                                     prefix: "",
                                     suffix: "",
-                                    inner: Literal {
-                                        literal: "",
+                                    inner: SingleCapture {
+                                        filter: None,
+                                        allow_empty: true,
                                     },
                                 },
                             },
                             hash: Component {
-                                pattern_string: "",
+                                pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "^$",
+                                        "^(.*)$",
                                     ),
                                 ),
-                                group_name_list: [],
+                                group_name_list: [
+                                    "0",
+                                ],
                                 matcher: Matcher {
                                     prefix: "",
                                     suffix: "",
-                                    inner: Literal {
-                                        literal: "",
+                                    inner: SingleCapture {
+                                        filter: None,
+                                        allow_empty: true,
                                     },
                                 },
                             },

--- a/examples/api/src-tauri/capabilities/run-app.json
+++ b/examples/api/src-tauri/capabilities/run-app.json
@@ -2,7 +2,10 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "run-app",
   "description": "permissions to run the app",
-  "windows": ["main", "main-*"],
+  "windows": [
+    "main",
+    "main-*"
+  ],
   "permissions": [
     {
       "identifier": "allow-log-operation",

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1141,7 +1141,7 @@
       ],
       "properties": {
         "urls": {
-          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).",
+          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).\n\n# Examples\n\n- \"https://*.mydomain.dev\": allows subdomains of mydomain.dev - \"https://mydomain.dev/api/*\": allows any subpath of mydomain.dev/api",
           "type": "array",
           "items": {
             "type": "string"


### PR DESCRIPTION
Changes the remote domain URL parsing to match the behaivor of the JavaScript implementation of URLPattern.
A pattern like `http://localhost` should automatically allow any subpath, query params and hash.
To define a custom query param match rule, you must escape the `?` character e.g. `http://localhost/path\\?q=*&x=*`