### PR TITLE
fix(core): run plugin init script in a separate context

### DIFF
--- a/.changes/plugin-init-script-context.md
+++ b/.changes/plugin-init-script-context.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Run each plugin initialization script on its own context so they do not interfere with each other or the Tauri init script.

--- a/.github/workflows/covector-version-or-publish-v1.yml
+++ b/.github/workflows/covector-version-or-publish-v1.yml
@@ -28,7 +28,7 @@ jobs:
             }
           - {
               target: x86_64-apple-darwin,
-              os: macos-latest,
+              os: macos-13,
               toolchain: '1.60.0'
             }
     steps:
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -43,7 +43,7 @@ jobs:
             }
           - {
               target: x86_64-apple-darwin,
-              os: macos-latest,
+              os: macos-13,
               toolchain: '1.60.0'
             }
         features:

--- a/core/tauri/scripts/init.js
+++ b/core/tauri/scripts/init.js
@@ -29,6 +29,4 @@
       window.__TAURI_INVOKE__('__initialized', { url: window.location.href })
     })
   }
-
-  __RAW_plugin_initialization_script__
 })()

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -607,14 +607,13 @@ impl<R: Runtime> PluginStore<R> {
   }
 
   /// Generates an initialization script from all plugins in the store.
-  pub(crate) fn initialization_script(&self) -> String {
+  pub(crate) fn initialization_script(&self) -> Vec<String> {
     self
       .store
       .values()
       .filter_map(|p| p.initialization_script())
-      .fold(String::new(), |acc, script| {
-        format!("{acc}\n(function () {{ {script} }})();")
-      })
+      .map(|script| format!("(function () {{ {script} }})();"))
+      .collect()
   }
 
   /// Runs the created hook for all plugins in the store.


### PR DESCRIPTION
Currently if a plugin init script is broken, it'll break the entire Tauri init script. We should run each of the scripts on its own context so it does not impact Tauri functionality such as IPC initialization.