### PR TITLE
fix(core): usage without the compression feature

### DIFF
--- a/.changes/fix-usage-without-compression.md
+++ b/.changes/fix-usage-without-compression.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch:bug
+"tauri-codegen": patch:bug
+---
+
+Fixes asset resolving when not using the `compression` feature.

--- a/core/tauri-codegen/Cargo.toml
+++ b/core/tauri-codegen/Cargo.toml
@@ -37,7 +37,6 @@ plist = "1"
 time = { version = "0.3", features = [ "parsing", "formatting" ] }
 
 [features]
-default = [ "compression" ]
 compression = [ "brotli", "tauri-utils/compression" ]
 isolation = [ "tauri-utils/isolation" ]
 config-json5 = [ "tauri-utils/config-json5" ]


### PR DESCRIPTION
Due to a regression introduced in #3133 the compression feature can be disabled but tauri-codegen enables it by default, introducing a conflict

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
