### PR TITLE
fix(core): Deadlock when using JsImage::Resource

### DIFF
--- a/core/tauri/src/menu/plugin.rs
+++ b/core/tauri/src/menu/plugin.rs
@@ -351,10 +351,11 @@ fn new<R: Runtime>(
   handler: Channel,
 ) -> crate::Result<(ResourceId, MenuId)> {
   let options = options.unwrap_or_default();
-  let mut resources_table = app.resources_table();
 
   let (rid, id) = match kind {
     ItemKind::Menu => {
+      // TODO: This doesn't work
+      let mut resources_table = app.resources_table();
       let mut builder = MenuBuilder::new(&app);
       if let Some(id) = options.id {
         builder = builder.id(id);
@@ -372,6 +373,8 @@ fn new<R: Runtime>(
     }
 
     ItemKind::Submenu => {
+      // TODO: This doesn't work
+      let mut resources_table = app.resources_table();
       let submenu = SubmenuPayload {
         id: options.id,
         text: options.text.unwrap_or_default(),
@@ -396,7 +399,7 @@ fn new<R: Runtime>(
       }
       .create_item(&webview)?;
       let id = item.id().clone();
-      let rid = resources_table.add(item);
+      let rid = app.resources_table().add(item);
       (rid, id)
     }
 
@@ -407,7 +410,7 @@ fn new<R: Runtime>(
       }
       .create_item(&webview)?;
       let id = item.id().clone();
-      let rid = resources_table.add(item);
+      let rid = app.resources_table().add(item);
       (rid, id)
     }
 
@@ -423,7 +426,7 @@ fn new<R: Runtime>(
       }
       .create_item(&webview)?;
       let id = item.id().clone();
-      let rid = resources_table.add(item);
+      let rid = app.resources_table().add(item);
       (rid, id)
     }
 
@@ -439,7 +442,7 @@ fn new<R: Runtime>(
       }
       .create_item(&webview)?;
       let id = item.id().clone();
-      let rid = resources_table.add(item);
+      let rid = app.resources_table().add(item);
       (rid, id)
     }
   };
@@ -838,8 +841,10 @@ fn set_icon<R: Runtime>(
   rid: ResourceId,
   icon: Option<Icon>,
 ) -> crate::Result<()> {
-  let resources_table = app.resources_table();
-  let icon_item = resources_table.get::<IconMenuItem<R>>(rid)?;
+  let icon_item = {
+    let resources_table = app.resources_table();
+    resources_table.get::<IconMenuItem<R>>(rid)?
+  };
 
   match icon {
     Some(Icon::Native(icon)) => icon_item.set_native_icon(Some(icon)),

--- a/tooling/api/src/menu/base.ts
+++ b/tooling/api/src/menu/base.ts
@@ -48,7 +48,6 @@ export async function newMenu(
   kind: ItemKind,
   opts?: unknown
 ): Promise<[number, string]> {
-  console.log('newMenu')
   const handler = new Channel<string>()
   let items: null | Array<
     | [number, string]
@@ -107,9 +106,15 @@ export async function newMenu(
 
   return invoke('plugin:menu|new', {
     kind,
-    options,
-  options: opts ? { ...opts, items } : undefined,
-* @ignore */
+    options: opts ? { ...opts, items } : undefined,
+    handler
+  })
+}
+
+export class MenuItemBase extends Resource {
+  /** @ignore */
+  readonly #id: string
+  /** @ignore */
   readonly #kind: ItemKind
 
   /** The id of this item. */

--- a/tooling/api/src/menu/base.ts
+++ b/tooling/api/src/menu/base.ts
@@ -48,6 +48,7 @@ export async function newMenu(
   kind: ItemKind,
   opts?: unknown
 ): Promise<[number, string]> {
+  console.log('newMenu')
   const handler = new Channel<string>()
   let items: null | Array<
     | [number, string]
@@ -62,6 +63,14 @@ export async function newMenu(
       handler.onmessage = opts.action as () => void
       delete opts.action
     }
+
+    if ('icon' in opts && opts.icon) {
+      // TODO:
+      // @ts-ignore
+      opts.icon = transformImage(opts.icon)
+    }
+
+    console.log(kind, opts)
 
     if ('items' in opts && opts.items) {
       items = (
@@ -84,6 +93,7 @@ export async function newMenu(
 
         if ('icon' in i && i.icon) {
           i.icon = transformImage(i.icon)
+          console.log('transformed', i.icon)
         }
 
         return injectChannel(i)
@@ -91,17 +101,15 @@ export async function newMenu(
     }
   }
 
+  const options = opts ? { ...opts, items } : undefined
+
+  console.log('options', options)
+
   return invoke('plugin:menu|new', {
     kind,
-    options: opts ? { ...opts, items } : undefined,
-    handler
-  })
-}
-
-export class MenuItemBase extends Resource {
-  /** @ignore */
-  readonly #id: string
-  /** @ignore */
+    options,
+  options: opts ? { ...opts, items } : undefined,
+* @ignore */
   readonly #kind: ItemKind
 
   /** The id of this item. */


### PR DESCRIPTION
Just showing the problem so we can discuss how to solve this.

The problem is that JsImage.into_img() locks the resource table (if it's rid) but we're also doing the same before so we end up with a deadlock. I've fixed this for the icon menu item but then realised that the menus themselves have the same problem if they have an icon child.

The easiest way to fix this is to change into_img to take a reference to the resources_table instead of a Manager but that's inconsistent with our other apis.

Maybe changing the (Sub)Menu's create_item and PayloadKind with_item to use a Manager reference instead of a resources table works too but i assume there was a reason you did this.

If you have another idea i'm all ears :) (if you wanna take over the pr, that's also fine 🤷)

P.S. This pr started as a js-only fix here: https://discord.com/channels/616186924390023171/1220447433914454156 (using Image in js for the icon didn't work because we didn't convert it from `{ rid }` to `rid`