### PR TITLE
fix(core): Fix menu.remove trying to remove the item from itself instead of from the menu

### DIFF
--- a/core/tauri/src/menu/plugin.rs
+++ b/core/tauri/src/menu/plugin.rs
@@ -541,15 +541,16 @@ fn remove<R: Runtime>(
   item: (ResourceId, ItemKind),
 ) -> crate::Result<()> {
   let resources_table = app.resources_table();
-  let (rid, kind) = item;
+  let (item_rid, item_kind) = item;
   match kind {
     ItemKind::Menu => {
       let menu = resources_table.get::<Menu<R>>(rid)?;
-      do_menu_item!(resources_table, rid, kind, |i| menu.remove(&*i))?;
+      do_menu_item!(resources_table, item_rid, item_kind, |i| menu.remove(&*i))?;
     }
     ItemKind::Submenu => {
       let submenu = resources_table.get::<Submenu<R>>(rid)?;
-      do_menu_item!(resources_table, rid, kind, |i| submenu.remove(&*i))?;
+      do_menu_item!(resources_table, item_rid, item_kind, |i| submenu
+        .remove(&*i))?;
     }
     _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
   };


### PR DESCRIPTION
follow up to https://github.com/tauri-apps/tauri/pull/9219/ - only noticed because clippy screamed at me in anothe pr.

don't mind the commit message, i was tired and mixed it up.

btw, i had to disable the isolation pattern in the api example app, otherwise _nothing_ worked (it even had css issues)