### PR TITLE
feat(bundler): add provides, conflicts and replaces for deb and rpm

### DIFF
--- a/.changes/deb-rpm-provides-conflicts-replaces.md
+++ b/.changes/deb-rpm-provides-conflicts-replaces.md
@@ -1,8 +1,6 @@
 ---
 'tauri-bundler': 'minor:feat'
 'tauri-utils': 'minor:feat'
-'tauri-cli': 'minor:feat'
-'@tauri-apps/cli': 'minor:feat'
 ---
 
 Added support for `provides`, `conflicts` and `replaces` (`obsoletes` for RPM) options for `bundler > deb` and `bundler > rpm` configs.

--- a/.changes/deb-rpm-provides-conflicts-replaces.md
+++ b/.changes/deb-rpm-provides-conflicts-replaces.md
@@ -2,7 +2,7 @@
 'tauri-bundler': 'minor:feat'
 'tauri-utils': 'minor:feat'
 'tauri-cli': 'minor:feat'
-'@tauri-apps/cli: 'minor:feat'
+'@tauri-apps/cli': 'minor:feat'
 ---
 
 Added support for `provides`, `conflicts` and `replaces` (`obsoletes` for RPM) options for `bundler > deb` and `bundler > rpm` configs.

--- a/.changes/deb-rpm-provides-conflicts-replaces.md
+++ b/.changes/deb-rpm-provides-conflicts-replaces.md
@@ -1,0 +1,7 @@
+---
+'tauri-bundler': 'minor:feat'
+'tauri-utils': 'minor:feat'
+'tauri-cli': 'minor:feat'
+---
+
+Added support for `provides`, `conflicts` and `replaces` (`obsoletes` for RPM) options for `bundler > deb` and `bundler > rpm` configs.

--- a/.changes/deb-rpm-provides-conflicts-replaces.md
+++ b/.changes/deb-rpm-provides-conflicts-replaces.md
@@ -2,6 +2,7 @@
 'tauri-bundler': 'minor:feat'
 'tauri-utils': 'minor:feat'
 'tauri-cli': 'minor:feat'
+'@tauri-apps/cli: 'minor:feat'
 ---
 
 Added support for `provides`, `conflicts` and `replaces` (`obsoletes` for RPM) options for `bundler > deb` and `bundler > rpm` configs.

--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -1335,6 +1335,36 @@
             "type": "string"
           }
         },
