### PR TITLE
fix(windows): changing WebView visibility on hide/show/minimize

### DIFF
--- a/.changes/fix-visibility-change.md
+++ b/.changes/fix-visibility-change.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Fix webview's visibility doesn't change with the app window

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2637,12 +2637,12 @@ fn handle_user_message<T: UserEvent>(
           WindowMessage::Show => {
             window.set_visible(true);
             #[cfg(windows)]
-            let _ = update_webview_visibility(&window, &webviews);
+            let _ = update_webview_visibility(&webviews, !window.is_minimized());
           }
           WindowMessage::Hide => {
             window.set_visible(false);
             #[cfg(windows)]
-            let _ = update_webview_visibility(&window, &webviews);
+            let _ = update_webview_visibility(&webviews, false);
           }
           WindowMessage::Close => {
             panic!("cannot handle `WindowMessage::Close` on the main thread")
@@ -3227,7 +3227,8 @@ fn handle_event_loop<T: UserEvent>(
                 }
               }
               #[cfg(windows)]
-              let _ = update_webview_visibility(&window, &webviews);
+              let _ =
+                update_webview_visibility(&webviews, window.is_visible() && !window.is_minimized());
             }
           }
           _ => {}
@@ -3965,10 +3966,9 @@ fn clear_window_surface(
 
 #[cfg(windows)]
 fn update_webview_visibility(
-  window: &Window,
   webviews: &[WebviewWrapper],
+  is_visible: bool,
 ) -> windows::core::Result<()> {
-  let is_visible = window.is_visible() && !window.is_minimized();
   for webview in webviews {
     let controller = webview.controller();
     unsafe { controller.SetIsVisible(is_visible) }?;

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2637,12 +2637,12 @@ fn handle_user_message<T: UserEvent>(
           WindowMessage::Show => {
             window.set_visible(true);
             #[cfg(windows)]
-            let _ = update_webview_visibility(&webviews, !window.is_minimized());
+            let _ = set_webview_visibility(&webviews, !window.is_minimized());
           }
           WindowMessage::Hide => {
             window.set_visible(false);
             #[cfg(windows)]
-            let _ = update_webview_visibility(&webviews, false);
+            let _ = set_webview_visibility(&webviews, false);
           }
           WindowMessage::Close => {
             panic!("cannot handle `WindowMessage::Close` on the main thread")
@@ -3228,7 +3228,7 @@ fn handle_event_loop<T: UserEvent>(
               }
               #[cfg(windows)]
               let _ =
-                update_webview_visibility(&webviews, window.is_visible() && !window.is_minimized());
+                set_webview_visibility(&webviews, window.is_visible() && !window.is_minimized());
             }
           }
           _ => {}
@@ -3965,7 +3965,7 @@ fn clear_window_surface(
 }
 
 #[cfg(windows)]
-fn update_webview_visibility(
+fn set_webview_visibility(
   webviews: &[WebviewWrapper],
   is_visible: bool,
 ) -> windows::core::Result<()> {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: #6864

We need to call `SetIsVisible` manually according to https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller?view=webview2-winrt-1.0.2365.46#isvisible

> Determines whether to show or hide the WebView. If IsVisible is set to false, the WebView is transparent and is not rendered. However, this does not affect the window containing the WebView (the ParentWindow parameter that was passed to [CoreWebView2Environment.CreateCoreWebView2ControllerAsync](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environment?view=webview2-winrt-1.0.2365.46#createcorewebview2controllerasync)). WebView as a child window does not get window messages when the top window is minimized or restored. For performance reasons, developers should set the IsVisible property of the WebView to false when the app window is minimized and back to true when the app window is restored. The app window does this by handling SIZE_MINIMIZED and SIZE_RESTORED command upon receiving WM_SIZE message. There are CPU and memory benefits when the page is hidden. For instance Chromium has code that throttles activities on the page like animations and some tasks are run less frequently. Similarly, WebView2 will purge some caches to reduce memory usage.

This is a quick dirty fix to make it work at least for minimize / restore / show / hide (no fully covered by other windows support yet) (`Resized` fires on minimized and restored, and since we don't have an is visible event yet, the best we can do is to hook onto those methods for now), we probably want to separate this event in https://github.com/tauri-apps/tao (issue https://github.com/tauri-apps/tao/issues/892) in the future