### PR TITLE
fix(bundler/nsis): Don't use /R flag on installation dir

### DIFF
--- a/.changes/bundler-r-flag.md
+++ b/.changes/bundler-r-flag.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:bug'
+---
+
+The NSIS uninstaller now won't mindlessly try to remove the whole installation folder when the "Remove application data" checkbox was ticked. This prevents data loss when the app was installed in a folder which contained other files.

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -641,14 +641,10 @@ Section Uninstall
   ; Delete uninstaller
   Delete "$INSTDIR\uninstall.exe"
 
-  ${If} $DeleteAppDataCheckboxState == 1
-    RMDir /R /REBOOTOK "$INSTDIR"
-  ${Else}
-    {{#each resources_ancestors}}
-    RMDir /REBOOTOK "$INSTDIR\\{{this}}"
-    {{/each}}
-    RMDir "$INSTDIR"
-  ${EndIf}
+  {{#each resources_ancestors}}
+  RMDir /REBOOTOK "$INSTDIR\\{{this}}"
+  {{/each}}
+  RMDir "$INSTDIR"
 
   ; Remove start menu shortcut
   !insertmacro MUI_STARTMENU_GETFOLDER Application $AppStartMenuFolder


### PR DESCRIPTION
ref https://github.com/tauri-apps/tauri/pull/9105
ref https://github.com/tauri-apps/tauri/issues/9277

The leftover rmdir installdir is fine because it won't delete the folder if it still contains files.

_note that this is for the 1.x branch_