### PR TITLE
fix: use $CARGO_MANIFEST_DIR to fully specify include_dir paths in tauri-cli

### DIFF
--- a/.changes/cli-include-dir-cargo-manifest-dir.md
+++ b/.changes/cli-include-dir-cargo-manifest-dir.md
@@ -1,0 +1,5 @@
+---
+"tauri-cli": patch:enhance
+---
+
+Use `$CARGO_MANIFEST_DIR` when including templates at build-time.

--- a/tooling/cli/src/init.rs
+++ b/tooling/cli/src/init.rs
@@ -22,7 +22,7 @@ use clap::Parser;
 use handlebars::{to_json, Handlebars};
 use include_dir::{include_dir, Dir};
 
-const TEMPLATE_DIR: Dir<'_> = include_dir!("templates/app");
+const TEMPLATE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates/app");
 const TAURI_CONF_TEMPLATE: &str = include_str!("../templates/tauri.conf.json");
 
 #[derive(Debug, Parser)]

--- a/tooling/cli/src/mobile/android/project.rs
+++ b/tooling/cli/src/mobile/android/project.rs
@@ -27,7 +27,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
-const TEMPLATE_DIR: Dir<'_> = include_dir!("templates/mobile/android");
+const TEMPLATE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates/mobile/android");
 
 pub fn gen(
   config: &Config,

--- a/tooling/cli/src/mobile/ios/project.rs
+++ b/tooling/cli/src/mobile/ios/project.rs
@@ -22,7 +22,7 @@ use std::{
   path::{Component, PathBuf},
 };
 
-const TEMPLATE_DIR: Dir<'_> = include_dir!("templates/mobile/ios");
+const TEMPLATE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates/mobile/ios");
 
 // unprefixed app_root seems pretty dangerous!!
 // TODO: figure out what cargo-mobile meant by that

--- a/tooling/cli/src/plugin/init.rs
+++ b/tooling/cli/src/plugin/init.rs
@@ -20,7 +20,7 @@ use std::{
   path::{Component, Path, PathBuf},
 };
 
-pub const TEMPLATE_DIR: Dir<'_> = include_dir!("templates/plugin");
+pub const TEMPLATE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates/plugin");
 
 #[derive(Debug, Parser)]
 #[clap(about = "Initialize a Tauri plugin project on an existing directory")]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
I ran into this while trying to use tauri-cli with Bazel.  Michael Bryan has a [great post](https://adventures.michaelfbryan.com/posts/bringing-include_dir-into-the-modern-era/) on why this should be the default.