### PR TITLE
refactor(tauri-runtime-wry): Arc instead of Rc, closes #9775

### DIFF
--- a/.changes/wry-arc.md
+++ b/.changes/wry-arc.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Use `Arc` instead of `Rc` on global shortcut and tray types to prevent crashes on macOS.

--- a/core/tauri-runtime-wry/src/global_shortcut.rs
+++ b/core/tauri-runtime-wry/src/global_shortcut.rs
@@ -72,7 +72,7 @@ impl StdError for AcceleratorParseErrorWrapper {}
 /// Wrapper around [`WryShortcutManager`].
 #[derive(Clone)]
 pub struct GlobalShortcutManagerHandle<T: UserEvent> {
-  pub context: Arc<Context<T>>,
+  pub context: Context<T>,
   pub shortcuts: Arc<Mutex<HashMap<String, (AcceleratorId, GlobalShortcutWrapper)>>>,
   pub listeners: GlobalShortcutListeners,
 }

--- a/core/tauri-runtime-wry/src/system_tray.rs
+++ b/core/tauri-runtime-wry/src/system_tray.rs
@@ -158,7 +158,7 @@ pub fn create_tray<T>(
 
 #[derive(Debug, Clone)]
 pub struct SystemTrayHandle<T: UserEvent> {
-  pub(crate) context: Arc<Context<T>>,
+  pub(crate) context: Context<T>,
   pub(crate) id: TrayId,
   pub(crate) proxy: EventLoopProxy<super::Message<T>>,
 }


### PR DESCRIPTION
Rc is not thread safe, so even though we are only using these types on the main thread, we need to ensure clones are safe across threads.

This is a follow up for #8402

I also changed the Context to use an Arc too, now after investigation doesn't seem like the context cloning was actually the problem but it doesn't harm to use an Arc here

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
