### PR TITLE
feat: configure a default runtime for menu and tray icon types

### DIFF
--- a/.changes/default-generic-for-menu.md
+++ b/.changes/default-generic-for-menu.md
@@ -1,0 +1,5 @@
+---
+'tauri': patch:enhance
+---
+
+Provide a default for the runtime generic on `Menu`, `MenuItem`, `Submenu`, `PredefinedMenuItem`, `CheckMenuItem` and `IconMenuItem`.

--- a/.changes/default-generic-for-tray.md
+++ b/.changes/default-generic-for-tray.md
@@ -1,0 +1,5 @@
+---
+'tauri': patch:enhance
+---
+
+Provide a default for the runtime generic on `TrayIcon`.

--- a/core/tauri/src/menu/mod.rs
+++ b/core/tauri/src/menu/mod.rs
@@ -70,7 +70,8 @@ macro_rules! gen_wrappers {
     ),*
   ) => {
     $(
-      pub(crate) struct $inner<R: $crate::Runtime = crate::Wry> {
+      #[tauri_macros::default_runtime(crate::Wry, wry)]
+      pub(crate) struct $inner<R: $crate::Runtime> {
         id: $crate::menu::MenuId,
         inner: ::std::option::Option<::muda::$type>,
         app_handle: $crate::AppHandle<R>,

--- a/core/tauri/src/menu/mod.rs
+++ b/core/tauri/src/menu/mod.rs
@@ -70,7 +70,7 @@ macro_rules! gen_wrappers {
     ),*
   ) => {
     $(
-      pub(crate) struct $inner<R: $crate::Runtime> {
+      pub(crate) struct $inner<R: $crate::Runtime = crate::Wry> {
         id: $crate::menu::MenuId,
         inner: ::std::option::Option<::muda::$type>,
         app_handle: $crate::AppHandle<R>,

--- a/core/tauri/src/tray/mod.rs
+++ b/core/tauri/src/tray/mod.rs
@@ -243,6 +243,7 @@ impl<R: Runtime> TrayIconBuilder<R> {
 /// This type is reference-counted and the icon is removed when the last instance is dropped.
 ///
 /// See [TrayIconBuilder] to construct this type.
+#[tauri_macros::default_runtime(crate::Wry, wry)]
 pub struct TrayIcon<R: Runtime> {
   id: TrayIconId,
   inner: tray_icon::TrayIcon,


### PR DESCRIPTION
I have noticed in Tauri v2 it's common for the `R: Runtime` to be set to `tauri::Wry`. This is great for users who don't know or care what a runtime is.

For example `AppHandle`, `App` and more types do this using the `default_runtime` macro.

I think this same default runtime makes sense on the menu type so this PR implements that.