### PR TITLE
fix(cli): upgrade heck to better support Chinese/Japanese prodcut name on Linux

### DIFF
--- a/.changes/cli-chinese-product-name.md
+++ b/.changes/cli-chinese-product-name.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Upgrade `heck` to v0.5 to better support Chinese and Japanese product name, because Chinese do not have word separation.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,6 +1666,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,7 +4041,7 @@ dependencies = [
  "glib",
  "glob",
  "gtk",
- "heck 0.4.1",
+ "heck 0.5.0",
  "http",
  "ico 0.2.0",
  "ignore",
@@ -4096,7 +4102,7 @@ dependencies = [
  "anyhow",
  "cargo_toml 0.15.2",
  "dirs-next",
- "heck 0.4.1",
+ "heck 0.5.0",
  "json-patch",
  "quote",
  "semver",
@@ -4147,7 +4153,7 @@ dependencies = [
 name = "tauri-macros"
 version = "1.4.3"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4204,7 +4210,7 @@ dependencies = [
  "dunce",
  "getrandom 0.2.12",
  "glob",
- "heck 0.4.1",
+ "heck 0.5.0",
  "html5ever",
  "infer 0.13.0",
  "json-patch",

--- a/core/tauri-build/Cargo.toml
+++ b/core/tauri-build/Cargo.toml
@@ -27,7 +27,7 @@ tauri-utils = { version = "1.5.3", path = "../tauri-utils", features = [
 cargo_toml = "0.15"
 serde = "1"
 serde_json = "1"
-heck = "0.4"
+heck = "0.5"
 json-patch = "1.2"
 tauri-winres = "0.1"
 semver = "1"

--- a/core/tauri-macros/Cargo.toml
+++ b/core/tauri-macros/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 syn = { version = "1", features = ["full"] }
-heck = "0.4"
+heck = "0.5"
 tauri-codegen = { version = "1.4.2", default-features = false, path = "../tauri-codegen" }
 tauri-utils = { version = "1.5.3", path = "../tauri-utils" }
 

--- a/core/tauri-utils/Cargo.toml
+++ b/core/tauri-utils/Cargo.toml
@@ -40,7 +40,7 @@ dunce = "1"
 log = "0.4.20"
 
 [target."cfg(target_os = \"linux\")".dependencies]
-heck = "0.4"
+heck = "0.5"
 
 [target."cfg(windows)".dependencies]
 windows-version = "0.1"

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -122,7 +122,7 @@ win7-notifications = { version = "0.4", optional = true }
   features = [ "Win32_Foundation" ]
 
 [build-dependencies]
-heck = "0.4"
+heck = "0.5"
 once_cell = "1"
 
 [dev-dependencies]

--- a/tooling/bundler/Cargo.toml
+++ b/tooling/bundler/Cargo.toml
@@ -62,7 +62,7 @@ plist = "1"
 regex = "1"
 
 [target."cfg(target_os = \"linux\")".dependencies]
-heck = "0.4"
+heck = "0.5"
 ar = "0.9.0"
 md5 = "0.7.0"
 

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -436,7 +436,7 @@ version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -1183,9 +1183,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3355,7 +3358,7 @@ dependencies = [
  "flate2",
  "glob",
  "handlebars",
- "heck",
+ "heck 0.5.0",
  "hex",
  "image",
  "log",
@@ -3401,7 +3404,7 @@ dependencies = [
  "env_logger",
  "glob",
  "handlebars",
- "heck",
+ "heck 0.5.0",
  "html5ever",
  "ignore",
  "image",
@@ -3467,7 +3470,7 @@ dependencies = [
  "dunce",
  "getrandom 0.2.11",
  "glob",
- "heck",
+ "heck 0.5.0",
  "html5ever",
  "infer",
  "json-patch",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -65,7 +65,7 @@ semver = "1.0"
 regex = "1.10.2"
 unicode-width = "0.1"
 zeroize = "1.6"
-heck = { version = "0.4", features = [ "unicode" ] }
+heck = "0.5"
 dialoguer = "0.11"
 url = { version = "2.4", features = [ "serde" ] }
 os_pipe = "1"


### PR DESCRIPTION
upgrade `heck` to v0.5 to support Chinese product name on Linux, fix #9295