### PR TITLE
feat(cli): show full expected path of `frontendDist` if not found

### DIFF
--- a/.changes/cli-frontend-dist-expected-path.md
+++ b/.changes/cli-frontend-dist-expected-path.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch
+"@tauri-apps/cli": patch
+---
+
+Show full expected path of `frontendDist` when if can't be found.

--- a/tooling/cli/src/build.rs
+++ b/tooling/cli/src/build.rs
@@ -175,9 +175,14 @@ pub fn setup(
 
   if let Some(FrontendDist::Directory(web_asset_path)) = &config_.build.frontend_dist {
     if !web_asset_path.exists() {
+      let absolute_path = web_asset_path
+        .parent()
+        .and_then(|p| p.canonicalize().ok())
+        .map(|p| p.join(web_asset_path.file_name().unwrap()))
+        .unwrap_or_else(|| std::env::current_dir().unwrap().join(web_asset_path));
       return Err(anyhow::anyhow!(
-          "Unable to find your web assets, did you forget to build your web app? Your frontendDist is set to \"{:?}\".",
-          web_asset_path
+          "Unable to find your web assets, did you forget to build your web app? Your frontendDist is set to \"{}\" (which is `{}`).",
+          web_asset_path.display(), absolute_path.display(),
         ));
     }
     if web_asset_path.canonicalize()?.file_name() == Some(std::ffi::OsStr::new("src-tauri")) {


### PR DESCRIPTION
It was unclear to me what the `frontendDist` path is relative to, so Tauri reporting it can't find it doesn't tell me much. I've added absolute path to the error, which clarifies where the directory is supposed to be exactly.