### PR TITLE
fix(cli/migrate): tolerate non-UTF-8 in migration

### DIFF
--- a/.changes/cli-migrate-non-utf8.md
+++ b/.changes/cli-migrate-non-utf8.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Gracefully handle Non-UTF8 files when using `tauri migrate`

--- a/core/tauri-plugin/src/build/mobile.rs
+++ b/core/tauri-plugin/src/build/mobile.rs
@@ -151,7 +151,7 @@ fn update_plist_file<P: AsRef<Path>, F: FnOnce(&mut plist::Dictionary)>(
       let mut plist_buf = Vec::new();
       let writer = Cursor::new(&mut plist_buf);
       plist::to_writer_xml(writer, &plist)?;
-      let new_plist_str = String::from_utf8_lossy(plist_buf)?;
+      let new_plist_str = String::from_utf8(plist_buf)?;
       if new_plist_str != plist_str {
         write(path, new_plist_str)?;
       }

--- a/core/tauri-plugin/src/build/mobile.rs
+++ b/core/tauri-plugin/src/build/mobile.rs
@@ -151,7 +151,7 @@ fn update_plist_file<P: AsRef<Path>, F: FnOnce(&mut plist::Dictionary)>(
       let mut plist_buf = Vec::new();
       let writer = Cursor::new(&mut plist_buf);
       plist::to_writer_xml(writer, &plist)?;
-      let new_plist_str = String::from_utf8(plist_buf)?;
+      let new_plist_str = String::from_utf8_lossy(plist_buf)?;
       if new_plist_str != plist_str {
         write(path, new_plist_str)?;
       }

--- a/core/tests/restart/tests/restart.rs
+++ b/core/tests/restart/tests/restart.rs
@@ -55,7 +55,7 @@ fn symlink_runner(create_symlinks: impl Fn(&Path) -> io::Result<Symlink>) -> Res
 
     if output.status.success() {
       // gather the output into a string
-      let stdout = String::from_utf8(output.stdout)?;
+      let stdout = String::from_utf8_lossy(&output.stdout);
 
       // we expect the output to be the bin path, twice
       assert_eq!(stdout, format!("{bin}\n{bin}\n", bin = bin.display()));
@@ -64,7 +64,7 @@ fn symlink_runner(create_symlinks: impl Fn(&Path) -> io::Result<Symlink>) -> Res
       not(feature = "process-relaunch-dangerous-allow-symlink-macos")
     )) {
       // we expect this to fail on macOS without the dangerous symlink flag set
-      let stderr = String::from_utf8(output.stderr)?;
+      let stderr = String::from_utf8_lossy(&output.stderr);
 
       // make sure it's the error that we expect
       assert!(stderr.contains(

--- a/tooling/bench/src/utils.rs
+++ b/tooling/bench/src/utils.rs
@@ -92,8 +92,8 @@ pub fn run_collect(cmd: &[&str]) -> (String, String) {
     stderr,
     status,
   } = prog.wait_with_output().expect("failed to wait on child");
-  let stdout = String::from_utf8(stdout).unwrap();
-  let stderr = String::from_utf8(stderr).unwrap();
+  let stdout = String::from_utf8_lossy(&stdout);
+  let stderr = String::from_utf8_lossy(&stderr);
   if !status.success() {
     eprintln!("stdout: <<<{}>>>", stdout);
     eprintln!("stderr: <<<{}>>>", stderr);

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1127,7 +1127,7 @@ fn get_cargo_metadata() -> crate::Result<CargoMetadata> {
   if !output.status.success() {
     return Err(anyhow::anyhow!(
       "cargo metadata command exited with a non zero exit code: {}",
-      String::from_utf8(output.stderr)?
+      String::from_utf8_lossy(&output.stderr)
     ));
   }
 

--- a/tooling/cli/src/migrate/config.rs
+++ b/tooling/cli/src/migrate/config.rs
@@ -12,7 +12,6 @@ use tauri_utils::acl::{
 
 use std::{
   collections::{BTreeMap, HashSet},
-  fs::{create_dir_all, write},
   path::Path,
 };
 
@@ -21,7 +20,7 @@ pub fn migrate(tauri_dir: &Path) -> Result<MigratedConfig> {
     tauri_utils_v1::config::parse::parse_value(tauri_dir.join("tauri.conf.json"))
   {
     let migrated = migrate_config(&mut config)?;
-    write(&config_path, serde_json::to_string_pretty(&config)?)?;
+    fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
 
     let mut permissions: Vec<PermissionEntry> = vec![
       "path:default",
@@ -38,8 +37,8 @@ pub fn migrate(tauri_dir: &Path) -> Result<MigratedConfig> {
     permissions.extend(migrated.permissions.clone());
 
     let capabilities_path = config_path.parent().unwrap().join("capabilities");
-    create_dir_all(&capabilities_path)?;
-    write(
+    fs::create_dir_all(&capabilities_path)?;
+    fs::write(
       capabilities_path.join("migrated.json"),
       serde_json::to_string_pretty(&Capability {
         identifier: "migrated".to_string(),

--- a/tooling/cli/src/migrate/config.rs
+++ b/tooling/cli/src/migrate/config.rs
@@ -12,6 +12,7 @@ use tauri_utils::acl::{
 
 use std::{
   collections::{BTreeMap, HashSet},
+  fs,
   path::Path,
 };
 

--- a/tooling/cli/src/migrate/frontend.rs
+++ b/tooling/cli/src/migrate/frontend.rs
@@ -6,6 +6,7 @@ use crate::{
   helpers::{app_paths::walk_builder, cargo, npm::PackageManager},
   Result,
 };
+use anyhow::Context;
 
 use std::{
   fs::{read_to_string, write},
@@ -78,18 +79,21 @@ pub fn migrate(app_dir: &Path, tauri_dir: &Path) -> Result<Vec<(PathBuf, String)
           });
 
         if new_contents != js_contents {
-          write(path, new_contents.as_bytes())?;
+          write(path, new_contents.as_bytes())
+            .with_context(|| format!("Error writing {}", path.display()))?;
         }
       }
     }
   }
 
   if !new_npm_packages.is_empty() {
-    pm.install(&new_npm_packages)?;
+    pm.install(&new_npm_packages)
+      .context("Error installing new npm packages")?;
   }
 
   if !new_cargo_packages.is_empty() {
-    cargo::install(&new_cargo_packages, Some(tauri_dir))?;
+    cargo::install(&new_cargo_packages, Some(tauri_dir))
+      .context("Error installing new Cargo packages")?;
   }
 
   Ok(skipped)

--- a/tooling/cli/src/migrate/frontend.rs
+++ b/tooling/cli/src/migrate/frontend.rs
@@ -35,9 +35,9 @@ pub fn migrate(app_dir: &Path, tauri_dir: &Path) -> Result<()> {
         let new_contents =
           tauri_api_import_regex.replace_all(&js_contents, |cap: &regex::bytes::Captures<'_>| {
             let module = cap.get(1).unwrap().as_bytes();
+            let module = String::from_utf8_lossy(module).to_string();
             let original = cap.get(0).unwrap().as_bytes();
-            let module = String::from_utf8_lossy(&module).to_string();
-            let original = String::from_utf8_lossy(&original).to_string();
+            let original = String::from_utf8_lossy(original).to_string();
 
             if module == "tauri" {
               let new = "@tauri-apps/api/core".to_string();

--- a/tooling/cli/src/migrate/mod.rs
+++ b/tooling/cli/src/migrate/mod.rs
@@ -6,6 +6,7 @@ use crate::{
   helpers::app_paths::{app_dir, tauri_dir},
   Result,
 };
+use anyhow::Context;
 
 mod config;
 mod frontend;
@@ -15,8 +16,8 @@ pub fn command() -> Result<()> {
   let tauri_dir = tauri_dir();
   let app_dir = app_dir();
 
-  let migrated = config::migrate(&tauri_dir)?;
-  manifest::migrate(&tauri_dir)?;
+  let migrated = config::migrate(&tauri_dir).context("Could not migrate config")?;
+  manifest::migrate(&tauri_dir).context("Could not migrate manifest")?;
   let skipped = frontend::migrate(app_dir, &tauri_dir)?;
 
   if !skipped.is_empty() {
@@ -29,11 +30,12 @@ pub fn command() -> Result<()> {
   // Add plugins
   for plugin in migrated.plugins {
     crate::add::command(crate::add::Options {
-      plugin,
+      plugin: plugin.clone(),
       branch: None,
       tag: None,
       rev: None,
-    })?
+    })
+    .with_context(|| format!("Could not migrate plugin '{plugin}'"))?
   }
 
   Ok(())

--- a/tooling/cli/src/migrate/mod.rs
+++ b/tooling/cli/src/migrate/mod.rs
@@ -17,7 +17,14 @@ pub fn command() -> Result<()> {
 
   let migrated = config::migrate(&tauri_dir)?;
   manifest::migrate(&tauri_dir)?;
-  frontend::migrate(app_dir, &tauri_dir)?;
+  let skipped = frontend::migrate(app_dir, &tauri_dir)?;
+
+  if !skipped.is_empty() {
+    log::warn!("Some frontend files could not be migrated, and were skipped:");
+    for (path, reason) in skipped {
+      log::warn!("{}: {reason}", path.display());
+    }
+  }
 
   // Add plugins
   for plugin in migrated.plugins {

--- a/tooling/cli/src/migrate/mod.rs
+++ b/tooling/cli/src/migrate/mod.rs
@@ -18,14 +18,7 @@ pub fn command() -> Result<()> {
 
   let migrated = config::migrate(&tauri_dir).context("Could not migrate config")?;
   manifest::migrate(&tauri_dir).context("Could not migrate manifest")?;
-  let skipped = frontend::migrate(app_dir, &tauri_dir)?;
-
-  if !skipped.is_empty() {
-    log::warn!("Some frontend files could not be migrated, and were skipped:");
-    for (path, reason) in skipped {
-      log::warn!("{}: {reason}", path.display());
-    }
-  }
+  frontend::migrate(app_dir, &tauri_dir)?;
 
   // Add plugins
   for plugin in migrated.plugins {


### PR DESCRIPTION
When I ran `cargo tauri migrate` I got only:

> Error Stream did not contain valid UTF-8

which is a completely unhelpful dead-end. 

* I've made stdout/stderr captures tolerate non-UTF-8 text.
* I've added context to migrator's errors that help locate the root cause.
* I've made migrator skip and warn about non-UTF-8 JavaScript files instead of aborting the entire operation.
