### PR TITLE
fix: fixed typo in menu and submenu tooling

### DIFF
--- a/tooling/api/src/menu/menu.ts
+++ b/tooling/api/src/menu/menu.ts
@@ -90,7 +90,7 @@ export class Menu extends MenuItemBase {
   /**
    * Add a menu item to the end of this menu.
    *
-   * ## Platform-spcific:
+   * ## Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -119,7 +119,7 @@ export class Menu extends MenuItemBase {
   /**
    * Add a menu item to the beginning of this menu.
    *
-   * ## Platform-spcific:
+   * ## Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -148,7 +148,7 @@ export class Menu extends MenuItemBase {
   /**
    * Add a menu item to the specified position in this menu.
    *
-   * ## Platform-spcific:
+   * ## Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */

--- a/tooling/api/src/menu/submenu.ts
+++ b/tooling/api/src/menu/submenu.ts
@@ -90,7 +90,7 @@ export class Submenu extends MenuItemBase {
   /**
    * Add a menu item to the end of this submenu.
    *
-   * ## Platform-spcific:
+   * ## Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -119,7 +119,7 @@ export class Submenu extends MenuItemBase {
   /**
    * Add a menu item to the beginning of this submenu.
    *
-   * ## Platform-spcific:
+   * ## Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -148,7 +148,7 @@ export class Submenu extends MenuItemBase {
   /**
    * Add a menu item to the specified position in this submenu.
    *
-   * ## Platform-spcific:
+   * ## Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */


### PR DESCRIPTION
Changed a bunch of typos from `Platform-spcific` to `Platform-specific` inside Tooling -> API -> Menu and SubMenu.
This will impact docs and `beta.tauri.app
