### PR TITLE
feat(nsis): add an option to opt out tauri utils plugin

### DIFF
--- a/.changes/opt-in-nsis-plugin.md
+++ b/.changes/opt-in-nsis-plugin.md
@@ -1,0 +1,7 @@
+---
+tauri-utils: minor:feat
+tauri-cli: minor:feat
+tauri-bundler: minor:feat
+---
+
+Add an option to replace nsis util plugin with built-in ones, this can reduce the final bundle size by ~0.8 MB.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -2294,6 +2294,11 @@
               "type": "null"
             }
           ]
+        },
+        "useTauriPlugin": {
+          "description": "Whether include and use tauri nsis plugin for compare semver, check and terminate running app, and download webview2 bootstrap, this will increase the installer size by around 0.8 MB when disabled, uses tools provided by the OS and nsis, this option has some downsides: - can't compare semver like 2.0.0-alpha.1 - no Windows 7 support when using webviewInstallMode downloadBootstrapper default to true",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -2296,7 +2296,7 @@
           ]
         },
         "useTauriPlugin": {
-          "description": "Whether include and use tauri nsis plugin for compare semver, check and terminate running app, and download webview2 bootstrap, this will increase the installer size by around 0.8 MB when disabled, uses tools provided by the OS and nsis, this option has some downsides: - can't compare semver like 2.0.0-alpha.1 - no Windows 7 support when using webviewInstallMode downloadBootstrapper default to true",
+          "description": "Whether to includede and use nsis-tauri-utils.dll plugin to compare semver, check and terminate running app, and download webview2 bootstrapper. This will increase the installer size by around 0.8 MB.\n\nIf disabled, the installer will use alternative tools provided by the OS and built-in NSIS plugins but this comes with downsides: - Can't compare semver with pre-release labels like `2.0.0-alpha.1` - Using `webviewInstallMode: downloadBootstrapper` may fail on Windows 7.\n\nDefaults to `true`.",
           "default": true,
           "type": "boolean"
         }

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -744,6 +744,16 @@ pub struct NsisConfig {
   ///
   /// See <https://nsis.sourceforge.io/Reference/SetCompressor>
   pub compression: Option<NsisCompression>,
+  /// Whether include and use tauri nsis plugin for
+  /// compare semver, check and terminate running app, and download webview2 bootstrap,
+  /// this will increase the installer size by around 0.8 MB
+  /// when disabled, uses tools provided by the OS and nsis,
+  /// this option has some downsides:
+  /// - can't compare semver like 2.0.0-alpha.1
+  /// - no Windows 7 support when using webviewInstallMode downloadBootstrapper
+  /// default to true
+  #[serde(default = "default_true")]
+  pub use_tauri_plugin: bool,
 }
 
 /// Install Modes for the NSIS installer.

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -744,14 +744,16 @@ pub struct NsisConfig {
   ///
   /// See <https://nsis.sourceforge.io/Reference/SetCompressor>
   pub compression: Option<NsisCompression>,
-  /// Whether include and use tauri nsis plugin for
-  /// compare semver, check and terminate running app, and download webview2 bootstrap,
-  /// this will increase the installer size by around 0.8 MB
-  /// when disabled, uses tools provided by the OS and nsis,
-  /// this option has some downsides:
-  /// - can't compare semver like 2.0.0-alpha.1
-  /// - no Windows 7 support when using webviewInstallMode downloadBootstrapper
-  /// default to true
+  /// Whether to includede and use nsis-tauri-utils.dll plugin to
+  /// compare semver, check and terminate running app, and download webview2 bootstrapper.
+  /// This will increase the installer size by around 0.8 MB.
+  ///
+  /// If disabled, the installer will use alternative tools provided by the OS
+  /// and built-in NSIS plugins but this comes with downsides:
+  /// - Can't compare semver with pre-release labels like `2.0.0-alpha.1`
+  /// - Using `webviewInstallMode: downloadBootstrapper` may fail on Windows 7.
+  ///
+  /// Defaults to `true`.
   #[serde(default = "default_true")]
   pub use_tauri_plugin: bool,
 }

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -415,14 +415,16 @@ pub struct NsisSettings {
   pub display_language_selector: bool,
   /// Set compression algorithm used to compress files in the installer.
   pub compression: Option<NsisCompression>,
-  /// Whether include and use tauri nsis plugin for
-  /// compare semver, check and terminate running app, and download webview2 bootstrap,
-  /// this will increase the installer size by around 0.8 MB
-  /// when disabled, uses tools provided by the OS and nsis,
-  /// this option has some downsides:
-  /// - can't compare semver like 2.0.0-alpha.1
-  /// - no Windows 7 support when using webviewInstallMode downloadBootstrapper
-  /// default to true
+  /// Whether to includede and use nsis-tauri-utils.dll plugin to
+  /// compare semver, check and terminate running app, and download webview2 bootstrapper.
+  /// This will increase the installer size by around 0.8 MB.
+  ///
+  /// If disabled, the installer will use alternative tools provided by the OS
+  /// and built-in NSIS plugins but this comes with downsides:
+  /// - Can't compare semver with pre-release labels like `2.0.0-alpha.1`
+  /// - Using `webviewInstallMode: downloadBootstrapper` may fail on Windows 7.
+  ///
+  /// Defaults to `true`.
   pub use_tauri_plugin: bool,
 }
 

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -415,6 +415,15 @@ pub struct NsisSettings {
   pub display_language_selector: bool,
   /// Set compression algorithm used to compress files in the installer.
   pub compression: Option<NsisCompression>,
+  /// Whether include and use tauri nsis plugin for
+  /// compare semver, check and terminate running app, and download webview2 bootstrap,
+  /// this will increase the installer size by around 0.8 MB
+  /// when disabled, uses tools provided by the OS and nsis,
+  /// this option has some downsides:
+  /// - can't compare semver like 2.0.0-alpha.1
+  /// - no Windows 7 support when using webviewInstallMode downloadBootstrapper
+  /// default to true
+  pub use_tauri_plugin: bool,
 }
 
 /// The Windows bundle settings.

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -285,6 +285,8 @@ fn build_nsis_app_installer(
       "display_language_selector",
       to_json(nsis.display_language_selector && languages.len() > 1),
     );
