### PR TITLE
fix(windows): resource_dir() return \\\?\\ prefix symbols

### DIFF
--- a/core/tauri-utils/src/platform.rs
+++ b/core/tauri-utils/src/platform.rs
@@ -351,6 +351,13 @@ mod tests {
   use crate::{Env, PackageInfo};
 
   #[test]
+  fn test_current_exe() {
+    let current = super::current_exe().unwrap();
+    let current_expected = std::env::current_exe().unwrap();
+    assert_eq!(current, current_expected);
+  }
+
+  #[test]
   fn resolve_resource_dir() {
     let package_info = PackageInfo {
       name: "MyApp".into(),

--- a/core/tauri-utils/src/platform/starting_binary.rs
+++ b/core/tauri-utils/src/platform/starting_binary.rs
@@ -34,7 +34,7 @@ impl StartingBinary {
     }
 
     // we canonicalize the path to resolve any symlinks to the real exe path
-    Self(dangerous_path.canonicalize())
+    Self(dunce::canonicalize(dangerous_path))
   }
 
   /// A clone of the [`PathBuf`] found to be the starting path.


### PR DESCRIPTION
`handle.path().resource_dir()` gives unexpected folder started with "\\\\?\\" due to current behavior of std::env::current_exe() described in https://github.com/rust-lang/rust/issues/99931

This does not allow the use of the folder in scripts or other programs called in Tauri application.