### PR TITLE
fix: permission file uses ':' in file name

### DIFF
--- a/.changes/fix-colon-in-file-path.md
+++ b/.changes/fix-colon-in-file-path.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": "patch:bug"
+---
+
+Fixed an issue where permission files will be generated with ':' in the file path.

--- a/core/tauri-utils/src/acl/build.rs
+++ b/core/tauri-utils/src/acl/build.rs
@@ -73,7 +73,7 @@ pub fn define_permissions<F: Fn(&Path) -> bool>(
 
   let permission_files_path = out_dir.join(format!(
     "{}-permission-files",
-    pkg_name.replace("tauri:", "tauri-")
+    pkg_name.replace(':', "-")
   ));
   std::fs::write(
     &permission_files_path,

--- a/core/tauri-utils/src/acl/build.rs
+++ b/core/tauri-utils/src/acl/build.rs
@@ -71,10 +71,8 @@ pub fn define_permissions<F: Fn(&Path) -> bool>(
     .filter(|p| p.parent().unwrap().file_name().unwrap() != PERMISSION_SCHEMAS_FOLDER_NAME)
     .collect::<Vec<PathBuf>>();
 
-  let permission_files_path = out_dir.join(format!(
-    "{}-permission-files",
-    pkg_name.replace(':', "-")
-  ));
+  let permission_files_path =
+    out_dir.join(format!("{}-permission-files", pkg_name.replace(':', "-")));
   std::fs::write(
     &permission_files_path,
     serde_json::to_string(&permission_files)?,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fixes #10484