### PR TITLE
refactor(bundler): output file name consistency, closes #10465

### DIFF
--- a/.changes/refactor-bundle-file-names.md
+++ b/.changes/refactor-bundle-file-names.md
@@ -18,9 +18,10 @@ Change bundle file names to a consistent `productName-version-arch.ext` format.
   - DMG
     - productName_version_x64.dmg => productName-version-x86_64.dmg
     - productName_version_aarch64.dmg => productName-version-aarch64.dmg
-  - macOS 
+  - macOS
     - still keeps the productName.app format as that is the name of the file that is actually installed on user machines.
   - MSI
+    - The $language suffix now uses `_` as separator instead of `-` (e.g. `en_US` instead of `en-US`).
     - productName_version_x86_$language.msi => productName-version-x86-$language.msi
     - productName_version_x64_$language.msi => productName-version-x86_64-$language.msi
     - productName_version_arm64_$language.msi => productName-version-aarch64-$language.msi

--- a/.changes/refactor-bundle-file-names.md
+++ b/.changes/refactor-bundle-file-names.md
@@ -1,0 +1,30 @@
+---
+'tauri-bundler': 'patch:breaking'
+'tauri-cli': 'patch:breaking'
+'@tauri-apps/cli': 'patch:breaking'
+---
+
+Change bundle file names to a consistent `productName-version-arch.ext` format.
+  - AppImage
+    - productName_version_i386.AppImage => productName-version-x86.AppImage
+    - productName_version_amd64.AppImage => productName-version-x86_64.AppImage
+  - Debian
+    - productName_version_i386.deb => productName-version-x86.deb
+    - productName_version_amd64.deb => productName-version-x86_64.deb
+    - productName_version_armhf.deb => productName-version-arm.deb
+    - productName_version.arm64.deb => productName-version-aarch64.deb
+  - RPM
+    - productName-version-$release.arch.rpm => productName-version-aarch64-$release.rpm
+  - DMG
+    - productName_version_x64.dmg => productName-version-x86_64.dmg
+    - productName_version_aarch64.dmg => productName-version-aarch64.dmg
+  - macOS 
+    - still keeps the productName.app format as that is the name of the file that is actually installed on user machines.
+  - MSI
+    - productName_version_x86_$language.msi => productName-version-x86-$language.msi
+    - productName_version_x64_$language.msi => productName-version-x86_64-$language.msi
+    - productName_version_arm64_$language.msi => productName-version-aarch64-$language.msi
+  - NSIS
+    - productName_version_x86_setup.exe => productName-version-x86-setup.exe
+    - productName_version_x64_setup.exe => productName-version-x86_64-setup.exe
+    - productName_version_arm64_setup.exe => productName-version-aarch64-setup.exe

--- a/.changes/refactor-bundle-file-names.md
+++ b/.changes/refactor-bundle-file-names.md
@@ -21,7 +21,6 @@ Change bundle file names to a consistent `productName-version-arch.ext` format.
   - macOS
     - still keeps the productName.app format as that is the name of the file that is actually installed on user machines.
   - MSI
-    - The $language suffix now uses `_` as separator instead of `-` (e.g. `en_US` instead of `en-US`).
     - productName_version_x86_$language.msi => productName-version-x86-$language.msi
     - productName_version_x64_$language.msi => productName-version-x86_64-$language.msi
     - productName_version_arm64_$language.msi => productName-version-aarch64-$language.msi

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -249,3 +249,21 @@ pub fn check_icons(settings: &Settings) -> crate::Result<bool> {
     Ok(true)
   }
 }
+
+pub(crate) fn bundle_name(settings: &Settings, ext: &str) -> String {
+  format!(
+    "{}-{}-{}.{ext}",
+    settings.product_name(),
+    settings.version_string(),
+    settings.binary_arch()
+  )
+}
+
+pub(crate) fn bundle_name_with_suffix(settings: &Settings, suffix: &str, ext: &str) -> String {
+  format!(
+    "{}-{}-{}-{suffix}.{ext}",
+    settings.product_name(),
+    settings.version_string(),
+    settings.binary_arch()
+  )
+}

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -260,6 +260,7 @@ pub(crate) fn bundle_name(settings: &Settings, ext: &str) -> String {
   )
 }
 
