### PR TITLE
fix(tauri-runtime-wry): ensure tray is created when event loop ready

### DIFF
--- a/.changes/ensure-tray-created-ready.md
+++ b/.changes/ensure-tray-created-ready.md
@@ -2,4 +2,7 @@
 "tauri-runtime-wry": patch:bug
 ---
 
-Ensure system tray is created when the event loop is ready.
+Ensure system tray is created when the event loop is ready. Menu item modifications are not applied unless it is ready.
+If you need to modify the menu items immediately after creating a tray in the setup hook,
+either directly configure the menu item change when creating the menu or move the code when `RunEvent::Ready` is fired.
+See https://docs.rs/tauri/latest/tauri/struct.App.html#method.run for more information.

--- a/.changes/ensure-tray-created-ready.md
+++ b/.changes/ensure-tray-created-ready.md
@@ -3,6 +3,3 @@
 ---
 
 Ensure system tray is created when the event loop is ready. Menu item modifications are not applied unless it is ready.
-If you need to modify the menu items immediately after creating a tray in the setup hook,
-either directly configure the menu item change when creating the menu or move the code when `RunEvent::Ready` is fired.
-See https://docs.rs/tauri/latest/tauri/struct.App.html#method.run for more information.

--- a/.changes/ensure-tray-created-ready.md
+++ b/.changes/ensure-tray-created-ready.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Ensure system tray is created when the event loop is ready.

--- a/core/tauri-runtime-wry/src/lib.rs
+++ b/core/tauri-runtime-wry/src/lib.rs
@@ -1835,7 +1835,11 @@ pub struct Wry<T: UserEvent> {
   clipboard_manager_handle: ClipboardManagerWrapper,
 
   event_loop: EventLoop<Message<T>>,
+
+  pending_ready_tasks: RefCell<Vec<PendingReadyTask<T>>>,
 }
+
+type PendingReadyTask<T> = Box<dyn FnOnce(&EventLoopWindowTarget<Message<T>>)>;
 
 impl<T: UserEvent> fmt::Debug for Wry<T> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1952,6 +1956,8 @@ impl<T: UserEvent> RuntimeHandle<T> for WryHandle<T> {
       context: self.context.clone(),
       id,
       proxy: self.context.proxy.clone(),
+      #[allow(clippy::arc_with_non_send_sync)]
+      pending: PendingSystemTray(Arc::new(RefCell::new(None))),
     })
   }
 
@@ -2033,6 +2039,8 @@ impl<T: UserEvent> Wry<T> {
       clipboard_manager_handle,
 
       event_loop,
+
+      pending_ready_tasks: RefCell::new(Vec::new()),
     })
   }
 
@@ -2129,34 +2137,48 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
   }
 
   #[cfg(all(desktop, feature = "system-tray"))]
-  fn system_tray(&self, mut system_tray: SystemTray) -> Result<Self::TrayHandler> {
+  fn system_tray(&self, system_tray: SystemTray) -> Result<Self::TrayHandler> {
+    let system_tray_manager = self.context.main_thread.system_tray_manager.clone();
+
     let id = system_tray.id;
-    let mut listeners = Vec::new();
-    if let Some(l) = system_tray.on_event.take() {
-      #[allow(clippy::arc_with_non_send_sync)]
-      listeners.push(Arc::new(l));
-    }
-    let (tray, items) = create_tray(WryTrayId(id), system_tray, &self.event_loop)?;
+    #[allow(clippy::arc_with_non_send_sync)]
+    let pending = PendingSystemTray(Arc::new(RefCell::new(Some(system_tray))));
+
+    let pending_ = pending.clone();
     self
-      .context
-      .main_thread
-      .system_tray_manager
-      .trays
-      .lock()
-      .unwrap()
-      .insert(
-        id,
-        TrayContext {
-          tray: Arc::new(TrayCell(RefCell::new(Some(tray)))),
-          listeners: Arc::new(TrayListenersCell(RefCell::new(listeners))),
-          items: Arc::new(TrayItemsCell(RefCell::new(items))),
-        },
-      );
+      .pending_ready_tasks
+      .borrow_mut()
+      .push(Box::new(move |event_loop| {
+        if let Some(mut system_tray) = pending_.0.borrow_mut().take() {
+          let mut listeners = Vec::new();
+          if let Some(l) = system_tray.on_event.take() {
+            #[allow(clippy::arc_with_non_send_sync)]
+            listeners.push(Arc::new(l));
+          }
+
+          match create_tray(WryTrayId(id), system_tray, event_loop) {
+            Ok((tray, items)) => {
+              system_tray_manager.trays.lock().unwrap().insert(
+                id,
+                TrayContext {
+                  tray: Arc::new(TrayCell(RefCell::new(Some(tray)))),
+                  listeners: Arc::new(TrayListenersCell(RefCell::new(listeners))),
+                  items: Arc::new(TrayItemsCell(RefCell::new(items))),
+                },
+              );
+            }
+            Err(e) => {
+              eprintln!("failed to build tray: {e}");
+            }
+          }
+        }
+      }));
 
     Ok(SystemTrayHandle {
       context: self.context.clone(),
       id,
-      proxy: self.event_loop.create_proxy(),
+      proxy: self.context.proxy.clone(),
+      pending,
     })
   }
 
@@ -2210,6 +2232,8 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
     #[cfg(all(desktop, feature = "system-tray"))]
     let system_tray_manager = self.context.main_thread.system_tray_manager.clone();
 
+    let pending_ready_tasks = &self.pending_ready_tasks;
+
     #[cfg(feature = "tracing")]
     let active_tracing_spans = self.context.main_thread.active_tracing_spans.clone();
 
@@ -2248,6 +2272,7 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
               system_tray_manager: system_tray_manager.clone(),
               #[cfg(feature = "tracing")]
               active_tracing_spans: active_tracing_spans.clone(),
+              pending_ready_tasks,
             },
             web_context,
           );
