### PR TITLE
Replace unmaintained dependency `zip` with `zip_next`

### DIFF
--- a/tooling/bundler/Cargo.toml
+++ b/tooling/bundler/Cargo.toml
@@ -38,7 +38,7 @@ hex = "0.4"
 semver = "1"
 sha1 = "0.10"
 sha2 = "0.10"
-zip = { version = "0.6", default-features = false, features = [ "deflate" ] }
+zip_next = { version = "1.0", default-features = false, features = [ "deflate" ] }
 dunce = "1"
 
 [target."cfg(target_os = \"windows\")".dependencies]

--- a/tooling/bundler/src/bundle/updater_bundle.rs
+++ b/tooling/bundler/src/bundle/updater_bundle.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use anyhow::Context;
-use zip::write::FileOptions;
+use zip_next::write::FileOptions;
 
 // Build update
 pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<Vec<PathBuf>> {
@@ -216,9 +216,9 @@ pub fn create_zip(src_file: &Path, dst_file: &Path) -> crate::Result<PathBuf> {
     .file_name()
     .expect("Can't extract file name from path");
 
-  let mut zip = zip::ZipWriter::new(writer);
+  let mut zip = zip_next::ZipWriter::new(writer);
   let options = FileOptions::default()
-    .compression_method(zip::CompressionMethod::Stored)
+    .compression_method(zip_next::CompressionMethod::Stored)
     .unix_permissions(0o755);
 
   zip.start_file(file_name.to_string_lossy(), options)?;

--- a/tooling/bundler/src/bundle/windows/util.rs
+++ b/tooling/bundler/src/bundle/windows/util.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use sha2::Digest;
-use zip::ZipArchive;
+use zip_next::ZipArchive;
 
 pub const WEBVIEW2_BOOTSTRAPPER_URL: &str = "https://go.microsoft.com/fwlink/p/?LinkId=2124703";
 pub const WEBVIEW2_OFFLINE_INSTALLER_X86_URL: &str =

--- a/tooling/bundler/src/error.rs
+++ b/tooling/bundler/src/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
   ConvertError(#[from] num::TryFromIntError),
   /// Zip error.
   #[error("`{0}`")]
-  ZipError(#[from] zip::result::ZipError),
+  ZipError(#[from] zip_next::result::ZipError),
   /// Hex error.
   #[error("`{0}`")]
   HexError(#[from] hex::FromHexError),


### PR DESCRIPTION
`zip` hasn't been updated in almost a year, and it has known bugs that can cause panics when trying to open an invalid ZIP file, or an encrypted file without the password. This PR replaces it with `zip_next`, a fork I actively maintain.