### PR TITLE
fix(cli): builtin dev server should also be forwarded for Android

### DIFF
--- a/.changes/fix-cli-dev-server-android.md
+++ b/.changes/fix-cli-dev-server-android.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fixes `android dev` not working when using the builtin dev server.

--- a/examples/api/src-tauri/tauri-plugin-sample/permissions/autogenerated/reference.md
+++ b/examples/api/src-tauri/tauri-plugin-sample/permissions/autogenerated/reference.md
@@ -1,5 +1,5 @@
 
-### Permission Table 
+## Permission Table 
 
 <table>
 <tr>

--- a/examples/api/src-tauri/tauri-plugin-sample/permissions/autogenerated/reference.md
+++ b/examples/api/src-tauri/tauri-plugin-sample/permissions/autogenerated/reference.md
@@ -1,5 +1,5 @@
 
-## Permission Table 
+### Permission Table 
 
 <table>
 <tr>

--- a/tooling/cli/src/helpers/config.rs
+++ b/tooling/cli/src/helpers/config.rs
@@ -215,3 +215,20 @@ pub fn reload(merge_config: Option<&serde_json::Value>) -> crate::Result<ConfigH
     Err(anyhow::anyhow!("config not loaded"))
   }
 }
+
+/// merges the loaded config with the given value
+pub fn merge_with(merge_config: &serde_json::Value) -> crate::Result<ConfigHandle> {
+  let handle = config_handle();
+  if let Some(config_metadata) = &mut *handle.lock().unwrap() {
+    let merge_config_str = serde_json::to_string(merge_config).unwrap();
+    set_var("TAURI_CONFIG", merge_config_str);
+
+    let mut value = serde_json::to_value(config_metadata.inner.clone())?;
+    merge(&mut value, merge_config);
+    config_metadata.inner = serde_json::from_value(value)?;
+
+    Ok(handle.clone())
+  } else {
+    Err(anyhow::anyhow!("config not loaded"))
+  }
+}

