### PR TITLE
fix(android): check version code in release mode

### DIFF
--- a/.changes/build-android-version-check.md
+++ b/.changes/build-android-version-check.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch:enhance
+---
+
+Check for Android version code before building the package in release mode.


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Ref: https://github.com/tauri-apps/tauri/pull/9856#discussion_r1616206721

CTA creates a new project with version `0.0.0` in `tauri.conf.json` and converts it to `VersionCode=0` which is an invalid
version.

If the user is using dev mode, we can clamp the number and make it pass. When the user is building in release mode, we should let it fail and give a hint about the version.