### PR TITLE
fix(bundler): Correct nsis pre-uninstall hook to post-uninstall

### DIFF
--- a/.changes/change-pr-10498.md
+++ b/.changes/change-pr-10498.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:bug
+---
+
+fix(bundler): Correct nsis pre-uninstall hook to post-uninstall

--- a/.changes/change-pr-10498.md
+++ b/.changes/change-pr-10498.md
@@ -2,4 +2,4 @@
 "tauri-bundler": patch:bug
 ---
 
-fix(bundler): Correct nsis pre-uninstall hook to post-uninstall
+Correct nsis pre-uninstall hook to post-uninstall

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -777,7 +777,7 @@ Section Uninstall
   ${EndIf}
 
   !ifmacrodef NSIS_HOOK_POSTUNINSTALL
-    !insertmacro NSIS_HOOK_PREUNINSTALL
+    !insertmacro NSIS_HOOK_POSTUNINSTALL
   !endif
 
   ; Auto close if passive mode


### PR DESCRIPTION
The NSIS_HOOK_PREUNINSTALL macro was where NSIS_HOOK_POSTUNINSTALL should have been.