### PR TITLE
fix(bundler/rpm): Reduce compression level to gzip/6

### DIFF
--- a/.changes/rpm-compression-level.md
+++ b/.changes/rpm-compression-level.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: patch:enhance
+---
+
+Reduced the compression level for rpm bundles from 9 (max) to 6. This has almost no effect on file size but should reduce build time by roughly 25%.

--- a/tooling/bundler/src/bundle/linux/rpm.rs
+++ b/tooling/bundler/src/bundle/linux/rpm.rs
@@ -47,7 +47,9 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let license = settings.license().unwrap_or_default();
   let mut builder = rpm::PackageBuilder::new(name, version, &license, arch, summary)
     .epoch(epoch)
-    .release(release);
+    .release(release)
+    // This matches .deb compression. On a 240MB source binary the bundle will be 100KB larger than rpm's default while reducing build times by ~25%.
+    .compression(rpm::CompressionWithLevel::Gzip(6));
 
   if let Some(description) = settings.long_description() {
     builder = builder.description(description.trim())


### PR DESCRIPTION
This matches the .deb builder to reduce build times. It's still much slower than .deb but this is probably something we have to live with or something to be fixed in the rpm crate itself. We could also look at how well other compression formats are supported across distro versions i guess (can't really do that for .deb yet).

p.s. the reason i do this is because rn the rpm bundler is as slow, or even slower than the appimage builder which shouldn't be possible considering how much more stuff the appimage contains...