+#[inline]
 pub(crate) fn bundle_name_with_suffix(settings: &Settings, suffix: &str, ext: &str) -> String {
   format!(
     "{}-{}-{}-{suffix}.{ext}",

--- a/tooling/bundler/src/bundle.rs
+++ b/tooling/bundler/src/bundle.rs
@@ -250,6 +250,7 @@ pub fn check_icons(settings: &Settings) -> crate::Result<bool> {
   }
 }
 
+#[inline]
 pub(crate) fn bundle_name(settings: &Settings, ext: &str) -> String {
   format!(
     "{}-{}-{}.{ext}",

--- a/tooling/bundler/src/bundle/linux/rpm.rs
+++ b/tooling/bundler/src/bundle/linux/rpm.rs
@@ -28,7 +28,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   let summary = settings.short_description().trim();
 
-  let rpm_name = crate::bundle::bundle_name_with_suffix(settings, release, "dmg");
+  let rpm_name = crate::bundle::bundle_name_with_suffix(settings, release, "rpm");
 
   let base_dir = settings.project_out_directory().join("bundle/rpm");
   let package_dir = base_dir.join(Path::new(&rpm_name).file_stem().unwrap());

--- a/tooling/bundler/src/bundle/macos/dmg.rs
+++ b/tooling/bundler/src/bundle/macos/dmg.rs
@@ -38,16 +38,8 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
 
   // get the target path
   let output_path = settings.project_out_directory().join("bundle/dmg");
-  let package_base_name = format!(
-    "{}_{}_{}",
-    settings.product_name(),
-    settings.version_string(),
-    match settings.binary_arch() {
-      "x86_64" => "x64",
-      other => other,
-    }
-  );
-  let dmg_name = format!("{}.dmg", &package_base_name);
+
+  let dmg_name = crate::bundle::bundle_name(settings, "dmg");
   let dmg_path = output_path.join(&dmg_name);
 
   let product_name = settings.product_name();

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -179,7 +179,7 @@ fn app_installer_output_path(
   updater: bool,
 ) -> crate::Result<PathBuf> {
   let msi_name =
-    crate::bundle::bundle_name_with_suffix(settings, language.replace('-', "_"), "msi");
+    crate::bundle::bundle_name_with_suffix(settings, &language.replace('-', "_"), "msi");
 
   Ok(settings.project_out_directory().to_path_buf().join(format!(
     "bundle/{}/{msi_name}",

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -178,8 +178,7 @@ fn app_installer_output_path(
   language: &str,
   updater: bool,
 ) -> crate::Result<PathBuf> {
-  let msi_name =
-    crate::bundle::bundle_name_with_suffix(settings, &language.replace('-', "_"), "msi");
+  let msi_name = crate::bundle::bundle_name_with_suffix(settings, language, "msi");
 
   Ok(settings.project_out_directory().to_path_buf().join(format!(
     "bundle/{}/{msi_name}",

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -178,7 +178,8 @@ fn app_installer_output_path(
   language: &str,
   updater: bool,
 ) -> crate::Result<PathBuf> {
-  let msi_name = crate::bundle::bundle_name_with_suffix(settings, language, "msi");
+  let msi_name =
+    crate::bundle::bundle_name_with_suffix(settings, language.replace('-', "_"), "msi");
 
   Ok(settings.project_out_directory().to_path_buf().join(format!(
     "bundle/{}/{msi_name}",

--- a/tooling/bundler/src/bundle/windows/msi/wix.rs
+++ b/tooling/bundler/src/bundle/windows/msi/wix.rs
@@ -347,6 +347,7 @@ fn run_light(
   Ok(())
 }
 
+#[inline]
 fn wix_arch(settings: &Settings) -> crate::Result<&'static str> {
   match settings.binary_arch() {
     "x86_64" => Ok("x64"),

--- a/tooling/bundler/src/bundle/windows/nsis.rs
+++ b/tooling/bundler/src/bundle/windows/nsis.rs
@@ -159,7 +159,7 @@ fn build_nsis_app_installer(
     }
   };
 
-  log::info!("Target: {}", arch);
+  log::info!("Target: {arch}");
 
   let output_path = settings.project_out_directory().join("nsis").join(arch);
   if output_path.exists() {
@@ -508,22 +508,17 @@ fn build_nsis_app_installer(
     handlebars.render("installer.nsi", &data)?,
   )?;
 
-  let package_base_name = format!(
-    "{}_{}_{}-setup",
-    settings.product_name(),
-    settings.version_string(),
-    arch,
-  );
+  let nsis_name = crate::bundle::bundle_name_with_suffix(settings, "setup", "exe");
 
   let nsis_output_path = output_path.join(out_file);
+
   let nsis_installer_path = settings.project_out_directory().to_path_buf().join(format!(
-    "bundle/{}/{}.exe",
+    "bundle/{}/{nsis_name}",
     if updater {
       NSIS_UPDATER_OUTPUT_FOLDER_NAME
     } else {
       NSIS_OUTPUT_FOLDER_NAME
     },
-    package_base_name
   ));
   fs::create_dir_all(nsis_installer_path.parent().unwrap())?;
 


### PR DESCRIPTION
I'm still not sure if we want to keep the release tag in the RPM file name, but I'll keep it for now.
Mainly wanted to raise awareness on this issue first.
I like the consistency of this, but I'm also not really a fan of using `-` instead of `_` as separator.

Note that `-` is also the separator used on the language string currently appended to the MSI file name. I think I'll just change that to use `_` instead.