### PR TITLE
fix(cli): adb port forward error handling, add logs, closes #9509

### DIFF
--- a/.changes/android-port-forward-fixes.md
+++ b/.changes/android-port-forward-fixes.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fixes `android dev` port forward failing under some conditions, add better logging and error handling.

--- a/tooling/cli/Cargo.lock
+++ b/tooling/cli/Cargo.lock
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-mobile2"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a375de334eab8b47e0f02421509c3fb6910499ec8353d36e4d977c2b5d7646b"
+checksum = "ebaedf7b7e292b7f41f892f5c96ee15544e21814e89d0b6b8dc06740a69dabe5"
 dependencies = [
  "colored",
  "core-foundation",

--- a/tooling/cli/Cargo.toml
+++ b/tooling/cli/Cargo.toml
@@ -39,7 +39,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [dependencies]
-cargo-mobile2 = { version = "0.13.1", default-features = false }
+cargo-mobile2 = { version = "0.13.2", default-features = false }
 jsonrpsee = { version = "0.24", features = [ "server" ] }
 jsonrpsee-core = "0.24"
 jsonrpsee-client-transport = { version = "0.24", features = [ "ws" ] }

--- a/tooling/cli/src/mobile/android/android_studio_script.rs
+++ b/tooling/cli/src/mobile/android/android_studio_script.rs
@@ -79,12 +79,35 @@ pub fn command(options: Options) -> Result<()> {
       .clone();
     if let Some(port) = dev_url.and_then(|url| url.port_or_known_default()) {
       let forward = format!("tcp:{port}");
-      // ignore errors in case we do not have a device available
-      let _ = adb::adb(&env, ["reverse", &forward, &forward])
-        .stdin_file(os_pipe::dup_stdin().unwrap())
-        .stdout_file(os_pipe::dup_stdout().unwrap())
-        .stderr_capture()
-        .run();
+      log::info!("Forwarding port {port} with adb");
+
+      let devices = adb::device_list(&env).unwrap_or_default();
+
+      // clear port forwarding for all devices
+      for device in &devices {
+        remove_adb_reverse(&env, device.serial_no(), &forward);
+      }
+
+      // if there's a known target, we should force use it
+      if let Some(target_device) = &cli_options.target_device {
+        run_adb_reverse(&env, &target_device.id, &forward, &forward).with_context(|| {
+          format!(
+            "failed to forward port with adb, is the {} device connected?",
+            target_device.name,
+          )
+        })?;
+      } else if devices.len() == 1 {
+        let device = devices.first().unwrap();
+        run_adb_reverse(&env, device.serial_no(), &forward, &forward).with_context(|| {
+          format!(
+            "failed to forward port with adb, is the {} device connected?",
+            device.name(),
+          )
+        })?;
+      } else {
+        anyhow::bail!("Multiple Android devices are connected ({}), please disconnect devices you do not intend to use so Tauri can determine which to use",
+      devices.iter().map(|d| d.name()).collect::<Vec<_>>().join(", "));
+      }
     }
   }
 
@@ -145,4 +168,30 @@ fn validate_lib(path: &Path) -> Result<()> {
   }
 
   Ok(())
+}
+
+fn run_adb_reverse(
+  env: &cargo_mobile2::android::env::Env,
+  device_serial_no: &str,
+  remote: &str,
+  local: &str,
+) -> std::io::Result<std::process::Output> {
+  adb::adb(env, ["-s", device_serial_no, "reverse", remote, local])
+    .stdin_file(os_pipe::dup_stdin().unwrap())
+    .stdout_file(os_pipe::dup_stdout().unwrap())
+    .stderr_file(os_pipe::dup_stdout().unwrap())
+    .run()
+}
+
+fn remove_adb_reverse(
+  env: &cargo_mobile2::android::env::Env,
+  device_serial_no: &str,
+  remote: &str,
+) {
+  // ignore errors in case the port is not forwarded
+  let _ = adb::adb(env, ["-s", device_serial_no, "reverse", "--remove", remote])
+    .stdin_file(os_pipe::dup_stdin().unwrap())
+    .stdout_file(os_pipe::dup_stdout().unwrap())
+    .stderr_file(os_pipe::dup_stdout().unwrap())
+    .run();
 }

--- a/tooling/cli/src/mobile/android/build.rs
+++ b/tooling/cli/src/mobile/android/build.rs
@@ -201,6 +201,7 @@ fn run_build(
     args: build_options.args.clone(),
     noise_level,
     vars: Default::default(),
+    target_device: None,
   };
   let handle = write_options(
     &tauri_config.lock().unwrap().as_ref().unwrap().identifier,

--- a/tooling/cli/src/mobile/android/dev.rs
+++ b/tooling/cli/src/mobile/android/dev.rs
@@ -14,7 +14,7 @@ use crate::{
     flock,
   },
   interface::{AppInterface, AppSettings, Interface, MobileOptions, Options as InterfaceOptions},
-  mobile::{write_options, CliOptions, DevChild, DevProcess},
+  mobile::{write_options, CliOptions, DevChild, DevProcess, TargetDevice},
   ConfigValue, Result,
 };
 use clap::{ArgAction, Parser};
@@ -232,6 +232,10 @@ fn run_dev(
         args: options.args.clone(),
         noise_level,
         vars: Default::default(),
+        target_device: device.as_ref().map(|d| TargetDevice {
+          id: d.serial_no().to_string(),
+          name: d.name().to_string(),
+        }),
       };
 
       let _handle = write_options(

--- a/tooling/cli/src/mobile/ios/build.rs
+++ b/tooling/cli/src/mobile/ios/build.rs
@@ -283,6 +283,7 @@ fn run_build(
     args: build_options.args.clone(),
     noise_level,
     vars: Default::default(),
+    target_device: None,
   };
   let handle = write_options(
     &tauri_config.lock().unwrap().as_ref().unwrap().identifier,

--- a/tooling/cli/src/mobile/ios/dev.rs
+++ b/tooling/cli/src/mobile/ios/dev.rs
@@ -387,6 +387,7 @@ fn run_dev(
         args: options.args.clone(),
         noise_level,
         vars: Default::default(),
+        target_device: None,
       };
       let _handle = write_options(
         &tauri_config.lock().unwrap().as_ref().unwrap().identifier,

--- a/tooling/cli/src/mobile/mod.rs
+++ b/tooling/cli/src/mobile/mod.rs
@@ -135,12 +135,19 @@ impl Target {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TargetDevice {
+  id: String,
+  name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliOptions {
   pub dev: bool,
   pub features: Option<Vec<String>>,
   pub args: Vec<String>,
   pub noise_level: NoiseLevel,
   pub vars: HashMap<String, OsString>,
+  pub target_device: Option<TargetDevice>,
 }
 
 impl Default for CliOptions {
@@ -151,6 +158,7 @@ impl Default for CliOptions {
       args: vec!["--lib".into()],
       noise_level: Default::default(),
       vars: Default::default(),
+      target_device: None,
     }
   }
 }


### PR DESCRIPTION
a port can only be forward to a single device connected with adb, so we must handle:
- multiple devices connected
- port already forwarded to another device

this change also includes better error handling and logs so it's easier for us to triage issues

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
