### PR TITLE
Fix Specta integration

### DIFF
--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -75,7 +75,7 @@ tracing = { version = "0.1", optional = true }
 heck = "0.5"
 log = "0.4"
 dunce = "1"
-specta = { version = "^2.0.0-rc.9", optional = true, default-features = false, features = [ "function" ] }
+specta = { version = "^2.0.0-rc.9", optional = true, default-features = false, features = [ "derive", "function" ] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
 muda = { version = "0.13.4", default-features = false, features = [ "serde" ] }


### PR DESCRIPTION
#10139 introduced a usage of `specta::Type` (the derive macro) which is not enabled by default. This PR adds the required `derive` feature to Specta.

This seems to have caused issues generating Rust documentation for the Tauri 2.0.0-beta.24 release. Due to the nature of Cargo dependencies this will only ever cause an error when using Tauri with the `specta` feature without the user having `specta` with the `derive` feature which should be exceedingly rare.