### PR TITLE
docs: Update tauri::app::Builder::setup example

### DIFF
--- a/core/tauri/src/app.rs
+++ b/core/tauri/src/app.rs
@@ -1342,7 +1342,7 @@ use tauri::Manager;
 tauri::Builder::default()
   .setup(|app| {
     let main_window = app.get_window("main").unwrap();
-    main_window.set_title("Tauri!");
+    main_window.set_title("Tauri!")?;
     Ok(())
   });
 ```


### PR DESCRIPTION
This resolves a warning emitted by following the example code: warning: unused `Result` that must be used.