### PR TITLE
fix(dialog): DRAFT granting file-access for `dialog.open` on Android devices

### DIFF
--- a/tooling/cli/templates/mobile/android/app/src/main/AndroidManifest.xml
+++ b/tooling/cli/templates/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+      android:maxSdkVersion="29" />
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
Once implemented, closes #9083 

Does not require a new version as this is a draft that suggests changes (merging not recommended unless it is confirmed to resolve the issue).

> **Context for those not following the discord discussion**: The solution for issue #9083 has progressed and now the `fileResponse.path` string is a file path (resolved [here in this PR](https://github.com/tauri-apps/plugins-workspace/pull/1056)). The latest release of `plugins-workspace/dialog` **v2** contains this fix, but now there is another issue - whilst the file path is provided, _attempting to access it_ via Rust produces a `Permission denied (os error 13)` result.

_Reference for discord discussions:_
- Part 1: `Tauri 2.0.0 - Convert content URI to filepath`
- Part 2: `open/readfile outside app dir?`

### Proposition

According to [this reference](https://developer.android.com/training/data-storage/shared/media#request-permissions), this happens is because the `AndroidManifest.xml` file generated (for granting permissions and other kinds of access) doesn't declare the `READ_EXTERNAL_STORAGE` flag (and optionally the `WRITE_EXTERNAL_STORAGE` flag, for users that want to write to the physical device's local storage)

Declaring this would grant access to storage outside the app, thus preventing `Permission denied (os error 13)` from occurring. I demonstrated what this may look like in the `Added hypothetical extra lines for granting file-access` commit.

### Why this is a draft
- I'm not sure whether the file in the commit is the right `AndroidManifest.xml` file that is generated every time `pnpm tauri android dev` and/or `pnpm tauri android build` is called. Another place I saw a similar implementation is in [PluginHandle.kt](https://github.com/tauri-apps/tauri/blob/dev/core/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginHandle.kt), which if I understand correctly, validates plugins and passes the appropriate permission flags to the `AndroidManifest.xml` file
- this seems like it can be solved in multiple ways (as long as the correct permissions are put in the right `AndroidManifest.xml` file) and I'm unsure which way the **Tauri Working Group** would prefer. If i understand correctly, it can be solved by either:
  1.  hard-coding the permissions on the template `AndroidManifest.xml` file like shown in the commit to implicitly let all users access external storage (making it work consistently like Windows and Unix), or
  2.  parsing it in `PluginHandle.kt` and creating an appropriate capabilities permission for the `src-tauri/capabilities` folder (meaning the documentation for `dialog.open` may need to be updated to reflect this, but adheres better to Tauri's "security" focus)

I'm unsure if what I found helps, but if it does, I'm happy to solve this in whatever way the TWG deems appropriate 😀