### PR TITLE
fix(core): IPC fallback hanging when sending responses, closes #10327

### DIFF
--- a/.changes/fix-ipc-fallback.md
+++ b/.changes/fix-ipc-fallback.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix IPC fallback (postMessage implementation when custom protocol fails) hanging when sending responses.

--- a/core/tauri/scripts/ipc-protocol.js
+++ b/core/tauri/scripts/ipc-protocol.js
@@ -62,7 +62,11 @@
             )
           }
         })
-        .catch(() => {
+        .catch((e) => {
+          console.warn(
+            'IPC custom protocol failed, Tauri will now use the postMessage interface instead',
+            e
+          )
           // failed to use the custom protocol IPC (either the webview blocked a custom protocol or it was a CSP error)
           // so we need to fallback to the postMessage interface
           customProtocolIpcFailed = true
@@ -74,7 +78,10 @@
         cmd,
         callback,
         error,
-        options,
+        options: {
+          ...options,
+          customProtocolIpcBlocked: customProtocolIpcFailed
+        },
         payload,
         __TAURI_INVOKE_KEY__
       })


### PR DESCRIPTION
The IPC fallback system kicks in when the custom protocol implementation cannot be used (e.g. CORS issues). The fallback uses the postMessage mechanism, which by default uses channels to send large responses. If the custom protocol implementation cannot be used, we should not use channels, but eval the response directly.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
