### PR TITLE
fix(bundler/wix): Add `AUTOLAUNCHAPP` and `LAUNCHAPPARGS` public properties

### DIFF
--- a/.changes/fix-wix-autostart-after-update.md
+++ b/.changes/fix-wix-autostart-after-update.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: patch:enhance
+---
+
+Added a public property to the msi to tell the installer to launch the app after installation. This was added for the updater plugin.

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -30,7 +30,9 @@
         <Property Id="REINSTALLMODE" Value="amus" />
 
         <!-- Check if this is an update from tauri-plugin-update to autostart the app after install -->
-        <Property Id="AUTOLAUNCHAPP" Value="no" Secure="yes" />
+        <Property Id="AUTOLAUNCHAPP" Secure="yes" />
+        <!-- Property to forward cli args to the launched app to not lose those of the pre-update instance -->
+        <Property Id="LAUNCHAPPARGS" Secure="yes" />
 
         {{#if allow_downgrades}}
             <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
@@ -73,8 +75,7 @@
         <!-- launch app checkbox -->
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.LaunchApp)" />
         <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
-        <Property Id="WixShellExecTarget" Value="[!Path]" />
-        <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+        <CustomAction Id="LaunchApplication" Impersonate="yes" FileKey="Path" ExeCommand="[LAUNCHAPPARGS]" Return="asyncNoWait" />
 
         <UI>
             <!-- launch app checkbox -->
@@ -338,7 +339,7 @@
         {{/if}}
 
         <InstallExecuteSequence>
-          <Custom Action="LaunchApplication" After="InstallFinalize"><![CDATA[NOT(AUTOLAUNCHAPP="True")]]> AND NOT Installed</Custom>
+          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP AND NOT Installed</Custom>
         </InstallExecuteSequence>
 
         <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -29,6 +29,9 @@
         <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
         <Property Id="REINSTALLMODE" Value="amus" />
 
+        <!-- Check if this is an update from tauri-plugin-update to autostart the app after install -->
+        <Property Id="AUTOLAUNCHAPP" Value="no" Secure="yes" />
+
         {{#if allow_downgrades}}
             <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
         {{else}}
@@ -333,6 +336,10 @@
             </Custom>
         </InstallExecuteSequence>
         {{/if}}
+
+        <InstallExecuteSequence>
+          <Custom Action="LaunchApplication" After="InstallFinalize"><![CDATA[NOT(AUTOLAUNCHAPP="True")]]> AND NOT Installed</Custom>
+        </InstallExecuteSequence>
 
         <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>
     </Product>

--- a/tooling/bundler/src/bundle/windows/templates/main.wxs
+++ b/tooling/bundler/src/bundle/windows/templates/main.wxs
@@ -29,7 +29,7 @@
         <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
         <Property Id="REINSTALLMODE" Value="amus" />
 
-        <!-- Check if this is an update from tauri-plugin-update to autostart the app after install -->
+        <!-- Auto launch app after installation, useful for passive mode which usually used in updates -->
         <Property Id="AUTOLAUNCHAPP" Secure="yes" />
         <!-- Property to forward cli args to the launched app to not lose those of the pre-update instance -->
         <Property Id="LAUNCHAPPARGS" Secure="yes" />


### PR DESCRIPTION
Currently the v2 updater plugin cannot restart the app after an update because we don't use powershell anymore. With this the updater will be able to tell the msi to start the app after the installation (plugin PR will be opened after https://github.com/tauri-apps/plugins-workspace/pull/1495 was merged cause i'm lazy)