+
+    data.insert("use_tauri_plugin", to_json(nsis.use_tauri_plugin));
   }
   data.insert(
     "install_mode",

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -464,7 +464,7 @@ Section WebView2
     !if "${USETAURIPLUGIN}" == "true"
       nsis_tauri_utils::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
     !else
-      nsExec::Exec `powershell -Command 'Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$TEMP\MicrosoftEdgeWebview2Setup.exe"'`
+      nsExec::Exec 'powershell -Command Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$TEMP\MicrosoftEdgeWebview2Setup.exe"'
     !endif
     Pop $0
     ${If} $0 == 0

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -568,9 +568,9 @@ SectionEnd
 
     kill:
       !if "${INSTALLMODE}" == "currentUser"
-        ExecShell open "taskkill" '/im "${MAINBINARYNAME}.exe" /fi "USERNAME eq %USERNAME%" /f' SW_HIDE
+        nsExec::Exec 'taskkill /im "${MAINBINARYNAME}.exe" /fi "USERNAME eq %USERNAME%" /f'
       !else
-        ExecShell open "taskkill" '/im "${MAINBINARYNAME}.exe" /f' SW_HIDE
+        nsExec::Exec 'taskkill /im "${MAINBINARYNAME}.exe" /f'
       !endif
 
       !insertmacro FIND_PROCESS "${MAINBINARYNAME}.exe" $R0

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -464,7 +464,7 @@ Section WebView2
     !if "${USETAURIPLUGIN}" == "true"
       nsis_tauri_utils::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
     !else
-      nsExec::Exec 'curl --location "https://go.microsoft.com/fwlink/p/?LinkId=2124703" --output "$TEMP\MicrosoftEdgeWebview2Setup.exe"'
+      nsExec::Exec `powershell -Command 'Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$TEMP\MicrosoftEdgeWebview2Setup.exe"'`
     !endif
     Pop $0
     ${If} $0 == 0

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -552,10 +552,10 @@ SectionEnd
   ; Modified from https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
   !macro FIND_PROCESS _FILE _ERR
     !if "${INSTALLMODE}" == "currentUser"
-      ExecShell open "cmd" '/c tasklist /fi "USERNAME eq %USERNAME%" /fi "IMAGENAME eq ${_FILE}" /fo csv | find "${_FILE}"' SW_HIDE
+      nsExec::Exec 'cmd /c tasklist /fi "USERNAME eq %USERNAME%" /fi "IMAGENAME eq ${_FILE}" /nh | find "${_FILE}"'
       Pop ${_ERR}
     !else
-      ExecShell open "cmd" '/c tasklist /fi "IMAGENAME eq ${_FILE}" /fo csv | find "${_FILE}"' SW_HIDE
+      nsExec::Exec 'cmd /c tasklist /fi "IMAGENAME eq ${_FILE}" /nh | find "${_FILE}"'
       Pop ${_ERR}
     !endif
   !macroend

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -550,6 +550,7 @@ SectionEnd
 !else
 !macro CheckIfAppIsRunning
   ; Modified from https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/templates/nsis/include/allowOnlyOneInstallerInstance.nsh
+  ; Pipe tasklist output to find to convert not found to an error
   !macro FIND_PROCESS _FILE _ERR
     !if "${INSTALLMODE}" == "currentUser"
       nsExec::Exec 'cmd /c tasklist /fi "USERNAME eq %USERNAME%" /fi "IMAGENAME eq ${_FILE}" /nh | find "${_FILE}"'

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -452,7 +452,7 @@ Section WebView2
   !if "${INSTALLWEBVIEW2MODE}" == "downloadBootstrapper"
     Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
     DetailPrint "$(webview2Downloading)"
-    nsExec::Exec 'curl --location "https://go.microsoft.com/fwlink/p/?LinkId=2124703" --output "$DESKTOP\MicrosoftEdgeWebview2Setup.exe"'
+    nsExec::Exec 'curl --location "https://go.microsoft.com/fwlink/p/?LinkId=2124703" --output "$TEMP\MicrosoftEdgeWebview2Setup.exe"'
     Pop $0
     ${If} $0 == 0
       DetailPrint "$(webview2DownloadSuccess)"

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -2294,6 +2294,11 @@
               "type": "null"
             }
           ]
