### PR TITLE
fix: Only provide `cargo-vet` suggestions for now

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Ensure that the tool cache is populated with the cargo-vet binary
         run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ env.CARGO_VET_VERSION }} cargo-vet
 
-      - name: Invoke cargo-vet
-        run: cargo vet --locked
+# Enable this again to break the workflow once we have a reasonable amount of suggestions to get to a clean base line
+#      - name: Invoke cargo-vet
+#        run: cargo vet --locked
 
       - name: Provide audit suggestions
         run: cargo vet --locked suggestions


### PR DESCRIPTION
As the workflow is failing because of a larger number of unvetted dependencies I transform this to suggestions only until we have a better vetting workflow and resources to audit available.
