### PR TITLE
fix: AppImage startup crash

### DIFF
--- a/.changes/appimage-duplicate-desktop-file.md
+++ b/.changes/appimage-duplicate-desktop-file.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": "patch:bug"
+---
+
+Fixed an issue that caused the AppImage to segfault on start due to an incorrect .desktop file.

--- a/tooling/bundler/src/bundle/linux/appimage.rs
+++ b/tooling/bundler/src/bundle/linux/appimage.rs
@@ -52,13 +52,10 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let appimage_path = output_path.join(&appimage_filename);
   path_utils::create(app_dir_path, true)?;
 
-  let upcase_app_name = settings.product_name().to_uppercase();
-
   // setup data to insert into shell script
   let mut sh_map = BTreeMap::new();
   sh_map.insert("arch", settings.target().split('-').next().unwrap());
-  sh_map.insert("app_name", settings.product_name());
-  sh_map.insert("app_name_uppercase", &upcase_app_name);
+  sh_map.insert("crate_name", settings.main_binary_name());
   sh_map.insert("appimage_filename", &appimage_filename);
   let tauri_tools_path = dirs::cache_dir().map_or_else(
     || output_path.to_path_buf(),

--- a/tooling/bundler/src/bundle/linux/templates/appimage
+++ b/tooling/bundler/src/bundle/linux/templates/appimage
@@ -17,10 +17,10 @@ else
     linuxdeploy_arch="$ARCH"
 fi
 
-mkdir -p "{{app_name}}.AppDir"
-cp -r ../appimage_deb/data/usr "{{app_name}}.AppDir"
+mkdir -p "{{crate_name}}.AppDir"
+cp -r ../appimage_deb/data/usr "{{crate_name}}.AppDir"
 
-cd "{{app_name}}.AppDir"
+cd "{{crate_name}}.AppDir"
 mkdir -p "usr/bin"
 mkdir -p "usr/lib"
 
@@ -56,14 +56,14 @@ find -L /usr/lib* -name libwebkit2gtkinjectedbundle.so -exec mkdir -p "$(dirname
 ( cd "{{tauri_tools_path}}" && ( wget -q -4 -N https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-${ARCH} || wget -q -4 -N https://github.com/AppImage/AppImageKit/releases/download/12/AppRun-${ARCH} ) )
 chmod +x "{{tauri_tools_path}}/AppRun-${ARCH}"
 
-# We need AppRun to be installed as {{app_name}}.AppDir/AppRun.
+# We need AppRun to be installed as {{crate_name}}.AppDir/AppRun.
 # Otherwise the linuxdeploy scripts will default to symlinking our main bin instead and will crash on trying to launch.
 cp "{{tauri_tools_path}}/AppRun-${ARCH}" AppRun
 
 cp "{{icon_path}}" .DirIcon
-ln -sf "{{icon_path}}" "{{app_name}}.png"
+ln -sf "{{icon_path}}" "{{crate_name}}.png"
 
-ln -sf "usr/share/applications/{{app_name}}.desktop" "{{app_name}}.desktop"
+ln -sf "usr/share/applications/{{crate_name}}.desktop" "{{crate_name}}.desktop"
 
 cd ..
 
@@ -83,4 +83,4 @@ chmod +x "{{tauri_tools_path}}/linuxdeploy-${linuxdeploy_arch}.AppImage"
 
 dd if=/dev/zero bs=1 count=3 seek=8 conv=notrunc of="{{tauri_tools_path}}/linuxdeploy-${linuxdeploy_arch}.AppImage"
 
-OUTPUT="{{appimage_filename}}" "{{tauri_tools_path}}/linuxdeploy-${linuxdeploy_arch}.AppImage" --appimage-extract-and-run --appdir "{{app_name}}.AppDir" --plugin gtk ${gst_plugin} --output appimage
+OUTPUT="{{appimage_filename}}" "{{tauri_tools_path}}/linuxdeploy-${linuxdeploy_arch}.AppImage" --appimage-extract-and-run --appdir "{{crate_name}}.AppDir" --plugin gtk ${gst_plugin} --output appimage


### PR DESCRIPTION
This fixes a crash on startup with AppImages that was caused by mismatched naming introduced in [#9375](https://github.com/tauri-apps/tauri/pull/9375)