### PR TITLE
ci: allow `actions: write` for version-or-publish to fix cli publishing

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -56,8 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 65
     permissions:
-      contents: write # required for workflow_dispatch
-      pull-requests: write
+      actions: write # required for workflow_dispatch
+      contents: write # required to create new releases
+      pull-requests: write # required to open version update pr
     outputs:
       change: ${{ steps.covector.outputs.change }}
       commandRan: ${{ steps.covector.outputs.commandRan }}


### PR DESCRIPTION
I shouldn't have blindly copied the docs/examples. They still used contents: write which doesn't work (anymore?). If i had not copied the permission part it should have worked but since we now committed to it, i opted into fixing it instead (i guess having granular permissions is a nice thing).

For reference, here are my repro steps: https://github.com/FabianLars/mwt-release/actions/workflows/trigger.yml 