### PR TITLE
fix(core): iOS compilation without the wry feature

### DIFF
--- a/.changes/with-webview-wry-feature.md
+++ b/.changes/with-webview-wry-feature.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Move `PluginApi::register_ios_plugin` behind the `wry` Cargo feature as `Webview::with_webview` is only available when that feature is enabled.

--- a/core/tauri/src/manager/webview.rs
+++ b/core/tauri/src/manager/webview.rs
@@ -631,7 +631,7 @@ impl<R: Runtime> WebviewManager<R> {
         .webview_created(webview_);
     });
 
-    #[cfg(target_os = "ios")]
+    #[cfg(all(target_os = "ios", feature = "wry"))]
     {
       webview
         .with_webview(|w| {

--- a/core/tauri/src/plugin/mobile.rs
+++ b/core/tauri/src/plugin/mobile.rs
@@ -152,7 +152,7 @@ impl<T> fmt::Display for ErrorResponse<T> {
 
 impl<R: Runtime, C: DeserializeOwned> PluginApi<R, C> {
   /// Registers an iOS plugin.
-  #[cfg(target_os = "ios")]
+  #[cfg(all(target_os = "ios", feature = "wry"))]
   pub fn register_ios_plugin(
     &self,
     init_fn: unsafe fn() -> *const std::ffi::c_void,


### PR DESCRIPTION
Ref https://github.com/tauri-apps/plugins-workspace/pull/1402

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
