### PR TITLE
refactor(core): return 200 on any IPC call, closes #10286

### DIFF
--- a/.changes/refactor-ipc-error.md
+++ b/.changes/refactor-ipc-error.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:changes
+---
+
+Change how IPC handles errors to simplify what's logged in the console.

--- a/core/tauri/scripts/ipc-protocol.js
+++ b/core/tauri/scripts/ipc-protocol.js
@@ -42,7 +42,8 @@
         }
       })
         .then((response) => {
-          const cb = response.ok ? callback : error
+          const cb =
+            response.headers.get('tauri-response') === 'ok' ? callback : error
           // we need to split here because on Android the content-type gets duplicated
           switch ((response.headers.get('content-type') || '').split(',')[0]) {
             case 'application/json':

--- a/core/tauri/scripts/ipc-protocol.js
+++ b/core/tauri/scripts/ipc-protocol.js
@@ -43,7 +43,7 @@
       })
         .then((response) => {
           const cb =
-            response.headers.get('tauri-response') === 'ok' ? callback : error
+            response.headers.get('Tauri-Response') === 'ok' ? callback : error
           // we need to split here because on Android the content-type gets duplicated
           switch ((response.headers.get('content-type') || '').split(',')[0]) {
             case 'application/json':

--- a/core/tauri/src/protocol/asset.rs
+++ b/core/tauri/src/protocol/asset.rs
@@ -16,7 +16,7 @@ pub fn get(scope: scope::fs::Scope, window_origin: String) -> UriSchemeProtocolH
       Ok(response) => responder.respond(response),
       Err(e) => responder.respond(
         http::Response::builder()
-          .status(http::StatusCode::BAD_REQUEST)
+          .status(http::StatusCode::INTERNAL_SERVER_ERROR)
           .header(CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
           .header("Access-Control-Allow-Origin", &window_origin)
           .body(e.to_string().as_bytes().to_vec())

--- a/core/tauri/src/protocol/isolation.rs
+++ b/core/tauri/src/protocol/isolation.rs
@@ -77,7 +77,7 @@ pub fn get<R: Runtime>(
     } else {
       responder.respond(
         http::Response::builder()
-          .status(http::StatusCode::BAD_REQUEST)
+          .status(http::StatusCode::INTERNAL_SERVER_ERROR)
           .body("failed to get response".as_bytes().to_vec())
           .unwrap(),
       );

--- a/core/tauri/src/protocol/tauri.rs
+++ b/core/tauri/src/protocol/tauri.rs
@@ -54,7 +54,7 @@ pub fn get<R: Runtime>(
       Ok(response) => responder.respond(response),
       Err(e) => responder.respond(
         HttpResponse::builder()
-          .status(StatusCode::BAD_REQUEST)
+          .status(StatusCode::INTERNAL_SERVER_ERROR)
           .header(CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
           .header("Access-Control-Allow-Origin", &window_origin)
           .body(e.to_string().as_bytes().to_vec())

--- a/examples/streaming/main.rs
+++ b/examples/streaming/main.rs
@@ -42,7 +42,7 @@ fn main() {
         Ok(http_response) => responder.respond(http_response),
         Err(e) => responder.respond(
           ResponseBuilder::new()
-            .status(StatusCode::BAD_REQUEST)
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header(CONTENT_TYPE, "text/plain")
             .body(e.to_string().as_bytes().to_vec())
             .unwrap(),


### PR DESCRIPTION
By default the webview prints a `Failed to load resource: the server responded with a status of 400 (Bad Request) ipc://localhost` error message when a command returns an error, which is confusing to users.

This changes the IPC to return status 200 on any call, with a header to indicate whether the result was ok or not. This removes the console error, which would only log the actual error result if it isn't caught by the user.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
