### PR TITLE
fix(utils): temp permission file names on windows

### DIFF
--- a/.changes/fix-temp-permission-file-name.md
+++ b/.changes/fix-temp-permission-file-name.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch
+---
+
+Replace `taur:` prefix with `tauri-` for temporary permission file names

--- a/.changes/fix-temp-permission-file-name.md
+++ b/.changes/fix-temp-permission-file-name.md
@@ -2,4 +2,4 @@
 "tauri-utils": patch
 ---
 
-Replace `taur:` prefix with `tauri-` for temporary permission file names
+Replace `tauri:` prefix with `tauri-` for temporary permission file names

--- a/.changes/fix-temp-permission-file-name.md
+++ b/.changes/fix-temp-permission-file-name.md
@@ -1,5 +1,5 @@
 ---
-"tauri-utils": patch
+"tauri-utils": "patch:bug"
 ---
 
 Replace `tauri:` prefix with `tauri-` for temporary permission file names

--- a/core/tauri-utils/src/acl/build.rs
+++ b/core/tauri-utils/src/acl/build.rs
@@ -71,7 +71,10 @@ pub fn define_permissions<F: Fn(&Path) -> bool>(
     .filter(|p| p.parent().unwrap().file_name().unwrap() != PERMISSION_SCHEMAS_FOLDER_NAME)
     .collect::<Vec<PathBuf>>();
 
-  let permission_files_path = out_dir.join(format!("{}-permission-files", pkg_name));
+  let permission_files_path = out_dir.join(format!(
+    "{}-permission-files",
+    pkg_name.replace("tauri:", "tauri-")
+  ));
   std::fs::write(
     &permission_files_path,
     serde_json::to_string(&permission_files)?,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Probably fixes #9045

We're currently using `tauri:` prefix on temporary permission file names for core plugins, but `:` is a reserved character on Windows file system, this PR replaces `tauri:` prefix with `tauri-`

> https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#:~:text=%3E%20(greater%20than)-,%3A%20(colon),-%22%20(double%20quote)

