### PR TITLE
fix(api): add type definitions to package.json exports

### DIFF
--- a/.changes/api-type-definitions.md
+++ b/.changes/api-type-definitions.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/api": patch:bug
+---
+
+Set the `exports > types` package.json field.

--- a/tooling/api/package.json
+++ b/tooling/api/package.json
@@ -24,11 +24,13 @@
   "exports": {
     ".": {
       "import": "./index.js",
-      "require": "./index.cjs"
+      "require": "./index.cjs",
+      "types": "./index.d.ts"
     },
     "./*": {
       "import": "./*.js",
-      "require": "./*.cjs"
+      "require": "./*.cjs",
+      "types": "./*.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/tooling/api/package.json
+++ b/tooling/api/package.json
@@ -21,6 +21,7 @@
   "type": "module",
   "main": "./index.cjs",
   "module": "./index.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
       "import": "./index.js",


### PR DESCRIPTION
This commit includes the typescript type definitions in the package exports of @tauri-apps/api.