### PR TITLE
fix(windows): Fix Windows System User build failures by using the current directory for bundling tools (fix: 9895)

### DIFF
--- a/.changes/bundler-local-tools-directory.md
+++ b/.changes/bundler-local-tools-directory.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:feat'
+---
+
+Add `Settings::local_tools_directory`.

--- a/.changes/cli-use-local-tools-directory.md
+++ b/.changes/cli-use-local-tools-directory.md
@@ -1,0 +1,7 @@
+---
+"tauri-cli": "patch:feat"
+"@tauri-apps/cli": "patch:feat"
+---
+
+Use cargo's target directory to store and cache bundling tools when `bundle > useLocalToolsDir` option is active.
+

--- a/.changes/fix-windows-build-failures.md
+++ b/.changes/fix-windows-build-failures.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:bug'
+---
+
+Fixes build failures on Windows when building as a System User.

--- a/.changes/fix-windows-build-failures.md
+++ b/.changes/fix-windows-build-failures.md
@@ -1,5 +1,0 @@
----
-'tauri-bundler': 'patch:bug'
----
-
-Fixes build failures on Windows when building as a System User.

--- a/.changes/utils-use-local-tools-directory.md
+++ b/.changes/utils-use-local-tools-directory.md
@@ -1,0 +1,5 @@
+---
+'tauri-utils': 'patch:feat'
+---
+
+Add `use_local_tools_dir` option.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -150,6 +150,7 @@
             "release": "1"
           },
           "targets": "all",
+          "useLocalToolPath": false,
           "windows": {
             "allowDowngrades": true,
             "certificateThumbprint": null,
@@ -157,7 +158,6 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
-            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -295,6 +295,7 @@
               "release": "1"
             },
             "targets": "all",
+            "useLocalToolPath": false,
             "windows": {
               "allowDowngrades": true,
               "certificateThumbprint": null,
@@ -302,7 +303,6 @@
               "nsis": null,
               "timestampUrl": null,
               "tsp": false,
-              "useLocalToolPath": false,
               "webviewFixedRuntimePath": null,
               "webviewInstallMode": {
                 "silent": true,
@@ -1124,6 +1124,11 @@
             "null"
           ]
         },
