### PR TITLE
fix(core/windows): scale positions when hittesting for undecorated resizing

### DIFF
--- a/.changes/undecorated-resizing-windows-non-100-scale.md
+++ b/.changes/undecorated-resizing-windows-non-100-scale.md
@@ -1,0 +1,7 @@
+---
+"tauri": "patch:bug"
+"tauri-runtime-wry": "patch"
+---
+
+Fixed undecorated window resizing on Windows when using display scale higher than 100%
+

--- a/core/tauri-runtime-wry/src/undecorated_resizing.rs
+++ b/core/tauri-runtime-wry/src/undecorated_resizing.rs
@@ -89,7 +89,10 @@ fn hit_test(
 mod windows {
   use super::{hit_test, HitTestResult};
 
-  use tao::window::{CursorIcon, ResizeDirection, Window};
+  use tao::{
+    dpi::LogicalPosition,
+    window::{CursorIcon, ResizeDirection, Window},
+  };
   use windows::Win32::UI::WindowsAndMessaging::{
     GetSystemMetrics, SM_CXFRAME, SM_CXPADDEDBORDER, SM_CYFRAME,
   };
@@ -165,12 +168,21 @@ mod windows {
             && !window.is_window_fullscreen
           {
             let (x, y) = args.split_once(',').unwrap();
-            let (x, y) = (x.parse().unwrap(), y.parse().unwrap());
+            let (x, y): (i32, i32) = (x.parse().unwrap(), y.parse().unwrap());
+            let postion = LogicalPosition::new(x, y).to_physical::<i32>(w.scale_factor());
             let size = w.inner_size();
             let padded_border = unsafe { GetSystemMetrics(SM_CXPADDEDBORDER) };
             let border_x = unsafe { GetSystemMetrics(SM_CXFRAME) + padded_border };
             let border_y = unsafe { GetSystemMetrics(SM_CYFRAME) + padded_border };
-            hit_test(size.width, size.height, x, y, border_x, border_y).change_cursor(w);
+            hit_test(
+              size.width,
+              size.height,
+              postion.x,
+              postion.y,
+              border_x,
+              border_y,
+            )
+            .change_cursor(w);
           }
         }
       }
@@ -186,12 +198,21 @@ mod windows {
             && !window.is_window_fullscreen
           {
             let (x, y) = args.split_once(',').unwrap();
-            let (x, y) = (x.parse().unwrap(), y.parse().unwrap());
+            let (x, y): (i32, i32) = (x.parse().unwrap(), y.parse().unwrap());
+            let postion = LogicalPosition::new(x, y).to_physical::<i32>(w.scale_factor());
             let size = w.inner_size();
             let padded_border = unsafe { GetSystemMetrics(SM_CXPADDEDBORDER) };
             let border_x = unsafe { GetSystemMetrics(SM_CXFRAME) + padded_border };
             let border_y = unsafe { GetSystemMetrics(SM_CYFRAME) + padded_border };
-            hit_test(size.width, size.height, x, y, border_x, border_y).drag_resize_window(w);
+            hit_test(
+              size.width,
+              size.height,
+              postion.x,
+              postion.y,
+              border_x,
+              border_y,
+            )
+            .drag_resize_window(w);
           }
         }
       }


### PR DESCRIPTION
closes #9464

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
