### PR TITLE
fix(macos): set default title-bar style to `Visible`, close #10225

### DIFF
--- a/.changes/runtime-macos-default-visible-titlebat.md
+++ b/.changes/runtime-macos-default-visible-titlebat.md
@@ -1,0 +1,6 @@
+---
+"tauri": "patch:bug"
+"tauri-runtime-wry": "patch"
+---
+
+On macOS, set default titlebar style to `Visible` to prevent webview move out of the view.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -715,7 +715,15 @@ unsafe impl Send for WindowBuilderWrapper {}
 impl WindowBuilderBase for WindowBuilderWrapper {}
 impl WindowBuilder for WindowBuilderWrapper {
   fn new() -> Self {
-    Self::default().focused(true)
+    #[allow(unused_mut)]
+    let mut builder = Self::default().focused(true);
+
+    #[cfg(target_os = "macos")]
+    {
+      builder = builder.title_bar_style(TitleBarStyle::Visible);
+    }
+
+    builder
   }
 
   fn with_config(config: &WindowConfig) -> Self {

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -720,6 +720,11 @@ impl WindowBuilder for WindowBuilderWrapper {
 
     #[cfg(target_os = "macos")]
     {
+      // TODO: find a proper way to prevent webview being pushed out of the window.
+      // Workround for issue: https://github.com/tauri-apps/tauri/issues/10225
+      // The window requies `NSFullSizeContentViewWindowMask` flag to prevent devtools
+      // pushing the content view out of the window.
+      // By setting the default style to `TitleBarStyle::Visible` should fix the issue for most of the users.
       builder = builder.title_bar_style(TitleBarStyle::Visible);
     }
 


### PR DESCRIPTION
Fix: #10225 

I'm unsure what happened inside, but setting it to `Visible` can fix the issue.
It also happened when creating the `WKWebView` in the Xcode project, so I guess it depends on how the OS implements the window.