### PR TITLE
skip prepublish on api

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -134,38 +134,6 @@
     "@tauri-apps/api": {
       "path": "./tooling/api",
       "manager": "javascript",
-      "assets": [
-        {
-          "path": "./tooling/api/dist/tauri-apps-api-${ pkgFile.version }.tgz",
-          "name": "tauri-apps-api-${ pkgFile.version }.tgz"
-        }
-      ],
-      "prepublish": [
-        {
-          "command": "pnpm i --frozen-lockfile",
-          "dryRunCommand": true
-        },
-        {
-          "command": "echo '<details>\n<summary><em><h4>PNPM Audit</h4></em></summary>\n\n```'",
-          "dryRunCommand": true,
-          "pipe": true
-        },
-        {
-          "command": "pnpm audit",
-          "dryRunCommand": true,
-          "runFromRoot": true,
-          "pipe": true
-        },
-        {
-          "command": "echo '```\n\n</details>\n'",
-          "dryRunCommand": true,
-          "pipe": true
-        },
-        {
-          "command": "pnpm npm-pack",
-          "dryRunCommand": true
-        }
-      ],
       "publish": [
         {
           "command": "echo '<details>\n<summary><em><h4>PNPM Publish</h4></em></summary>\n\n```'",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

## Motivation

Trying to reduce the publish config. I removed the prepublish step which it can pull from the generic javascript manager docs.
