### PR TITLE
fix: set window origin default to null, close #9572

### DIFF
--- a/.changes/tauri-window-origin-default-to-null.md
+++ b/.changes/tauri-window-origin-default-to-null.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Set default window origin to `null`. Prevent window crash when loading `about:blank`.

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -253,16 +253,18 @@ impl<R: Runtime> WebviewManager<R> {
       && window_url.scheme() != "https"
     {
       format!("http://{}.localhost", window_url.scheme())
-    } else {
+    } else if let Some(host) = window_url.host() {
       format!(
         "{}://{}{}",
         window_url.scheme(),
-        window_url.host().unwrap(),
+        host,
         window_url
           .port()
           .map(|p| format!(":{p}"))
           .unwrap_or_default()
       )
+    } else {
+      "null".into()
     };
 
     if !registered_scheme_protocols.contains(&"tauri".into()) {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
Fixed: https://github.com/tauri-apps/tauri/issues/9572

`about:blank` will be parsed as `{ scheme: about, path: blank }`