### PR TITLE
feat(bundler): added provides, conflicts and replaces for deb and rpm

### DIFF
--- a/.changes/deb-rpm-provides-conflicts-replaces.md
+++ b/.changes/deb-rpm-provides-conflicts-replaces.md
@@ -4,20 +4,3 @@
 ---
 
 Added support for `provides`, `conflicts` and `replaces` (`obsoletes` for RPM) options for `bundler > deb` and `bundler > rpm` configs.
-
-```json
-{
-  "bundler": {
-    "deb": {
-      "provides": ["my-package"],
-      "conflicts": ["my-package"],
-      "replaces": ["my-package"]
-    },
-    "rpm": {
-      "provides": ["my-package"],
-      "conflicts": ["my-package"],
-      "obsoletes": ["my-package"]
-    }
-  }
-}
-```

--- a/.changes/deb-rpm-provides-conflicts-replaces.md
+++ b/.changes/deb-rpm-provides-conflicts-replaces.md
@@ -1,0 +1,23 @@
+---
+'tauri-bundler': 'minor:feat'
+'tauri-utils': 'minor:feat'
+---
+
+Added support for `provides`, `conflicts` and `replaces` (`obsoletes` for RPM) options for `bundler > deb` and `bundler > rpm` configs.
+
+```json
+{
+  "bundler": {
+    "deb": {
+      "provides": ["my-package"],
+      "conflicts": ["my-package"],
+      "replaces": ["my-package"]
+    },
+    "rpm": {
+      "provides": ["my-package"],
+      "conflicts": ["my-package"],
+      "obsoletes": ["my-package"]
+    }
+  }
+}
+```

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -2422,6 +2422,36 @@
             "type": "string"
           }
         },
