### PR TITLE
fix(bundler): armv7 appimage bundler script 404 links [closes #6579]

### DIFF
--- a/.changes/change-pr-10619.md
+++ b/.changes/change-pr-10619.md
@@ -1,18 +1,5 @@
 ---
-"@tauri-apps/api": patch
-"tauri-utils": patch
-"tauri-macos-sign": patch
-"tauri-bundler": patch
-"tauri-runtime": patch
-"tauri-runtime-wry": patch
-"tauri-codegen": patch
-"tauri-macros": patch
-"tauri-plugin": patch
-"tauri-build": patch
-"tauri": patch
-"@tauri-apps/cli": patch
-"tauri-cli": patch
-"tauri-driver": patch
+"tauri-bundler": "patch:bug"
 ---
 
-fix(bundler): armv7 
+Fixed an issue that caused the bundler to not be able to download the AppImage tooling when building for ARM 32bit.

--- a/.changes/change-pr-10619.md
+++ b/.changes/change-pr-10619.md
@@ -1,0 +1,18 @@
+---
+"@tauri-apps/api": patch
+"tauri-utils": patch
+"tauri-macos-sign": patch
+"tauri-bundler": patch
+"tauri-runtime": patch
+"tauri-runtime-wry": patch
+"tauri-codegen": patch
+"tauri-macros": patch
+"tauri-plugin": patch
+"tauri-build": patch
+"tauri": patch
+"@tauri-apps/cli": patch
+"tauri-cli": patch
+"tauri-driver": patch
+---
+
+fix(bundler): armv7 

--- a/tooling/bundler/src/bundle/linux/appimage.rs
+++ b/tooling/bundler/src/bundle/linux/appimage.rs
@@ -27,7 +27,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let arch = match settings.binary_arch() {
     "x86" => "i386",
     "x86_64" => "amd64",
-    "armv7" => "armhf"
+    "armv7" => "armhf",
     other => other,
   };
   let package_dir = settings.project_out_directory().join("bundle/appimage_deb");

--- a/tooling/bundler/src/bundle/linux/appimage.rs
+++ b/tooling/bundler/src/bundle/linux/appimage.rs
@@ -27,6 +27,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let arch = match settings.binary_arch() {
     "x86" => "i386",
     "x86_64" => "amd64",
+    "armv7" => "armhf"
     other => other,
   };
   let package_dir = settings.project_out_directory().join("bundle/appimage_deb");


### PR DESCRIPTION
[closed #6579]

The appimage bundler on armv7 use error link, The fix is ​​given in [#6579]