### PR TITLE
chore: emit rustc-check-cfg for nightly

### DIFF
--- a/.changes/rustc-check-cfg.md
+++ b/.changes/rustc-check-cfg.md
@@ -1,0 +1,9 @@
+---
+"tauri": patch:changes
+"tauri-build": patch:changes
+"tauri-runtime": patch:changes
+"tauri-runtime-wry": patch:changes
+"tauri-plugin": patch:changes
+---
+
+Emit `cargo:rustc-check-cfg` instruction so Cargo validates custom cfg attributes on Rust 1.80 (or nightly-2024-05-05).

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -211,9 +211,8 @@ fn copy_frameworks(dest_dir: &Path, frameworks: &[String]) -> Result<()> {
 // creates a cfg alias if `has_feature` is true.
 // `alias` must be a snake case string.
 fn cfg_alias(alias: &str, has_feature: bool) {
-  println!("cargo::rustc-check-cfg=cfg({alias})");
+  println!("cargo:rustc-check-cfg=cfg({alias})");
   if has_feature {
-    println!("cargo::rustc-cfg={alias}");
     println!("cargo:rustc-cfg={alias}");
   }
 }

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -212,6 +212,7 @@ fn copy_frameworks(dest_dir: &Path, frameworks: &[String]) -> Result<()> {
 // `alias` must be a snake case string.
 fn cfg_alias(alias: &str, has_feature: bool) {
   if has_feature {
+    println!("cargo::rustc-cfg={alias}");
     println!("cargo:rustc-cfg={alias}");
   }
 }

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -211,6 +211,7 @@ fn copy_frameworks(dest_dir: &Path, frameworks: &[String]) -> Result<()> {
 // creates a cfg alias if `has_feature` is true.
 // `alias` must be a snake case string.
 fn cfg_alias(alias: &str, has_feature: bool) {
+  println!("cargo::rustc-check-cfg=cfg({alias})");
   if has_feature {
     println!("cargo::rustc-cfg={alias}");
     println!("cargo:rustc-cfg={alias}");

--- a/core/tauri-plugin/src/build/mod.rs
+++ b/core/tauri-plugin/src/build/mod.rs
@@ -139,6 +139,7 @@ impl<'a> Builder<'a> {
 }
 
 fn cfg_alias(alias: &str, has_feature: bool) {
+  println!("cargo:rustc-check-cfg=cfg({alias})");
   if has_feature {
     println!("cargo:rustc-cfg={alias}");
   }

--- a/core/tauri-runtime-wry/build.rs
+++ b/core/tauri-runtime-wry/build.rs
@@ -5,6 +5,7 @@
 // creates a cfg alias if `has_feature` is true.
 // `alias` must be a snake case string.
 fn alias(alias: &str, has_feature: bool) {
+  println!("cargo:rustc-check-cfg=cfg({alias})");
   if has_feature {
     println!("cargo:rustc-cfg={alias}");
   }

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -3965,7 +3965,7 @@ fn create_webview<T: UserEvent>(
 
   webview_builder = webview_builder.with_ipc_handler(create_ipc_handler(
     kind,
-    window_id,
+    window_id.clone(),
     id,
     context.clone(),
     label.clone(),

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -3394,7 +3394,7 @@ fn handle_event_loop<T: UserEvent>(
             }
           }
           TaoWindowEvent::CloseRequested => {
-            on_close_requested(callback, window_id, windows.clone());
+            on_close_requested(callback, window_id, windows);
           }
           TaoWindowEvent::Destroyed => {
             let removed = windows.0.borrow_mut().remove(&window_id).is_some();
@@ -3455,10 +3455,10 @@ fn handle_event_loop<T: UserEvent>(
         }
       }
       Message::Window(id, WindowMessage::Close) => {
-        on_close_requested(callback, id, windows.clone());
+        on_close_requested(callback, id, windows);
       }
       Message::Window(id, WindowMessage::Destroy) => {
-        on_window_close(id, windows.clone());
+        on_window_close(id, windows);
       }
       Message::UserEvent(t) => callback(RunEvent::UserEvent(t)),
       message => {
@@ -3965,7 +3965,7 @@ fn create_webview<T: UserEvent>(
 
   webview_builder = webview_builder.with_ipc_handler(create_ipc_handler(
     kind,
-    window_id.clone(),
+    window_id,
     id,
     context.clone(),
     label.clone(),

--- a/core/tauri-runtime/build.rs
+++ b/core/tauri-runtime/build.rs
@@ -5,6 +5,7 @@
 // creates a cfg alias if `has_feature` is true.
 // `alias` must be a snake case string.
 fn alias(alias: &str, has_feature: bool) {
+  println!("cargo:rustc-check-cfg=cfg({alias})");
   if has_feature {
     println!("cargo:rustc-cfg={alias}");
   }

--- a/core/tauri/build.rs
+++ b/core/tauri/build.rs
@@ -215,6 +215,7 @@ fn has_feature(feature: &str) -> bool {
 // creates a cfg alias if `has_feature` is true.
 // `alias` must be a snake case string.
 fn alias(alias: &str, has_feature: bool) {
+  println!("cargo:rustc-check-cfg=cfg({alias})");
   if has_feature {
     println!("cargo:rustc-cfg={alias}");
   }

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -329,7 +329,7 @@ impl<R: Runtime> Clone for AppHandle<R> {
 impl<'de, R: Runtime> CommandArg<'de, R> for AppHandle<R> {
   /// Grabs the [`Window`] from the [`CommandItem`] and returns the associated [`AppHandle`]. This will never fail.
   fn from_command(command: CommandItem<'de, R>) -> Result<Self, InvokeError> {
-    Ok(command.message.webview().window().app_handle.clone())
+    Ok(command.message.webview().window().app_handle)
   }
 }
 

--- a/core/tauri/src/event/listener.rs
+++ b/core/tauri/src/event/listener.rs
@@ -197,7 +197,7 @@ impl Listeners {
     let mut maybe_pending = false;
 
     match self.inner.handlers.try_lock() {
-      Err(_) => self.insert_pending(Pending::Emit(emit_args.clone())),
+      Err(_) => self.insert_pending(Pending::Emit(emit_args)),
       Ok(lock) => {
         if let Some(handlers) = lock.get(&emit_args.event_name) {
           let handlers = handlers.iter();

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -518,13 +518,6 @@ impl<R: Runtime> Context<R> {
       plugin_global_api_scripts,
     }
   }
-
-  /// Sets the app shell scope.
-  #[cfg(shell_scope)]
-  #[inline(always)]
-  pub fn set_shell_scope(&mut self, scope: scope::ShellScopeConfig) {
-    self.shell_scope = scope;
-  }
 }
 
 // TODO: expand these docs

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -275,8 +275,7 @@ impl<R: Runtime> WebviewManager<R> {
     }
 
     if !registered_scheme_protocols.contains(&"ipc".into()) {
-      let protocol =
-        crate::ipc::protocol::get(manager.manager_owned().clone(), pending.label.clone());
+      let protocol = crate::ipc::protocol::get(manager.manager_owned(), pending.label.clone());
       pending.register_uri_scheme_protocol("ipc", move |request, responder| {
         protocol(request, UriSchemeResponder(responder))
       });
@@ -613,7 +612,7 @@ impl<R: Runtime> WebviewManager<R> {
     }
 
     // let plugins know that a new webview has been added to the manager
-    let manager = webview.manager_owned().clone();
+    let manager = webview.manager_owned();
     let webview_ = webview.clone();
     // run on main thread so the plugin store doesn't dead lock with the event loop handler in App
     let _ = webview.run_on_main_thread(move || {

--- a/core/tauri/src/protocol/tauri.rs
+++ b/core/tauri/src/protocol/tauri.rs
@@ -37,7 +37,6 @@ pub fn get<R: Runtime>(
     url
   };
 
-  let manager = manager.clone();
   let window_origin = window_origin.to_string();
 
   #[cfg(all(dev, mobile))]

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -307,7 +307,7 @@ impl Scope {
       path.to_path_buf()
     };
     let path = if !path.exists() {
-      crate::Result::Ok(path.to_path_buf())
+      crate::Result::Ok(path)
     } else {
       std::fs::canonicalize(path).map_err(Into::into)
     };

--- a/core/tauri/src/webview/webview_window.rs
+++ b/core/tauri/src/webview/webview_window.rs
@@ -1044,7 +1044,7 @@ tauri::Builder::default()
     menu: &M,
     position: P,
   ) -> crate::Result<()> {
-    menu.popup_at(self.webview.window().clone(), position)
+    menu.popup_at(self.webview.window(), position)
   }
 }
 

--- a/core/tauri/src/window/mod.rs
+++ b/core/tauri/src/window/mod.rs
@@ -240,7 +240,7 @@ async fn reopen_window(app: tauri::AppHandle) {
   ///
   /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
   pub fn from_config(manager: &'a M, config: &WindowConfig) -> crate::Result<Self> {
-    #[cfg_attr(not(unstable), allow(unused_mut))]
+    #[cfg_attr(not(windows), allow(unused_mut))]
     let mut builder = Self {
       manager,
       label: config.label.clone(),

--- a/core/tauri/src/window/mod.rs
+++ b/core/tauri/src/window/mod.rs
@@ -968,7 +968,7 @@ impl<R: Runtime> ManagerBase<R> for Window<R> {
 impl<'de, R: Runtime> CommandArg<'de, R> for Window<R> {
   /// Grabs the [`Window`] from the [`CommandItem`]. This will never fail.
   fn from_command(command: CommandItem<'de, R>) -> Result<Self, InvokeError> {
-    Ok(command.message.webview().window().clone())
+    Ok(command.message.webview().window())
   }
 }
 


### PR DESCRIPTION
The old `cargo:` instruction syntax has been deprecated with version 1.77 and newer features (such as the `check-cfg` feature introduced in 1.79) require the new double colon `cargo::` syntax. 
This change keeps the old syntax around since it is ignored on newer versions and still necessary for our MSRV policy.