### PR TITLE
feat(bundler): display name for bundle

### DIFF
--- a/.changes/display-name-tauri-conf.md
+++ b/.changes/display-name-tauri-conf.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"tauri-build": patch:enhance
+---
+
+Added a new configuration option `tauri.conf.json > displayName` to specify a user-friendly name for the bundle. If it is empty, the default value is the `productName` field.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -19,6 +19,13 @@
       ],
       "pattern": "^[^/\\:*?\"<>|]+$"
     },
+    "displayName": {
+      "description": "App display name, will use `productName` if not set.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "version": {
       "description": "App version. It is a semver version number or a path to a `package.json` file containing the `version` field. If removed the version number from `Cargo.toml` is used.",
       "type": [

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -1973,6 +1973,9 @@ pub struct Config {
   #[serde(alias = "product-name")]
   #[cfg_attr(feature = "schema", validate(regex(pattern = "^[^/\\:*?\"<>|]+$")))]
   pub product_name: Option<String>,
+  /// App display name, will use `productName` if not set.
+  #[serde(alias = "display-name")]
+  pub display_name: Option<String>,
   /// App version. It is a semver version number or a path to a `package.json` file containing the `version` field. If removed the version number from `Cargo.toml` is used.
   #[serde(deserialize_with = "version_deserializer", default)]
   pub version: Option<String>,
@@ -2578,6 +2581,7 @@ mod build {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let schema = quote!(None);
       let product_name = opt_str_lit(self.product_name.as_ref());
+      let display_name = opt_str_lit(self.display_name.as_ref());
       let version = opt_str_lit(self.version.as_ref());
       let identifier = str_lit(&self.identifier);
       let app = &self.app;
@@ -2590,6 +2594,7 @@ mod build {
         ::tauri::utils::config::Config,
         schema,
         product_name,
+        display_name,
         version,
         identifier,
         app,

--- a/core/tauri/src/test/mod.rs
+++ b/core/tauri/src/test/mod.rs
@@ -99,6 +99,7 @@ pub fn mock_context<R: Runtime, A: Assets<R>>(assets: A) -> crate::Context<R> {
     config: Config {
       schema: None,
       product_name: Default::default(),
+      display_name: Default::default(),
       version: Default::default(),
       identifier: Default::default(),
       app: AppConfig {

--- a/tooling/bundler/src/bundle/linux/freedesktop.rs
+++ b/tooling/bundler/src/bundle/linux/freedesktop.rs
@@ -160,7 +160,7 @@ pub fn generate_desktop_file(
       },
       exec: bin_name,
       icon: bin_name,
-      name: settings.product_name(),
+      name: settings.display_name(),
       mime_type,
     },
     file,

--- a/tooling/bundler/src/bundle/macos/app.rs
+++ b/tooling/bundler/src/bundle/macos/app.rs
@@ -197,7 +197,7 @@ fn create_info_plist(
 
   let mut plist = plist::Dictionary::new();
   plist.insert("CFBundleDevelopmentRegion".into(), "English".into());
-  plist.insert("CFBundleDisplayName".into(), settings.product_name().into());
+  plist.insert("CFBundleDisplayName".into(), settings.display_name().into());
   plist.insert(
     "CFBundleExecutable".into(),
     settings.main_binary_name().into(),

--- a/tooling/bundler/src/bundle/macos/ios.rs
+++ b/tooling/bundler/src/bundle/macos/ios.rs
@@ -160,7 +160,7 @@ fn generate_info_plist(
   writeln!(
     file,
     "  <key>CFBundleDisplayName</key>\n  <string>{}</string>",
-    settings.product_name()
+    settings.display_name()
   )?;
   writeln!(
     file,

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -141,6 +141,8 @@ const ALL_PACKAGE_TYPES: &[PackageType] = &[
 pub struct PackageSettings {
   /// the package's product name.
   pub product_name: String,
+  /// the package's display name.
+  pub display_name: String,
   /// the package's version.
   pub version: String,
   /// the package's description.
@@ -792,6 +794,11 @@ impl Settings {
   /// Returns the product name.
   pub fn product_name(&self) -> &str {
     &self.package.product_name
+  }
+
+  /// Returns the display name.
+  pub fn display_name(&self) -> &str {
+    &self.package.display_name
   }
 
   /// Returns the bundle's identifier

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -517,6 +517,7 @@ pub fn build_wix_app_installer(
     .unwrap_or_default();
 
   data.insert("product_name", to_json(settings.product_name()));
+  data.insert("display_name", to_json(settings.display_name()));
   data.insert("version", to_json(app_version));
   let bundle_id = settings.bundle_identifier();
   let manufacturer = settings
@@ -744,7 +745,8 @@ pub fn build_wix_app_installer(
     let locale_strings = include_str!("./default-locale-strings.xml")
       .replace("__language__", &language_metadata.lang_id.to_string())
       .replace("__codepage__", &language_metadata.ascii_code.to_string())
-      .replace("__productName__", settings.product_name());
+      .replace("__productName__", settings.product_name())
+      .replace("__displayName__", settings.display_name());
 
     let mut unset_locale_strings = String::new();
     let prefix_len = "<String ".len();

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -209,6 +209,7 @@ fn build_nsis_app_installer(
   data.insert("bundle_id", to_json(bundle_id));
   data.insert("manufacturer", to_json(manufacturer));
   data.insert("product_name", to_json(settings.product_name()));
+  data.insert("display_name", to_json(settings.display_name()));
   data.insert("short_description", to_json(settings.short_description()));
   data.insert("copyright", to_json(settings.copyright_string()));
 

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -18,6 +18,7 @@ ${StrLoc}
 
 !define MANUFACTURER "{{manufacturer}}"
 !define PRODUCTNAME "{{product_name}}"
+!define DISPLAYNAME "{{display_name}}"
 !define VERSION "{{version}}"
 !define VERSIONWITHBUILD "{{version_with_build}}"
 !define SHORTDESCRIPTION "{{short_description}}"
@@ -44,7 +45,7 @@ ${StrLoc}
 !define UNINSTALLERSIGNCOMMAND "{{uninstaller_sign_cmd}}"
 !define ESTIMATEDSIZE "{{estimated_size}}"
 
-Name "${PRODUCTNAME}"
+Name "${DISPLAYNAME}"
 BrandingText "${COPYRIGHT}"
 OutFile "${OUTFILE}"
 
@@ -557,7 +558,7 @@ Section Install
   ; Create file associations
   {{#each file_associations as |association| ~}}
     {{#each association.ext as |ext| ~}}
-       !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${PRODUCTNAME}" "$INSTDIR\${MAINBINARYNAME}.exe $\"%1$\""
+       !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${DISPLAYNAME}" "$INSTDIR\${MAINBINARYNAME}.exe $\"%1$\""
     {{/each}}
   {{/each}}
 
@@ -582,7 +583,7 @@ Section Install
   !endif
 
   ; Registry information for add/remove programs
-  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayName" "${PRODUCTNAME}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayName" "${DISPLAYNAME}"
   WriteRegStr SHCTX "${UNINSTKEY}" "DisplayIcon" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\""
   WriteRegStr SHCTX "${UNINSTKEY}" "DisplayVersion" "${VERSION}"
   WriteRegStr SHCTX "${UNINSTKEY}" "Publisher" "${MANUFACTURER}"

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -93,7 +93,7 @@
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="DesktopFolder" Name="Desktop">
                 <Component Id="ApplicationShortcutDesktop" Guid="*">
-                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{product_name}}" Description="Runs {{product_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
+                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{display_name}}" Description="Runs {{display_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
                     <RemoveFolder Id="DesktopFolder" On="uninstall" />
                     <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
                 </Component>
@@ -131,7 +131,7 @@
                 {{#each association.ext as |ext| ~}}
                 <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="yes" Description="{{association.description}}">
                     <Extension Id="{{ext}}" Advertise="yes">
-                        <Verb Id="open" Command="Open with {{../../product_name}}" Argument="&quot;%1&quot;" />
+                        <Verb Id="open" Command="Open with {{../../display_name}}" Argument="&quot;%1&quot;" />
                     </Extension>
                 </ProgId>
                 {{/each~}}
@@ -157,8 +157,8 @@
             <Component Id="CMP_UninstallShortcut" Guid="*">
 
                 <Shortcut Id="UninstallShortcut"
-						  Name="Uninstall {{product_name}}"
-						  Description="Uninstalls {{product_name}}"
+						  Name="Uninstall {{display_name}}"
+						  Description="Uninstalls {{display_name}}"
 						  Target="[System64Folder]msiexec.exe"
 						  Arguments="/x [ProductCode]" />
 
@@ -177,8 +177,8 @@
         <DirectoryRef Id="ApplicationProgramsFolder">
             <Component Id="ApplicationShortcut" Guid="*">
                 <Shortcut Id="ApplicationStartMenuShortcut"
-                    Name="{{product_name}}"
-                    Description="Runs {{product_name}}"
+                    Name="{{display_name}}"
+                    Description="Runs {{display_name}}"
                     Target="[!Path]"
                     Icon="ProductIcon"
                     WorkingDirectory="INSTALLDIR">

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -19,6 +19,13 @@
       ],
       "pattern": "^[^/\\:*?\"<>|]+$"
     },
+    "displayName": {
+      "description": "App display name, will use `productName` if not set.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "version": {
       "description": "App version. It is a semver version number or a path to a `package.json` file containing the `version` field. If removed the version number from `Cargo.toml` is used.",
       "type": [

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1001,13 +1001,15 @@ impl RustAppSettings {
       .workspace
       .and_then(|v| v.package);
 
+    let product_name = config.product_name.clone().unwrap_or_else(|| {
+      cargo_package_settings
+        .name
+        .clone()
+        .expect("Cargo manifest must have the `package.name` field")
+    });
     let package_settings = PackageSettings {
-      product_name: config.product_name.clone().unwrap_or_else(|| {
-        cargo_package_settings
-          .name
-          .clone()
-          .expect("Cargo manifest must have the `package.name` field")
-      }),
+      product_name: product_name.clone(),
+      display_name: config.display_name.clone().unwrap_or_else(|| product_name.clone()),
       version: config.version.clone().unwrap_or_else(|| {
         cargo_package_settings
           .version

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1009,7 +1009,10 @@ impl RustAppSettings {
     });
     let package_settings = PackageSettings {
       product_name: product_name.clone(),
-      display_name: config.display_name.clone().unwrap_or_else(|| product_name.clone()),
+      display_name: config
+        .display_name
+        .clone()
+        .unwrap_or_else(|| product_name.clone()),
       version: config.version.clone().unwrap_or_else(|| {
         cargo_package_settings
           .version


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This PR Is for #8109, #8349 and #8363.

For Linux, productName needs to be converted to lower-kebab-case. To make sure app desktop entry displays user friendly name, `displayName` has been added.

Example:

```json
{
  "productName": "myapp",
  "displayName": "My App"
}
```