### PR TITLE
changes(nsis): move pre hooks before kill app

### DIFF
--- a/.changes/nsis-pre-hooks-timing.md
+++ b/.changes/nsis-pre-hooks-timing.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": "patch:changes"
+---
+
+Make `NSIS_HOOK_PREINSTALL` and `NSIS_HOOK_PREUNINSTALL` run before `CheckIfAppIsRunning` (which checks if the app is running and asks the user if they want to kill the app)

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -556,11 +556,11 @@ SectionEnd
 Section Install
   SetOutPath $INSTDIR
 
-  !insertmacro CheckIfAppIsRunning
-
   !ifmacrodef NSIS_HOOK_PREINSTALL
     !insertmacro NSIS_HOOK_PREINSTALL
   !endif
+
+  !insertmacro CheckIfAppIsRunning
 
   ; Copy main executable
   File "${MAINBINARYSRCPATH}"
@@ -683,11 +683,11 @@ FunctionEnd
 
 Section Uninstall
 
-  !insertmacro CheckIfAppIsRunning
-
   !ifmacrodef NSIS_HOOK_PREUNINSTALL
     !insertmacro NSIS_HOOK_PREUNINSTALL
   !endif
+
+  !insertmacro CheckIfAppIsRunning
 
   ; Delete the app directory and its content from disk
   ; Copy main executable


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Make `NSIS_HOOK_PREINSTALL` and `NSIS_HOOK_PREUNINSTALL` run before `CheckIfAppIsRunning` (which checks if the app is running and asks the user if they want to kill the app)

pre-install an pre-uninstall hooks should run before everything else we do, this gives the user the ability to run their own check app running logics (in my case I registered a service with the same name and I need to clean it up before `CheckIfAppIsRunning`)

If the user wants to have the app killed before their hook, they can call `CheckIfAppIsRunning` in their hooks