@@ -2272,6 +2297,7 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
             system_tray_manager: system_tray_manager.clone(),
             #[cfg(feature = "tracing")]
             active_tracing_spans: active_tracing_spans.clone(),
+            pending_ready_tasks,
           },
           web_context,
         );
@@ -2284,6 +2310,7 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
     let windows = self.context.main_thread.windows.clone();
     let webview_id_map = self.context.webview_id_map.clone();
     let web_context = self.context.main_thread.web_context.clone();
+    let pending_ready_tasks = self.pending_ready_tasks;
     let mut plugins = self.plugins;
 
     #[cfg(feature = "tracing")]
@@ -2318,6 +2345,7 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
             system_tray_manager: system_tray_manager.clone(),
             #[cfg(feature = "tracing")]
             active_tracing_spans: active_tracing_spans.clone(),
+            pending_ready_tasks: &pending_ready_tasks,
           },
           &web_context,
         );
@@ -2341,6 +2369,7 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
           system_tray_manager: system_tray_manager.clone(),
           #[cfg(feature = "tracing")]
           active_tracing_spans: active_tracing_spans.clone(),
+          pending_ready_tasks: &pending_ready_tasks,
         },
         &web_context,
       );
@@ -2360,6 +2389,7 @@ pub struct EventLoopIterationContext<'a, T: UserEvent> {
   pub system_tray_manager: SystemTrayManager,
   #[cfg(feature = "tracing")]
   pub active_tracing_spans: ActiveTraceSpanStore,
