### PR TITLE
fix(cli): only validate iOS lib on debug builds

### DIFF
--- a/.changes/only-validate-ios-lib-debug.md
+++ b/.changes/only-validate-ios-lib-debug.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Only validate the output iOS library on debug builds.

--- a/tooling/cli/src/mobile/ios/xcode_script.rs
+++ b/tooling/cli/src/mobile/ios/xcode_script.rs
@@ -217,7 +217,10 @@ pub fn command(options: Options) -> Result<()> {
       return Err(anyhow::anyhow!("Library not found at {}. Make sure your Cargo.toml file has a [lib] block with `crate-type = [\"staticlib\", \"cdylib\", \"lib\"]`", lib_path.display()));
     }
 
-    validate_lib(&lib_path)?;
+    // for some reason the app works on release, but `nm <path>` does not print the start_app symbol
+    if profile == Profile::Debug {
+      validate_lib(&lib_path)?;
+    }
 
     let project_dir = config.project_dir();
     let externals_lib_dir = project_dir.join(format!("Externals/{arch}/{}", profile.as_str()));


### PR DESCRIPTION
for some reason the app works on release, but `nm <path>` does not print the start_app symbol.. I couldn't find a solution

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
