### PR TITLE
fix(runtime-wry): don't hide/show webview when showing/hiding parent

### DIFF
--- a/.changes/wry-visiblit-change-regression.md
+++ b/.changes/wry-visiblit-change-regression.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime-wry": "patch"
+---
+
+Fix regression on Windows, where calling `window.show` would flash a white screen before showing the webview.
+


### PR DESCRIPTION
This fixes a regression introduced in #9246 where previously users would wait for `DOMContentLoaded` before showing the window to avoid having a white flash, also introduce a regression for apps that is hidden by default and is shown on global shortcuts or some other action.

Also accoding to the MSDN docs for webview2's `IsVisible` they only recommend to change the webview visibility on when un/minimizing.

closes #9393
ref: https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2controller?view=webview2-winrt-1.0.2365.46#isvisible

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
