### PR TITLE
fix(core): Set json content type for errors returned from commands

### DIFF
--- a/.changes/fix-ipc-error-json.md
+++ b/.changes/fix-ipc-error-json.md
@@ -1,0 +1,5 @@
+---
+tauri: 'patch:bug'
+---
+
+Fixed an issue where errors where returned as strings instead of objects from commands.

--- a/core/tauri/src/ipc/protocol.rs
+++ b/core/tauri/src/ipc/protocol.rs
@@ -92,7 +92,7 @@ pub fn get<R: Runtime>(manager: Arc<AppManager<R>>, label: String) -> UriSchemeP
                       let mut response =
                         http::Response::new(serde_json::to_vec(&e.0).unwrap().into());
                       *response.status_mut() = StatusCode::BAD_REQUEST;
-                      (response, mime::TEXT_PLAIN)
+                      (response, mime::APPLICATION_JSON)
                     }
                   };
 
@@ -305,7 +305,7 @@ fn handle_ipc_message<R: Runtime>(message: String, manager: &AppManager<R>, labe
                 mime_type = match &response {
                   InvokeResponse::Ok(InvokeBody::Json(_)) => mime::APPLICATION_JSON,
                   InvokeResponse::Ok(InvokeBody::Raw(_)) => mime::APPLICATION_OCTET_STREAM,
-                  InvokeResponse::Err(_) => mime::TEXT_PLAIN,
+                  InvokeResponse::Err(_) => mime::APPLICATION_JSON,
                 }
                 .essence_str()
               )


### PR DESCRIPTION
https://discord.com/channels/616186924390023171/1213116215397187624 (not the only time we talked about this but they tested this branch)