### PR TITLE
fix(cli): properly exit with code 1 on panic when running with bun

### DIFF
--- a/.changes/fix-cli-panic-bun.md
+++ b/.changes/fix-cli-panic-bun.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/cli": patch:bug
+---
+
+Exit with code 1 if a panic occurs when running the CLI with `bun`.


### PR DESCRIPTION
Found out about this when testing #10569 (maybe bun handles this differently when using NAPI?)