### PR TITLE
fix(example/state): correct invoke method path to __TAURI__.core.invoke()

### DIFF
--- a/examples/state/index.html
+++ b/examples/state/index.html
@@ -35,14 +35,14 @@
       }
 
       incrementBtn.addEventListener('click', () => {
-        window.__TAURI__
+        window.__TAURI__.core
           .invoke('increment_counter')
           .then(updateResponse)
           .catch(updateResponse)
       })
 
       storeBtn.addEventListener('click', () => {
-        window.__TAURI__
+        window.__TAURI__.core
           .invoke('db_insert', {
             key: KEY,
             value: storeInput.value
@@ -52,7 +52,7 @@
       })
 
       readBtn.addEventListener('click', () => {
-        window.__TAURI__
+        window.__TAURI__.core
           .invoke('db_read', {
             key: KEY
           })


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
I fixed `window.__TAURI__.invoke()` to `window.__TAURI__.core.invoke()`.

This fix addresses an oversight during PR #8077 (issue #8073), which modified `window.__TAURI__.invoke()` to `window.__TAURI__.primitives.invoke()`. Additionally, it reflects the change from `primitives` to `core` made in PR #8273.

- [x] `cargo test` passed
- [x] `cargo clippy` passed