### PR TITLE
feat(cli): allow skipping rustfmt project reformatting when adding a plugin

### DIFF
--- a/.changes/cli-add-no-fmt.md
+++ b/.changes/cli-add-no-fmt.md
@@ -1,0 +1,7 @@
+---
+---
+"tauri-cli": "patch:enhance"
+"@tauri-apps/cli": "patch:enhance"
+---
+
+Added `--no-fmt` option to the `add` command to skip formatting the code after applying changes.

--- a/.changes/cli-add-no-fmt.md
+++ b/.changes/cli-add-no-fmt.md
@@ -1,5 +1,4 @@
 ---
----
 "tauri-cli": "patch:enhance"
 "@tauri-apps/cli": "patch:enhance"
 ---

--- a/tooling/cli/src/add.rs
+++ b/tooling/cli/src/add.rs
@@ -229,4 +229,3 @@ pub fn command(options: Options) -> Result<()> {
 
   Ok(())
 }
-

--- a/tooling/cli/src/add.rs
+++ b/tooling/cli/src/add.rs
@@ -86,9 +86,9 @@ pub struct Options {
   /// Git branch to use.
   #[clap(short, long)]
   pub branch: Option<String>,
-  /// Don't reformat code with rustfmt
+  /// Don't format code with rustfmt
   #[clap(long)]
-  pub no_reformatting: bool,
+  pub no_fmt: bool,
 }
 
 pub fn command(options: Options) -> Result<()> {
@@ -188,7 +188,7 @@ pub fn command(options: Options) -> Result<()> {
       log::info!("Adding plugin to {}", file.display());
       std::fs::write(file, out.as_bytes())?;
 
-      if !options.no_reformatting {
+      if !options.no_fmt {
         // reformat code with rustfmt
         log::info!("Running `cargo fmt`...");
         let _ = Command::new("cargo")

--- a/tooling/cli/src/add.rs
+++ b/tooling/cli/src/add.rs
@@ -86,6 +86,9 @@ pub struct Options {
   /// Git branch to use.
   #[clap(short, long)]
   pub branch: Option<String>,
+  /// Don't reformat code with rustfmt
+  #[clap(long)]
+  pub no_reformatting: bool,
 }
 
 pub fn command(options: Options) -> Result<()> {
@@ -185,12 +188,15 @@ pub fn command(options: Options) -> Result<()> {
       log::info!("Adding plugin to {}", file.display());
       std::fs::write(file, out.as_bytes())?;
 
-      // run cargo fmt
-      log::info!("Running `cargo fmt`...");
-      let _ = Command::new("cargo")
-        .arg("fmt")
-        .current_dir(&tauri_dir)
-        .status();
+      if !options.no_reformatting {
+        // reformat code with rustfmt
+        log::info!("Running `cargo fmt`...");
+        let _ = Command::new("cargo")
+          .arg("fmt")
+          .current_dir(&tauri_dir)
+          .status();
+      }
+
       return Ok(());
     }
   }
@@ -223,3 +229,4 @@ pub fn command(options: Options) -> Result<()> {
 
   Ok(())
 }
+

--- a/tooling/cli/src/migrate/migrations/v1/mod.rs
+++ b/tooling/cli/src/migrate/migrations/v1/mod.rs
@@ -28,6 +28,7 @@ pub fn run() -> Result<()> {
       branch: None,
       tag: None,
       rev: None,
+      no_fmt: false,
     })
     .with_context(|| format!("Could not migrate plugin '{plugin}'"))?;
   }

--- a/tooling/cli/src/mobile/ios/dev.rs
+++ b/tooling/cli/src/mobile/ios/dev.rs
@@ -310,7 +310,7 @@ fn use_network_address_for_dev_url(
       .host
       .unwrap_or_default()
       .unwrap_or_else(|| *local_ip_address(options.force_ip_prompt));
-    dev_options.host.replace(ip.clone());
+    dev_options.host.replace(ip);
     Some(ip)
   } else {
     None


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Normally, each time, for example `pnpm tauri add dialog` is ran, the project is automatically reformatted using rustfmt (`cargo fmt`).

I added an option allowing it to be skipped. Maybe it is even better to have it removed all together?
I don't think adding a plugin to a project should automatically reformat all your code. Those two things are entirely unrelated.