### PR TITLE
fix(core): allow any headers on custom protocol IPC

### DIFF
--- a/.changes/ipc-allow-headers.md
+++ b/.changes/ipc-allow-headers.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Allow any headers on the IPC custom protocol.

--- a/core/tauri/src/ipc/protocol.rs
+++ b/core/tauri/src/ipc/protocol.rs
@@ -137,10 +137,8 @@ pub fn get<R: Runtime>(manager: Arc<AppManager<R>>, label: String) -> UriSchemeP
 
       Method::OPTIONS => {
         let mut r = http::Response::new(Vec::new().into());
-        r.headers_mut().insert(
-          ACCESS_CONTROL_ALLOW_HEADERS,
-          HeaderValue::from_static("Content-Type, Tauri-Callback, Tauri-Error, Tauri-Channel-Id"),
-        );
+        r.headers_mut()
+          .insert(ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static("*"));
         respond(r);
       }
 


### PR DESCRIPTION
This is only enforced on Windows so we should just allow any headers since we also expose an API to set such headers on the invoke level (useful if your command wants to read the request as bytes but you also need additional metadata in the request).