+        },
+        "useTauriPlugin": {
+          "description": "Whether include and use tauri nsis plugin for compare semver, check and terminate running app, and download webview2 bootstrap, this will increase the installer size by around 0.8 MB when disabled, uses tools provided by the OS and nsis, this option has some downsides: - can't compare semver like 2.0.0-alpha.1 - no Windows 7 support when using webviewInstallMode downloadBootstrapper default to true",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -2296,7 +2296,7 @@
           ]
         },
         "useTauriPlugin": {
-          "description": "Whether include and use tauri nsis plugin for compare semver, check and terminate running app, and download webview2 bootstrap, this will increase the installer size by around 0.8 MB when disabled, uses tools provided by the OS and nsis, this option has some downsides: - can't compare semver like 2.0.0-alpha.1 - no Windows 7 support when using webviewInstallMode downloadBootstrapper default to true",
+          "description": "Whether to includede and use nsis-tauri-utils.dll plugin to compare semver, check and terminate running app, and download webview2 bootstrapper. This will increase the installer size by around 0.8 MB.\n\nIf disabled, the installer will use alternative tools provided by the OS and built-in NSIS plugins but this comes with downsides: - Can't compare semver with pre-release labels like `2.0.0-alpha.1` - Using `webviewInstallMode: downloadBootstrapper` may fail on Windows 7.\n\nDefaults to `true`.",
           "default": true,
           "type": "boolean"
         }

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -106,6 +106,7 @@ pub fn nsis_settings(config: NsisConfig) -> tauri_bundler::NsisSettings {
     custom_language_files: config.custom_language_files,
     display_language_selector: config.display_language_selector,
     compression: config.compression,
+    use_tauri_plugin: config.use_tauri_plugin,
   }
 }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Add an option to replace nsis util plugin with built-in ones, this can reduce the final bundle size by ~0.8 MB

Downsides including:

- Can't compare semver like `2.0.0-alpha.1`
- No Windows 7 support when using [downloadBootstrapper](https://tauri.app/v1/guides/building/windows/#downloaded-bootstrapper) option due to Windows 7 ~~doesn't have curl installed by default~~ doesn't have tls 1.2 enabled by default (this option is not recommended for Windows 7 anyway)