### PR TITLE
docs: Minor: 'cargo doc' reports links need to be wrapped in angle brackets.

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # The Tauri Architecture
 
-https://tauri.app
+<https://tauri.app>
 
-https://github.com/tauri-apps/tauri
+<https://github.com/tauri-apps/tauri>
 
 ## Introduction
 
@@ -113,9 +113,9 @@ Generally speaking, plugins are authored by third parties (even though there may
 
 Here are several examples of Tauri Plugins:
 
-- https://github.com/tauri-apps/tauri-plugin-sql
-- https://github.com/tauri-apps/tauri-plugin-stronghold
-- https://github.com/tauri-apps/tauri-plugin-authenticator
+- <https://github.com/tauri-apps/tauri-plugin-sql>
+- <https://github.com/tauri-apps/tauri-plugin-stronghold>
+- <https://github.com/tauri-apps/tauri-plugin-authenticator>
 
 # Workflows
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Thank you to everyone contributing to Tauri!
 
 ### Documentation
 
-Documentation in a polyglot system is a tricky proposition. To this end, we prefer to use inline documentation in the Rust & JS source code as much as possible. Check out the hosting repository for the documentation site for further information: https://github.com/tauri-apps/tauri-docs
+Documentation in a polyglot system is a tricky proposition. To this end, we prefer to use inline documentation in the Rust & JS source code as much as possible. Check out the hosting repository for the documentation site for further information: <https://github.com/tauri-apps/tauri-docs>
 
 ## Partners
 

--- a/core/tauri-build/CHANGELOG.md
+++ b/core/tauri-build/CHANGELOG.md
@@ -397,7 +397,7 @@
 
 - [`52474e47`](https://www.github.com/tauri-apps/tauri/commit/52474e479d695865299d8c8d868fb98b99731020)([#7141](https://www.github.com/tauri-apps/tauri/pull/7141)) Enhance Cargo features check.
 - [`af937290`](https://www.github.com/tauri-apps/tauri/commit/af93729031565a69d1fde6cf16bea3b9b6e43a65)([#6676](https://www.github.com/tauri-apps/tauri/pull/6676)) On Windows, set `LegalCopyright` and `FileDescription` file properties on the executable from `tauri.bundle.copyright` and `tauri.bundle.shortDescription`,
-- [`d2710e9d`](https://www.github.com/tauri-apps/tauri/commit/d2710e9d2e8fd93975ef6494512370faa8cb3b7e)([#6944](https://www.github.com/tauri-apps/tauri/pull/6944)) Unpin `time`, `ignore`, and `winnow` crate versions. Developers now have to pin crates if needed themselves. A list of crates that need pinning to adhere to Tauri's MSRV will be visible in Tauri's GitHub workflow: https://github.com/tauri-apps/tauri/blob/dev/.github/workflows/test-core.yml#L85.
+- [`d2710e9d`](https://www.github.com/tauri-apps/tauri/commit/d2710e9d2e8fd93975ef6494512370faa8cb3b7e)([#6944](https://www.github.com/tauri-apps/tauri/pull/6944)) Unpin `time`, `ignore`, and `winnow` crate versions. Developers now have to pin crates if needed themselves. A list of crates that need pinning to adhere to Tauri's MSRV will be visible in Tauri's GitHub workflow: <https://github.com/tauri-apps/tauri/blob/dev/.github/workflows/test-core.yml#L85>.
 
 ## \[1.3.0]
 

--- a/core/tauri-build/src/static_vcruntime.rs
+++ b/core/tauri-build/src/static_vcruntime.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-// taken from https://github.com/ChrisDenton/static_vcruntime/
+// taken from <https://github.com/ChrisDenton/static_vcruntime/>
 // we're not using static_vcruntime directly because we want this for debug builds too
 
 use std::{env, fs, io::Write, path::Path};

--- a/core/tauri-macros/CHANGELOG.md
+++ b/core/tauri-macros/CHANGELOG.md
@@ -427,7 +427,7 @@
 
 - `ring` -> `getrandom`
 
-See https://github.com/tauri-apps/tauri/pull/3773 for more information about
+See <https://github.com/tauri-apps/tauri/pull/3773> for more information about
 these specific choices.
 
 - [8661e3e2](https://www.github.com/tauri-apps/tauri/commit/8661e3e24d96c399bfbcdee5d8e9d6beba2265a7) replace dependencies with long build times when used together (closes [#3571](https://www.github.com/tauri-apps/tauri/pull/3571)) ([#3773](https://www.github.com/tauri-apps/tauri/pull/3773)) on 2022-03-27

--- a/core/tauri-utils/src/acl/identifier.rs
+++ b/core/tauri-utils/src/acl/identifier.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 const IDENTIFIER_SEPARATOR: u8 = b':';
 const PLUGIN_PREFIX: &str = "tauri-plugin-";
 
-// https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field
+// <https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field>
 const MAX_LEN_PREFIX: usize = 64 - PLUGIN_PREFIX.len();
 const MAX_LEN_BASE: usize = 64;
 const MAX_LEN_IDENTIFIER: usize = MAX_LEN_PREFIX + 1 + MAX_LEN_BASE;

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -333,7 +333,7 @@ pub struct DebConfig {
   /// Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`
   pub priority: Option<String>,
   /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
-  /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+  /// <https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes>
   pub changelog: Option<PathBuf>,
   /// Path to a custom desktop file Handlebars template.
   ///
@@ -341,19 +341,19 @@ pub struct DebConfig {
   #[serde(alias = "desktop-template")]
   pub desktop_template: Option<PathBuf>,
   /// Path to script that will be executed before the package is unpacked. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   #[serde(alias = "pre-install-script")]
   pub pre_install_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is unpacked. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   #[serde(alias = "post-install-script")]
   pub post_install_script: Option<PathBuf>,
   /// Path to script that will be executed before the package is removed. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   #[serde(alias = "pre-remove-script")]
   pub pre_remove_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is removed. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   #[serde(alias = "post-remove-script")]
   pub post_remove_script: Option<PathBuf>,
 }
@@ -408,19 +408,19 @@ pub struct RpmConfig {
   #[serde(alias = "desktop-template")]
   pub desktop_template: Option<PathBuf>,
   /// Path to script that will be executed before the package is unpacked. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   #[serde(alias = "pre-install-script")]
   pub pre_install_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is unpacked. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   #[serde(alias = "post-install-script")]
   pub post_install_script: Option<PathBuf>,
   /// Path to script that will be executed before the package is removed. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   #[serde(alias = "pre-remove-script")]
   pub pre_remove_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is removed. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   #[serde(alias = "post-remove-script")]
   pub post_remove_script: Option<PathBuf>,
 }

--- a/core/tauri-utils/src/html.rs
+++ b/core/tauri-utils/src/html.rs
@@ -28,7 +28,7 @@ pub const SCRIPT_NONCE_TOKEN: &str = "__TAURI_SCRIPT_NONCE__";
 /// The token used for style nonces.
 pub const STYLE_NONCE_TOKEN: &str = "__TAURI_STYLE_NONCE__";
 
-// taken from https://github.com/kuchiki-rs/kuchiki/blob/57ee6920d835315a498e748ba4b07a851ae5e498/src/serializer.rs#L12
+// taken from <https://github.com/kuchiki-rs/kuchiki/blob/57ee6920d835315a498e748ba4b07a851ae5e498/src/serializer.rs#L12>
 fn serialize_node_ref_internal<S: Serializer>(
   node: &NodeRef,
   serializer: &mut S,

--- a/core/tauri-utils/src/lib.rs
+++ b/core/tauri-utils/src/lib.rs
@@ -294,7 +294,7 @@ impl Default for Env {
       if env.appimage.is_some() || env.appdir.is_some() {
         // validate that we're actually running on an AppImage
         // an AppImage is mounted to `/$TEMPDIR/.mount_${appPrefix}${hash}`
-        // see https://github.com/AppImage/AppImageKit/blob/1681fd84dbe09c7d9b22e13cdb16ea601aa0ec47/src/runtime.c#L501
+        // see <https://github.com/AppImage/AppImageKit/blob/1681fd84dbe09c7d9b22e13cdb16ea601aa0ec47/src/runtime.c#L501>
         // note that it is safe to use `std::env::current_exe` here since we just loaded an AppImage.
         let is_temp = std::env::current_exe()
           .map(|p| {

--- a/core/tauri-utils/src/mime_type.rs
+++ b/core/tauri-utils/src/mime_type.rs
@@ -71,7 +71,7 @@ impl MimeType {
       // Assume HTML when a TLD is found for eg. `wry:://tauri.app` | `wry://hello.com`
       Some(_) => fallback,
       // using octet stream according to this:
-      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+      // <https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types>
       None => Self::OctetStream,
     }
   }

--- a/core/tauri-utils/src/tokens.rs
+++ b/core/tauri-utils/src/tokens.rs
@@ -131,7 +131,7 @@ where
 
 /// Create a `serde_json::Value` variant `TokenStream` for a number
 pub fn json_value_number_lit(num: &serde_json::Number) -> TokenStream {
-  // See https://docs.rs/serde_json/1/serde_json/struct.Number.html for guarantees
+  // See <https://docs.rs/serde_json/1/serde_json/struct.Number.html> for guarantees
   let prefix = quote! { ::serde_json::Value };
   if num.is_u64() {
     // guaranteed u64

--- a/core/tauri/build.rs
+++ b/core/tauri/build.rs
@@ -209,7 +209,7 @@ fn has_feature(feature: &str) -> bool {
     .push(feature.to_string());
 
   // when a feature is enabled, Cargo sets the `CARGO_FEATURE_<name>` env var to 1
-  // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+  // <https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts>
   std::env::var(format!("CARGO_FEATURE_{}", AsShoutySnakeCase(feature)))
     .map(|x| x == "1")
     .unwrap_or(false)

--- a/core/tauri/src/manager/mod.rs
+++ b/core/tauri/src/manager/mod.rs
@@ -102,7 +102,7 @@ pub(crate) fn set_csp<R: Runtime>(
   csp
 }
 
-// inspired by https://github.com/rust-lang/rust/blob/1be5c8f90912c446ecbdc405cbc4a89f9acd20fd/library/alloc/src/str.rs#L260-L297
+// inspired by <https://github.com/rust-lang/rust/blob/1be5c8f90912c446ecbdc405cbc4a89f9acd20fd/library/alloc/src/str.rs#L260-L297>
 fn replace_with_callback<F: FnMut() -> String>(
   original: &str,
   pattern: &str,

--- a/core/tauri/src/path/plugin.rs
+++ b/core/tauri/src/path/plugin.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Normalize a path, removing things like `.` and `..`, this snippet is taken from cargo's paths util.
-/// https://github.com/rust-lang/cargo/blob/46fa867ff7043e3a0545bf3def7be904e1497afd/crates/cargo-util/src/paths.rs#L73-L106
+/// <https://github.com/rust-lang/cargo/blob/46fa867ff7043e3a0545bf3def7be904e1497afd/crates/cargo-util/src/paths.rs#L73-L106>
 fn normalize_path(path: &Path) -> PathBuf {
   let mut components = path.components().peekable();
   let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
@@ -44,7 +44,7 @@ fn normalize_path(path: &Path) -> PathBuf {
 
 /// Normalize a path, removing things like `.` and `..`, this snippet is taken from cargo's paths util but
 /// slightly modified to not resolve absolute paths.
-/// https://github.com/rust-lang/cargo/blob/46fa867ff7043e3a0545bf3def7be904e1497afd/crates/cargo-util/src/paths.rs#L73-L106
+/// <https://github.com/rust-lang/cargo/blob/46fa867ff7043e3a0545bf3def7be904e1497afd/crates/cargo-util/src/paths.rs#L73-L106>
 fn normalize_path_no_absolute(path: &Path) -> PathBuf {
   let mut components = path.components().peekable();
   let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {

--- a/core/tauri/src/scope/fs.rs
+++ b/core/tauri/src/scope/fs.rs
@@ -171,7 +171,7 @@ impl Scope {
       next_event_id: Default::default(),
       match_options: glob::MatchOptions {
         // this is needed so `/dir/*` doesn't match files within subdirectories such as `/dir/subdir/file.txt`
-        // see: https://github.com/tauri-apps/tauri/security/advisories/GHSA-6mv3-wm7j-h4w5
+        // see: <https://github.com/tauri-apps/tauri/security/advisories/GHSA-6mv3-wm7j-h4w5>
         require_literal_separator: true,
         require_literal_leading_dot,
         ..Default::default()
@@ -362,7 +362,7 @@ mod tests {
       next_event_id: Default::default(),
       match_options: glob::MatchOptions {
         // this is needed so `/dir/*` doesn't match files within subdirectories such as `/dir/subdir/file.txt`
-        // see: https://github.com/tauri-apps/tauri/security/advisories/GHSA-6mv3-wm7j-h4w5
+        // see: <https://github.com/tauri-apps/tauri/security/advisories/GHSA-6mv3-wm7j-h4w5>
         require_literal_separator: true,
         // dotfiles are not supposed to be exposed by default on unix
         #[cfg(unix)]

--- a/core/tauri/src/webview/mod.rs
+++ b/core/tauri/src/webview/mod.rs
@@ -1028,8 +1028,8 @@ fn main() {
       main_webview.with_webview(|webview| {
         #[cfg(target_os = "linux")]
         {
-          // see https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/struct.WebView.html
-          // and https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/trait.WebViewExt.html
+          // see <https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/struct.WebView.html>
+          // and <https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/trait.WebViewExt.html>
           use webkit2gtk::WebViewExt;
           webview.inner().set_zoom_level(4.);
         }

--- a/core/tauri/src/webview/webview_window.rs
+++ b/core/tauri/src/webview/webview_window.rs
@@ -1609,15 +1609,15 @@ impl<R: Runtime> WebviewWindow<R> {
   ///       main_webview.with_webview(|webview| {
   ///         #[cfg(target_os = "linux")]
   ///         {
-  ///           // see https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/struct.WebView.html
-  ///           // and https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/trait.WebViewExt.html
+  ///           // see <https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/struct.WebView.html>
+  ///           // and <https://docs.rs/webkit2gtk/2.0.0/webkit2gtk/trait.WebViewExt.html>
   ///           use webkit2gtk::WebViewExt;
   ///           webview.inner().set_zoom_level(4.);
   ///         }
   ///
   ///         #[cfg(windows)]
   ///         unsafe {
-  ///           // see https://docs.rs/webview2-com/0.19.1/webview2_com/Microsoft/Web/WebView2/Win32/struct.ICoreWebView2Controller.html
+  ///           // see <https://docs.rs/webview2-com/0.19.1/webview2_com/Microsoft/Web/WebView2/Win32/struct.ICoreWebView2Controller.html>
   ///           webview.controller().SetZoomFactor(4.).unwrap();
   ///         }
   ///

--- a/core/tests/restart/tests/restart.rs
+++ b/core/tests/restart/tests/restart.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 /// Helper for generic catch-all errors.
 type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
-/// https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699-
+/// <https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--1300-1699->
 #[cfg(windows)]
 const ERROR_PRIVILEGE_NOT_HELD: i32 = 1314;
 

--- a/tooling/bundler/src/bundle/category.rs
+++ b/tooling/bundler/src/bundle/category.rs
@@ -145,7 +145,7 @@ impl AppCategory {
   /// Map an AppCategory to the closest set of Freedesktop registered
   /// categories that matches that category.
   ///
-  /// Cf https://specifications.freedesktop.org/menu-spec/latest/
+  /// Cf <https://specifications.freedesktop.org/menu-spec/latest/>
   pub fn freedesktop_categories(self) -> &'static str {
     match &self {
       AppCategory::Business => "Office;",

--- a/tooling/bundler/src/bundle/common.rs
+++ b/tooling/bundler/src/bundle/common.rs
@@ -15,7 +15,7 @@ use std::{
 /// Returns true if the path has a filename indicating that it is a high-density
 /// "retina" icon.  Specifically, returns true the file stem ends with
 /// "@2x" (a convention specified by the [Apple developer docs](
-/// https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html)).
+/// <https://developer.apple.com/library/mac/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html>)).
 #[allow(dead_code)]
 pub fn is_retina<P: AsRef<Path>>(path: P) -> bool {
   path

--- a/tooling/bundler/src/bundle/linux/debian.rs
+++ b/tooling/bundler/src/bundle/linux/debian.rs
@@ -129,7 +129,7 @@ pub fn generate_data(
 }
 
 /// Generate the Changelog file by compressing, to be stored at /usr/share/doc/package-name/changelog.gz. See
-/// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+/// <https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes>
 fn generate_changelog_file(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
   if let Some(changelog_src_path) = &settings.deb().changelog {
     let mut src_file = File::open(changelog_src_path)?;

--- a/tooling/bundler/src/bundle/settings.rs
+++ b/tooling/bundler/src/bundle/settings.rs
@@ -187,25 +187,25 @@ pub struct DebianSettings {
   #[doc = include_str!("./linux/templates/main.desktop")]
   /// ```
   pub desktop_template: Option<PathBuf>,
-  /// Define the section in Debian Control file. See : https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections
+  /// Define the section in Debian Control file. See : <https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections>
   pub section: Option<String>,
   /// Change the priority of the Debian Package. By default, it is set to `optional`.
   /// Recognized Priorities as of now are :  `required`, `important`, `standard`, `optional`, `extra`
   pub priority: Option<String>,
   /// Path of the uncompressed Changelog file, to be stored at /usr/share/doc/package-name/changelog.gz. See
-  /// https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes
+  /// <https://www.debian.org/doc/debian-policy/ch-docs.html#changelog-files-and-release-notes>
   pub changelog: Option<PathBuf>,
   /// Path to script that will be executed before the package is unpacked. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   pub pre_install_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is unpacked. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   pub post_install_script: Option<PathBuf>,
   /// Path to script that will be executed before the package is removed. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   pub pre_remove_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is removed. See
-  /// https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
+  /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
   pub post_remove_script: Option<PathBuf>,
 }
 
@@ -246,16 +246,16 @@ pub struct RpmSettings {
   /// ```
   pub desktop_template: Option<PathBuf>,
   /// Path to script that will be executed before the package is unpacked. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   pub pre_install_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is unpacked. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   pub post_install_script: Option<PathBuf>,
   /// Path to script that will be executed before the package is removed. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   pub pre_remove_script: Option<PathBuf>,
   /// Path to script that will be executed after the package is removed. See
-  /// http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html
+  /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   pub post_remove_script: Option<PathBuf>,
 }
 

--- a/tooling/macos-sign/src/keychain.rs
+++ b/tooling/macos-sign/src/keychain.rs
@@ -52,7 +52,7 @@ impl Keychain {
   /// By example you can use; openssl base64 -in MyCertificate.p12 -out MyCertificate-base64.txt
   /// Then use the value of the base64 as `certificate_encoded`.
   /// You need to set certificate_password to the password you set when you exported your certificate.
-  /// https://help.apple.com/xcode/mac/current/#/dev154b28f09 see: `Export a signing certificate`
+  /// <https://help.apple.com/xcode/mac/current/#/dev154b28f09> see: `Export a signing certificate`
   pub fn with_certificate(
     certificate_encoded: &OsString,
     certificate_password: &OsString,


### PR DESCRIPTION
While running cargo doc locally ....

I saw lots of lint warnings about bare-urls 

In short lots of changes of the form 
```
-https://github.com/tauri-apps/tauri
+<https://github.com/tauri-apps/tauri>
```




