### PR TITLE
fix: missing depends for rpm package

### DIFF
--- a/.changes/fix-missing-depends.md
+++ b/.changes/fix-missing-depends.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+Add missing dependency `libayatana-appindicator3.so.1` for rpm package.

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -1213,6 +1213,7 @@ fn tauri_config_to_bundle_settings(
       match tray_kind {
         pkgconfig_utils::TrayKind::Ayatana => {
           depends_deb.push("libayatana-appindicator3-1".into());
+          libs.push("libayatana-appindicator3.so.1".into());
         }
         pkgconfig_utils::TrayKind::Libappindicator => {
           depends_deb.push("libappindicator3-1".into());


### PR DESCRIPTION
rpm package missing `libayatana-appindicator3.so.1` dependency

#10015 for dev branch