+        "provides": {
+          "description": "The list of dependencies the package provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of package conflicts.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "replaces": {
+          "description": "The list of package replaces.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "files": {
           "description": "The files to include on the package.",
           "default": {},
@@ -1387,6 +1417,36 @@
         },
         "depends": {
           "description": "The list of RPM dependencies your application relies on.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "provides": {
+          "description": "The list of RPM dependencies your application provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of RPM dependencies your application conflicts with. They must not be present in order for the package to be installed.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "obsoletes": {
+          "description": "The list of RPM dependencies your application supersedes - if this package is installed, packages listed as “obsoletes” will be automatically removed (if they are present).",
           "type": [
             "array",
             "null"

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -271,6 +271,12 @@ pub struct AppImageConfig {
 pub struct DebConfig {
   /// The list of deb dependencies your application relies on.
   pub depends: Option<Vec<String>>,
+  /// The list of dependencies the package provides.
+  pub provides: Option<Vec<String>>,
+  /// The list of package conflicts.
+  pub conflicts: Option<Vec<String>>,
+  /// The list of package replaces.
+  pub replaces: Option<Vec<String>>,
   /// The files to include on the package.
   #[serde(default)]
   pub files: HashMap<PathBuf, PathBuf>,
@@ -299,6 +305,14 @@ pub struct RpmConfig {
   pub license: Option<String>,
   /// The list of RPM dependencies your application relies on.
   pub depends: Option<Vec<String>>,
+  /// The list of RPM dependencies your application provides.
+  pub provides: Option<Vec<String>>,
+  /// The list of RPM dependencies your application conflicts with. They must not be present
+  /// in order for the package to be installed.
+  pub conflicts: Option<Vec<String>>,
+  /// The list of RPM dependencies your application supersedes - if this package is installed,
+  /// packages listed as “obsoletes” will be automatically removed (if they are present).
+  pub obsoletes: Option<Vec<String>>,
   /// The RPM release tag.
   #[serde(default = "default_release")]
   pub release: String,
@@ -319,6 +333,9 @@ impl Default for RpmConfig {
     Self {
       license: None,
       depends: None,
+      provides: None,
+      conflicts: None,
+      obsoletes: None,
       release: default_release(),
       epoch: 0,
       files: Default::default(),

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -180,6 +180,18 @@ fn generate_control_file(
   if !dependencies.is_empty() {
     writeln!(file, "Depends: {}", dependencies.join(", "))?;
   }
+  let provides = settings.deb().provides.as_ref().cloned().unwrap_or_default();
+  if !provides.is_empty() {
+    writeln!(file, "Provides: {}", provides.join(", "))?;
+  }
+  let conflicts = settings.deb().conflicts.as_ref().cloned().unwrap_or_default();
+  if !conflicts.is_empty() {
+    writeln!(file, "Conflicts: {}", conflicts.join(", "))?;
+  }
+  let replaces = settings.deb().replaces.as_ref().cloned().unwrap_or_default();
+  if !replaces.is_empty() {
+    writeln!(file, "Replaces: {}", replaces.join(", "))?;
+  }
   let mut short_description = settings.short_description().trim();
   if short_description.is_empty() {
     short_description = "(none)";

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -180,15 +180,30 @@ fn generate_control_file(
   if !dependencies.is_empty() {
     writeln!(file, "Depends: {}", dependencies.join(", "))?;
   }
-  let provides = settings.deb().provides.as_ref().cloned().unwrap_or_default();
+  let provides = settings
+    .deb()
+    .provides
+    .as_ref()
+    .cloned()
+    .unwrap_or_default();
   if !provides.is_empty() {
     writeln!(file, "Provides: {}", provides.join(", "))?;
   }
-  let conflicts = settings.deb().conflicts.as_ref().cloned().unwrap_or_default();
+  let conflicts = settings
+    .deb()
+    .conflicts
+    .as_ref()
+    .cloned()
+    .unwrap_or_default();
   if !conflicts.is_empty() {
     writeln!(file, "Conflicts: {}", conflicts.join(", "))?;
   }
-  let replaces = settings.deb().replaces.as_ref().cloned().unwrap_or_default();
+  let replaces = settings
+    .deb()
+    .replaces
+    .as_ref()
+    .cloned()
+    .unwrap_or_default();
   if !replaces.is_empty() {
     writeln!(file, "Replaces: {}", replaces.join(", "))?;
   }

--- a/tooling/bundler/src/bundle/linux/rpm.rs
+++ b/tooling/bundler/src/bundle/linux/rpm.rs
@@ -67,16 +67,34 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     builder = builder.requires(Dependency::any(dep));
   }
   // Add provides
-  for dep in settings.rpm().provides.as_ref().cloned().unwrap_or_default() {
+  for dep in settings
+    .rpm()
+    .provides
+    .as_ref()
+    .cloned()
+    .unwrap_or_default()
+  {
     builder = builder.provides(Dependency::any(dep));
   }
   // Add conflicts
-  for dep in settings.rpm().conflicts.as_ref().cloned().unwrap_or_default() {
+  for dep in settings
+    .rpm()
+    .conflicts
+    .as_ref()
+    .cloned()
+    .unwrap_or_default()
+  {
     builder = builder.conflicts(Dependency::any(dep));
   }
 
   // Add obsoletes
-  for dep in settings.rpm().obsoletes.as_ref().cloned().unwrap_or_default() {
+  for dep in settings
+    .rpm()
+    .obsoletes
+    .as_ref()
+    .cloned()
+    .unwrap_or_default()
+  {
     builder = builder.obsoletes(Dependency::any(dep));
   }
 

--- a/tooling/bundler/src/bundle/linux/rpm.rs
+++ b/tooling/bundler/src/bundle/linux/rpm.rs
@@ -66,6 +66,19 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   for dep in settings.rpm().depends.as_ref().cloned().unwrap_or_default() {
     builder = builder.requires(Dependency::any(dep));
   }
+  // Add provides
+  for dep in settings.rpm().provides.as_ref().cloned().unwrap_or_default() {
+    builder = builder.provides(Dependency::any(dep));
+  }
+  // Add conflicts
+  for dep in settings.rpm().conflicts.as_ref().cloned().unwrap_or_default() {
+    builder = builder.conflicts(Dependency::any(dep));
+  }
+
+  // Add obsoletes
+  for dep in settings.rpm().obsoletes.as_ref().cloned().unwrap_or_default() {
+    builder = builder.obsoletes(Dependency::any(dep));
+  }
 
   // Add binaries
   for bin in settings.binaries() {

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -176,6 +176,12 @@ pub struct DebianSettings {
   // OS-specific settings:
   /// the list of debian dependencies.
   pub depends: Option<Vec<String>>,
+  /// the list of dependencies the package provides.
+  pub provides: Option<Vec<String>>,
+  /// the list of package conflicts.
+  pub conflicts: Option<Vec<String>>,
+  /// the list of package replaces.
+  pub replaces: Option<Vec<String>>,
   /// List of custom files to add to the deb package.
   /// Maps the path on the debian package to the path of the file to include (relative to the current working directory).
   pub files: HashMap<PathBuf, PathBuf>,
@@ -205,6 +211,14 @@ pub struct RpmSettings {
   pub license: Option<String>,
   /// The list of RPM dependencies your application relies on.
   pub depends: Option<Vec<String>>,
+  /// The list of RPM dependencies your application provides.
+  pub provides: Option<Vec<String>>,
+  /// The list of RPM dependencies your application conflicts with. They must not be present
+  /// in order for the package to be installed.
+  pub conflicts: Option<Vec<String>>,
+  /// The list of RPM dependencies your application supersedes - if this package is installed,
+  /// packages listed as “obsoletes” will be automatically removed (if they are present).
+  pub obsoletes: Option<Vec<String>>,
   /// The RPM release tag.
   pub release: String,
   /// The RPM epoch.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -1335,6 +1335,36 @@
             "type": "string"
           }
         },
+        "provides": {
+          "description": "The list of dependencies the package provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of package conflicts.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "replaces": {
+          "description": "The list of package replaces.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "files": {
           "description": "The files to include on the package.",
           "default": {},
@@ -1387,6 +1417,36 @@
         },
         "depends": {
           "description": "The list of RPM dependencies your application relies on.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "provides": {
+          "description": "The list of RPM dependencies your application provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "conflicts": {
+          "description": "The list of RPM dependencies your application conflicts with. They must not be present in order for the package to be installed.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "obsoletes": {
+          "description": "The list of RPM dependencies your application supersedes - if this package is installed, packages listed as “obsoletes” will be automatically removed (if they are present).",
           "type": [
             "array",
             "null"

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1145,9 +1145,9 @@ fn tauri_config_to_bundle_settings(
       } else {
         Some(depends_deb)
       },
-      provides: config.linux.deb.provides,
-      conflicts: config.linux.deb.conflicts,
-      replaces: config.linux.deb.replaces,
+      provides: config.deb.provides,
+      conflicts: config.deb.conflicts,
+      replaces: config.deb.replaces,
       files: config.deb.files,
       desktop_template: config.deb.desktop_template,
       section: config.deb.section,
@@ -1161,9 +1161,9 @@ fn tauri_config_to_bundle_settings(
       } else {
         Some(depends_rpm)
       },
-      provides: config.linux.rpm.provides,
-      conflicts: config.linux.rpm.conflicts,
-      obsoletes: config.linux.rpm.obsoletes,
+      provides: config.rpm.provides,
+      conflicts: config.rpm.conflicts,
+      obsoletes: config.rpm.obsoletes,
       release: config.rpm.release,
       epoch: config.rpm.epoch,
       files: config.rpm.files,

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1145,6 +1145,9 @@ fn tauri_config_to_bundle_settings(
       } else {
         Some(depends_deb)
       },
+      provides: config.linux.deb.provides,
+      conflicts: config.linux.deb.conflicts,
+      replaces: config.linux.deb.replaces,
       files: config.deb.files,
       desktop_template: config.deb.desktop_template,
       section: config.deb.section,
@@ -1158,6 +1161,9 @@ fn tauri_config_to_bundle_settings(
       } else {
         Some(depends_rpm)
       },
+      provides: config.linux.rpm.provides,
+      conflicts: config.linux.rpm.conflicts,
+      obsoletes: config.linux.rpm.obsoletes,
       release: config.rpm.release,
       epoch: config.rpm.epoch,
       files: config.rpm.files,


### PR DESCRIPTION
This PR added support for provides, conflicts and replaces (obsoletes for RPM) options for `bundler > deb` and `bundler > rpm` configs.


Backport of #9331