### PR TITLE
fix(core): check if listener.handler is undefined

### DIFF
--- a/core/tauri/src/event/mod.rs
+++ b/core/tauri/src/event/mod.rs
@@ -231,7 +231,7 @@ pub fn event_initialization_script(function: &str, listeners: &str) -> String {
         const listeners = (window['{listeners}'] && window['{listeners}'][eventData.event]) || []
         for (const id of ids) {{
           const listener = listeners[id]
-          if (listener) {{
+          if (listener && listener.handler) {{
             eventData.id = id
             listener.handler(eventData)
           }}


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Bug Details
- Event handler registered in `listen` in frontend is not executed
(Event firing from backend -> frontend is succeeding)

Cause
- When an event fires, https://github.com/tauri-apps/tauri/blob/5b769948a81cac333f64c870a470ba6525bd5cd3/core/tauri/src/event/mod.rs#L230 this function is executed, but `listener.handler` may be `undefined`, causing an exception and preventing the event handler from being executed.
- <img width="284" alt="__internal_unstable_listeners_object_id__" src="https://github.com/tauri-apps/tauri/assets/6227619/f4ebaf78-b72f-4691-a096-6fc354bbf98b">

Solution
- The root cause was that `listener.handler` was registered as `undefined`, but I could not find the cause, so I added a check to see if `listener.handler` is `undefined`.


Reference from Discord chat: https://discord.com/channels/616186924390023171/1215591289953718304/1217419467840028682