### PR TITLE
feat(bundler): respects binary name in Cargo.toml

### DIFF
--- a/tooling/cli/src/interface/mod.rs
+++ b/tooling/cli/src/interface/mod.rs
@@ -31,6 +31,7 @@ pub trait AppSettings {
     features: &[String],
   ) -> crate::Result<tauri_bundler::BundleSettings>;
   fn app_binary_path(&self, options: &Options) -> crate::Result<PathBuf>;
+  fn app_has_binary_name(&self) -> bool;
   fn get_binaries(
     &self,
     config: &Config,

--- a/tooling/cli/src/interface/rust/desktop.rs
+++ b/tooling/cli/src/interface/rust/desktop.rs
@@ -185,7 +185,10 @@ pub fn build(
       .with_context(|| "failed to build app")?;
   }
 
-  rename_app(target_os, &bin_path, product_name.as_deref())?;
+  // Don't rename the app if the binary name is already set
+  if !app_settings.app_has_binary_name() {
+    rename_app(target_os, &bin_path, product_name.as_deref())?;
+  }
 
   Ok(())
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This PR supersedes #9175 with a non-breaking way. It fixes bundler issue when the app has a specified binary name, as follows

```toml
[[bin]]
name = "mylowercasedname"
path = "src/main.rs"
```

If binary name has been specified, it will not be renamed.