### PR TITLE
prevent unnecessary rebuilds when working in the cargo workspace

### DIFF
--- a/core/tauri-acl-schema/build.rs
+++ b/core/tauri-acl-schema/build.rs
@@ -5,9 +5,11 @@
 use std::{error::Error, path::PathBuf};
 
 use schemars::schema_for;
-use tauri_utils::acl::capability::Capability;
-use tauri_utils::acl::{Permission, Scopes};
-use tauri_utils::write_if_changed;
+use tauri_utils::{
+  acl::capability::Capability,
+  acl::{Permission, Scopes},
+  write_if_changed,
+};
 
 macro_rules! schema {
   ($name:literal, $path:ty) => {

--- a/core/tauri-acl-schema/build.rs
+++ b/core/tauri-acl-schema/build.rs
@@ -2,33 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::{
-  error::Error,
-  fs::File,
-  io::{BufWriter, Write},
-  path::PathBuf,
-};
+use std::{error::Error, path::PathBuf};
 
-use schemars::schema::RootSchema;
+use schemars::schema_for;
+use tauri_utils::acl::capability::Capability;
+use tauri_utils::acl::{Permission, Scopes};
+use tauri_utils::write_if_changed;
 
-pub fn main() -> Result<(), Box<dyn Error>> {
-  let cap_schema = schemars::schema_for!(tauri_utils::acl::capability::Capability);
-  let perm_schema = schemars::schema_for!(tauri_utils::acl::Permission);
-  let scope_schema = schemars::schema_for!(tauri_utils::acl::Scopes);
-
-  let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
-
-  write_schema_file(cap_schema, crate_dir.join("capability-schema.json"))?;
-  write_schema_file(perm_schema, crate_dir.join("permission-schema.json"))?;
-  write_schema_file(scope_schema, crate_dir.join("scope-schema.json"))?;
-
-  Ok(())
+macro_rules! schema {
+  ($name:literal, $path:ty) => {
+    (concat!($name, "-schema.json"), schema_for!($path))
+  };
 }
 
-fn write_schema_file(schema: RootSchema, outpath: PathBuf) -> Result<(), Box<dyn Error>> {
-  let schema_str = serde_json::to_string_pretty(&schema).unwrap();
-  let mut schema_file = BufWriter::new(File::create(outpath)?);
-  write!(schema_file, "{schema_str}")?;
+pub fn main() -> Result<(), Box<dyn Error>> {
+  let schemas = [
+    schema!("capability", Capability),
+    schema!("permission", Permission),
+    schema!("scope", Scopes),
+  ];
+
+  let out = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
+  for (filename, schema) in schemas {
+    let schema = serde_json::to_string_pretty(&schema)?;
+    write_if_changed(out.join(filename), schema)?;
+  }
 
   Ok(())
 }

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -7,11 +7,6 @@ use std::convert::identity;
 use std::path::{Path, PathBuf};
 use std::{ffi::OsStr, str::FromStr};
 
-use base64::Engine;
-use proc_macro2::TokenStream;
-use quote::quote;
-use sha2::{Digest, Sha256};
-
 use crate::{
   embedded_assets::{
     ensure_out_dir, AssetOptions, CspHashes, EmbeddedAssets, EmbeddedAssetsResult,
@@ -19,18 +14,22 @@ use crate::{
   image::CachedIcon,
   Cached,
 };
+use base64::Engine;
+use proc_macro2::TokenStream;
+use quote::quote;
+use sha2::{Digest, Sha256};
 use syn::Expr;
-use tauri_utils::acl::capability::{Capability, CapabilityFile};
-use tauri_utils::acl::manifest::Manifest;
-use tauri_utils::acl::resolved::Resolved;
-use tauri_utils::assets::AssetKey;
-use tauri_utils::config::{CapabilityEntry, Config, FrontendDist, PatternKind};
-use tauri_utils::html::{
-  inject_nonce_token, parse as parse_html, serialize_node as serialize_html_node, NodeRef,
+use tauri_utils::{
+  acl::capability::{Capability, CapabilityFile},
+  acl::manifest::Manifest,
+  acl::resolved::Resolved,
+  assets::AssetKey,
+  config::{CapabilityEntry, Config, FrontendDist, PatternKind},
+  html::{inject_nonce_token, parse as parse_html, serialize_node as serialize_html_node, NodeRef},
+  platform::Target,
+  plugin::GLOBAL_API_SCRIPT_FILE_LIST_PATH,
+  tokens::{map_lit, str_lit},
 };
-use tauri_utils::platform::Target;
-use tauri_utils::plugin::GLOBAL_API_SCRIPT_FILE_LIST_PATH;
-use tauri_utils::tokens::{map_lit, str_lit};
 
 const ACL_MANIFESTS_FILE_NAME: &str = "acl-manifests.json";
 const CAPABILITIES_FILE_NAME: &str = "capabilities.json";

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -263,7 +263,7 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
     }
 
     let icon = CachedIcon::new_raw(&root, &icon_path)?;
-    quote!(::std::option::Option::Some(Vec::from(#icon)))
+    quote!(::std::option::Option::Some(#icon.to_vec()))
   } else {
     quote!(::std::option::Option::None)
   };

--- a/core/tauri-codegen/src/context.rs
+++ b/core/tauri-codegen/src/context.rs
@@ -12,7 +12,6 @@ use crate::{
     ensure_out_dir, AssetOptions, CspHashes, EmbeddedAssets, EmbeddedAssetsResult,
   },
   image::CachedIcon,
-  Cached,
 };
 use base64::Engine;
 use proc_macro2::TokenStream;
@@ -329,7 +328,7 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
     let plist_contents =
       String::from_utf8_lossy(&plist_contents.into_inner().unwrap()).into_owned();
 
-    let plist = Cached::try_from(plist_contents)?;
+    let plist = crate::Cached::try_from(plist_contents)?;
     quote!({
       tauri::embed_plist::embed_info_plist!(#plist);
     })

--- a/core/tauri-codegen/src/image.rs
+++ b/core/tauri-codegen/src/image.rs
@@ -122,7 +122,7 @@ impl CachedIcon {
   /// as the data being checked.
   fn cache(buf: &[u8]) -> EmbeddedAssetsResult<PathBuf> {
     let hash = crate::checksum(buf).map_err(EmbeddedAssetsError::Hex)?;
-    let filename = PathBuf::from(dbg!(hash));
+    let filename = PathBuf::from(hash);
     let path = ensure_out_dir()?.join(&filename);
     if let Ok(existing) = std::fs::read(&path) {
       if existing == buf {
@@ -130,12 +130,10 @@ impl CachedIcon {
       }
     }
 
-    dbg!(
-      std::fs::write(&path, buf).map_err(|error| EmbeddedAssetsError::AssetWrite {
-        path: path.to_owned(),
-        error,
-      })?
-    );
+    std::fs::write(&path, buf).map_err(|error| EmbeddedAssetsError::AssetWrite {
+      path: path.to_owned(),
+      error,
+    })?;
 
     Ok(filename)
   }

--- a/core/tauri-codegen/src/lib.rs
+++ b/core/tauri-codegen/src/lib.rs
@@ -13,7 +13,7 @@
 )]
 
 pub use self::context::{context_codegen, ContextData};
-use crate::embedded_assets::{ensure_out_dir, EmbeddedAssetsError, EmbeddedAssetsResult};
+use crate::embedded_assets::{ensure_out_dir, EmbeddedAssetsError};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens, TokenStreamExt};
 use std::{
@@ -117,8 +117,11 @@ fn checksum(bytes: &[u8]) -> Result<String, fmt::Error> {
   Ok(hex)
 }
 
-pub struct Cached {
-  pub content: Vec<u8>,
+/// Cache the data to `$OUT_DIR`, only if it does not already exist.
+///
+/// Due to using a checksum as the filename, an existing file should be the exact same content
+/// as the data being checked.
+struct Cached {
   checksum: String,
 }
 
@@ -138,7 +141,7 @@ impl TryFrom<Vec<u8>> for Cached {
     let path = ensure_out_dir()?.join(&checksum);
 
     write_if_changed(&path, &content)
-      .map(|_| Self { content, checksum })
+      .map(|_| Self { checksum })
       .map_err(|error| EmbeddedAssetsError::AssetWrite { path, error })
   }
 }

--- a/core/tauri-config-schema/build.rs
+++ b/core/tauri-config-schema/build.rs
@@ -2,23 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::{
-  error::Error,
-  fs::File,
-  io::{BufWriter, Write},
-  path::PathBuf,
-};
+use std::{error::Error, path::PathBuf};
+use tauri_utils::{config::Config, write_if_changed};
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-  let schema = schemars::schema_for!(tauri_utils::config::Config);
-  let schema_str = serde_json::to_string_pretty(&schema).unwrap();
-  let crate_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
-  for file in [
-    crate_dir.join("schema.json"),
-    crate_dir.join("../../tooling/cli/schema.json"),
-  ] {
-    let mut schema_file = BufWriter::new(File::create(file)?);
-    write!(schema_file, "{schema_str}")?;
+  let schema = schemars::schema_for!(Config);
+  let schema = serde_json::to_string_pretty(&schema)?;
+  let out = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
+  for path in ["schema.json", "../../tooling/cli/schema.json"] {
+    write_if_changed(out.join(path), &schema)?;
   }
 
   Ok(())

--- a/core/tauri-macros/src/lib.rs
+++ b/core/tauri-macros/src/lib.rs
@@ -17,6 +17,7 @@ use crate::context::ContextItems;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse2, parse_macro_input, LitStr};
+use tauri_codegen::image::CachedIcon;
 
 mod command;
 mod menu;
@@ -203,13 +204,9 @@ pub fn include_image(tokens: TokenStream) -> TokenStream {
     );
     return quote!(compile_error!(#error_string)).into();
   }
-  match tauri_codegen::include_image_codegen(
-    &resolved_path,
-    resolved_path.file_name().unwrap().to_str().unwrap(),
-  )
-  .map_err(|error| error.to_string())
-  {
-    Ok(output) => output,
+
+  match CachedIcon::try_from(&resolved_path).map_err(|error| error.to_string()) {
+    Ok(output) => output.codegen(&quote!(::tauri)),
     Err(error) => quote!(compile_error!(#error)),
   }
   .into()

--- a/core/tauri-macros/src/lib.rs
+++ b/core/tauri-macros/src/lib.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use crate::context::ContextItems;
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{parse2, parse_macro_input, LitStr};
 use tauri_codegen::image::CachedIcon;
 
@@ -205,8 +205,8 @@ pub fn include_image(tokens: TokenStream) -> TokenStream {
     return quote!(compile_error!(#error_string)).into();
   }
 
-  match CachedIcon::try_from(&resolved_path).map_err(|error| error.to_string()) {
-    Ok(output) => output.codegen(&quote!(::tauri)),
+  match CachedIcon::new(&quote!(::tauri), &resolved_path).map_err(|error| error.to_string()) {
+    Ok(icon) => icon.into_token_stream(),
     Err(error) => quote!(compile_error!(#error)),
   }
   .into()

--- a/core/tauri-utils/src/lib.rs
+++ b/core/tauri-utils/src/lib.rs
@@ -379,3 +379,20 @@ pub fn display_path<P: AsRef<Path>>(p: P) -> String {
     .display()
     .to_string()
 }
+
+/// Write the file only if the content of the existing file (if any) is different.
+///
+/// This will always write unless the file exists with identical content.
+pub fn write_if_changed<P, C>(path: P, content: C) -> std::io::Result<()>
+where
+  P: AsRef<Path>,
+  C: AsRef<[u8]>,
+{
+  if let Ok(existing) = std::fs::read(&path) {
+    if existing == content.as_ref() {
+      return Ok(());
+    }
+  }
+
+  std::fs::write(path, content)
+}


### PR DESCRIPTION
this tackles 3 separate issues, all having the same underlying cause

1. icons for the examples/integration tests write over each other into a predicable filename.
2. `Info.plist` on macOS write over each other into a predicable filename.
3. schemas for config and ACL things always wrote to disk, even if contents are identical

all 3 are stopped by `tauri_utils::write_if_changed(path, contents)` which skips writing to the specified file if it already exists and contains the same content.

the icons/plist need to not share names, so i made a `Cached` wrapper around `write_if_changed` that represents a buffer that was written to `$OUT_DIR/<content-checksum>` since the actual names of the cached icons/plist do not matter. this allows examples/tests to have different icons/plists without overwriting the already written one - causing rebuilds on any workspace command which built the tauri crate.