### PR TITLE
feat(core): allow defining global API script on plugin build

### DIFF
--- a/.changes/global-api-script-path-plugins.md
+++ b/.changes/global-api-script-path-plugins.md
@@ -1,0 +1,8 @@
+---
+"tauri": patch:feat
+"tauri-codegen": patch:feat
+"tauri-build": patch:feat
+"tauri-plugin": patch:feat
+---
+
+Allow plugins to define (at compile time) JavaScript that are initialized when `withGlobalTauri` is true.

--- a/.changes/plugin-global-api-script.md
+++ b/.changes/plugin-global-api-script.md
@@ -1,0 +1,5 @@
+---
+"tauri-plugin": patch:feat
+---
+
+Added `Builder::global_api_script_path` to define a JavaScript file containing the initialization script for the plugin API bindings when `withGlobalTauri` is used.

--- a/.changes/tauri-utils-plugin-module.md
+++ b/.changes/tauri-utils-plugin-module.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:feat
+---
+
+Added the `plugin` module.

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -524,6 +524,8 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
 
   acl::save_acl_manifests(&acl_manifests)?;
 
+  tauri_utils::plugin::load_global_api_scripts(&out_dir);
+
   println!("cargo:rustc-env=TAURI_ENV_TARGET_TRIPLE={target_triple}");
 
   // TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/5457>

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -457,13 +457,13 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
   let resolved = Resolved::resolve(&acl, capabilities, target).expect("failed to resolve ACL");
   let runtime_authority = quote!(#root::ipc::RuntimeAuthority::new(#acl_tokens, #resolved));
 
-  let global_api_script_path = out_dir.join(COLLECTED_GLOBAL_API_SCRIPT_PATH);
-  let global_api_script = if config.app.with_global_tauri {
-    std::fs::read_to_string(&global_api_script_path).ok()
+  let plugin_global_api_script_path = out_dir.join(COLLECTED_GLOBAL_API_SCRIPT_PATH);
+  let plugin_global_api_script = if config.app.with_global_tauri {
+    std::fs::read_to_string(plugin_global_api_script_path).ok()
   } else {
     None
   };
-  let global_api_script = if let Some(s) = global_api_script {
+  let plugin_global_api_script = if let Some(s) = plugin_global_api_script {
     quote!(::std::option::Option::Some(#s.into()))
   } else {
     quote!(::std::option::Option::None)
@@ -480,7 +480,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
       #info_plist,
       #pattern,
       #runtime_authority,
-      #global_api_script
+      #plugin_global_api_script
     );
     #with_tray_icon_code
     context

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -481,7 +481,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
     };
 
   let plugin_global_api_script = if let Some(scripts) = plugin_global_api_script {
-    let scripts = scripts.into_iter().map(|s| quote!(#s.into()));
+    let scripts = scripts.into_iter().map(|s| quote!(#s));
     quote!(::std::option::Option::Some(vec![#(#scripts),*]))
   } else {
     quote!(::std::option::Option::None)

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -482,7 +482,7 @@ pub fn context_codegen(data: ContextData) -> Result<TokenStream, EmbeddedAssetsE
 
   let plugin_global_api_script = if let Some(scripts) = plugin_global_api_script {
     let scripts = scripts.into_iter().map(|s| quote!(#s));
-    quote!(::std::option::Option::Some(vec![#(#scripts),*]))
+    quote!(::std::option::Option::Some(&[#(#scripts),*]))
   } else {
     quote!(::std::option::Option::None)
   };

--- a/core/tauri-plugin/src/build/mod.rs
+++ b/core/tauri-plugin/src/build/mod.rs
@@ -31,6 +31,7 @@ pub fn plugin_config<T: DeserializeOwned>(name: &str) -> Option<T> {
 pub struct Builder<'a> {
   commands: &'a [&'static str],
   global_scope_schema: Option<schemars::schema::RootSchema>,
+  global_api_script_path: Option<PathBuf>,
   android_path: Option<PathBuf>,
   ios_path: Option<PathBuf>,
 }
@@ -40,6 +41,7 @@ impl<'a> Builder<'a> {
     Self {
       commands,
       global_scope_schema: None,
+      global_api_script_path: None,
       android_path: None,
       ios_path: None,
     }
@@ -48,6 +50,14 @@ impl<'a> Builder<'a> {
   /// Sets the global scope JSON schema.
   pub fn global_scope_schema(mut self, schema: schemars::schema::RootSchema) -> Self {
     self.global_scope_schema.replace(schema);
+    self
+  }
+
+  /// Sets the path to the script that is injected in the webview when the `withGlobalTauri` configuration is set to true.
+  ///
+  /// This is usually an IIFE that injects the plugin API JavaScript bindings to `window.__TAURI__`.
+  pub fn global_api_script_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+    self.global_api_script_path.replace(path.into());
     self
   }
 
@@ -116,6 +126,10 @@ impl<'a> Builder<'a> {
 
     if let Some(global_scope_schema) = self.global_scope_schema {
       acl::build::define_global_scope_schema(global_scope_schema, &name, &out_dir)?;
+    }
+
+    if let Some(path) = self.global_api_script_path {
+      tauri_utils::plugin::define_global_api_script_path(path);
     }
 
     mobile::setup(self.android_path, self.ios_path)?;

--- a/core/tauri-utils/src/lib.rs
+++ b/core/tauri-utils/src/lib.rs
@@ -29,6 +29,7 @@ pub mod html;
 pub mod io;
 pub mod mime_type;
 pub mod platform;
+pub mod plugin;
 /// Prepare application resources and sidecars.
 #[cfg(feature = "resources")]
 pub mod resources;

--- a/core/tauri-utils/src/plugin.rs
+++ b/core/tauri-utils/src/plugin.rs
@@ -1,0 +1,60 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+//! Compile-time and runtime types for Tauri plugins.
+#[cfg(feature = "build")]
+pub use build::*;
+
+#[cfg(feature = "build")]
+mod build {
+  use std::{
+    env::vars_os,
+    path::{Path, PathBuf},
+  };
+
+  const GLOBAL_API_SCRIPT_PATH_KEY: &str = "GLOBAL_API_SCRIPT_PATH";
+  /// Known file name of the script that contains all API scripts defined with [`define_global_api_script_path`].
+  pub const COLLECTED_GLOBAL_API_SCRIPT_PATH: &str = "__global-api-script.js";
+
+  /// Defines the path to the global API script using Cargo instructions.
+  pub fn define_global_api_script_path(path: PathBuf) {
+    println!(
+      "cargo:{GLOBAL_API_SCRIPT_PATH_KEY}={}",
+      path
+        .canonicalize()
+        .expect("failed to canonicalize global API script path")
+        .display()
+    )
+  }
+
+  /// Loads all the global API scripts defined with [`define_global_api_script_path`]
+  /// and saves them to the out dir with filename [`COLLECTED_GLOBAL_API_SCRIPT_PATH`].
+  pub fn load_global_api_scripts(out_dir: &Path) {
+    let mut merged_script = String::new();
+
+    for (key, value) in vars_os() {
+      let key = key.to_string_lossy();
+
+      if key.starts_with("DEP_") && key.ends_with(GLOBAL_API_SCRIPT_PATH_KEY) {
+        let script_path = PathBuf::from(value);
+        let script = std::fs::read_to_string(&script_path).unwrap_or_else(|e| {
+          panic!(
+            "failed to read global script path at {}: {e}",
+            script_path.display()
+          )
+        });
+
+        merged_script.push_str(";(function () {\n");
+        merged_script.push_str(&script);
+        merged_script.push_str("})()");
+      }
+    }
+
+    std::fs::write(
+      out_dir.join(COLLECTED_GLOBAL_API_SCRIPT_PATH),
+      merged_script,
+    )
+    .expect("failed to write global API script");
+  }
+}

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -388,7 +388,7 @@ pub struct Context<R: Runtime> {
   pub(crate) _info_plist: (),
   pub(crate) pattern: Pattern,
   pub(crate) runtime_authority: RuntimeAuthority,
-  pub(crate) plugin_global_api_scripts: Option<Vec<String>>,
+  pub(crate) plugin_global_api_scripts: Option<Vec<&'static str>>,
 }
 
 impl<R: Runtime> fmt::Debug for Context<R> {
@@ -502,7 +502,7 @@ impl<R: Runtime> Context<R> {
     info_plist: (),
     pattern: Pattern,
     runtime_authority: RuntimeAuthority,
-    plugin_global_api_scripts: Option<Vec<String>>,
+    plugin_global_api_scripts: Option<Vec<&'static str>>,
   ) -> Self {
     Self {
       config,

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -388,6 +388,7 @@ pub struct Context<R: Runtime> {
   pub(crate) _info_plist: (),
   pub(crate) pattern: Pattern,
   pub(crate) runtime_authority: RuntimeAuthority,
+  pub(crate) global_api_script: Option<String>,
 }
 
 impl<R: Runtime> fmt::Debug for Context<R> {
@@ -397,7 +398,8 @@ impl<R: Runtime> fmt::Debug for Context<R> {
       .field("default_window_icon", &self.default_window_icon)
       .field("app_icon", &self.app_icon)
       .field("package_info", &self.package_info)
-      .field("pattern", &self.pattern);
+      .field("pattern", &self.pattern)
+      .field("global_api_script", &self.global_api_script);
 
     #[cfg(all(desktop, feature = "tray-icon"))]
     d.field("tray_icon", &self.tray_icon);
@@ -500,6 +502,7 @@ impl<R: Runtime> Context<R> {
     info_plist: (),
     pattern: Pattern,
     runtime_authority: RuntimeAuthority,
+    global_api_script: Option<String>,
   ) -> Self {
     Self {
       config,
@@ -512,6 +515,7 @@ impl<R: Runtime> Context<R> {
       _info_plist: info_plist,
       pattern,
       runtime_authority,
+      global_api_script,
     }
   }
 

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -388,7 +388,7 @@ pub struct Context<R: Runtime> {
   pub(crate) _info_plist: (),
   pub(crate) pattern: Pattern,
   pub(crate) runtime_authority: RuntimeAuthority,
-  pub(crate) global_api_script: Option<String>,
+  pub(crate) plugin_global_api_script: Option<String>,
 }
 
 impl<R: Runtime> fmt::Debug for Context<R> {
@@ -399,7 +399,7 @@ impl<R: Runtime> fmt::Debug for Context<R> {
       .field("app_icon", &self.app_icon)
       .field("package_info", &self.package_info)
       .field("pattern", &self.pattern)
-      .field("global_api_script", &self.global_api_script);
+      .field("plugin_global_api_script", &self.plugin_global_api_script);
 
     #[cfg(all(desktop, feature = "tray-icon"))]
     d.field("tray_icon", &self.tray_icon);
@@ -502,7 +502,7 @@ impl<R: Runtime> Context<R> {
     info_plist: (),
     pattern: Pattern,
     runtime_authority: RuntimeAuthority,
-    global_api_script: Option<String>,
+    plugin_global_api_script: Option<String>,
   ) -> Self {
     Self {
       config,
@@ -515,7 +515,7 @@ impl<R: Runtime> Context<R> {
       _info_plist: info_plist,
       pattern,
       runtime_authority,
-      global_api_script,
+      plugin_global_api_script,
     }
   }
 

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -388,7 +388,7 @@ pub struct Context<R: Runtime> {
   pub(crate) _info_plist: (),
   pub(crate) pattern: Pattern,
   pub(crate) runtime_authority: RuntimeAuthority,
-  pub(crate) plugin_global_api_script: Option<String>,
+  pub(crate) plugin_global_api_scripts: Option<Vec<String>>,
 }
 
 impl<R: Runtime> fmt::Debug for Context<R> {
@@ -399,7 +399,7 @@ impl<R: Runtime> fmt::Debug for Context<R> {
       .field("app_icon", &self.app_icon)
       .field("package_info", &self.package_info)
       .field("pattern", &self.pattern)
-      .field("plugin_global_api_script", &self.plugin_global_api_script);
+      .field("plugin_global_api_scripts", &self.plugin_global_api_scripts);
 
     #[cfg(all(desktop, feature = "tray-icon"))]
     d.field("tray_icon", &self.tray_icon);
@@ -502,7 +502,7 @@ impl<R: Runtime> Context<R> {
     info_plist: (),
     pattern: Pattern,
     runtime_authority: RuntimeAuthority,
-    plugin_global_api_script: Option<String>,
+    plugin_global_api_scripts: Option<Vec<String>>,
   ) -> Self {
     Self {
       config,
@@ -515,7 +515,7 @@ impl<R: Runtime> Context<R> {
       _info_plist: info_plist,
       pattern,
       runtime_authority,
-      plugin_global_api_script,
+      plugin_global_api_scripts,
     }
   }
 

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -388,7 +388,7 @@ pub struct Context<R: Runtime> {
   pub(crate) _info_plist: (),
   pub(crate) pattern: Pattern,
   pub(crate) runtime_authority: RuntimeAuthority,
-  pub(crate) plugin_global_api_scripts: Option<Vec<&'static str>>,
+  pub(crate) plugin_global_api_scripts: Option<&'static [&'static str]>,
 }
 
 impl<R: Runtime> fmt::Debug for Context<R> {
@@ -502,7 +502,7 @@ impl<R: Runtime> Context<R> {
     info_plist: (),
     pattern: Pattern,
     runtime_authority: RuntimeAuthority,
-    plugin_global_api_scripts: Option<Vec<&'static str>>,
+    plugin_global_api_scripts: Option<&'static [&'static str]>,
   ) -> Self {
     Self {
       config,

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -189,7 +189,7 @@ pub struct AppManager<R: Runtime> {
   pub pattern: Arc<Pattern>,
 
   /// Global API scripts collected from plugins.
-  pub plugin_global_api_scripts: Arc<Option<Vec<&'static str>>>,
+  pub plugin_global_api_scripts: Arc<Option<&'static [&'static str]>>,
 
   /// Application Resources Table
   pub(crate) resources_table: Arc<Mutex<ResourceTable>>,

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -188,8 +188,8 @@ pub struct AppManager<R: Runtime> {
   /// Application pattern.
   pub pattern: Arc<Pattern>,
 
-  /// Global API script collected from plugins.
-  pub plugin_global_api_script: Arc<Option<String>>,
+  /// Global API scripts collected from plugins.
+  pub plugin_global_api_scripts: Arc<Option<Vec<String>>>,
 
   /// Application Resources Table
   pub(crate) resources_table: Arc<Mutex<ResourceTable>>,
@@ -277,7 +277,7 @@ impl<R: Runtime> AppManager<R> {
       app_icon: context.app_icon,
       package_info: context.package_info,
       pattern: Arc::new(context.pattern),
-      plugin_global_api_script: Arc::new(context.plugin_global_api_script),
+      plugin_global_api_scripts: Arc::new(context.plugin_global_api_scripts),
       resources_table: Arc::default(),
     }
   }

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -189,7 +189,7 @@ pub struct AppManager<R: Runtime> {
   pub pattern: Arc<Pattern>,
 
   /// Global API scripts collected from plugins.
-  pub plugin_global_api_scripts: Arc<Option<Vec<String>>>,
+  pub plugin_global_api_scripts: Arc<Option<Vec<&'static str>>>,
 
   /// Application Resources Table
   pub(crate) resources_table: Arc<Mutex<ResourceTable>>,

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -188,6 +188,9 @@ pub struct AppManager<R: Runtime> {
   /// Application pattern.
   pub pattern: Arc<Pattern>,
 
+  /// Global API script.
+  pub global_api_script: Arc<Option<String>>,
+
   /// Application Resources Table
   pub(crate) resources_table: Arc<Mutex<ResourceTable>>,
 }
@@ -274,6 +277,7 @@ impl<R: Runtime> AppManager<R> {
       app_icon: context.app_icon,
       package_info: context.package_info,
       pattern: Arc::new(context.pattern),
+      global_api_script: Arc::new(context.global_api_script),
       resources_table: Arc::default(),
     }
   }

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -188,8 +188,8 @@ pub struct AppManager<R: Runtime> {
   /// Application pattern.
   pub pattern: Arc<Pattern>,
 
-  /// Global API script.
-  pub global_api_script: Arc<Option<String>>,
+  /// Global API script collected from plugins.
+  pub plugin_global_api_script: Arc<Option<String>>,
 
   /// Application Resources Table
   pub(crate) resources_table: Arc<Mutex<ResourceTable>>,
@@ -277,7 +277,7 @@ impl<R: Runtime> AppManager<R> {
       app_icon: context.app_icon,
       package_info: context.package_info,
       pattern: Arc::new(context.pattern),
-      global_api_script: Arc::new(context.global_api_script),
+      plugin_global_api_script: Arc::new(context.plugin_global_api_script),
       resources_table: Arc::default(),
     }
   }

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -208,8 +208,8 @@ impl<R: Runtime> WebviewManager<R> {
       );
     }
 
-    if let Some(global_api_script) = &*app_manager.global_api_script {
-      webview_attributes = webview_attributes.initialization_script(global_api_script);
+    if let Some(plugin_global_api_script) = &*app_manager.plugin_global_api_script {
+      webview_attributes = webview_attributes.initialization_script(plugin_global_api_script);
     }
 
     pending.webview_attributes = webview_attributes;

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -209,7 +209,7 @@ impl<R: Runtime> WebviewManager<R> {
     }
 
     if let Some(plugin_global_api_scripts) = &*app_manager.plugin_global_api_scripts {
-      for script in plugin_global_api_scripts {
+      for script in plugin_global_api_scripts.iter() {
         webview_attributes = webview_attributes.initialization_script(script);
       }
     }

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -208,6 +208,10 @@ impl<R: Runtime> WebviewManager<R> {
       );
     }
 
+    if let Some(global_api_script) = &*app_manager.global_api_script {
+      webview_attributes = webview_attributes.initialization_script(global_api_script);
+    }
+
     pending.webview_attributes = webview_attributes;
 
     let mut registered_scheme_protocols = Vec::new();

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -208,8 +208,10 @@ impl<R: Runtime> WebviewManager<R> {
       );
     }
 
-    if let Some(plugin_global_api_script) = &*app_manager.plugin_global_api_script {
-      webview_attributes = webview_attributes.initialization_script(plugin_global_api_script);
+    if let Some(plugin_global_api_scripts) = &*app_manager.plugin_global_api_scripts {
+      for script in plugin_global_api_scripts {
+        webview_attributes = webview_attributes.initialization_script(script);
+      }
     }
 
     pending.webview_attributes = webview_attributes;

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -127,7 +127,7 @@ pub fn mock_context<R: Runtime, A: Assets<R>>(assets: A) -> crate::Context<R> {
     _info_plist: (),
     pattern: Pattern::Brownfield,
     runtime_authority: RuntimeAuthority::new(Default::default(), Resolved::default()),
-    global_api_script: None,
+    plugin_global_api_script: None,
   }
 }
 

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -127,6 +127,7 @@ pub fn mock_context<R: Runtime, A: Assets<R>>(assets: A) -> crate::Context<R> {
     _info_plist: (),
     pattern: Pattern::Brownfield,
     runtime_authority: RuntimeAuthority::new(Default::default(), Resolved::default()),
+    global_api_script: None,
   }
 }
 

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -127,7 +127,7 @@ pub fn mock_context<R: Runtime, A: Assets<R>>(assets: A) -> crate::Context<R> {
     _info_plist: (),
     pattern: Pattern::Brownfield,
     runtime_authority: RuntimeAuthority::new(Default::default(), Resolved::default()),
-    plugin_global_api_script: None,
+    plugin_global_api_scripts: None,
   }
 }
 

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -3152,7 +3152,7 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tauri"
-version = "2.0.0-beta.10"
+version = "2.0.0-beta.11"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3223,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "base64 0.22.0",
  "brotli",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "anyhow",
  "glob",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "gtk",
  "http",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "cocoa",
  "gtk",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.0-beta.8"
+version = "2.0.0-beta.9"
 dependencies = [
  "aes-gcm",
  "brotli",

--- a/examples/api/src-tauri/tauri-plugin-sample/api-iife.js
+++ b/examples/api/src-tauri/tauri-plugin-sample/api-iife.js
@@ -1,3 +1,7 @@
-if ("__TAURI__" in window) {
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+if ('__TAURI__' in window) {
   window.__TAURI__.sample = {}
 }

--- a/examples/api/src-tauri/tauri-plugin-sample/api-iife.js
+++ b/examples/api/src-tauri/tauri-plugin-sample/api-iife.js
@@ -1,0 +1,3 @@
+if ("__TAURI__" in window) {
+  window.__TAURI__.sample = {}
+}

--- a/examples/api/src-tauri/tauri-plugin-sample/build.rs
+++ b/examples/api/src-tauri/tauri-plugin-sample/build.rs
@@ -8,5 +8,6 @@ fn main() {
   tauri_plugin::Builder::new(COMMANDS)
     .android_path("android")
     .ios_path("ios")
+    .global_api_script_path("./api-iife.js")
     .build();
 }


### PR DESCRIPTION
Adds `tauri_plugin::Builder::global_api_script_path` so plugin authors can define the JavaScript global API bindings (supposed to be injected to `window.__TAURI__`) at compile time, so the string is only part of the binary when withGlobalTauri is true. Currently this needs to be done manually at runtime (and it's always added to the binary via include_str).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
