### PR TITLE
fix(android): fix Android Studio project plugin link

### DIFF
--- a/examples/api/src-tauri/tauri-plugin-sample/android/settings.gradle
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/settings.gradle
@@ -1,2 +1,31 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            switch (requested.id.id) {
+                case "com.android.library":
+                    useVersion("8.0.2")
+                    break
+                case "org.jetbrains.kotlin.android":
+                    useVersion("1.8.20")
+                    break
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        google()
+
+    }
+}
+
 include ':tauri-android'
 project(':tauri-android').projectDir = new File('./.tauri/tauri-api')

--- a/tooling/cli/templates/plugin/android/settings.gradle
+++ b/tooling/cli/templates/plugin/android/settings.gradle
@@ -1,2 +1,31 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+    resolutionStrategy {
+        eachPlugin {
+            switch (requested.id.id) {
+                case "com.android.library":
+                    useVersion("8.0.2")
+                    break
+                case "org.jetbrains.kotlin.android":
+                    useVersion("1.8.20")
+                    break
+            }
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        google()
+
+    }
+}
+
 include ':tauri-android'
 project(':tauri-android').projectDir = new File('./.tauri/tauri-api')


### PR DESCRIPTION
Android Studio and other JetBrains IDEs fail to link to the plugin project due to missing plugin repositories.
This fixes it
