### PR TITLE
feat: add `Builder::append_invoke_initialization_script`

### DIFF
--- a/.changes/append_invoke_initialization_script.md
+++ b/.changes/append_invoke_initialization_script.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Added `Builder::append_invoke_initialization_script`.

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1336,8 +1336,13 @@ impl<R: Runtime> Builder<R> {
   ///   app.run(|_, _| {});
   /// }
   /// ```
-  pub fn append_invoke_initialization_script(mut self, initialization_script: &String) -> Self {
-    self.invoke_initialization_script.push_str(initialization_script);
+  pub fn append_invoke_initialization_script(
+    mut self,
+    initialization_script: impl AsRef<str>,
+  ) -> Self {
+    self
+      .invoke_initialization_script
+      .push_str(initialization_script.as_ref());
     self
   }
 

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1318,9 +1318,9 @@ impl<R: Runtime> Builder<R> {
   ///
   ///       return invoke(command, args).then(result => {
   ///           if (window.build.debug) {
-  ///               window["console"]["log"](`call: ${command}`);
-  ///               window["console"]["log"](`args: ${JSON.stringify(args)}`);
-  ///               window["console"]["log"](`return: ${JSON.stringify(result)}`);
+  ///               console.log(`call: ${command}`);
+  ///               console.log(`args: ${JSON.stringify(args)}`);
+  ///               console.log(`return: ${JSON.stringify(result)}`);
   ///           }
   ///
   ///           return result;

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1294,6 +1294,48 @@ impl<R: Runtime> Builder<R> {
   }
 
   /// Append a custom initialization script.
+  ///
+  /// Allow to append custom initialization script instend of replacing entire invoke system.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// fn main() {
+  ///   let custom_script = r#"
+  ///   // A custom call system bridge build on top of tauri invoke system.
+  ///   async function invoke(cmd, args = {}) {
+  ///       if (!args) args = {};
+  ///
+  ///       let prefix = "";
+  ///
+  ///       if (args?.__module) {
+  ///           prefix = `plugin:hybridcall.${args.__module}|`;
+  ///       }
+  ///
+  ///       const command = `${prefix}tauri_${cmd}`;
+  ///
+  ///       const invoke = window.__TAURI_INVOKE__ || (window.__TAURI_INTERNALS__ && window.__TAURI_INTERNALS__.invoke);
+  ///
+  ///       return invoke(command, args).then(result => {
+  ///           if (window.build.debug) {
+  ///               window["console"]["log"](`call: ${command}`);
+  ///               window["console"]["log"](`args: ${JSON.stringify(args)}`);
+  ///               window["console"]["log"](`return: ${JSON.stringify(result)}`);
+  ///           }
+  ///
+  ///           return result;
+  ///       });
+  ///   }
+  ///   "#;
+  ///
+  ///   let app = tauri::Builder::default()
+  ///       .append_invoke_initialization_script(custom_script)
+  ///       .build(tauri::generate_context!())
+  ///       .expect("failed to launch");
+  ///
+  ///   app.run(|_, _| {});
+  /// }
+  /// ```
   pub fn append_invoke_initialization_script(mut self, initialization_script: &String) -> Self {
     self.invoke_initialization_script.push_str(initialization_script);
     self

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1293,6 +1293,12 @@ impl<R: Runtime> Builder<R> {
     self
   }
 
+  /// Append a custom initialization script.
+  pub fn append_invoke_initialization_script(mut self, initialization_script: &String) -> Self {
+    self.invoke_initialization_script.push_str(initialization_script);
+    self
+  }
+
   /// Defines the setup hook.
   ///
   /// # Examples

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1314,7 +1314,7 @@ impl<R: Runtime> Builder<R> {
   ///
   ///       const command = `${prefix}tauri_${cmd}`;
   ///
-  ///       const invoke = window.__TAURI_INVOKE__ || (window.__TAURI_INTERNALS__ && window.__TAURI_INTERNALS__.invoke);
+  ///       const invoke = window.__TAURI_INTERNALS__.invoke;
   ///
   ///       return invoke(command, args).then(result => {
   ///           if (window.build.debug) {

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1300,37 +1300,35 @@ impl<R: Runtime> Builder<R> {
   /// # Examples
   ///
   /// ```
-  /// fn main() {
-  ///   let custom_script = r#"
-  ///   // A custom call system bridge build on top of tauri invoke system.
-  ///   async function invoke(cmd, args = {}) {
-  ///       if (!args) args = {};
+  /// let custom_script = r#"
+  /// // A custom call system bridge build on top of tauri invoke system.
+  /// async function invoke(cmd, args = {}) {
+  ///   if (!args) args = {};
   ///
-  ///       let prefix = "";
+  ///   let prefix = "";
   ///
-  ///       if (args?.__module) {
-  ///           prefix = `plugin:hybridcall.${args.__module}|`;
-  ///       }
-  ///
-  ///       const command = `${prefix}tauri_${cmd}`;
-  ///
-  ///       const invoke = window.__TAURI_INTERNALS__.invoke;
-  ///
-  ///       return invoke(command, args).then(result => {
-  ///           if (window.build.debug) {
-  ///               console.log(`call: ${command}`);
-  ///               console.log(`args: ${JSON.stringify(args)}`);
-  ///               console.log(`return: ${JSON.stringify(result)}`);
-  ///           }
-  ///
-  ///           return result;
-  ///       });
+  ///   if (args?.__module) {
+  ///     prefix = `plugin:hybridcall.${args.__module}|`;
   ///   }
-  ///   "#;
   ///
-  ///   tauri::Builder::default()
-  ///       .append_invoke_initialization_script(custom_script);
+  ///   const command = `${prefix}tauri_${cmd}`;
+  ///
+  ///   const invoke = window.__TAURI_INTERNALS__.invoke;
+  ///
+  ///   return invoke(command, args).then(result => {
+  ///     if (window.build.debug) {
+  ///       console.log(`call: ${command}`);
+  ///       console.log(`args: ${JSON.stringify(args)}`);
+  ///       console.log(`return: ${JSON.stringify(result)}`);
+  ///     }
+  ///
+  ///     return result;
+  ///   });
   /// }
+  /// "#;
+  ///
+  /// tauri::Builder::default()
+  ///   .append_invoke_initialization_script(custom_script);
   /// ```
   pub fn append_invoke_initialization_script(
     mut self,

--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1328,12 +1328,8 @@ impl<R: Runtime> Builder<R> {
   ///   }
   ///   "#;
   ///
-  ///   let app = tauri::Builder::default()
-  ///       .append_invoke_initialization_script(custom_script)
-  ///       .build(tauri::generate_context!())
-  ///       .expect("failed to launch");
-  ///
-  ///   app.run(|_, _| {});
+  ///   tauri::Builder::default()
+  ///       .append_invoke_initialization_script(custom_script);
   /// }
   /// ```
   pub fn append_invoke_initialization_script(


### PR DESCRIPTION
We have `Builder::invoke_system` to implement our own invoke system, but most of the time we just want to add some logic into the invoke system, not replace the entire system.