### PR TITLE
fix(bundler/macos): Fix incorrect deep link plist property

### DIFF
--- a/.changes/fix-macos-deep-link-cfbundleurlname.md
+++ b/.changes/fix-macos-deep-link-cfbundleurlname.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: "patch:bug"
+---
+
+Fixed an issue causing the deep link feature to create invalid `Info.plist` values on macOS.

--- a/tooling/bundler/src/bundle/macos/app.rs
+++ b/tooling/bundler/src/bundle/macos/app.rs
@@ -293,7 +293,7 @@ fn create_info_plist(
               ),
             );
             dict.insert(
-              "CFBundleTypeName".into(),
+              "CFBundleURLName".into(),
               protocol
                 .name
                 .clone()


### PR DESCRIPTION
no idea where the pr for this branch went lol

p.s. the file-association example uses the example plist file from my v1 deep link plugin - i don't have access to my computer so can't fix that :)