### PR TITLE
feat(core/windows): Convert UNC paths to simple paths in JS apis.

### DIFF
--- a/.changes/api-simplify-unc-paths.md
+++ b/.changes/api-simplify-unc-paths.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:enhance
+---
+
+Tauri's built-in commands for the JS api will now return simplified paths on Windows, removing the `\\?\` prefix.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,7 @@ dependencies = [
  "cocoa",
  "data-url",
  "dirs-next",
+ "dunce",
  "embed_plist",
  "futures-util",
  "getrandom 0.2.12",

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -73,6 +73,7 @@ http-range = { version = "0.1.5", optional = true }
 tracing = { version = "0.1", optional = true }
 heck = "0.4"
 log = "0.4"
+dunce = "1"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
 muda = { version = "0.13", default-features = false, features = [ "serde" ] }

--- a/core/tauri/src/path/plugin.rs
+++ b/core/tauri/src/path/plugin.rs
@@ -92,7 +92,7 @@ pub fn resolve_directory<R: Runtime>(
   directory: BaseDirectory,
   path: Option<PathBuf>,
 ) -> Result<PathBuf> {
-  super::resolve_path(&resolver, directory, path)
+  super::resolve_path(&resolver, directory, path).map(|p| dunce::simplified(&p).to_path_buf())
 }
 
 #[command(root = "crate")]
@@ -107,12 +107,12 @@ pub fn resolve(paths: Vec<String>) -> Result<PathBuf> {
   for p in paths {
     path.push(p);
   }
-  Ok(normalize_path(&path))
+  Ok(dunce::simplified(&normalize_path(&path)).to_path_buf())
 }
 
 #[command(root = "crate")]
 pub fn normalize(path: String) -> String {
-  let mut p = normalize_path_no_absolute(Path::new(&path))
+  let mut p = dunce::simplified(&normalize_path_no_absolute(Path::new(&path)))
     .to_string_lossy()
     .to_string();
 
@@ -149,9 +149,10 @@ pub fn join(mut paths: Vec<String>) -> String {
       .collect::<String>(),
   );
 
-  let p = normalize_path_no_absolute(&path)
+  let p = dunce::simplified(&normalize_path_no_absolute(&path))
     .to_string_lossy()
     .to_string();
+
   if p.is_empty() {
     ".".into()
   } else {
@@ -162,7 +163,7 @@ pub fn join(mut paths: Vec<String>) -> String {
 #[command(root = "crate")]
 pub fn dirname(path: String) -> Result<PathBuf> {
   match Path::new(&path).parent() {
-    Some(p) => Ok(p.to_path_buf()),
+    Some(p) => Ok(dunce::simplified(p).to_path_buf()),
     None => Err(Error::NoParent),
   }
 }


### PR DESCRIPTION
partially fixes #9407 

Not much in here i guess. That's all i found looking at the plugins / searching for various formats of the `#[command]` macro.