### PR TITLE
fix: DragDropEvent should have the same structure

### DIFF
--- a/tooling/api/src/webview.ts
+++ b/tooling/api/src/webview.ts
@@ -33,11 +33,7 @@ import { Window, getCurrentWindow } from './window'
 import { WebviewWindow } from './webviewWindow'
 
 /** The drag and drop event types. */
-type DragDropEvent =
-  | { type: 'enter'; paths: string[]; position: PhysicalPosition }
-  | { type: 'over'; position: PhysicalPosition }
-  | { type: 'drop'; paths: string[]; position: PhysicalPosition }
-  | { type: 'leave' }
+type DragDropEvent = {type: 'enter' | 'over' | 'drop' | 'leave', paths?: string[], position?: PhysicalPosition}
 
 /**
  * Get an instance of `Webview` for the current webview.

--- a/tooling/api/src/webview.ts
+++ b/tooling/api/src/webview.ts
@@ -513,8 +513,8 @@ class Webview {
    * ```typescript
    * import { getCurrent } from "@tauri-apps/api/webview";
    * const unlisten = await getCurrentWebview().onDragDropEvent((event) => {
-   *  if (event.payload.type === 'hover') {
-   *    console.log('User hovering', event.payload.paths);
+   *  if (event.payload.type === 'over') {
+   *    console.log('User over', event.payload.paths);
    *  } else if (event.payload.type === 'drop') {
    *    console.log('User dropped', event.payload.paths);
    *  } else {
@@ -555,7 +555,8 @@ class Webview {
           ...event,
           payload: {
             type: 'over',
-            position: mapPhysicalPosition(event.payload.position)
+            paths: [],
+            position: mapPhysicalPosition(event.payload.position),
           }
         })
       }
@@ -578,7 +579,14 @@ class Webview {
     const unlistenDragLeave = await this.listen<null>(
       TauriEvent.DRAG_LEAVE,
       (event) => {
-        handler({ ...event, payload: { type: 'leave' } })
+        handler({ 
+          ...event, 
+           payload: { 
+             type: 'leave',
+             paths: [],
+             position: undefined
+           } 
+        })
       }
     )
 

--- a/tooling/api/src/webview.ts
+++ b/tooling/api/src/webview.ts
@@ -514,9 +514,9 @@ class Webview {
    * import { getCurrent } from "@tauri-apps/api/webview";
    * const unlisten = await getCurrentWebview().onDragDropEvent((event) => {
    *  if (event.payload.type === 'over') {
-   *    console.log('User over', event.payload.paths);
+   *    console.log('User over', event.payload);
    *  } else if (event.payload.type === 'drop') {
-   *    console.log('User dropped', event.payload.paths);
+   *    console.log('User dropped', event.payload);
    *  } else {
    *    console.log('File drop cancelled');
    *  }

--- a/tooling/api/src/webview.ts
+++ b/tooling/api/src/webview.ts
@@ -579,13 +579,13 @@ class Webview {
     const unlistenDragLeave = await this.listen<null>(
       TauriEvent.DRAG_LEAVE,
       (event) => {
-        handler({ 
-          ...event, 
-           payload: { 
-             type: 'leave',
-             paths: [],
-             position: undefined
-           } 
+        handler({
+          ...event,
+          payload: {
+            type: 'leave',
+            paths: [],
+            position: undefined
+           }
         })
       }
     )


### PR DESCRIPTION
The types for the DragDropEvent should be the same regardless and not present if no data. 


3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md

Unsure if it does or not.
