### PR TITLE
refactor: rename `tauri::dev` to `is_dev` and mark as constant fn

### DIFF
--- a/.changes/tauri-build-dev-fn.md
+++ b/.changes/tauri-build-dev-fn.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": "patch:breaking"
+---
+
+Renamed `dev` function to `is_dev`

--- a/.changes/tauri-dev-fn-const.md
+++ b/.changes/tauri-dev-fn-const.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:breaking"
+---
+
+Renamed `dev` function to `is_dev` and marked it as `const fn`

--- a/core/tauri-build/src/codegen/context.rs
+++ b/core/tauri-build/src/codegen/context.rs
@@ -121,7 +121,7 @@ impl CodegenContext {
     );
 
     let code = context_codegen(ContextData {
-      dev: crate::dev(),
+      dev: crate::is_dev(),
       config,
       config_parent,
       // it's very hard to have a build script for unit tests, so assume this is always called from

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -386,7 +386,7 @@ impl Attributes {
   }
 }
 
-pub fn dev() -> bool {
+pub fn is_dev() -> bool {
   std::env::var("DEP_TAURI_DEV")
     .expect("missing `cargo:dev` instruction, please update tauri to latest")
     == "true"
@@ -474,7 +474,7 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
     mobile::generate_gradle_files(project_dir, &config)?;
   }
 
-  cfg_alias("dev", dev());
+  cfg_alias("dev", is_dev());
 
   let ws_path = get_workspace_dir()?;
   let mut manifest =

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -335,7 +335,7 @@ macro_rules! tauri_build_context {
 pub use pattern::Pattern;
 
 /// Whether we are running in development mode or not.
-pub const fn dev() -> bool {
+pub const fn is_dev() -> bool {
   !cfg!(feature = "custom-protocol")
 }
 

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -335,7 +335,7 @@ macro_rules! tauri_build_context {
 pub use pattern::Pattern;
 
 /// Whether we are running in development mode or not.
-pub fn dev() -> bool {
+pub const fn dev() -> bool {
   !cfg!(feature = "custom-protocol")
 }
 

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -330,7 +330,7 @@ impl<R: Runtime> AppManager<R> {
   }
 
   fn csp(&self) -> Option<Csp> {
-    if !crate::dev() {
+    if !crate::is_dev() {
       self.config.app.security.csp.clone()
     } else {
       self


### PR DESCRIPTION
this enables the `tauri::dev()` can be used as const or static

### Example
```rs
// Prevents additional console window on Windows in release, DO NOT REMOVE!!
#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]

use tauri::Manager;
use tauri_plugin_autostart::MacosLauncher;

static IS_DEV: bool = tauri::dev();

fn main() {
    tauri::Builder::default()
        .plugin(tauri_plugin_autostart::init(
            MacosLauncher::LaunchAgent,
            Some(vec![]),
        ))
        .plugin(tauri_plugin_shell::init())
        .setup(|app| {
            if IS_DEV {
                let window = app.get_webview_window("main").unwrap();
                window.open_devtools();
            } else {
                use tauri_plugin_autostart::ManagerExt;
                let autostart_manager = app.autolaunch();
                if !autostart_manager.is_enabled().unwrap() {
                    let _ = autostart_manager.enable();
                }
            }
            Ok(())
        })
        .run(tauri::generate_context!())
        .expect("error while running tauri application");
}
```

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