+  pub pending_ready_tasks: &'a RefCell<Vec<PendingReadyTask<T>>>,
 }
 
 struct UserMessageContext {
@@ -2817,6 +2847,7 @@ fn handle_event_loop<T: UserEvent>(
     system_tray_manager,
     #[cfg(feature = "tracing")]
     active_tracing_spans,
+    pending_ready_tasks,
   } = context;
   if *control_flow != ControlFlow::Exit {
     *control_flow = ControlFlow::Wait;
@@ -2824,6 +2855,10 @@ fn handle_event_loop<T: UserEvent>(
 
   match event {
     Event::NewEvents(StartCause::Init) => {
+      for task in pending_ready_tasks.replace(Vec::new()) {
+        task(event_loop);
+      }
+
       callback(RunEvent::Ready);
     }
 

--- a/core/tauri-runtime-wry/src/system_tray.rs
+++ b/core/tauri-runtime-wry/src/system_tray.rs
@@ -161,69 +161,102 @@ pub struct SystemTrayHandle<T: UserEvent> {
   pub(crate) context: Context<T>,
   pub(crate) id: TrayId,
   pub(crate) proxy: EventLoopProxy<super::Message<T>>,
+  pub(crate) pending: PendingSystemTray,
 }
 
 impl<T: UserEvent> TrayHandle for SystemTrayHandle<T> {
   fn set_icon(&self, icon: Icon) -> Result<()> {
-    self
-      .proxy
-      .send_event(Message::Tray(self.id, TrayMessage::UpdateIcon(icon)))
-      .map_err(|_| Error::FailedToSendMessage)
+    if let Some(pending) = &mut *self.pending.0.borrow_mut() {
+      pending.icon.replace(icon);
+      Ok(())
+    } else {
+      self
+        .proxy
+        .send_event(Message::Tray(self.id, TrayMessage::UpdateIcon(icon)))
+        .map_err(|_| Error::FailedToSendMessage)
+    }
   }
 
   fn set_menu(&self, menu: SystemTrayMenu) -> Result<()> {
-    self
-      .proxy
-      .send_event(Message::Tray(self.id, TrayMessage::UpdateMenu(menu)))
-      .map_err(|_| Error::FailedToSendMessage)
+    if let Some(pending) = &mut *self.pending.0.borrow_mut() {
+      pending.menu.replace(menu);
+      Ok(())
+    } else {
+      self
+        .proxy
+        .send_event(Message::Tray(self.id, TrayMessage::UpdateMenu(menu)))
+        .map_err(|_| Error::FailedToSendMessage)
+    }
   }
 
   fn update_item(&self, id: u16, update: MenuUpdate) -> Result<()> {
-    self
-      .proxy
-      .send_event(Message::Tray(self.id, TrayMessage::UpdateItem(id, update)))
-      .map_err(|_| Error::FailedToSendMessage)
+    if let Some(_pending) = &mut *self.pending.0.borrow_mut() {
+      // do nothing
+      Ok(())
+    } else {
+      self
+        .proxy
+        .send_event(Message::Tray(self.id, TrayMessage::UpdateItem(id, update)))
+        .map_err(|_| Error::FailedToSendMessage)
+    }
   }
 
   #[cfg(target_os = "macos")]
   fn set_icon_as_template(&self, is_template: bool) -> tauri_runtime::Result<()> {
-    self
-      .proxy
-      .send_event(Message::Tray(
-        self.id,
-        TrayMessage::UpdateIconAsTemplate(is_template),
-      ))
-      .map_err(|_| Error::FailedToSendMessage)
+    if let Some(pending) = &mut *self.pending.0.borrow_mut() {
+      pending.icon_as_template = is_template;
+      Ok(())
+    } else {
+      self
+        .proxy
+        .send_event(Message::Tray(
+          self.id,
+          TrayMessage::UpdateIconAsTemplate(is_template),
+        ))
+        .map_err(|_| Error::FailedToSendMessage)
+    }
   }
 
   #[cfg(target_os = "macos")]
   fn set_title(&self, title: &str) -> tauri_runtime::Result<()> {
-    self
-      .proxy
-      .send_event(Message::Tray(
-        self.id,
-        TrayMessage::UpdateTitle(title.to_owned()),
-      ))
-      .map_err(|_| Error::FailedToSendMessage)
+    if let Some(pending) = &mut *self.pending.0.borrow_mut() {
+      pending.title.replace(title.to_string());
+      Ok(())
+    } else {
+      self
+        .proxy
+        .send_event(Message::Tray(
+          self.id,
+          TrayMessage::UpdateTitle(title.to_owned()),
+        ))
+        .map_err(|_| Error::FailedToSendMessage)
+    }
   }
 
   fn set_tooltip(&self, tooltip: &str) -> Result<()> {
-    self
-      .proxy
-      .send_event(Message::Tray(
-        self.id,
-        TrayMessage::UpdateTooltip(tooltip.to_owned()),
-      ))
-      .map_err(|_| Error::FailedToSendMessage)
+    if let Some(pending) = &mut *self.pending.0.borrow_mut() {
+      pending.tooltip.replace(tooltip.to_string());
+      Ok(())
+    } else {
+      self
+        .proxy
+        .send_event(Message::Tray(
+          self.id,
+          TrayMessage::UpdateTooltip(tooltip.to_owned()),
+        ))
+        .map_err(|_| Error::FailedToSendMessage)
+    }
   }
 
   fn destroy(&self) -> Result<()> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    send_user_message(
-      &self.context,
-      Message::Tray(self.id, TrayMessage::Destroy(tx)),
-    )?;
-    rx.recv().unwrap()?;
+    if self.pending.0.borrow_mut().take().is_none() {
+      let (tx, rx) = std::sync::mpsc::channel();
+      send_user_message(
+        &self.context,
+        Message::Tray(self.id, TrayMessage::Destroy(tx)),
+      )?;
+      rx.recv().unwrap()?;
+    }
     Ok(())
   }
 }
@@ -267,3 +300,14 @@ pub fn to_wry_context_menu(
   }
   tray_menu
 }
+
+#[derive(Debug, Clone)]
+pub struct PendingSystemTray(pub Arc<RefCell<Option<SystemTray>>>);
+
+// SAFETY: we ensure this type is only used on the main thread.
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl Send for PendingSystemTray {}
+
+// SAFETY: we ensure this type is only used on the main thread.
+#[allow(clippy::non_send_fields_in_send_ty)]
+unsafe impl Sync for PendingSystemTray {}


### PR DESCRIPTION
closes #9480

see https://github.com/tauri-apps/tray-icon/pull/122

this PR is kinda dangerous, reviewing this CRAZY workaround might make you never want to open github again