### PR TITLE
feat: re-enable TLS checks for Android and dev proxy

### DIFF
--- a/.changes/remove-unsecure-configs.md
+++ b/.changes/remove-unsecure-configs.md
@@ -1,0 +1,8 @@
+---
+"tauri-cli": patch:sec
+"@tauri-apps/cli": patch:sec
+"tauri": patch:sec
+---
+
+Re-enable TLS checks that were previously disabled to support an insecure HTTPS custom protocol on Android which is no longer used.
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,8 +3470,9 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "2.0.0-rc.15"
-source = "git+https://github.com/oscartbeaumont/specta?branch=optional-feature#e4cce4040a6cb8048273b531fe79b367fbac96c5"
+version = "2.0.0-rc.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd9fd8ec58ec895d2e947a7b431b5c8d2218956a1e378bbfdc3b7414109e2c5"
 dependencies = [
  "paste",
  "specta-macros",
@@ -3480,13 +3481,14 @@ dependencies = [
 
 [[package]]
 name = "specta-macros"
-version = "2.0.0-rc.15"
-source = "git+https://github.com/oscartbeaumont/specta?branch=optional-feature#e4cce4040a6cb8048273b531fe79b367fbac96c5"
+version = "2.0.0-rc.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649713524bd94bb77336b3d2924e3686a88de3cea780a57d45051923d5a5add4"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/core/tauri/src/protocol/tauri.rs
+++ b/core/tauri/src/protocol/tauri.rs
@@ -103,13 +103,8 @@ fn get_response<R: Runtime>(
       .decode_utf8_lossy()
       .to_string();
     let url = format!("{url}{decoded_path}");
-    #[allow(unused_mut)]
-    let mut client_builder = reqwest::ClientBuilder::new();
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-    {
-      client_builder = client_builder.danger_accept_invalid_certs(true);
-    }
-    let mut proxy_builder = client_builder
+
+    let mut proxy_builder = reqwest::ClientBuilder::new()
       .build()
       .unwrap()
       .request(request.method().clone(), &url);

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -3033,7 +3033,7 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tauri"
-version = "2.0.0-beta.23"
+version = "2.0.0-beta.24"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3142,7 +3142,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "anyhow",
  "glob",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 dependencies = [
  "dpi",
  "gtk",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.20"
 dependencies = [
  "cocoa",
  "gtk",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.0-beta.18"
+version = "2.0.0-beta.19"
 dependencies = [
  "aes-gcm",
  "brotli",

--- a/examples/api/vite.config.js
+++ b/examples/api/vite.config.js
@@ -33,8 +33,8 @@ export default defineConfig({
     hmr: mobile
       ? {
           protocol: 'ws',
-          host: internalIpV4Sync(),
-          port: 1421
+          host: mobile ? internalIpV4Sync() : 'localhost',
+          port: 1430
         }
       : undefined,
     fs: {

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -5368,9 +5368,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa 1.0.10",
@@ -5389,9 +5389,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/tooling/cli/src/mobile/android/build.rs
+++ b/tooling/cli/src/mobile/android/build.rs
@@ -26,7 +26,7 @@ use cargo_mobile2::{
   target::TargetTrait,
 };
 
-use std::env::{set_current_dir, set_var};
+use std::env::set_current_dir;
 
 #[derive(Debug, Clone, Parser)]
 #[clap(
@@ -121,9 +121,6 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
     );
     (interface, app, config, metadata)
   };
-
-  set_var("WRY_RUSTWEBVIEWCLIENT_CLASS_EXTENSION", "");
-  set_var("WRY_RUSTWEBVIEW_CLASS_INIT", "");
 
   let profile = if options.debug {
     Profile::Debug

--- a/tooling/cli/src/mobile/android/dev.rs
+++ b/tooling/cli/src/mobile/android/dev.rs
@@ -32,16 +32,7 @@ use cargo_mobile2::{
   target::TargetTrait,
 };
 
-use std::env::{set_current_dir, set_var};
-
-const WEBVIEW_CLIENT_CLASS_EXTENSION: &str = "
-    @android.annotation.SuppressLint(\"WebViewClientOnReceivedSslError\")
-    override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler, error: android.net.http.SslError) {
-        handler.proceed()
-    }
-";
-const WEBVIEW_CLASS_INIT: &str =
-  "this.settings.mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW";
+use std::env::set_current_dir;
 
 #[derive(Debug, Clone, Parser)]
 #[clap(
@@ -153,12 +144,6 @@ fn run_command(options: Options, noise_level: NoiseLevel) -> Result<()> {
     );
     (interface, app, config, metadata)
   };
-
-  set_var(
-    "WRY_RUSTWEBVIEWCLIENT_CLASS_EXTENSION",
-    WEBVIEW_CLIENT_CLASS_EXTENSION,
-  );
-  set_var("WRY_RUSTWEBVIEW_CLASS_INIT", WEBVIEW_CLASS_INIT);
 
   let tauri_path = tauri_dir();
   set_current_dir(tauri_path).with_context(|| "failed to change current working directory")?;


### PR DESCRIPTION
No longer needed since we're not using HTTPS for dev servers or the custom protocol anymore