### PR TITLE
refactor: rename `TAURI_SIGNTOOL_PATH` -> `TAURI_WINDOWS_SIGNTOOL_PATH`

### DIFF
--- a/.changes/cli-signtool-path.md
+++ b/.changes/cli-signtool-path.md
@@ -2,4 +2,4 @@
 "tauri-bundler": patch:feat
 ---
 
-`TAURI_SIGNTOOL_PATH` environment variable for specifying the path to signtool.exe.
+`TAURI_WINDOWS_SIGNTOOL_PATH` environment variable for specifying the path to signtool.exe.

--- a/tooling/bundler/src/bundle/windows/sign.rs
+++ b/tooling/bundler/src/bundle/windows/sign.rs
@@ -59,7 +59,7 @@ fn signtool() -> Option<PathBuf> {
   static SIGN_TOOL: OnceLock<crate::Result<PathBuf>> = OnceLock::new();
   SIGN_TOOL
     .get_or_init(|| {
-      if let Some(signtool) = std::env::var_os("TAURI_SIGNTOOL_PATH") {
+      if let Some(signtool) = std::env::var_os("TAURI_WINDOWS_SIGNTOOL_PATH") {
         return Ok(PathBuf::from(signtool));
       }
 

--- a/tooling/cli/ENVIRONMENT_VARIABLES.md
+++ b/tooling/cli/ENVIRONMENT_VARIABLES.md
@@ -20,6 +20,7 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — The signing private key password, see `TAURI_SIGNING_PRIVATE_KEY`.
 - `TAURI_SIGNING_RPM_KEY` — The private GPG key used to sign the RPM bundle, exported to its ASCII-armored format.
 - `TAURI_SIGNING_RPM_KEY_PASSPHRASE` — The GPG key passphrase for `TAURI_SIGNING_RPM_KEY`, if needed.
+- `TAURI_WINDOWS_SIGNTOOL_PATH` — Specify a path to `signtool.exe` used for code signing the application on Windows.
 - `APPLE_CERTIFICATE` — Base64 encoded of the `.p12` certificate for code signing. To get this value, run `openssl base64 -in MyCertificate.p12 -out MyCertificate-base64.txt`.
 - `APPLE_CERTIFICATE_PASSWORD` — The password you used to export the certificate.
 - `APPLE_ID` — The Apple ID used to notarize the application. If this environment variable is provided, `APPLE_PASSWORD` and `APPLE_TEAM_ID` must also be set. Alternatively, `APPLE_API_KEY` and `APPLE_API_ISSUER` can be used to authenticate.


### PR DESCRIPTION
immediately after merging #10588 I noticed that the variable name might be a bit ambigious and could cause confusion on other pl atforms other than Windows

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
