### PR TITLE
fix: rename `kill-children.sh` to `tauri-stop-dev-processes.sh`

### DIFF
--- a/tooling/cli/src/dev.rs
+++ b/tooling/cli/src/dev.rs
@@ -469,7 +469,7 @@ pub fn kill_before_dev_process() {
     {
       use std::io::Write;
       let mut kill_children_script_path = std::env::temp_dir();
-      kill_children_script_path.push("kill-children.sh");
+      kill_children_script_path.push("tauri-stop-dev-processes.sh");
 
       if !kill_children_script_path.exists() {
         if let Ok(mut file) = std::fs::File::create(&kill_children_script_path) {


### PR DESCRIPTION
closes #9665

Removing the file after each use imo doesn't make sense, so at least make it obvious that the file belongs to tauri.

i feel like "kill" was more correct than "stop" but whatever.