### PR TITLE
feat(core): allow swapping the assets implementation

### DIFF
--- a/.changes/codegen-set-assets.md
+++ b/.changes/codegen-set-assets.md
@@ -1,0 +1,6 @@
+---
+"tauri-macros": patch:feat
+"tauri-codegen": patch:feat
+---
+
+The `Context` codegen now accepts a `assets` input to define a custom `tauri::Assets` implementation.

--- a/.changes/context-assets-unbox.md
+++ b/.changes/context-assets-unbox.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:breaking
+---
+
+`Context::assets` now returns `&dyn Assets` instead of `Box<&dyn Assets>`.

--- a/.changes/context-remove-assets-generics.md
+++ b/.changes/context-remove-assets-generics.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:breaking
+---
+
+The `Context` type no longer uses the `<A: Assets>` generic so the assets implementation can be swapped with `Context::assets_mut`.

--- a/core/tauri-build/src/codegen/context.rs
+++ b/core/tauri-build/src/codegen/context.rs
@@ -128,6 +128,7 @@ impl CodegenContext {
       // outside the tauri crate, making the ::tauri root valid.
       root: quote::quote!(::tauri),
       capabilities: self.capabilities,
+      assets: None,
     })?;
 
     // get the full output file path

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -19,7 +19,7 @@ use crate::{
   },
   sealed::{ManagerBase, RuntimeOrDispatch},
   utils::config::Config,
-  utils::{assets::Assets, Env},
+  utils::Env,
   webview::PageLoadPayload,
   Context, DeviceEventFilter, EventLoopMessage, Manager, Monitor, Runtime, Scopes, StateManager,
   Theme, Webview, WebviewWindowBuilder, Window,
@@ -1581,7 +1581,7 @@ tauri::Builder::default()
     feature = "tracing",
     tracing::instrument(name = "app::build", skip_all)
   )]
-  pub fn build<A: Assets>(mut self, context: Context<A>) -> crate::Result<App<R>> {
+  pub fn build(mut self, context: Context) -> crate::Result<App<R>> {
     #[cfg(target_os = "macos")]
     if self.menu.is_none() && self.enable_macos_default_menu {
       self.menu = Some(Box::new(|app_handle| {
@@ -1749,7 +1749,7 @@ tauri::Builder::default()
   }
 
   /// Runs the configured Tauri application.
-  pub fn run<A: Assets>(self, context: Context<A>) -> crate::Result<()> {
+  pub fn run(self, context: Context) -> crate::Result<()> {
     self.build(context)?.run(|_, _| {});
     Ok(())
   }

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -343,9 +343,9 @@ pub fn dev() -> bool {
 /// # Stability
 /// This is the output of the [`generate_context`] macro, and is not considered part of the stable API.
 /// Unless you know what you are doing and are prepared for this type to have breaking changes, do not create it yourself.
-pub struct Context<A: Assets> {
+pub struct Context {
   pub(crate) config: Config,
-  pub(crate) assets: Box<A>,
+  pub(crate) assets: Box<dyn Assets>,
   pub(crate) default_window_icon: Option<image::Image<'static>>,
   pub(crate) app_icon: Option<Vec<u8>>,
   #[cfg(all(desktop, feature = "tray-icon"))]
@@ -356,7 +356,7 @@ pub struct Context<A: Assets> {
   pub(crate) runtime_authority: RuntimeAuthority,
 }
 
-impl<A: Assets> fmt::Debug for Context<A> {
+impl fmt::Debug for Context {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let mut d = f.debug_struct("Context");
     d.field("config", &self.config)
@@ -372,7 +372,7 @@ impl<A: Assets> fmt::Debug for Context<A> {
   }
 }
 
-impl<A: Assets> Context<A> {
+impl Context {
   /// The config the application was prepared with.
   #[inline(always)]
   pub fn config(&self) -> &Config {
@@ -387,13 +387,14 @@ impl<A: Assets> Context<A> {
 
   /// The assets to be served directly by Tauri.
   #[inline(always)]
-  pub fn assets(&self) -> &A {
+  #[allow(clippy::borrowed_box)]
+  pub fn assets(&self) -> &Box<dyn Assets> {
     &self.assets
   }
 
   /// A mutable reference to the assets to be served directly by Tauri.
   #[inline(always)]
-  pub fn assets_mut(&mut self) -> &mut A {
+  pub fn assets_mut(&mut self) -> &mut Box<dyn Assets> {
     &mut self.assets
   }
 
@@ -459,7 +460,7 @@ impl<A: Assets> Context<A> {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     config: Config,
-    assets: Box<A>,
+    assets: Box<dyn Assets>,
     default_window_icon: Option<image::Image<'static>>,
     app_icon: Option<Vec<u8>>,
     package_info: PackageInfo,

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -387,9 +387,8 @@ impl Context {
 
   /// The assets to be served directly by Tauri.
   #[inline(always)]
-  #[allow(clippy::borrowed_box)]
-  pub fn assets(&self) -> &Box<dyn Assets> {
-    &self.assets
+  pub fn assets(&self) -> &dyn Assets {
+    self.assets.as_ref()
   }
 
   /// A mutable reference to the assets to be served directly by Tauri.

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -216,7 +216,7 @@ impl<R: Runtime> fmt::Debug for AppManager<R> {
 impl<R: Runtime> AppManager<R> {
   #[allow(clippy::too_many_arguments, clippy::type_complexity)]
   pub(crate) fn with_handlers(
-    #[allow(unused_mut)] mut context: Context<impl Assets>,
+    #[allow(unused_mut)] mut context: Context,
     plugins: PluginStore<R>,
     invoke_handler: Box<InvokeHandler<R>>,
     on_page_load: Option<Arc<OnPageLoad<R>>>,

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -94,7 +94,7 @@ pub fn noop_assets() -> NoopAsset {
 }
 
 /// Creates a new [`crate::Context`] for testing.
-pub fn mock_context<A: Assets>(assets: A) -> crate::Context<A> {
+pub fn mock_context<A: Assets>(assets: A) -> crate::Context {
   Context {
     config: Config {
       schema: None,

--- a/examples/splashscreen/main.rs
+++ b/examples/splashscreen/main.rs
@@ -78,7 +78,7 @@ mod ui {
   }
 }
 
-fn context() -> tauri::Context<tauri::utils::assets::EmbeddedAssets> {
+fn context() -> tauri::Context {
   tauri::generate_context!("../../examples/splashscreen/tauri.conf.json")
 }
 


### PR DESCRIPTION
The current `Context::assets_mut` is useless since you must provide a type that matches the generic arg in Context, so we're dropping it in favor of a Box<dyn Assets> instead.

Additionally, during codegen you can now define your custom assets implementation (by default we embed the frontendDist assets):
```rust
struct MyAssets {
...
}
impl tauri::Assets for MyAssets {
...
}

fn main() {
  let assets = MyAssets {};
  tauri::generate_context(
    assets = assets
  );
}
```