### PR TITLE
fix(bundler): fix error when renaming the downloaded zip of NSIS 

### DIFF
--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -122,12 +122,10 @@ fn get_and_extract_nsis(nsis_toolset_path: &Path, _tauri_tools_path: &Path) -> c
     NSIS_TAURI_UTILS_SHA1,
     HashAlgorithm::Sha1,
   )?;
-  write(
-    nsis_plugins
-      .join("x86-unicode")
-      .join("nsis_tauri_utils.dll"),
-    data,
-  )?;
+
+  let target_folder = nsis_plugins.join("x86-unicode");
+  create_dir_all(&target_folder)?;
+  write(target_folder.join("nsis_tauri_utils.dll"), data)?;
 
   Ok(())
 }

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -68,6 +68,10 @@ pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<P
     .map(|d| d.join(".tauri"))
     .unwrap_or_else(|| dirs_next::cache_dir().unwrap().join("tauri"));
 
+  if !tauri_tools_path.exists() {
+    create_dir_all(&tauri_tools_path)?;
+  }
+
   let nsis_toolset_path = tauri_tools_path.join("NSIS");
 
   if !nsis_toolset_path.exists() {

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -71,7 +71,6 @@ pub fn bundle_project(settings: &Settings, updater: bool) -> crate::Result<Vec<P
   let nsis_toolset_path = tauri_tools_path.join("NSIS");
 
   if !nsis_toolset_path.exists() {
-    create_dir_all(&nsis_toolset_path)?;
     get_and_extract_nsis(&nsis_toolset_path, &tauri_tools_path)?;
   } else if NSIS_REQUIRED_FILES
     .iter()
@@ -119,10 +118,12 @@ fn get_and_extract_nsis(nsis_toolset_path: &Path, _tauri_tools_path: &Path) -> c
     NSIS_TAURI_UTILS_SHA1,
     HashAlgorithm::Sha1,
   )?;
-
-  let target_folder = nsis_plugins.join("x86-unicode");
-  create_dir_all(&target_folder)?;
-  write(target_folder.join("nsis_tauri_utils.dll"), data)?;
+  write(
+    nsis_plugins
+      .join("x86-unicode")
+      .join("nsis_tauri_utils.dll"),
+    data,
+  )?;
 
   Ok(())
 }


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/tauri-apps/tauri/pull/9902#pullrequestreview-2095258915. Creating an `NSIS` folder in advance will cause subsequent renaming failures after extract. Additionally, the `Plugins/x86-unicode` directory already exists in the extracted directory and does not need to be created again.