+        "provides": {
+          "description": "The list of dependencies the package provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of package conflicts.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "replaces": {
+          "description": "The list of package replaces.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "files": {
           "description": "The files to include on the package.",
           "default": {},
@@ -2495,6 +2525,36 @@
       "properties": {
         "depends": {
           "description": "The list of RPM dependencies your application relies on.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "provides": {
+          "description": "The list of RPM dependencies your application provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of RPM dependencies your application conflicts with. They must not be present in order for the package to be installed.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "obsoletes": {
+          "description": "The list of RPM dependencies your application supersedes - if this package is installed, packages listed as “obsoletes” will be automatically removed (if they are present).",
           "type": [
             "array",
             "null"

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -323,6 +323,12 @@ pub struct AppImageConfig {
 pub struct DebConfig {
   /// The list of deb dependencies your application relies on.
   pub depends: Option<Vec<String>>,
+  /// The list of dependencies the package provides.
+  pub provides: Option<Vec<String>>,
+  /// The list of package conflicts.
+  pub conflicts: Option<Vec<String>>,
+  /// The list of package replaces.
+  pub replaces: Option<Vec<String>>,
   /// The files to include on the package.
   #[serde(default)]
   pub files: HashMap<PathBuf, PathBuf>,
@@ -384,6 +390,14 @@ pub struct LinuxConfig {
 pub struct RpmConfig {
   /// The list of RPM dependencies your application relies on.
   pub depends: Option<Vec<String>>,
+  /// The list of RPM dependencies your application provides.
+  pub provides: Option<Vec<String>>,
+  /// The list of RPM dependencies your application conflicts with. They must not be present
+  /// in order for the package to be installed.
+  pub conflicts: Option<Vec<String>>,
+  /// The list of RPM dependencies your application supersedes - if this package is installed,
+  /// packages listed as “obsoletes” will be automatically removed (if they are present).
+  pub obsoletes: Option<Vec<String>>,
   /// The RPM release tag.
   #[serde(default = "default_release")]
   pub release: String,
@@ -420,6 +434,9 @@ impl Default for RpmConfig {
   fn default() -> Self {
     Self {
       depends: None,
+      provides: None,
+      conflicts: None,
+      obsoletes: None,
       release: default_release(),
       epoch: 0,
       files: Default::default(),

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -182,15 +182,30 @@ fn generate_control_file(
   if !dependencies.is_empty() {
     writeln!(file, "Depends: {}", dependencies.join(", "))?;
   }
-  let provides = settings.deb().provides.as_ref().cloned().unwrap_or_default();
+  let provides = settings
+    .deb()
+    .provides
+    .as_ref()
+    .cloned()
+    .unwrap_or_default();
   if !provides.is_empty() {
     writeln!(file, "Provides: {}", provides.join(", "))?;
   }
-  let conflicts = settings.deb().conflicts.as_ref().cloned().unwrap_or_default();
+  let conflicts = settings
+    .deb()
+    .conflicts
+    .as_ref()
+    .cloned()
+    .unwrap_or_default();
   if !conflicts.is_empty() {
     writeln!(file, "Conflicts: {}", conflicts.join(", "))?;
   }
-  let replaces = settings.deb().replaces.as_ref().cloned().unwrap_or_default();
+  let replaces = settings
+    .deb()
+    .replaces
+    .as_ref()
+    .cloned()
+    .unwrap_or_default();
   if !replaces.is_empty() {
     writeln!(file, "Replaces: {}", replaces.join(", "))?;
   }

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -182,6 +182,18 @@ fn generate_control_file(
   if !dependencies.is_empty() {
     writeln!(file, "Depends: {}", dependencies.join(", "))?;
   }
+  let provides = settings.deb().provides.as_ref().cloned().unwrap_or_default();
+  if !provides.is_empty() {
+    writeln!(file, "Provides: {}", provides.join(", "))?;
+  }
+  let conflicts = settings.deb().conflicts.as_ref().cloned().unwrap_or_default();
+  if !conflicts.is_empty() {
+    writeln!(file, "Conflicts: {}", conflicts.join(", "))?;
+  }
+  let replaces = settings.deb().replaces.as_ref().cloned().unwrap_or_default();
+  if !replaces.is_empty() {
+    writeln!(file, "Replaces: {}", replaces.join(", "))?;
+  }
   let mut short_description = settings.short_description().trim();
   if short_description.is_empty() {
     short_description = "(none)";

--- a/tooling/bundler/src/bundle/linux/rpm.rs
+++ b/tooling/bundler/src/bundle/linux/rpm.rs
@@ -58,6 +58,21 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     builder = builder.requires(Dependency::any(dep));
   }
 
+  // Add provides
+  for dep in settings.rpm().provides.as_ref().cloned().unwrap_or_default() {
+    builder = builder.provides(Dependency::any(dep));
+  }
+
+  // Add conflicts
+  for dep in settings.rpm().conflicts.as_ref().cloned().unwrap_or_default() {
+    builder = builder.conflicts(Dependency::any(dep));
+  }
+
+  // Add obsoletes
+  for dep in settings.rpm().obsoletes.as_ref().cloned().unwrap_or_default() {
+    builder = builder.obsoletes(Dependency::any(dep));
+  }
+
   // Add binaries
   for bin in settings.binaries() {
     let src = settings.binary_path(bin);

--- a/tooling/bundler/src/bundle/linux/rpm.rs
+++ b/tooling/bundler/src/bundle/linux/rpm.rs
@@ -59,17 +59,35 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   }
 
   // Add provides
-  for dep in settings.rpm().provides.as_ref().cloned().unwrap_or_default() {
+  for dep in settings
+    .rpm()
+    .provides
+    .as_ref()
+    .cloned()
+    .unwrap_or_default()
+  {
     builder = builder.provides(Dependency::any(dep));
   }
 
   // Add conflicts
-  for dep in settings.rpm().conflicts.as_ref().cloned().unwrap_or_default() {
+  for dep in settings
+    .rpm()
+    .conflicts
+    .as_ref()
+    .cloned()
+    .unwrap_or_default()
+  {
     builder = builder.conflicts(Dependency::any(dep));
   }
 
   // Add obsoletes
-  for dep in settings.rpm().obsoletes.as_ref().cloned().unwrap_or_default() {
+  for dep in settings
+    .rpm()
+    .obsoletes
+    .as_ref()
+    .cloned()
+    .unwrap_or_default()
+  {
     builder = builder.obsoletes(Dependency::any(dep));
   }
 

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -168,6 +168,12 @@ pub struct DebianSettings {
   // OS-specific settings:
   /// the list of debian dependencies.
   pub depends: Option<Vec<String>>,
+  /// the list of dependencies the package provides.
+  pub provides: Option<Vec<String>>,
+  /// the list of package conflicts.
+  pub conflicts: Option<Vec<String>>,
+  /// the list of package replaces.
+  pub replaces: Option<Vec<String>>,
   /// List of custom files to add to the deb package.
   /// Maps the path on the debian package to the path of the file to include (relative to the current working directory).
   pub files: HashMap<PathBuf, PathBuf>,
@@ -214,6 +220,14 @@ pub struct AppImageSettings {
 pub struct RpmSettings {
   /// The list of RPM dependencies your application relies on.
   pub depends: Option<Vec<String>>,
+  /// The list of RPM dependencies your application provides.
+  pub provides: Option<Vec<String>>,
+  /// The list of RPM dependencies your application conflicts with. They must not be present
+  /// in order for the package to be installed.
+  pub conflicts: Option<Vec<String>>,
+  /// The list of RPM dependencies your application supersedes - if this package is installed,
+  /// packages listed as “obsoletes” will be automatically removed (if they are present).
+  pub obsoletes: Option<Vec<String>>,
   /// The RPM release tag.
   pub release: String,
   /// The RPM epoch.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -2422,6 +2422,36 @@
             "type": "string"
           }
         },
+        "provides": {
+          "description": "The list of dependencies the package provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of package conflicts.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "replaces": {
+          "description": "The list of package replaces.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "files": {
           "description": "The files to include on the package.",
           "default": {},
@@ -2495,6 +2525,36 @@
       "properties": {
         "depends": {
           "description": "The list of RPM dependencies your application relies on.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "provides": {
+          "description": "The list of RPM dependencies your application provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of RPM dependencies your application conflicts with. They must not be present in order for the package to be installed.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "obsoletes": {
+          "description": "The list of RPM dependencies your application supersedes - if this package is installed, packages listed as “obsoletes” will be automatically removed (if they are present).",
           "type": [
             "array",
             "null"

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1209,7 +1209,20 @@ fn tauri_config_to_bundle_settings(
   #[allow(unused_mut)]
   let mut depends_deb = config.linux.deb.depends.unwrap_or_default();
   #[allow(unused_mut)]
+  let mut provides_deb = config.linux.deb.provides.unwrap_or_default();
+  #[allow(unused_mut)]
+  let mut conflicts_deb = config.linux.deb.conflicts.unwrap_or_default();
+  #[allow(unused_mut)]
+  let mut replaces_deb = config.linux.deb.replaces.unwrap_or_default();
+
+  #[allow(unused_mut)]
   let mut depends_rpm = config.linux.rpm.depends.unwrap_or_default();
+  #[allow(unused_mut)]
+  let mut provides_rpm = config.linux.rpm.provides.unwrap_or_default();
+  #[allow(unused_mut)]
+  let mut conflicts_rpm = config.linux.rpm.conflicts.unwrap_or_default();
+  #[allow(unused_mut)]
+  let mut obsoletes_rpm = config.linux.rpm.obsoletes.unwrap_or_default();
 
   // set env vars used by the bundler and inject dependencies
   #[cfg(target_os = "linux")]
@@ -1330,6 +1343,21 @@ fn tauri_config_to_bundle_settings(
       } else {
         Some(depends_deb)
       },
+      provides: if provides_deb.is_empty() {
+        None
+      } else {
+        Some(provides_deb)
+      },
+      conflicts: if conflicts_deb.is_empty() {
+        None
+      } else {
+        Some(conflicts_deb)
+      },
+      replaces: if replaces_deb.is_empty() {
+        None
+      } else {
+        Some(replaces_deb)
+      },
       files: config.linux.deb.files,
       desktop_template: config.linux.deb.desktop_template,
       section: config.linux.deb.section,
@@ -1348,6 +1376,21 @@ fn tauri_config_to_bundle_settings(
         None
       } else {
         Some(depends_rpm)
+      },
+      provides: if provides_rpm.is_empty() {
+        None
+      } else {
+        Some(provides_rpm)
+      },
+      conflicts: if conflicts_rpm.is_empty() {
+        None
+      } else {
+        Some(conflicts_rpm)
+      },
+      obsoletes: if obsoletes_rpm.is_empty() {
+        None
+      } else {
+        Some(obsoletes_rpm)
       },
       release: config.linux.rpm.release,
       epoch: config.linux.rpm.epoch,

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1208,21 +1208,9 @@ fn tauri_config_to_bundle_settings(
     .unwrap_or(BundleResources::List(Vec::new()));
   #[allow(unused_mut)]
   let mut depends_deb = config.linux.deb.depends.unwrap_or_default();
-  #[allow(unused_mut)]
-  let mut provides_deb = config.linux.deb.provides.unwrap_or_default();
-  #[allow(unused_mut)]
-  let mut conflicts_deb = config.linux.deb.conflicts.unwrap_or_default();
-  #[allow(unused_mut)]
-  let mut replaces_deb = config.linux.deb.replaces.unwrap_or_default();
 
   #[allow(unused_mut)]
   let mut depends_rpm = config.linux.rpm.depends.unwrap_or_default();
-  #[allow(unused_mut)]
-  let mut provides_rpm = config.linux.rpm.provides.unwrap_or_default();
-  #[allow(unused_mut)]
-  let mut conflicts_rpm = config.linux.rpm.conflicts.unwrap_or_default();
-  #[allow(unused_mut)]
-  let mut obsoletes_rpm = config.linux.rpm.obsoletes.unwrap_or_default();
 
   // set env vars used by the bundler and inject dependencies
   #[cfg(target_os = "linux")]
@@ -1343,21 +1331,9 @@ fn tauri_config_to_bundle_settings(
       } else {
         Some(depends_deb)
       },
-      provides: if provides_deb.is_empty() {
-        None
-      } else {
-        Some(provides_deb)
-      },
-      conflicts: if conflicts_deb.is_empty() {
-        None
-      } else {
-        Some(conflicts_deb)
-      },
-      replaces: if replaces_deb.is_empty() {
-        None
-      } else {
-        Some(replaces_deb)
-      },
+      provides: config.linux.deb.provides,
+      conflicts: config.linux.deb.conflicts,
+      replaces: config.linux.deb.replaces,
       files: config.linux.deb.files,
       desktop_template: config.linux.deb.desktop_template,
       section: config.linux.deb.section,
@@ -1377,21 +1353,9 @@ fn tauri_config_to_bundle_settings(
       } else {
         Some(depends_rpm)
       },
-      provides: if provides_rpm.is_empty() {
-        None
-      } else {
-        Some(provides_rpm)
-      },
-      conflicts: if conflicts_rpm.is_empty() {
-        None
-      } else {
-        Some(conflicts_rpm)
-      },
-      obsoletes: if obsoletes_rpm.is_empty() {
-        None
-      } else {
-        Some(obsoletes_rpm)
-      },
+      provides: config.linux.rpm.provides,
+      conflicts: config.linux.rpm.conflicts,
+      obsoletes: config.linux.rpm.obsoletes,
       release: config.linux.rpm.release,
       epoch: config.linux.rpm.epoch,
       files: config.linux.rpm.files,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This PR added support for `provides`, `conflicts` and `replaces` (`obsoletes` for RPM) options for `bundler > deb` and `bundler > rpm` configs.

```json
{
  "bundler": {
    "deb": {
      "provides": ["my-package"],
      "conflicts": ["my-package"],
      "replaces": ["my-package"]
    },
    "rpm": {
      "provides": ["my-package"],
      "conflicts": ["my-package"],
      "obsoletes": ["my-package"]
    }
  }
}
```

When the package needs to completely replace another one, these kind of options will come in handy.
