### PR TITLE
chore(template): template format error

### DIFF
--- a/tooling/cli/templates/plugin/with-api/examples/tauri-app/src-tauri/Cargo.crate-manifest
+++ b/tooling/cli/templates/plugin/with-api/examples/tauri-app/src-tauri/Cargo.crate-manifest
@@ -11,13 +11,13 @@ rust-version = "1.60"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = "1"
+tauri-build = {{ tauri_build_dep }}
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = "1"
-tauri-plugin-PLUGIN_NAME = { path = "../../../" }
+tauri = {{ tauri_example_dep }}
+tauri-plugin-{{ plugin_name }} = { path = "../../../" }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/tooling/cli/templates/plugin/with-api/examples/tauri-app/src-tauri/Cargo.toml
+++ b/tooling/cli/templates/plugin/with-api/examples/tauri-app/src-tauri/Cargo.toml
@@ -11,13 +11,13 @@ rust-version = "1.60"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = {{ tauri_build_dep }}
+tauri-build = "1"
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = {{ tauri_example_dep }}
-tauri-plugin-{{ plugin_name }} = { path = "../../../" }
+tauri = "1"
+tauri-plugin-PLUGIN_NAME = { path = "../../../" }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.


### PR DESCRIPTION
The Latest tauri show these error when build:

```
error: invalid inline table
expected `}`
  --> C:\Users\runneradmin\.cargo\git\checkouts\tauri-9dcc2f9152472c1a\3752eb1\tooling\cli\templates\plugin\with-api\examples\tauri-app\src-tauri\Cargo.toml:14:16
   |
14 | tauri-build = {{ tauri_build_dep }}
```

I think it's same as https://github.com/tauri-apps/plugins-workspace/pull/1087