### PR TITLE
fix(core): better error when deserializing plugin config

### DIFF
--- a/.changes/better-error-for-invalid-plugin-config.md
+++ b/.changes/better-error-for-invalid-plugin-config.md
@@ -1,0 +1,5 @@
+---
+'tauri': patch:enhance
+---
+
+Improve the error message that is shown when deserializing the Tauri plugin config.

--- a/core/tauri/src/plugin.rs
+++ b/core/tauri/src/plugin.rs
@@ -677,7 +677,12 @@ impl<R: Runtime, C: DeserializeOwned> Plugin<R> for TauriPlugin<R, C> {
           name: self.name,
           handle: app.clone(),
           raw_config: Arc::new(config.clone()),
-          config: serde_json::from_value(config)?,
+          config: serde_json::from_value(config).map_err(|err| {
+            format!(
+              "Error deserializing 'plugins.{}' within your Tauri configuration: {err}",
+              self.name
+            )
+          })?,
         },
       )?;
     }


### PR DESCRIPTION
Before:
```
Error: PluginInitialization("updater", "invalid type: null, expected struct Config")
```

After:
```
Error: PluginInitialization("updater", "Error deserializing 'plugins.updater' within your Tauri configuration: invalid type: null, expected struct Config")
```