### PR TITLE
fix(core): Update webview metadata on window close

### DIFF
--- a/.changes/fix-metadata-on-close.md
+++ b/.changes/fix-metadata-on-close.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes an issue causing `getAll()` to list webviews that were already destroyed.

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -544,6 +544,12 @@ impl<R: Runtime> AppManager<R> {
 
   pub(crate) fn on_webview_close(&self, label: &str) {
     self.webview.webviews_lock().remove(label);
+
+    if let Ok(webview_labels_array) = serde_json::to_string(&self.webview.labels()) {
+      let _ = self.webview.eval_script_all(format!(
+          r#"(function () {{ const metadata = window.__TAURI_INTERNALS__.metadata; if (metadata != null) {{ metadata.webviews = {webview_labels_array}.map(function (label) {{ return {{ label: label }} }}) }} }})()"#,
+        ));
+    }
   }
 
   pub fn windows(&self) -> HashMap<String, Window<R>> {

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -167,12 +167,12 @@ fn on_window_event<R: Runtime>(window: &Window<R>, event: &WindowEvent) -> crate
     WindowEvent::Destroyed => {
       window.emit_to_window(WINDOW_DESTROYED_EVENT, ())?;
       let label = window.label();
-      let webviews_map = window.manager().webview.webviews_lock();
-      let webviews = webviews_map.values();
-      for webview in webviews {
-        webview.eval(&format!(
-          r#"(function () {{ const metadata = window.__TAURI_INTERNALS__.metadata; if (metadata != null) {{ metadata.windows = window.__TAURI_INTERNALS__.metadata.windows.filter(w => w.label !== "{label}"); metadata.webviews = window.__TAURI_INTERNALS__.metadata.webviews.filter(w => w.label !== "{label}"); }} }})()"#,
-        ))?;
+
+      if let Ok(webview_labels_array) = serde_json::to_string(&window.manager().webview.labels()) {
+        let _ = window.manager().webview.eval_script_all(format!(
+          r#"(function () {{ const metadata = window.__TAURI_INTERNALS__.metadata; if (metadata != null) {{ metadata.windows = window.__TAURI_INTERNALS__.metadata.windows.filter(w => w.label !== "{label}"); metadata.webviews = {webview_labels_array}.map(function (label) {{ return {{ label: label }} }}) }} }})()"#,
+
+        ));
       }
     }
     WindowEvent::Focused(focused) => window.emit_to_window(

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -171,7 +171,7 @@ fn on_window_event<R: Runtime>(window: &Window<R>, event: &WindowEvent) -> crate
       let webviews = webviews_map.values();
       for webview in webviews {
         webview.eval(&format!(
-          r#"(function () {{ const metadata = window.__TAURI_INTERNALS__.metadata; if (metadata != null) {{ metadata.windows = window.__TAURI_INTERNALS__.metadata.windows.filter(w => w.label !== "{label}"); }} }})()"#,
+          r#"(function () {{ const metadata = window.__TAURI_INTERNALS__.metadata; if (metadata != null) {{ metadata.windows = window.__TAURI_INTERNALS__.metadata.windows.filter(w => w.label !== "{label}"); metadata.webviews = window.__TAURI_INTERNALS__.metadata.webviews.filter(w => w.label !== "{label}"); }} }})()"#,
         ))?;
       }
     }

--- a/core/tauri/src/manager/window.rs
+++ b/core/tauri/src/manager/window.rs
@@ -171,7 +171,6 @@ fn on_window_event<R: Runtime>(window: &Window<R>, event: &WindowEvent) -> crate
       if let Ok(webview_labels_array) = serde_json::to_string(&window.manager().webview.labels()) {
         let _ = window.manager().webview.eval_script_all(format!(
           r#"(function () {{ const metadata = window.__TAURI_INTERNALS__.metadata; if (metadata != null) {{ metadata.windows = window.__TAURI_INTERNALS__.metadata.windows.filter(w => w.label !== "{label}"); metadata.webviews = {webview_labels_array}.map(function (label) {{ return {{ label: label }} }}) }} }})()"#,
-
         ));
       }
     }


### PR DESCRIPTION
fixes #9353
follow up to #9211 - no idea how i missed this.

The first commit wasn't really working for the multiwebview example so i tried to fix that in the second and third commits. As the last commit states, there's no webview-destroyed event yet but idk what the plans are.