### PR TITLE
[v2] nsis: add files

### DIFF
--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -2294,6 +2294,14 @@
               "type": "null"
             }
           ]
+        },
+        "files": {
+          "description": "The files to include into NSIS installer.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -744,6 +744,9 @@ pub struct NsisConfig {
   ///
   /// See <https://nsis.sourceforge.io/Reference/SetCompressor>
   pub compression: Option<NsisCompression>,
+  /// The files to include into NSIS installer.
+  #[serde(default)]
+  pub files: HashMap<PathBuf, PathBuf>,
 }
 
 /// Install Modes for the NSIS installer.

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -415,6 +415,8 @@ pub struct NsisSettings {
   pub display_language_selector: bool,
   /// Set compression algorithm used to compress files in the installer.
   pub compression: Option<NsisCompression>,
+  /// The files to include into NSIS installer.
+  pub files: HashMap<PathBuf, PathBuf>,
 }
 
 /// The Windows bundle settings.

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -557,6 +557,14 @@ Section Install
     File /a "/oname={{this.[1]}}" "{{@key}}"
   {{/each}}
 
+  ; Copy files
+  {{#each files_dirs}}
+    CreateDirectory "$INSTDIR\\{{this}}"
+  {{/each}}
+  {{#each files}}
+    File /a "/oname={{this.[1]}}" "{{@key}}"
+  {{/each}}
+
   ; Copy external binaries
   {{#each binaries}}
     File /a "/oname={{this}}" "{{@key}}"

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -2294,6 +2294,14 @@
               "type": "null"
             }
           ]
+        },
+        "files": {
+          "description": "The files to include into NSIS installer.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -106,6 +106,7 @@ pub fn nsis_settings(config: NsisConfig) -> tauri_bundler::NsisSettings {
     custom_language_files: config.custom_language_files,
     display_language_selector: config.display_language_selector,
     compression: config.compression,
+    files: config.files,
   }
 }
 


### PR DESCRIPTION
This PR adds support for `files` for NSIS installer, similar setting can be found under `macOS` configuration. The rationale for adding this is the following:

- Other platforms already support bundling additional platform-dependent files.
- Using `files` section makes it possible to bundle external binaries _and_ their resources under individual folders. External binaries setting does not provide such flexibility.

## Further thoughts

Making custom `installer.nsi` is difficult. It would be better to provide a way to have a pre and post install hooks. Maybe we could include custom `.nsh` files that would augment the behavior of `templates/installer.nsi`.

This is still work in progress and I am not able to test it. Somehow I keep stumbling upon the following error which is a dead end given that it does mention the source of this error:

> Error [tauri_cli] failed to bundle project: `The system cannot find the file specified. (os error 2)`

Closes https://github.com/tauri-apps/tauri/issues/9652