### PR TITLE
fix(bundler): Add support for File Association in Linux by default

### DIFF
--- a/.changes/bundler-fix-file-association.md
+++ b/.changes/bundler-fix-file-association.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": "patch:feat"
+---
+
+Add support for File Association in Linux by default.

--- a/tooling/bundler/src/bundle/linux/freedesktop.rs
+++ b/tooling/bundler/src/bundle/linux/freedesktop.rs
@@ -97,6 +97,8 @@ pub fn generate_desktop_file(
   data_dir: &Path,
 ) -> crate::Result<(PathBuf, PathBuf)> {
   let bin_name = settings.main_binary_name();
+  // %F is to enable file association for the application.
+  let exec_command = format!("{} %F", bin_name);
   let desktop_file_name = format!("{bin_name}.desktop");
   let path = PathBuf::from("usr/share/applications").join(desktop_file_name);
   let dest_path = PathBuf::from("/").join(&path);
@@ -159,7 +161,7 @@ pub fn generate_desktop_file(
       } else {
         None
       },
-      exec: bin_name,
+      exec: &exec_command,
       icon: bin_name,
       name: settings.product_name(),
       mime_type,


### PR DESCRIPTION
- Fixes Linux part of https://github.com/tauri-apps/tauri/issues/9803

Added `%F` to open the file with Tauri Application.

However, developer have to handle the argument received himself ( obviously )