### PR TITLE
fix: 'ndecorated' typo in window shadow description

### DIFF
--- a/core/tauri-config-schema/schema.json
+++ b/core/tauri-config-schema/schema.json
@@ -427,7 +427,7 @@
           ]
         },
         "shadow": {
-          "description": "Whether or not the window has shadow.\n\n ## Platform-specific\n\n - **Windows:**\n   - `false` has no effect on decorated window, shadow are always ON.\n   - `true` will make ndecorated window have a 1px white border,\n and on Windows 11, it will have a rounded corners.\n - **Linux:** Unsupported.",
+          "description": "Whether or not the window has shadow.\n\n ## Platform-specific\n\n - **Windows:**\n   - `false` has no effect on decorated window, shadow are always ON.\n   - `true` will make undecorated window have a 1px white border,\n and on Windows 11, it will have a rounded corners.\n - **Linux:** Unsupported.",
           "default": true,
           "type": "boolean"
         },

--- a/core/tauri-runtime/src/window.rs
+++ b/core/tauri-runtime/src/window.rs
@@ -360,7 +360,7 @@ pub trait WindowBuilder: WindowBuilderBase {
   ///
   /// - **Windows:**
   ///   - `false` has no effect on decorated window, shadows are always ON.
-  ///   - `true` will make ndecorated window have a 1px white border,
+  ///   - `true` will make undecorated window have a 1px white border,
   ///     and on Windows 11, it will have a rounded corners.
   /// - **Linux:** Unsupported.
   #[must_use]

--- a/core/tauri-utils/src/config.rs
+++ b/core/tauri-utils/src/config.rs
@@ -1365,7 +1365,7 @@ pub struct WindowConfig {
   ///
   /// - **Windows:**
   ///   - `false` has no effect on decorated window, shadow are always ON.
-  ///   - `true` will make ndecorated window have a 1px white border,
+  ///   - `true` will make undecorated window have a 1px white border,
   /// and on Windows 11, it will have a rounded corners.
   /// - **Linux:** Unsupported.
   #[serde(default = "default_true")]

--- a/core/tauri/src/webview/webview_window.rs
+++ b/core/tauri/src/webview/webview_window.rs
@@ -590,7 +590,7 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   ///
   /// - **Windows:**
   ///   - `false` has no effect on decorated window, shadows are always ON.
-  ///   - `true` will make ndecorated window have a 1px white border,
+  ///   - `true` will make undecorated window have a 1px white border,
   ///     and on Windows 11, it will have a rounded corners.
   /// - **Linux:** Unsupported.
   #[must_use]
@@ -1394,7 +1394,7 @@ impl<R: Runtime> WebviewWindow<R> {
   ///
   /// - **Windows:**
   ///   - `false` has no effect on decorated window, shadow are always ON.
-  ///   - `true` will make ndecorated window have a 1px white border,
+  ///   - `true` will make undecorated window have a 1px white border,
   ///     and on Windows 11, it will have a rounded corners.
   /// - **Linux:** Unsupported.
   pub fn set_shadow(&self, enable: bool) -> crate::Result<()> {

--- a/tooling/api/src/window.ts
+++ b/tooling/api/src/window.ts
@@ -1126,7 +1126,7 @@ class Window {
    *
    * - **Windows:**
    *   - `false` has no effect on decorated window, shadows are always ON.
-   *   - `true` will make ndecorated window have a 1px white border,
+   *   - `true` will make undecorated window have a 1px white border,
    * and on Windows 11, it will have a rounded corners.
    * - **Linux:** Unsupported.
    *
@@ -2172,7 +2172,7 @@ interface WindowOptions {
    *
    * - **Windows:**
    *   - `false` has no effect on decorated window, shadows are always ON.
-   *   - `true` will make ndecorated window have a 1px white border,
+   *   - `true` will make undecorated window have a 1px white border,
    * and on Windows 11, it will have a rounded corners.
    * - **Linux:** Unsupported.
    *

--- a/tooling/cli/schema.json
+++ b/tooling/cli/schema.json
@@ -427,7 +427,7 @@
           ]
         },
         "shadow": {
-          "description": "Whether or not the window has shadow.\n\n ## Platform-specific\n\n - **Windows:**\n   - `false` has no effect on decorated window, shadow are always ON.\n   - `true` will make ndecorated window have a 1px white border,\n and on Windows 11, it will have a rounded corners.\n - **Linux:** Unsupported.",
+          "description": "Whether or not the window has shadow.\n\n ## Platform-specific\n\n - **Windows:**\n   - `false` has no effect on decorated window, shadow are always ON.\n   - `true` will make undecorated window have a 1px white border,\n and on Windows 11, it will have a rounded corners.\n - **Linux:** Unsupported.",
           "default": true,
           "type": "boolean"
         },


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This PR renames all **"ndecorated"** occurrences to **"undecorated"**.