### PR TITLE
For linting and testing auto update the node version to "lts/*"

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -23,7 +23,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm i --frozen-lockfile
       - run: pnpm format:check
@@ -35,7 +35,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm i --frozen-lockfile
       - run: pnpm eslint:check
@@ -47,7 +47,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm i --frozen-lockfile
       - run: pnpm ts:check


### PR DESCRIPTION
This deprecation notice.

```
version-or-publish
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/setup-node@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

seen in this test run.

<https://github.com/martinfrances107/tauri/actions/runs/9995204078>

