### PR TITLE
fix: missing depends for rpm package

### DIFF
--- a/.changes/fix-missing-depends.md
+++ b/.changes/fix-missing-depends.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+Add missing dependency `libayatana-appindicator3.so.1` for rpm package.

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1064,6 +1064,7 @@ fn tauri_config_to_bundle_settings(
       let tray = std::env::var("TAURI_TRAY").unwrap_or_else(|_| "ayatana".to_string());
       if tray == "ayatana" {
         depends_deb.push("libayatana-appindicator3-1".into());
+        libs.push("libayatana-appindicator3.so.1".into());
       } else {
         depends_deb.push("libappindicator3-1".into());
         libs.push("libappindicator3.so.1".into());


### PR DESCRIPTION
rpm package missing `libayatana-appindicator3.so.1` dependency