### PR TITLE
feat(cli): setup Android signing

### DIFF
--- a/.changes/android-signing.md
+++ b/.changes/android-signing.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:feat
+"@tauri-apps/cli": patch:feat
+---
+
+Setup Android signing by reading the `src-tauri/gen/android/keystore.properties` file which should have the `keyAlias=<key-alias>`, `password=<keystore-password>`, `storeFile=<path/to/keystore.jks>` key value pairs separated by new lines.

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -107,13 +107,25 @@ jobs:
         env:
           NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
-      - name: setup Android signing
+      - name: setup Android signing secrets
         working-directory: ./examples/api/src-tauri/gen/android
         run: |
           echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" > keystore.properties
           echo "password=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
+
+      - name: setup Android signing key (Unix)
+        if: matrix.platform != 'windows-latest'
+        working-directory: ./examples/api/src-tauri/gen/android
+        run: |
           base64 -d <<< "${{ secrets.ANDROID_KEY_BASE64 }}" > $RUNNER_TEMP/keystore.jks
           echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
+
+      - name: setup Android signing key (Windows)
+        if: matrix.platform == 'windows-latest'
+        working-directory: ./examples/api/src-tauri/gen/android
+        run: |
+          [System.Convert]::FromBase64String("${{ secrets.ANDROID_KEY_BASE64 }}") | Set-Content $env:RUNNER_TEMP\keystore.jks -Encoding Byte
+          echo "storeFile=$env:RUNNER_TEMP\keystore.jks" >> keystore.properties
 
       - name: build APK
         working-directory: ./examples/api

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -124,7 +124,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         working-directory: ./examples/api/src-tauri/gen/android
         run: |
-          [System.Convert]::FromBase64String("${{ secrets.ANDROID_KEY_BASE64 }}") | Set-Content $env:RUNNER_TEMP\keystore.jks -Encoding Byte
+          [System.Convert]::FromBase64String("${{ secrets.ANDROID_KEY_BASE64 }}") | Set-Content $env:RUNNER_TEMP\keystore.jks -AsByteStream
           echo "storeFile=$env:RUNNER_TEMP\keystore.jks" >> keystore.properties
 
       - name: build APK

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -107,6 +107,14 @@ jobs:
         env:
           NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
 
+      - name: setup Android signing
+        working-directory: ./examples/api/src-tauri/gen/android
+        run: |
+          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" > keystore.properties
+          echo "password=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
+          base64 -d <<< "${{ secrets.ANDROID_KEY_BASE64 }}" > $RUNNER_TEMP/keystore.jks
+          echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
+
       - name: build APK
         working-directory: ./examples/api
         run: cargo tauri android build

--- a/tooling/cli/templates/mobile/android/.gitignore
+++ b/tooling/cli/templates/mobile/android/.gitignore
@@ -17,3 +17,5 @@ key.properties
 
 /.tauri
 /tauri.settings.gradle
+
+keystore.properties

--- a/tooling/cli/templates/mobile/android/keystore.properties.dummy
+++ b/tooling/cli/templates/mobile/android/keystore.properties.dummy
@@ -1,0 +1,3 @@
+keyAlias=tauri-dummy
+password=dummy-pwd
+storeFile=./dummy-keystore.jks


### PR DESCRIPTION
Tweaks the default Android project to include a simple setup for Android signing.

Example Github Action usage:

```yml
- name: setup Android signing
        working-directory: src-tauri/gen/android
        run: |
          echo "keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}" > keystore.properties
          echo "password=${{ secrets.ANDROID_KEY_PASSWORD }}" >> keystore.properties
          base64 -d <<< "${{ secrets.ANDROID_KEY_BASE64 }}" > $RUNNER_TEMP/keystore.jks
          echo "storeFile=$RUNNER_TEMP/keystore.jks" >> keystore.properties
```