### PR TITLE
fix(core): fix incorrect `isTauri` return type

### DIFF
--- a/.changes/api-isTauri-type.md
+++ b/.changes/api-isTauri-type.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/api": "patch:bug"
+---
+
+Fix `isTauri` incorrect return type. 

--- a/tooling/api/src/core.ts
+++ b/tooling/api/src/core.ts
@@ -239,7 +239,7 @@ export class Resource {
 }
 
 function isTauri() {
-  return 'isTauri' in window && window.isTauri
+  return 'isTauri' in window && !!window.isTauri
 }
 
 export type { InvokeArgs, InvokeOptions }

--- a/tooling/api/src/core.ts
+++ b/tooling/api/src/core.ts
@@ -238,7 +238,7 @@ export class Resource {
   }
 }
 
-function isTauri() {
+function isTauri(): boolean {
   return 'isTauri' in window && !!window.isTauri
 }
 


### PR DESCRIPTION
A tiny patch to #9539: `() => unknown` to `() => boolean`