### PR TITLE
fix(cli): not working with `license.workspace = true`

### DIFF
--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -607,6 +607,7 @@ struct WorkspacePackageSettings {
   description: Option<String>,
   homepage: Option<String>,
   version: Option<String>,
+  license: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -630,7 +631,7 @@ pub struct CargoPackageSettings {
   /// the package's authors.
   pub authors: Option<MaybeWorkspace<Vec<String>>>,
   /// the package's license.
-  pub license: Option<String>,
+  pub license: Option<MaybeWorkspace<String>>,
   /// the default binary to run.
   pub default_run: Option<String>,
 }
@@ -910,7 +911,16 @@ impl RustAppSettings {
           })
           .unwrap()
       }),
-      license: cargo_package_settings.license.clone(),
+      license: cargo_package_settings.license.clone().map(|license| {
+        license
+          .resolve("license", || {
+            ws_package_settings
+              .as_ref()
+              .and_then(|v| v.license.clone())
+              .ok_or_else(|| anyhow::anyhow!("Couldn't inherit value for `license` from workspace"))
+          })
+          .unwrap()
+      }),
       default_run: cargo_package_settings.default_run.clone(),
     };
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fixes #9997

This fix only affects unreleased changes so No changelog entry is created.

This fixes problem with following cargo.toml

```toml
[package]
license.workspace = true
```