### PR TITLE
chore: update brotli dependency to v6

### DIFF
--- a/.changes/brotli-6.md
+++ b/.changes/brotli-6.md
@@ -1,0 +1,6 @@
+---
+"tauri-codegen": patch:deps
+"tauri-utils": patch:deps
+---
+
+Updated brotli to v6.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",

--- a/core/tauri-codegen/Cargo.toml
+++ b/core/tauri-codegen/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1"
 tauri-utils = { version = "2.0.0-beta.19", path = "../tauri-utils", features = [ "build" ] }
 thiserror = "1"
 walkdir = "2"
-brotli = { version = "3", optional = true, default-features = false, features = [ "std" ] }
+brotli = { version = "6", optional = true, default-features = false, features = [ "std" ] }
 regex = { version = "1", optional = true }
 uuid = { version = "1", features = [ "v4" ] }
 semver = "1"

--- a/core/tauri-utils/Cargo.toml
+++ b/core/tauri-utils/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 thiserror = "1"
 phf = { version = "0.11", features = [ "macros" ] }
-brotli = { version = "3", optional = true, default-features = false, features = [ "std" ] }
+brotli = { version = "6", optional = true, default-features = false, features = [ "std" ] }
 url = { version = "2", features = [ "serde" ] }
 html5ever = "0.26"
 kuchiki = { package = "kuchikiki", version = "0.8" }

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",


### PR DESCRIPTION
brotli v6 plays nice with other versions of the same crate