### PR TITLE
Fix Specta remote implementation for `Channel`

### DIFF
--- a/.changes/change-pr-10435.md
+++ b/.changes/change-pr-10435.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix Specta remote implementation target for `Channel`.

--- a/core/tauri/src/ipc/channel.rs
+++ b/core/tauri/src/ipc/channel.rs
@@ -46,7 +46,7 @@ pub struct Channel<TSend = InvokeBody> {
 #[cfg(feature = "specta")]
 const _: () = {
   #[derive(specta::Type)]
-  #[specta(remote = Channel, rename = "TAURI_CHANNEL")]
+  #[specta(remote = super::Channel, rename = "TAURI_CHANNEL")]
   struct Channel<TSend>(std::marker::PhantomData<TSend>);
 };
 

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -992,7 +992,7 @@ pub mod test;
 
 #[cfg(feature = "specta")]
 const _: () = {
-  use specta::{function::FunctionArg, DataType, TypeMap};
+  use specta::{function::FunctionArg, datatype::DataType, TypeMap};
 
   impl<'r, T: Send + Sync + 'static> FunctionArg for crate::State<'r, T> {
     fn to_datatype(_: &mut TypeMap) -> Option<DataType> {

--- a/core/tauri/src/lib.rs
+++ b/core/tauri/src/lib.rs
@@ -992,7 +992,7 @@ pub mod test;
 
 #[cfg(feature = "specta")]
 const _: () = {
-  use specta::{function::FunctionArg, datatype::DataType, TypeMap};
+  use specta::{datatype::DataType, function::FunctionArg, TypeMap};
 
   impl<'r, T: Send + Sync + 'static> FunctionArg for crate::State<'r, T> {
     fn to_datatype(_: &mut TypeMap) -> Option<DataType> {


### PR DESCRIPTION
The `remote = Channel` is refering to the module local `Channel` not the `super::Channel` so the Specta traits are implemented on the wrong type.