### PR TITLE
chore(deps): update `cargo-mobile2` crate

### DIFF
--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-mobile2"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4151a9a0e09e3acc2695c326cfdcf0b5ce5b04ab617cea6405a085f639b001"
+checksum = "13791faaa60df73f79fdd6328e46fd7a95cc3e9ee9320831eb028502d4e522a7"
 dependencies = [
  "colored",
  "core-foundation",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -39,7 +39,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [dependencies]
-cargo-mobile2 = { version = "0.10.3", default-features = false }
+cargo-mobile2 = { version = "0.10.4", default-features = false }
 jsonrpsee = { version = "0.22", features = [ "server" ] }
 jsonrpsee-core = "0.22"
 jsonrpsee-client-transport = { version = "0.22", features = [ "ws" ] }


### PR DESCRIPTION
* chore(deps): update `cargo-mobile2` crate

* brings fixes from #9067

* lock file
