### PR TITLE
chore: use from string instead of `from_anyhow` `anyhow!`

### DIFF
--- a/core/tauri/src/ipc/channel.rs
+++ b/core/tauri/src/ipc/channel.rs
@@ -211,7 +211,7 @@ impl<'de, R: Runtime, TSend: Clone> CommandArg<'de, R> for Channel<TSend> {
     JavaScriptChannelId::from_str(&value)
       .map(|id| id.channel_on(webview))
       .map_err(|_| {
-        InvokeError::from_anyhow(anyhow::anyhow!(
+        InvokeError::from(format!(
 	        "invalid channel value `{value}`, expected a string in the `{IPC_PAYLOAD_PREFIX}ID` format"
 	      ))
       })

--- a/core/tauri/src/webview/webview_window.rs
+++ b/core/tauri/src/webview/webview_window.rs
@@ -932,9 +932,7 @@ impl<'de, R: Runtime> CommandArg<'de, R> for WebviewWindow<R> {
     if webview.window().is_webview_window() {
       Ok(Self { webview })
     } else {
-      Err(InvokeError::from(format!(
-        "current webview is not a WebviewWindow"
-      )))
+      Err(InvokeError::from("current webview is not a WebviewWindow"))
     }
   }
 }

--- a/core/tauri/src/webview/webview_window.rs
+++ b/core/tauri/src/webview/webview_window.rs
@@ -932,7 +932,7 @@ impl<'de, R: Runtime> CommandArg<'de, R> for WebviewWindow<R> {
     if webview.window().is_webview_window() {
       Ok(Self { webview })
     } else {
-      Err(InvokeError::from_anyhow(anyhow::anyhow!(
+      Err(InvokeError::from(format!(
         "current webview is not a WebviewWindow"
       )))
     }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Was trying to see if I can do `impl From<anyhow::Error> for InvokeError` so that `#[command]` can return `anyhow::Error`, no luck on that, but did catch some weird usages of `InvokeError::from_anyhow(anyhow::anyhow!("..."))`