### PR TITLE
docs: added example of tauri.allowlist.protocol

### DIFF
--- a/tooling/api/src/tauri.ts
+++ b/tooling/api/src/tauri.ts
@@ -106,6 +106,19 @@ async function invoke<T>(cmd: string, args: InvokeArgs = {}): Promise<T> {
  *
  * Additionally, `asset` must be added to [`tauri.allowlist.protocol`](https://tauri.app/v1/api/config/#allowlistconfig.protocol)
  * in `tauri.conf.json` and its access scope must be defined on the `assetScope` array on the same `protocol` object.
+ * For example: 
+ * ```json
+ * {
+ *   "tauri": {
+ *     "allowlist": {
+ *       "protocol": {
+ *         "asset": true,
+ *         "assetScope": ["$APPDATA/assets/*"]
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
  *
  * @param  filePath The file path.
  * @param  protocol The protocol to use. Defaults to `asset`. You only need to set this when using a custom protocol.


### PR DESCRIPTION
I prefer docs that do not assume I've read other parts of the docs. It took me some time to figure out the right format for the protocol allowlist. Also, from this page alone it is not clear that I should be using the runtime variables for the scope array.