### PR TITLE
feat(bundler): infer signing identity from certificate to import

### DIFF
--- a/.changes/infer-signing-identity.md
+++ b/.changes/infer-signing-identity.md
@@ -1,0 +1,7 @@
+---
+"tauri-bundler": patch:enhance
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Infer macOS codesign identity from the `APPLE_CERTIFICATE` environment variable when provided, meaning the identity no longer needs to be provided when signing on CI using that option. If the imported certificate name does not match a provided signingIdentity configuration, an error is returned.

--- a/tooling/bundler/src/bundle/macos/app.rs
+++ b/tooling/bundler/src/bundle/macos/app.rs
@@ -105,7 +105,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   copy_custom_files_to_bundle(&bundle_directory, settings)?;
 
-  if let Some(identity) = &settings.macos().signing_identity {
+  if let Some(keychain) = super::sign::keychain(settings.macos().signing_identity.as_deref())? {
     // Sign frameworks and sidecar binaries first, per apple, signing must be done inside out
     // https://developer.apple.com/forums/thread/701514
     sign_paths.push(SignTarget {
@@ -118,7 +118,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     remove_extra_attr(&app_bundle_path)?;
 
     // sign application
-    let keychain = sign(sign_paths, identity, settings)?;
+    sign(&keychain, sign_paths, settings)?;
 
     // notarization is required for distribution
     match notarize_auth() {

--- a/tooling/bundler/src/bundle/macos/dmg.rs
+++ b/tooling/bundler/src/bundle/macos/dmg.rs
@@ -186,13 +186,14 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
   fs::rename(bundle_dir.join(dmg_name), dmg_path.clone())?;
 
   // Sign DMG if needed
-  if let Some(identity) = &settings.macos().signing_identity {
+
+  if let Some(keychain) = super::sign::keychain(settings.macos().signing_identity.as_deref())? {
     super::sign::sign(
+      &keychain,
       vec![super::sign::SignTarget {
         path: dmg_path.clone(),
         is_an_executable: false,
       }],
-      identity,
       settings,
     )?;
   }

--- a/tooling/cli/ENVIRONMENT_VARIABLES.md
+++ b/tooling/cli/ENVIRONMENT_VARIABLES.md
@@ -31,9 +31,9 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `API_PRIVATE_KEYS_DIR` — Specify the directory where your AuthKey file is located. See `APPLE_API_KEY`.
 - `APPLE_API_ISSUER` — Issuer ID. Required if `APPLE_API_KEY` is specified.
 - `APPLE_API_KEY_PATH` - path to the API key `.p8` file. If not specified, the bundler searches the following directories in sequence for a private key file with the name of 'AuthKey\_<api_key>.p8': './private_keys', '~/private_keys', '~/.private_keys', and '~/.appstoreconnect/private_keys'.
-- `APPLE_SIGNING_IDENTITY` — The identity used to code sign. Overwrites `tauri.conf.json > bundle > macOS > signingIdentity`.
+- `APPLE_SIGNING_IDENTITY` — The identity used to code sign. Overwrites `tauri.conf.json > bundle > macOS > signingIdentity`. If neither are set, it is inferred from `APPLE_CERTIFICATE` when provided.
 - `APPLE_PROVIDER_SHORT_NAME` — If your Apple ID is connected to multiple teams, you have to specify the provider short name of the team you want to use to notarize your app. Overwrites `tauri.conf.json > bundle > macOS > providerShortName`.
-- `APPLE_DEVELOPMENT_TEAM` — TODO
+- `APPLE_DEVELOPMENT_TEAM` — The team ID used to code sign on iOS. Overwrites `tauri.conf.json > bundle > iOS > developmentTeam`. Can be found in https://developer.apple.com/account#MembershipDetailsCard.
 - `TAURI_WEBVIEW_AUTOMATION` — Enables webview automation (Linux Only).
 - `TAURI_ANDROID_PROJECT_PATH` — Path of the tauri android project, usually will be `<project>/src-tauri/gen/android`.
 - `TAURI_IOS_PROJECT_PATH` — Path of the tauri iOS project, usually will be `<project>/src-tauri/gen/ios`.


### PR DESCRIPTION
Changes the bundler to not require the signingIdentity configuration (which either comes from tauri.conf.json or APPLE_SIGNING_IDENTITY env var) by pulling the value from the certificate to import (APPLE_CERTIFICATE env var).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