--- a/tooling/cli/src/lib.rs
+++ b/tooling/cli/src/lib.rs
@@ -34,7 +34,7 @@ use clap::{ArgAction, CommandFactory, FromArgMatches, Parser, Subcommand, ValueE
 use env_logger::fmt::style::{AnsiColor, Style};
 use env_logger::Builder;
 use log::Level;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::io::{BufReader, Write};
 use std::process::{exit, Command, ExitStatus, Output, Stdio};
 use std::{
@@ -48,7 +48,7 @@ use std::{
 };
 
 /// Tauri configuration argument option.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigValue(pub(crate) serde_json::Value);
 
 impl FromStr for ConfigValue {

--- a/tooling/cli/src/mobile/android/android_studio_script.rs
+++ b/tooling/cli/src/mobile/android/android_studio_script.rs
@@ -59,12 +59,17 @@ pub fn command(options: Options) -> Result<()> {
     );
     (config, metadata, cli_options)
   };
+
   ensure_init(
     &tauri_config,
     config.app(),
     config.project_dir(),
     MobileTarget::Android,
   )?;
+
+  if let Some(config) = &cli_options.config {
+    crate::helpers::config::merge_with(&config.0)?;
+  }
 
   let env = env()?;
 
@@ -77,6 +82,7 @@ pub fn command(options: Options) -> Result<()> {
       .build
       .dev_url
       .clone();
+
     if let Some(port) = dev_url.and_then(|url| url.port_or_known_default()) {
       let forward = format!("tcp:{port}");
       // ignore errors in case we do not have a device available

--- a/tooling/cli/src/mobile/android/android_studio_script.rs
+++ b/tooling/cli/src/mobile/android/android_studio_script.rs
@@ -89,7 +89,7 @@ pub fn command(options: Options) -> Result<()> {
       let _ = adb::adb(&env, ["reverse", &forward, &forward])
         .stdin_file(os_pipe::dup_stdin().unwrap())
         .stdout_file(os_pipe::dup_stdout().unwrap())
-        .stderr_file(os_pipe::dup_stdout().unwrap())
+        .stderr_capture()
         .run();
     }
   }

--- a/tooling/cli/src/mobile/android/android_studio_script.rs
+++ b/tooling/cli/src/mobile/android/android_studio_script.rs
@@ -90,7 +90,7 @@ pub fn command(options: Options) -> Result<()> {
       let result = adb::adb(&env, ["reverse", &forward, &forward])
         .stdin_file(os_pipe::dup_stdin().unwrap())
         .stdout_file(os_pipe::dup_stdout().unwrap())
-        .stderr_capture()
+        .stderr_file(os_pipe::dup_stdout().unwrap())
         .run();
       if let Err(e) = result {
         log::error!("Failed to forward port {port}: {e}");

--- a/tooling/cli/src/mobile/android/android_studio_script.rs
+++ b/tooling/cli/src/mobile/android/android_studio_script.rs
@@ -85,12 +85,16 @@ pub fn command(options: Options) -> Result<()> {
 
     if let Some(port) = dev_url.and_then(|url| url.port_or_known_default()) {
       let forward = format!("tcp:{port}");
+      log::info!("Forwarding port {port} with adb");
       // ignore errors in case we do not have a device available
-      let _ = adb::adb(&env, ["reverse", &forward, &forward])
+      let result = adb::adb(&env, ["reverse", &forward, &forward])
         .stdin_file(os_pipe::dup_stdin().unwrap())
         .stdout_file(os_pipe::dup_stdout().unwrap())
         .stderr_capture()
         .run();
+      if let Err(e) = result {
+        log::error!("Failed to forward port {port}: {e}");
+      }
     }
   }
 

--- a/tooling/cli/src/mobile/android/android_studio_script.rs
+++ b/tooling/cli/src/mobile/android/android_studio_script.rs
@@ -85,16 +85,12 @@ pub fn command(options: Options) -> Result<()> {
 
     if let Some(port) = dev_url.and_then(|url| url.port_or_known_default()) {
       let forward = format!("tcp:{port}");
-      log::info!("Forwarding port {port} with adb");
       // ignore errors in case we do not have a device available
-      let result = adb::adb(&env, ["reverse", &forward, &forward])
+      let _ = adb::adb(&env, ["reverse", &forward, &forward])
         .stdin_file(os_pipe::dup_stdin().unwrap())
         .stdout_file(os_pipe::dup_stdout().unwrap())
         .stderr_file(os_pipe::dup_stdout().unwrap())
         .run();
-      if let Err(e) = result {
-        log::error!("Failed to forward port {port}: {e}");
-      }
     }
   }
 

--- a/tooling/cli/src/mobile/android/build.rs
+++ b/tooling/cli/src/mobile/android/build.rs
@@ -201,6 +201,7 @@ fn run_build(
     args: build_options.args.clone(),
     noise_level,
     vars: Default::default(),
+    config: build_options.config.clone(),
   };
   let handle = write_options(
     &tauri_config.lock().unwrap().as_ref().unwrap().identifier,

--- a/tooling/cli/src/mobile/android/dev.rs
+++ b/tooling/cli/src/mobile/android/dev.rs
@@ -222,7 +222,7 @@ fn run_dev(
       debug: !options.release_mode,
       features: options.features,
       args: Vec::new(),
-      config: options.config,
+      config: dev_options.config.clone(),
       no_watch: options.no_watch,
     },
     |options| {
@@ -232,6 +232,7 @@ fn run_dev(
         args: options.args.clone(),
         noise_level,
         vars: Default::default(),
+        config: dev_options.config.clone(),
       };
 
       let _handle = write_options(

--- a/tooling/cli/src/mobile/ios/build.rs
+++ b/tooling/cli/src/mobile/ios/build.rs
@@ -283,6 +283,7 @@ fn run_build(
     args: build_options.args.clone(),
     noise_level,
     vars: Default::default(),
+    config: build_options.config.clone(),
   };
   let handle = write_options(
     &tauri_config.lock().unwrap().as_ref().unwrap().identifier,

--- a/tooling/cli/src/mobile/ios/dev.rs
+++ b/tooling/cli/src/mobile/ios/dev.rs
@@ -36,6 +36,8 @@ use std::{
   sync::OnceLock,
 };
 
+const PHYSICAL_IPHONE_DEV_WARNING: &str = "To develop on physical phones you need the `--host` option (not required for Simulators). See the documentation for more information: https://v2.tauri.app/develop/#development-server";
+
 #[derive(Debug, Clone, Parser)]
 #[clap(
   about = "Run your app in development mode on iOS",
@@ -367,6 +369,8 @@ fn run_dev(
   let out_dir = bin_path.parent().unwrap();
   let _lock = flock::open_rw(out_dir.join("lock").with_extension("ios"), "iOS")?;
 
+  let set_host = options.host.is_some();
+
   configure_cargo(app, None)?;
 
   let open = options.open;
@@ -377,7 +381,7 @@ fn run_dev(
       debug: true,
       features: options.features,
       args: Vec::new(),
-      config: options.config,
+      config: dev_options.config.clone(),
       no_watch: options.no_watch,
     },
     |options| {
@@ -387,6 +391,7 @@ fn run_dev(
         args: options.args.clone(),
         noise_level,
         vars: Default::default(),
+        config: dev_options.config.clone(),
       };
       let _handle = write_options(
         &tauri_config.lock().unwrap().as_ref().unwrap().identifier,
@@ -394,6 +399,9 @@ fn run_dev(
       )?;
 
       if open {
+        if !set_host {
+          log::warn!("{PHYSICAL_IPHONE_DEV_WARNING}");
+        }
         open_and_wait(config, &env)
       } else if let Some(device) = &device {
         match run(device, options, config, &env) {
@@ -409,6 +417,9 @@ fn run_dev(
           }
         }
       } else {
+        if !set_host {
+          log::warn!("{PHYSICAL_IPHONE_DEV_WARNING}");
+        }
         open_and_wait(config, &env)
       }
     },

--- a/tooling/cli/src/mobile/mod.rs
+++ b/tooling/cli/src/mobile/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     config::{Config as TauriConfig, ConfigHandle},
   },
   interface::{AppInterface, AppSettings, DevProcess, Interface, Options as InterfaceOptions},
+  ConfigValue,
 };
 #[cfg(target_os = "macos")]
 use anyhow::Context;
@@ -141,6 +142,7 @@ pub struct CliOptions {
   pub args: Vec<String>,
   pub noise_level: NoiseLevel,
   pub vars: HashMap<String, OsString>,
+  pub config: Option<ConfigValue>,
 }
 
 impl Default for CliOptions {
@@ -151,6 +153,7 @@ impl Default for CliOptions {
       args: vec!["--lib".into()],
       noise_level: Default::default(),
       vars: Default::default(),
+      config: None,
     }
   }
 }


### PR DESCRIPTION
This changes the CLI to persist the "merge config" across mobile command usage (required to pull this config on the xcode and android studio build scripts). This is required because the builtin dev server makes modifications to the Tauri config (devUrl rewrite) and we need to detect that to forward the dev URL port to Android using ADB.

Also adds a warning on iOS when using `dev --open`: you need the `--host` option to run on physical devices.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
