### PR TITLE
fix(cli): append extension to app binary manually on rename

### DIFF
--- a/.changes/cli-rename-app.md
+++ b/.changes/cli-rename-app.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Fixed an issue that caused the CLI to rename app binaries incorrectly if the product name contained a `.` which resulted in the bundling step to fail.

--- a/tooling/cli/src/interface/rust/desktop.rs
+++ b/tooling/cli/src/interface/rust/desktop.rs
@@ -357,11 +357,12 @@ fn rename_app(
       product_name.into()
     };
 
+    let binary_extension = if target_os == "windows" { ".exe" } else { "" };
+
     let product_path = bin_path
       .parent()
       .unwrap()
-      .join(product_name)
-      .with_extension(bin_path.extension().unwrap_or_default());
+      .join(format!("{product_name}{binary_extension}"));
 
     rename(bin_path, &product_path).with_context(|| {
       format!(


### PR DESCRIPTION
fixes #9488
fixes #8848

v2 will be fixed by https://github.com/tauri-apps/tauri/pull/9375

to give an example for the issue. If you set `tauri.app` as your product name the exe currently will be renamed to `tauri.exe`. With this PR it will be `tauri.app.exe`