### PR TITLE
fix(bundler): Fix path seperators for deep link registry entries

### DIFF
--- a/.changes/bundler-deep-link-reg-path.md
+++ b/.changes/bundler-deep-link-reg-path.md
@@ -1,5 +1,5 @@
 ---
-'tauri-bundler': 'patch:fix'
+'tauri-bundler': 'patch:bug'
 ---
 
 Fixed an issue that caused the msi bundler to crash when deep link schemes were configured.

--- a/.changes/bundler-deep-link-reg-path.md
+++ b/.changes/bundler-deep-link-reg-path.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:fix'
+---
+
+Fixed an issue that caused the msi bundler to crash when deep link schemes were configured.

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -113,13 +113,13 @@
                 </RegistryKey>
                 <!-- Change the Root to HKCU for perUser installations -->
                 {{#each deep_link_protocols as |protocol| ~}}
-                <RegistryKey Root="HKLM" Key="Software\\Classes\\{{protocol}}">
+                <RegistryKey Root="HKLM" Key="Software\Classes\\{{protocol}}">
                     <RegistryValue Type="string" Name="URL Protocol" Value=""/>
                     <RegistryValue Type="string" Value="URL:{{bundle_id}} protocol"/>
                     <RegistryKey Key="DefaultIcon">
                         <RegistryValue Type="string" Value="&quot;[!Path]&quot;,0" />
                     </RegistryKey>
-                    <RegistryKey Key="shell\\open\\command">
+                    <RegistryKey Key="shell\open\command">
                         <RegistryValue Type="string" Value="&quot;[!Path]&quot; &quot;%1&quot;" />
                     </RegistryKey>
                 </RegistryKey>


### PR DESCRIPTION
this still doesn't make sense to me

https://discord.com/channels/616186924390023171/1217502717078147132