### PR TITLE
fix(bundler): warning for self contained updaters

### DIFF
--- a/.changes/fix-updater-warning.md
+++ b/.changes/fix-updater-warning.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: patch:bug
+---
+
+Fix bundler warns about no updater-enabled targets were built for self contained updaters like app image, nsis, msi

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -161,7 +161,15 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<Bundle>> {
         package_type: PackageType::Updater,
         bundle_paths: updater_paths,
       });
-    } else {
+    } else if updater.v1_compatible
+      || !package_types.iter().any(|package_type| {
+        // Self contained updater, no need to zip
+        matches!(
+          package_type,
+          PackageType::AppImage | PackageType::Nsis | PackageType::WindowsMsi
+        )
+      })
+    {
       log::warn!("The bundler was configured to create updater artifacts but no updater-enabled targets were built. Please enable one of these targets: app, appimage, msi, nsis");
     }
     if updater.v1_compatible {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix regression from #10188, bundler warns about no updater-enabled targets were built for self contained updaters like app image, nsis, msi