+        "useLocalToolPath": {
+          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing build tools (e.g., Wix) when building this application.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\.tauri-tools`. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.",
+          "default": false,
+          "type": "boolean"
+        },
         "appimage": {
           "description": "Configuration for the AppImage bundle.",
           "default": {
@@ -1189,7 +1194,6 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
-            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -1563,11 +1567,6 @@
               "type": "null"
             }
           ]
-        },
-        "useLocalToolPath": {
-          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.",
-          "default": false,
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -157,6 +157,7 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
+            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -301,6 +302,7 @@
               "nsis": null,
               "timestampUrl": null,
               "tsp": false,
+              "useLocalToolPath": false,
               "webviewFixedRuntimePath": null,
               "webviewInstallMode": {
                 "silent": true,
@@ -1187,6 +1189,7 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
+            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -1560,6 +1563,11 @@
               "type": "null"
             }
           ]
+        },
+        "useLocalToolPath": {
+          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -150,7 +150,7 @@
             "release": "1"
           },
           "targets": "all",
-          "useLocalToolPath": false,
+          "useLocalToolsDir": false,
           "windows": {
             "allowDowngrades": true,
             "certificateThumbprint": null,
@@ -295,7 +295,7 @@
               "release": "1"
             },
             "targets": "all",
-            "useLocalToolPath": false,
+            "useLocalToolsDir": false,
             "windows": {
               "allowDowngrades": true,
               "certificateThumbprint": null,
@@ -1124,8 +1124,8 @@
             "null"
           ]
         },
-        "useLocalToolPath": {
-          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing build tools (e.g., Wix) when building this application.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\.tauri-tools`. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.",
+        "useLocalToolsDir": {
+          "description": "Whether to use the project's `target` directory, for caching build tools (e.g., Wix and NSIS) when building this application. Defaults to `false`.\n\nIf true, tools will be cached in `target\\.tauri-tools`. If false, tools will be cached in the current user's platform-specific cache directory.\n\nAn example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.",
           "default": false,
           "type": "boolean"
         },

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -760,13 +760,15 @@ pub struct BundleConfig {
   /// A longer, multi-line description of the application.
   #[serde(alias = "long-description")]
   pub long_description: Option<String>,
-  /// Whether to use the project's local workspace or the current user's Tauri app data cache, for managing build tools (e.g., Wix) when building this application.
+  /// Whether to use the project's `target` directory, for caching build tools (e.g., Wix and NSIS) when building this application. Defaults to `false`.
   ///
-  /// If true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\.tauri-tools`. If false, these tools are cached in the current user's platform-specific app data directory.
+  /// If true, tools will be cached in `target\.tauri-tools`.
+  /// If false, tools will be cached in the current user's platform-specific cache directory.
   ///
-  /// An example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.
-  #[serde(default, alias = "use-local-tool-path")]
-  pub use_local_tool_path: bool,
+  /// An example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads),
+  /// because the Window system's app data directory is restricted.
+  #[serde(default, alias = "use-local-tools-dir")]
+  pub use_local_tools_dir: bool,
   /// Configuration for the AppImage bundle.
   #[serde(default)]
   pub appimage: AppImageConfig,
@@ -3601,7 +3603,7 @@ mod build {
       let category = quote!(None);
       let short_description = quote!(None);
       let long_description = quote!(None);
-      let use_local_tool_path = self.use_local_tool_path;
+      let use_local_tools_dir = self.use_local_tools_dir;
       let appimage = quote!(Default::default());
       let deb = quote!(Default::default());
       let rpm = quote!(Default::default());
@@ -3622,7 +3624,7 @@ mod build {
         category,
         short_description,
         long_description,
-        use_local_tool_path,
+        use_local_tools_dir,
         appimage,
         deb,
         rpm,
@@ -4066,7 +4068,7 @@ mod test {
         category: None,
         short_description: None,
         long_description: None,
-        use_local_tool_path: false,
+        use_local_tools_dir: false,
         appimage: Default::default(),
         deb: Default::default(),
         rpm: Default::default(),

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -674,13 +674,6 @@ pub struct WindowsConfig {
   pub wix: Option<WixConfig>,
   /// Configuration for the installer generated with NSIS.
   pub nsis: Option<NsisConfig>,
-  /// Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.
-  ///
-  /// If true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.
-  ///
-  /// An example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.
-  #[serde(default, alias = "use-local-tool-path")]
-  pub use_local_tool_path: bool,
 }
 
 impl Default for WindowsConfig {
@@ -695,7 +688,6 @@ impl Default for WindowsConfig {
       allow_downgrades: true,
       wix: None,
       nsis: None,
-      use_local_tool_path: false,
     }
   }
 }
@@ -768,6 +760,13 @@ pub struct BundleConfig {
   /// A longer, multi-line description of the application.
   #[serde(alias = "long-description")]
   pub long_description: Option<String>,
+  /// Whether to use the project's local workspace or the current user's Tauri app data cache, for managing build tools (e.g., Wix) when building this application.
+  ///
+  /// If true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\.tauri-tools`. If false, these tools are cached in the current user's platform-specific app data directory.
+  ///
+  /// An example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.
+  #[serde(default, alias = "use-local-tool-path")]
+  pub use_local_tool_path: bool,
   /// Configuration for the AppImage bundle.
   #[serde(default)]
   pub appimage: AppImageConfig,
@@ -3602,6 +3601,7 @@ mod build {
       let category = quote!(None);
       let short_description = quote!(None);
       let long_description = quote!(None);
+      let use_local_tool_path = self.use_local_tool_path;
       let appimage = quote!(Default::default());
       let deb = quote!(Default::default());
       let rpm = quote!(Default::default());
@@ -3622,6 +3622,7 @@ mod build {
         category,
         short_description,
         long_description,
+        use_local_tool_path,
         appimage,
         deb,
         rpm,
@@ -4065,6 +4066,7 @@ mod test {
         category: None,
         short_description: None,
         long_description: None,
+        use_local_tool_path: false,
         appimage: Default::default(),
         deb: Default::default(),
         rpm: Default::default(),

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -674,6 +674,13 @@ pub struct WindowsConfig {
   pub wix: Option<WixConfig>,
   /// Configuration for the installer generated with NSIS.
   pub nsis: Option<NsisConfig>,
+  /// Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.
+  ///
+  /// If true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.
+  ///
+  /// An example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.
+  #[serde(default, alias = "use-local-tool-path")]
+  pub use_local_tool_path: bool,
 }
 
 impl Default for WindowsConfig {
@@ -688,6 +695,7 @@ impl Default for WindowsConfig {
       allow_downgrades: true,
       wix: None,
       nsis: None,
+      use_local_tool_path: false,
     }
   }
 }

--- a/tooling/bundler/src/bundle/linux/appimage.rs
+++ b/tooling/bundler/src/bundle/linux/appimage.rs
@@ -55,15 +55,14 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   sh_map.insert("app_name", settings.main_binary_name());
   sh_map.insert("app_name_uppercase", &upcase_app_name);
   sh_map.insert("appimage_filename", &appimage_filename);
-  let tauri_tools_path = dirs_next::cache_dir().map_or_else(
-    || output_path.to_path_buf(),
-    |mut p| {
-      p.push("tauri");
-      p
-    },
-  );
+
+  let tauri_tools_path = settings
+    .local_tools_directory()
+    .map(|d| d.join(".tauri"))
+    .unwrap_or_else(|| dirs_next::cache_dir().unwrap().join("tauri"));
   std::fs::create_dir_all(&tauri_tools_path)?;
   let tauri_tools_path_str = tauri_tools_path.to_string_lossy();
+
   sh_map.insert("tauri_tools_path", &tauri_tools_path_str);
   let larger_icon = icons
     .iter()

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -385,6 +385,12 @@ pub struct WindowsSettings {
   ///
   /// /// The default value of this flag is `true`.
   pub allow_downgrades: bool,
+  /// Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.
+  ///
+  /// If true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.
+  ///
+  /// An example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.
+  pub use_local_tool_path: bool,
 }
 
 impl Default for WindowsSettings {
@@ -400,6 +406,7 @@ impl Default for WindowsSettings {
       webview_install_mode: Default::default(),
       webview_fixed_runtime_path: None,
       allow_downgrades: true,
+      use_local_tool_path: false,
     }
   }
 }

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -385,12 +385,6 @@ pub struct WindowsSettings {
   ///
   /// /// The default value of this flag is `true`.
   pub allow_downgrades: bool,
-  /// Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.
-  ///
-  /// If true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.
-  ///
-  /// An example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.
-  pub use_local_tool_path: bool,
 }
 
 impl Default for WindowsSettings {
@@ -406,7 +400,6 @@ impl Default for WindowsSettings {
       webview_install_mode: Default::default(),
       webview_fixed_runtime_path: None,
       allow_downgrades: true,
-      use_local_tool_path: false,
     }
   }
 }
@@ -441,6 +434,12 @@ pub struct BundleSettings {
   pub short_description: Option<String>,
   /// the app's long description.
   pub long_description: Option<String>,
+  /// Whether to use the project's local workspace or the current user's Tauri app data cache, for managing build tools (e.g., Wix) when building this application.
+  ///
+  /// If true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\.tauri-tools`. If false, these tools are cached in the current user's platform-specific app data directory.
+  ///
+  /// An example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.
+  pub use_local_tool_path: bool,
   // Bundles for other binaries:
   /// Configuration map for the apps to bundle.
   pub bin: Option<HashMap<String, BundleSettings>>,
@@ -891,6 +890,11 @@ impl Settings {
   /// Returns the app's long description.
   pub fn long_description(&self) -> Option<&str> {
     self.bundle_settings.long_description.as_deref()
+  }
+
+  /// Returns whether to use a local tool path for Tauri build tools.
+  pub fn use_local_tool_path(&self) -> bool {
+    self.bundle_settings.use_local_tool_path
   }
 
   /// Returns the debian settings.

--- a/tooling/bundler/src/bundle/windows/msi.rs
+++ b/tooling/bundler/src/bundle/windows/msi.rs
@@ -28,7 +28,7 @@ const WIX_REQUIRED_FILES: &[&str] = &[
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
   let mut wix_path = dirs_next::cache_dir().unwrap();
   wix_path.push("tauri/WixTools314");
-  if settings.use_local_tool_path() == true {
+  if settings.use_local_tool_path() {
     wix_path = settings.project_out_directory().join("../.tauri-tools/Wix")
   }
   if !wix_path.exists() {

--- a/tooling/bundler/src/bundle/windows/msi.rs
+++ b/tooling/bundler/src/bundle/windows/msi.rs
@@ -26,9 +26,8 @@ const WIX_REQUIRED_FILES: &[&str] = &[
 /// Runs all of the commands to build the MSI installer.
 /// Returns a vector of PathBuf that shows where the MSI was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let mut wix_path = dirs_next::cache_dir().unwrap();
-  wix_path.push("tauri/WixTools314");
-
+  let tauri_tools_path = std::env::current_dir().unwrap().join("target/tools");
+  let wix_path = tauri_tools_path.join("Wix");
   if !wix_path.exists() {
     wix::get_and_extract_wix(&wix_path)?;
   } else if WIX_REQUIRED_FILES

--- a/tooling/bundler/src/bundle/windows/msi.rs
+++ b/tooling/bundler/src/bundle/windows/msi.rs
@@ -28,8 +28,8 @@ const WIX_REQUIRED_FILES: &[&str] = &[
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
   let mut wix_path = dirs_next::cache_dir().unwrap();
   wix_path.push("tauri/WixTools314");
-  if settings.windows().use_local_tool_path == true {
-    wix_path = settings.project_out_directory().join("../tools/Wix")
+  if settings.use_local_tool_path() == true {
+    wix_path = settings.project_out_directory().join("../.tauri-tools/Wix")
   }
   if !wix_path.exists() {
     wix::get_and_extract_wix(&wix_path)?;

--- a/tooling/bundler/src/bundle/windows/msi.rs
+++ b/tooling/bundler/src/bundle/windows/msi.rs
@@ -26,11 +26,13 @@ const WIX_REQUIRED_FILES: &[&str] = &[
 /// Runs all of the commands to build the MSI installer.
 /// Returns a vector of PathBuf that shows where the MSI was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let mut wix_path = dirs_next::cache_dir().unwrap();
-  wix_path.push("tauri/WixTools314");
-  if settings.use_local_tool_path() {
-    wix_path = settings.project_out_directory().join("../.tauri-tools/Wix")
-  }
+  let tauri_tools_path = settings
+    .local_tools_directory()
+    .map(|d| d.join(".tauri"))
+    .unwrap_or_else(|| dirs_next::cache_dir().unwrap().join("tauri"));
+
+  let wix_path = tauri_tools_path.join("WixTools314");
+
   if !wix_path.exists() {
     wix::get_and_extract_wix(&wix_path)?;
   } else if WIX_REQUIRED_FILES

--- a/tooling/bundler/src/bundle/windows/msi.rs
+++ b/tooling/bundler/src/bundle/windows/msi.rs
@@ -26,8 +26,11 @@ const WIX_REQUIRED_FILES: &[&str] = &[
 /// Runs all of the commands to build the MSI installer.
 /// Returns a vector of PathBuf that shows where the MSI was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let tauri_tools_path = std::env::current_dir().unwrap().join("target/tools");
-  let wix_path = tauri_tools_path.join("Wix");
+  let mut wix_path = dirs_next::cache_dir().unwrap();
+  wix_path.push("tauri/WixTools314");
+  if settings.windows().use_local_tool_path == true {
+    wix_path = settings.project_out_directory().join("../tools/Wix")
+  }
   if !wix_path.exists() {
     wix::get_and_extract_wix(&wix_path)?;
   } else if WIX_REQUIRED_FILES

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -64,10 +64,11 @@ const NSIS_REQUIRED_FILES_HASH: &[(&str, &str, &str, HashAlgorithm)] = &[(
 /// Runs all of the commands to build the NSIS installer.
 /// Returns a vector of PathBuf that shows where the NSIS installer was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let mut tauri_tools_path = dirs_next::cache_dir().unwrap().join("tauri");
-  if settings.use_local_tool_path() {
-    tauri_tools_path = settings.project_out_directory().join("../.tauri-tools");
-  }
+  let tauri_tools_path = settings
+    .local_tools_directory()
+    .map(|d| d.join(".tauri"))
+    .unwrap_or_else(|| dirs_next::cache_dir().unwrap().join("tauri"));
+
   let nsis_toolset_path = tauri_tools_path.join("NSIS");
 
   if !nsis_toolset_path.exists() {

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -65,7 +65,7 @@ const NSIS_REQUIRED_FILES_HASH: &[(&str, &str, &str, HashAlgorithm)] = &[(
 /// Returns a vector of PathBuf that shows where the NSIS installer was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
   let mut tauri_tools_path = dirs_next::cache_dir().unwrap().join("tauri");
-  if settings.use_local_tool_path() == true {
+  if settings.use_local_tool_path() {
     tauri_tools_path = settings.project_out_directory().join("../.tauri-tools");
   }
   let nsis_toolset_path = tauri_tools_path.join("NSIS");

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -64,7 +64,7 @@ const NSIS_REQUIRED_FILES_HASH: &[(&str, &str, &str, HashAlgorithm)] = &[(
 /// Runs all of the commands to build the NSIS installer.
 /// Returns a vector of PathBuf that shows where the NSIS installer was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let tauri_tools_path = dirs_next::cache_dir().unwrap().join("tauri");
+  let tauri_tools_path = std::env::current_dir().unwrap().join("target/tools");
   let nsis_toolset_path = tauri_tools_path.join("NSIS");
 
   if !nsis_toolset_path.exists() {

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -65,8 +65,8 @@ const NSIS_REQUIRED_FILES_HASH: &[(&str, &str, &str, HashAlgorithm)] = &[(
 /// Returns a vector of PathBuf that shows where the NSIS installer was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
   let mut tauri_tools_path = dirs_next::cache_dir().unwrap().join("tauri");
-  if settings.windows().use_local_tool_path == true {
-    tauri_tools_path = settings.project_out_directory().join("../tools");
+  if settings.use_local_tool_path() == true {
+    tauri_tools_path = settings.project_out_directory().join("../.tauri-tools");
   }
   let nsis_toolset_path = tauri_tools_path.join("NSIS");
 

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -64,7 +64,10 @@ const NSIS_REQUIRED_FILES_HASH: &[(&str, &str, &str, HashAlgorithm)] = &[(
 /// Runs all of the commands to build the NSIS installer.
 /// Returns a vector of PathBuf that shows where the NSIS installer was created.
 pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<PathBuf>> {
-  let tauri_tools_path = std::env::current_dir().unwrap().join("target/tools");
+  let mut tauri_tools_path = dirs_next::cache_dir().unwrap().join("tauri");
+  if settings.windows().use_local_tool_path == true {
+    tauri_tools_path = settings.project_out_directory().join("../tools");
+  }
   let nsis_toolset_path = tauri_tools_path.join("NSIS");
 
   if !nsis_toolset_path.exists() {

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -986,6 +986,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsa"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48bc224a9084ad760195584ce5abb3c2c34a225fa312a128ad245a6b412b7689"
+dependencies = [
+ "digest",
+ "num-bigint-dig",
+ "num-traits",
+ "pkcs8",
+ "rfc6979",
+ "sha2",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,6 +1827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "iter-read"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a598c1abae8e3456ebda517868b254b6bc2a9bb6501ffd5b9d0875bf332e048b"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1940,20 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -2424,6 +2460,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
@@ -2670,9 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "pgp"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e1f8e085bfa9b85763fe3ddaacbe90a09cd847b3833129153a6cb063bbe132"
+checksum = "031fa1e28c4cb54c90502ef0642a44ef10ec8349349ebe6372089f1b1ef4f297"
 dependencies = [
  "aes",
  "base64",
@@ -2687,23 +2744,27 @@ dependencies = [
  "cfb-mode",
  "chrono",
  "cipher",
+ "const-oid",
  "crc24",
  "curve25519-dalek",
  "derive_builder",
  "des",
  "digest",
+ "dsa",
  "ed25519-dalek",
  "elliptic-curve",
  "flate2",
  "generic-array",
  "hex",
  "idea",
+ "iter-read",
+ "k256",
  "log",
  "md-5",
  "nom",
  "num-bigint-dig",
- "num-derive",
  "num-traits",
+ "num_enum",
  "p256",
  "p384",
  "rand 0.8.5",
@@ -2983,6 +3044,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -3267,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "rpm"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a681f5d3dc43f62b636c8e2d0b709e85673cf12eb036cde5a48b26e930a6777"
+checksum = "e68a0d60350e5f4229cd69f08ec8f373e34424701702d1ee51a89aee1e9adcd1"
 dependencies = [
  "bitflags 2.4.1",
  "bzip2",

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -150,6 +150,7 @@
             "release": "1"
           },
           "targets": "all",
+          "useLocalToolPath": false,
           "windows": {
             "allowDowngrades": true,
             "certificateThumbprint": null,
@@ -157,7 +158,6 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
-            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -295,6 +295,7 @@
               "release": "1"
             },
             "targets": "all",
+            "useLocalToolPath": false,
             "windows": {
               "allowDowngrades": true,
               "certificateThumbprint": null,
@@ -302,7 +303,6 @@
               "nsis": null,
               "timestampUrl": null,
               "tsp": false,
-              "useLocalToolPath": false,
               "webviewFixedRuntimePath": null,
               "webviewInstallMode": {
                 "silent": true,
@@ -1124,6 +1124,11 @@
             "null"
           ]
         },
+        "useLocalToolPath": {
+          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing build tools (e.g., Wix) when building this application.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\.tauri-tools`. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.",
+          "default": false,
+          "type": "boolean"
+        },
         "appimage": {
           "description": "Configuration for the AppImage bundle.",
           "default": {
@@ -1189,7 +1194,6 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
-            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -1563,11 +1567,6 @@
               "type": "null"
             }
           ]
-        },
-        "useLocalToolPath": {
-          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.",
-          "default": false,
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -157,6 +157,7 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
+            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -301,6 +302,7 @@
               "nsis": null,
               "timestampUrl": null,
               "tsp": false,
+              "useLocalToolPath": false,
               "webviewFixedRuntimePath": null,
               "webviewInstallMode": {
                 "silent": true,
@@ -1187,6 +1189,7 @@
             "nsis": null,
             "timestampUrl": null,
             "tsp": false,
+            "useLocalToolPath": false,
             "webviewFixedRuntimePath": null,
             "webviewInstallMode": {
               "silent": true,
@@ -1560,6 +1563,11 @@
               "type": "null"
             }
           ]
+        },
+        "useLocalToolPath": {
+          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing the Windows build tools (e.g., Wix) when building this project for Windows.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\\\tools` when building for Windows. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it might be appropriate to set this to `true` is when building this application as a System user (e.g., AWS EC2 workloads), only because their app data directory is restricted.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -150,7 +150,7 @@
             "release": "1"
           },
           "targets": "all",
-          "useLocalToolPath": false,
+          "useLocalToolsDir": false,
           "windows": {
             "allowDowngrades": true,
             "certificateThumbprint": null,
@@ -295,7 +295,7 @@
               "release": "1"
             },
             "targets": "all",
-            "useLocalToolPath": false,
+            "useLocalToolsDir": false,
             "windows": {
               "allowDowngrades": true,
               "certificateThumbprint": null,
@@ -1124,8 +1124,8 @@
             "null"
           ]
         },
-        "useLocalToolPath": {
-          "description": "Whether to use the project's local workspace or the current user's Tauri app data cache, for managing build tools (e.g., Wix) when building this application.\n\nIf true, installs and uses bundling tools (e.g., Wix) in the project's local workspace, under `target\\.tauri-tools`. If false, these tools are cached in the current user's platform-specific app data directory.\n\nAn example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.",
+        "useLocalToolsDir": {
+          "description": "Whether to use the project's `target` directory, for caching build tools (e.g., Wix and NSIS) when building this application. Defaults to `false`.\n\nIf true, tools will be cached in `target\\.tauri-tools`. If false, tools will be cached in the current user's platform-specific cache directory.\n\nAn example where it can be appropriate to set this to `true` is when building this application as a Windows System user (e.g., AWS EC2 workloads), because the Window system's app data directory is restricted.",
           "default": false,
           "type": "boolean"
         },

--- a/tooling/cli/src/interface/mod.rs
+++ b/tooling/cli/src/interface/mod.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use crate::helpers::config::Config;
+use anyhow::Context;
 use tauri_bundler::bundle::{PackageType, Settings, SettingsBuilder};
 
 pub use rust::{Options, Rust as AppInterface};
@@ -57,6 +58,14 @@ pub trait AppSettings {
 
     if let Some(types) = package_types {
       settings_builder = settings_builder.package_types(types);
+    }
+
+    if config.tauri.bundle.use_local_tools_dir {
+      settings_builder = settings_builder.local_tools_directory(
+        rust::get_cargo_metadata()
+          .context("failed to get cargo metadata")?
+          .target_directory,
+      )
     }
 
     settings_builder.build().map_err(Into::into)

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1139,6 +1139,7 @@ fn tauri_config_to_bundle_settings(
     short_description: config.short_description,
     long_description: config.long_description,
     external_bin: config.external_bin,
+    use_local_tool_path: config.use_local_tool_path,
     deb: DebianSettings {
       depends: if depends_deb.is_empty() {
         None
@@ -1195,7 +1196,6 @@ fn tauri_config_to_bundle_settings(
       webview_install_mode: config.windows.webview_install_mode,
       webview_fixed_runtime_path: config.windows.webview_fixed_runtime_path,
       allow_downgrades: config.windows.allow_downgrades,
-      use_local_tool_path: config.windows.use_local_tool_path,
     },
     updater: Some(UpdaterSettings {
       active: updater_config.active,

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1195,6 +1195,7 @@ fn tauri_config_to_bundle_settings(
       webview_install_mode: config.windows.webview_install_mode,
       webview_fixed_runtime_path: config.windows.webview_fixed_runtime_path,
       allow_downgrades: config.windows.allow_downgrades,
+      use_local_tool_path: config.windows.use_local_tool_path,
     },
     updater: Some(UpdaterSettings {
       active: updater_config.active,

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -962,12 +962,12 @@ impl RustAppSettings {
 }
 
 #[derive(Deserialize)]
-struct CargoMetadata {
-  target_directory: PathBuf,
-  workspace_root: PathBuf,
+pub struct CargoMetadata {
+  pub target_directory: PathBuf,
+  pub workspace_root: PathBuf,
 }
 
-fn get_cargo_metadata() -> crate::Result<CargoMetadata> {
+pub fn get_cargo_metadata() -> crate::Result<CargoMetadata> {
   let output = Command::new("cargo")
     .args(["metadata", "--no-deps", "--format-version", "1"])
     .current_dir(tauri_dir())
@@ -1139,7 +1139,6 @@ fn tauri_config_to_bundle_settings(
     short_description: config.short_description,
     long_description: config.long_description,
     external_bin: config.external_bin,
-    use_local_tool_path: config.use_local_tool_path,
     deb: DebianSettings {
       depends: if depends_deb.is_empty() {
         None


### PR DESCRIPTION
Closes #9895 with details on the issue there.

As a summary: Tauri uses Wix/NSIS toolsets for bundling .msi and .exe files respectively. Currently, it installs/retrieves these toolchains from the user app directory. However, this approach fails if the current user is a System user, since their app directory (the system directory) is restricted, which results in the bundling failing due to unusable Wix/NSIS executables.

This PR solves the problem by instead installing/retrieving the Wix/NSIS toolset from the current project directory, in `target/tools`. For example, Wix would be at `target/tools/Wix`. This would:

- Be a known location that should be accessible, since it is the current project's workspace.
- Enable deterministic builds across different Windows Users, since the tools are in the project's workspace rather than being user-specific
- Enable controlled builds for the same Windows User across different Tauri projects, in case support comes later to use a specific version of these tools for a specific project.
- Better support as-is offline builds wherein these tools can be configured in the project's workspace ahead-of-time (rather than configuring them on-the-fly).

Tested this code change locally:
- `cargo test`
- `cargo clippy`
- Using it on my Windows machine with Tauri Quickstart guide example, to generate .msi and .exe (tests Wix and NSIS flows, respectively). They both built successfully. Also confirmed both of them work for app installation
