### PR TITLE
fix(core): race between drop old JS listeners and create new listeners on page load

### DIFF
--- a/.changes/fix-js-unlisten-all-race.md
+++ b/.changes/fix-js-unlisten-all-race.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix old JS listeners being dropped on page load after it was possible to create new listeners.

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -571,7 +571,7 @@ tauri::Builder::default()
       .on_page_load_handler
       .replace(Box::new(move |url, event| {
         if let Some(w) = manager_.get_webview(&label_) {
-          if let PageLoadEvent::Finished = event {
+          if let PageLoadEvent::Started = event {
             w.unlisten_all_js();
           }
           if let Some(handler) = self.on_page_load_handler.as_ref() {


### PR DESCRIPTION
@amrbashir mentioned removing a `for` loop (not sure which one) as an alternate solution on [Discord](<https://discord.com/channels/616186924390023171/986184094050316358/1216134672317284445>) so let's go with that if it's the better solution.