### PR TITLE
ci: pin `cross` to a commit before they bumped msrv

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ matrix.platform.cross }}
         # update or remove the rev once we update the MSRV from 1.70.0
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --rev 1b8cf50d20180c1a394099e608141480f934b7f7 --locked
+          cargo install cross --git https://github.com/cross-rs/cross --rev 20c73df79c9aaf78a2ad2e9fe8ae981668a729dc --locked
           cross ${{ matrix.platform.command }} --target ${{ matrix.platform.target }} ${{ matrix.features.args }}
 
       - name: test (using cargo)

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -93,8 +93,9 @@ jobs:
 
       - name: test (using cross)
         if: ${{ matrix.platform.cross }}
+        # update or remove the rev once we update the MSRV from 1.70.0
         run: |
-          cargo install cross --git https://github.com/cross-rs/cross --locked
+          cargo install cross --git https://github.com/cross-rs/cross --rev 1b8cf50d20180c1a394099e608141480f934b7f7 --locked
           cross ${{ matrix.platform.command }} --target ${{ matrix.platform.target }} ${{ matrix.features.args }}
 
       - name: test (using cargo)


### PR DESCRIPTION
bump commit: https://github.com/cross-rs/cross/commit/7129d5ab15c5b293cfeb439a0d41e116988edcc2
pre-bump commit: https://github.com/cross-rs/cross/commit/20c73df79c9aaf78a2ad2e9fe8ae981668a729dc

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
