### PR TITLE
fix(core): revert fix visibility change (#9246)

### DIFF
--- a/.changes/fix-visibility-change.md
+++ b/.changes/fix-visibility-change.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Fix webview's visibility doesn't change with the app window

--- a/.changes/fix-visibility-change.md
+++ b/.changes/fix-visibility-change.md
@@ -1,5 +1,0 @@
----
-"tauri-runtime-wry": patch:bug
----
-
-Fix webview's visibility doesn't change with the app window

--- a/.changes/revert-fix-visibility-change.md
+++ b/.changes/revert-fix-visibility-change.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Revert webview's visibility doesn't change with the app window, the previous change causes flickering on show/restore, so revert it for now

--- a/.changes/revert-fix-visibility-change.md
+++ b/.changes/revert-fix-visibility-change.md
@@ -2,4 +2,4 @@
 "tauri-runtime-wry": patch:bug
 ---
 
-Revert fix webview's visibility doesn't change with the app window, the previous change causes flickering on show/restore, so revert it for now
+Revert the [fix](https://github.com/tauri-apps/tauri/pull/9246) for webview's visibility doesn't change with the app window on Windows as it caused white flashes on show/restore.

--- a/.changes/revert-fix-visibility-change.md
+++ b/.changes/revert-fix-visibility-change.md
@@ -2,4 +2,4 @@
 "tauri-runtime-wry": patch:bug
 ---
 
-Revert webview's visibility doesn't change with the app window, the previous change causes flickering on show/restore, so revert it for now
+Revert fix webview's visibility doesn't change with the app window, the previous change causes flickering on show/restore, so revert it for now

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -2699,16 +2699,8 @@ fn handle_user_message<T: UserEvent>(
           WindowMessage::Unmaximize => window.set_maximized(false),
           WindowMessage::Minimize => window.set_minimized(true),
           WindowMessage::Unminimize => window.set_minimized(false),
-          WindowMessage::Show => {
-            window.set_visible(true);
-            #[cfg(windows)]
-            let _ = set_webview_visibility(&webviews, !window.is_minimized());
-          }
-          WindowMessage::Hide => {
-            window.set_visible(false);
-            #[cfg(windows)]
-            let _ = set_webview_visibility(&webviews, false);
-          }
+          WindowMessage::Show => window.set_visible(true),
+          WindowMessage::Hide => window.set_visible(false),
           WindowMessage::Close => {
             panic!("cannot handle `WindowMessage::Close` on the main thread")
           }
@@ -3369,7 +3361,7 @@ fn handle_event_loop<T: UserEvent>(
               .map(|w| (w.inner.clone(), w.webviews.clone()))
             {
               let size = size.to_logical::<f32>(window.scale_factor());
-              for webview in &webviews {
+              for webview in webviews {
                 if let Some(b) = &*webview.bounds.lock().unwrap() {
                   if let Err(e) = webview.set_bounds(wry::Rect {
                     position: LogicalPosition::new(size.width * b.x_rate, size.height * b.y_rate)
@@ -3381,9 +3373,6 @@ fn handle_event_loop<T: UserEvent>(
                   }
                 }
               }
-              #[cfg(windows)]
-              let _ =
-                set_webview_visibility(&webviews, window.is_visible() && !window.is_minimized());
             }
           }
           _ => {}
@@ -4155,16 +4144,4 @@ fn clear_window_surface(
     buffer.fill(0);
     let _ = buffer.present();
   }
-}
-
-#[cfg(windows)]
-fn set_webview_visibility(
-  webviews: &[WebviewWrapper],
-  is_visible: bool,
-) -> windows::core::Result<()> {
-  for webview in webviews {
-    let controller = webview.controller();
-    unsafe { controller.SetIsVisible(is_visible) }?;
-  }
-  Ok(())
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Closes #9393

#9246 causes flickering on show/restore, so revert it for now

> More discussions at #9415