### PR TITLE
fix(core/windows): Remove UNC prefix from tempdir fn

### DIFF
--- a/.changes/fix-remove-tempdir-unc-prefix.md
+++ b/.changes/fix-remove-tempdir-unc-prefix.md
@@ -1,0 +1,5 @@
+---
+tauri: "patch:bug"
+---
+
+Fixed a regression that added the `\\?\` UNC prefix to the path returned from the `tempdir()` command.

--- a/core/tauri/src/endpoints/operating_system.rs
+++ b/core/tauri/src/endpoints/operating_system.rs
@@ -42,7 +42,12 @@ impl Cmd {
   }
 
   fn tempdir<R: Runtime>(_context: InvokeContext<R>) -> super::Result<PathBuf> {
-    Ok(std::env::temp_dir().canonicalize()?)
+    #[cfg(windows)]
+    use dunce::canonicalize;
+    #[cfg(not(windows))]
+    use std::fs::canonicalize;
+
+    Ok(canonicalize(std::env::temp_dir())?)
   }
 
   fn locale<R: Runtime>(_context: InvokeContext<R>) -> super::Result<Option<String>> {


### PR DESCRIPTION
fixes #10285