### PR TITLE
chore: Correct grammar typo in documentation of `generate_handler` macro

### DIFF
--- a/core/tauri-macros/src/lib.rs
+++ b/core/tauri-macros/src/lib.rs
@@ -42,7 +42,7 @@ pub fn mobile_entry_point(attributes: TokenStream, item: TokenStream) -> TokenSt
   mobile::entry_point(attributes, item)
 }
 
-/// Accepts a list of commands functions. Creates a handler that allows commands to be called from JS with invoke().
+/// Accepts a list of command functions. Creates a handler that allows commands to be called from JS with invoke().
 ///
 /// # Examples
 /// ```rust,ignore


### PR DESCRIPTION
The documentation of the `generate_handler` macro includes this sentence:
"Accepts a list of commands functions."

This commit corrects the grammar of this sentence to read:
"Accepts a list of command functions."