### PR TITLE
fix(cli/migrate): fix `clipboard `permissions migration

### DIFF
--- a/.changes/cli-clipboard-manager-migrate-perms.md
+++ b/.changes/cli-clipboard-manager-migrate-perms.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+Fix `migrate` command, migrating incorrect permissions for `clipboard`.

--- a/tooling/cli/src/migrate/config.rs
+++ b/tooling/cli/src/migrate/config.rs
@@ -501,8 +501,8 @@ fn allowlist_to_permissions(
   permissions!(allowlist, permissions, process, relaunch => "process:allow-restart");
   permissions!(allowlist, permissions, process, exit => "process:allow-exit");
   // clipboard
-  permissions!(allowlist, permissions, clipboard, read_text => "clipboard-manager:allow-read");
-  permissions!(allowlist, permissions, clipboard, write_text => "clipboard-manager:allow-write");
+  permissions!(allowlist, permissions, clipboard, read_text => "clipboard-manager:allow-read-text");
+  permissions!(allowlist, permissions, clipboard, write_text => "clipboard-manager:allow-write-text");
   // app
   permissions!(allowlist, permissions, app, show => "app:allow-app-show");
   permissions!(allowlist, permissions, app, hide => "app:allow-app-hide");


### PR DESCRIPTION
closes #10185

The plugin has been updated recently and its permissions has changed.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
