### PR TITLE
refactor(android): Remove targetSdk from gradle config 

### DIFF
--- a/.changes/feat-remove-target-sdk.md
+++ b/.changes/feat-remove-target-sdk.md
@@ -2,4 +2,4 @@
 "tauri": patch:refactor
 ---
 
-Remove targetSdk for gradle files
+Remove targetSdk from gradle files

--- a/.changes/feat-remove-target-sdk.md
+++ b/.changes/feat-remove-target-sdk.md
@@ -1,5 +1,7 @@
 ---
-"tauri": patch:refactor
+"tauri": patch:changes
+"@tauri-apps/cli": patch:changes
+"tauri-cli": patch:changes
 ---
 
 Remove targetSdk from gradle files

--- a/.changes/feat-remove-target-sdk.md
+++ b/.changes/feat-remove-target-sdk.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:refactor
+---
+
+Remove targetSdk for gradle files

--- a/core/tauri/mobile/android/build.gradle.kts
+++ b/core/tauri/mobile/android/build.gradle.kts
@@ -9,7 +9,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("proguard-rules.pro")

--- a/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
@@ -9,7 +9,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/tooling/cli/templates/mobile/android/app/build.gradle.kts
+++ b/tooling/cli/templates/mobile/android/app/build.gradle.kts
@@ -22,7 +22,6 @@ android {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "{{reverse-domain app.identifier}}"
         minSdk = {{android.min-sdk-version}}
-        targetSdk = 34
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }

--- a/tooling/cli/templates/plugin/android/build.gradle.kts
+++ b/tooling/cli/templates/plugin/android/build.gradle.kts
@@ -9,7 +9,6 @@ android {
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 34
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
This PR aims to fix the following warning
```
w: file:///C:/Users/Windows/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.0.0-rc.2/mobile/android/build.gradle.kts:12:9: 'targetSdk: Int?' is deprecated. Will be removed from library DSL in v9.0. Use testOptions.targetSdk or/and lint.targetSdk instead
```

It removes targetSdk from the gradle kts files as it is deprecated and will be removed in DSL v9.0