### PR TITLE
fix: use specta's derive feature

### DIFF
--- a/.changes/specta-derive-feature.md
+++ b/.changes/specta-derive-feature.md
@@ -1,5 +1,5 @@
 ---
-"tauri": patch:fix
+"tauri": patch:bug
 ---
 
 use specta rc 15's derive feature

--- a/.changes/specta-derive-feature.md
+++ b/.changes/specta-derive-feature.md
@@ -2,4 +2,4 @@
 "tauri": patch:bug
 ---
 
-use specta rc 15's derive feature
+Use `specta rc.15's `derive` feature which fixes build issues in docs.rs.

--- a/.changes/specta-derive-feature.md
+++ b/.changes/specta-derive-feature.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:fix
+---
+
+use specta rc 15's derive feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3471,11 +3471,9 @@ dependencies = [
 [[package]]
 name = "specta"
 version = "2.0.0-rc.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c724a69c6d78156078a2b915df0c7031334402a669a150fbacc4f626120998"
+source = "git+https://github.com/oscartbeaumont/specta?branch=optional-feature#e4cce4040a6cb8048273b531fe79b367fbac96c5"
 dependencies = [
  "paste",
- "serde",
  "specta-macros",
  "thiserror",
 ]
@@ -3483,8 +3481,7 @@ dependencies = [
 [[package]]
 name = "specta-macros"
 version = "2.0.0-rc.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169054738abd29aa5e8a3cf152ed5e3d736dc6987ba049bf4aaa12ecdd03a5d8"
+source = "git+https://github.com/oscartbeaumont/specta?branch=optional-feature#e4cce4040a6cb8048273b531fe79b367fbac96c5"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -3221,9 +3221,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3470,11 +3470,10 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3624a07cbde326fdf1ec37cbd39d06a224660fa0199b7db7316f2349583df981"
+checksum = "49c724a69c6d78156078a2b915df0c7031334402a669a150fbacc4f626120998"
 dependencies = [
- "once_cell",
  "paste",
  "serde",
  "specta-macros",
@@ -3483,14 +3482,14 @@ dependencies = [
 
 [[package]]
 name = "specta-macros"
-version = "2.0.0-rc.10"
+version = "2.0.0-rc.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef33e9678ae36993fcbfc46aa29568ef10d32fd54428808759c6a450998c43ec"
+checksum = "169054738abd29aa5e8a3cf152ed5e3d736dc6987ba049bf4aaa12ecdd03a5d8"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.71",
 ]
 
 [[package]]

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -75,7 +75,7 @@ tracing = { version = "0.1", optional = true }
 heck = "0.5"
 log = "0.4"
 dunce = "1"
-specta = { version = "^2.0.0-rc.9", optional = true, default-features = false, features = [ "function", "derive" ] }
+specta = { version = "^2.0.0-rc.15", optional = true, default-features = false, features = [ "function", "derive" ] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
 muda = { version = "0.13.4", default-features = false, features = [ "serde" ] }

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -75,7 +75,8 @@ tracing = { version = "0.1", optional = true }
 heck = "0.5"
 log = "0.4"
 dunce = "1"
-specta = { version = "^2.0.0-rc.15", optional = true, default-features = false, features = [ "function", "derive" ] }
+# specta = { version = "^2.0.0-rc.15", optional = true, default-features = false, features = [ "function", "derive" ] }
+specta = { git = "https://github.com/oscartbeaumont/specta", branch="optional-feature", optional = true, default-features = false, features = [ "function", "derive" ] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
 muda = { version = "0.13.4", default-features = false, features = [ "serde" ] }

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -75,7 +75,7 @@ tracing = { version = "0.1", optional = true }
 heck = "0.5"
 log = "0.4"
 dunce = "1"
-specta = { version = "^2.0.0-rc.9", optional = true, default-features = false, features = [ "function" ] }
+specta = { version = "^2.0.0-rc.9", optional = true, default-features = false, features = [ "function", "derive" ] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
 muda = { version = "0.13.4", default-features = false, features = [ "serde" ] }

--- a/core/tauri/Cargo.toml
+++ b/core/tauri/Cargo.toml
@@ -75,8 +75,7 @@ tracing = { version = "0.1", optional = true }
 heck = "0.5"
 log = "0.4"
 dunce = "1"
-# specta = { version = "^2.0.0-rc.15", optional = true, default-features = false, features = [ "function", "derive" ] }
-specta = { git = "https://github.com/oscartbeaumont/specta", branch="optional-feature", optional = true, default-features = false, features = [ "function", "derive" ] }
+specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, features = [ "function", "derive" ] }
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
 muda = { version = "0.13.4", default-features = false, features = [ "serde" ] }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Specta recently moved the `specta::Type` macro to the `derive` feature, which broke the docs.rs build for beta 24. This PR fixes that, moving to specta rc 16 as the minimum and using the `derive` feature.