### PR TITLE
feat: Support bundle.ios.frameworks

### DIFF
--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -2856,6 +2856,16 @@
             "string",
             "null"
           ]
+        },
+        "frameworks": {
+          "description": "A list of strings indicating any iOS frameworks that need to be bundled with the application.\n\nIf a name is used, \".framework\" must be omitted and it will look for standard install locations. You may also use a path to a specific framework.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -1826,6 +1826,10 @@ pub struct IosConfig {
   /// The `APPLE_DEVELOPMENT_TEAM` environment variable can be set to overwrite it.
   #[serde(alias = "development-team")]
   pub development_team: Option<String>,
+  /// A list of strings indicating any iOS frameworks that need to be bundled with the application.
+  ///
+  /// If a name is used, ".framework" must be omitted and it will look for standard install locations. You may also use a path to a specific framework.
+  pub frameworks: Option<Vec<String>>,
 }
 
 /// General configuration for the iOS target.

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -2856,6 +2856,16 @@
             "string",
             "null"
           ]
+        },
+        "frameworks": {
+          "description": "A list of strings indicating any iOS frameworks that need to be bundled with the application.\n\nIf a name is used, \".framework\" must be omitted and it will look for standard install locations. You may also use a path to a specific framework.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/tooling/cli/src/mobile/ios/mod.rs
+++ b/tooling/cli/src/mobile/ios/mod.rs
@@ -140,22 +140,23 @@ pub fn get_config(
     ios_version: Some(TARGET_IOS_VERSION.into()),
     ..Default::default()
   };
-  let config = AppleConfig::from_raw(app.clone(), Some(raw)).unwrap();
+  let apple_config = AppleConfig::from_raw(app.clone(), Some(raw)).unwrap();
 
   let metadata = AppleMetadata {
     supported: true,
     ios: ApplePlatform {
       cargo_args: Some(ios_options.args),
       features: ios_options.features,
+      frameworks: config.bundle.ios.frameworks.clone(),
       ..Default::default()
     },
     macos: Default::default(),
   };
 
-  set_var("TAURI_IOS_PROJECT_PATH", config.project_dir());
-  set_var("TAURI_IOS_APP_NAME", config.app().name());
+  set_var("TAURI_IOS_PROJECT_PATH", apple_config.project_dir());
+  set_var("TAURI_IOS_APP_NAME", apple_config.app().name());
 
-  (config, metadata)
+  (apple_config, metadata)
 }
 
 fn connected_device_prompt<'a>(env: &'_ Env, target: Option<&str>) -> Result<Device<'a>> {

--- a/tooling/cli/templates/mobile/ios/project.yml
+++ b/tooling/cli/templates/mobile/ios/project.yml
@@ -101,7 +101,7 @@ targets:
       - sdk: QuartzCore.framework
       - sdk: Security.framework
       - sdk: UIKit.framework
-      {{~#each ios-frameworks}}
+      {{#each ios-frameworks}}
       - sdk: {{this}}.framework{{/each}}
       - sdk: WebKit.framework
     preBuildScripts:


### PR DESCRIPTION
This PR adds support for `bundle.ios.frameworks` for mobile iOS apps. This should close https://github.com/tauri-apps/tauri/issues/9962.

## Work

From what I gathered, these were the necessary steps:

 - Add the`frameworks` field to `IosConfig`, just like it exists for `MacConfig`.
 - Copy the value over from `IosConfig` to the `MetaData` passed into `cargo_mobile2` that generates the Xcode project.

Moreover, I found a bug in the `project.yml` handlebars file, where the frameworks weren't unrolled correctly.

## Checks

I've inspected the resulting `project.yml` and Xcode project and the framework is listed in the _Link Binary with Libraries_ step.

I get a build error in the Xcode build phase running `cargo tauri ios xcode-script`, but I'm not sure how to figure out what's wrong. If any of the iOS devs could help me out, that would be sublime. :)

## Questions

- I am not sure if the comment within for the `IosConfig::frameworks` field is entirely correct. I copy/pasted it from `MacConfig` and replaced MacOS with iOS. Can we use full paths here as well, like it states?
- I'm reading the frameworks from `IosConfig`, but do we want to check for an environment variable first (just like the development team id)? What should its name be?
- I have no idea if this PR requires a new version. 🤷 How do I decide that?
