### PR TITLE
fix: Correctly export `DefaultPermissionsRule`

### DIFF
--- a/.changes/fix-export-default-permissions.md
+++ b/.changes/fix-export-default-permissions.md
@@ -1,5 +1,5 @@
 ---
-"tauri-build": patch:fix
+"tauri-build": patch:bug
 ---
 
 Correctly export `DefaultPermissionsRule`

--- a/.changes/fix-export-default-permissions.md
+++ b/.changes/fix-export-default-permissions.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch:fix
+---
+
+Correctly export `DefaultPermissionsRule`

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -40,7 +40,7 @@ mod static_vcruntime;
 #[cfg_attr(docsrs, doc(cfg(feature = "codegen")))]
 pub use codegen::context::CodegenContext;
 
-pub use acl::{AppManifest, InlinedPlugin, DefaultPermissionRule};
+pub use acl::{AppManifest, DefaultPermissionRule, InlinedPlugin};
 
 const ACL_MANIFESTS_FILE_NAME: &str = "acl-manifests.json";
 const CAPABILITIES_FILE_NAME: &str = "capabilities.json";

--- a/core/tauri-build/src/lib.rs
+++ b/core/tauri-build/src/lib.rs
@@ -40,7 +40,7 @@ mod static_vcruntime;
 #[cfg_attr(docsrs, doc(cfg(feature = "codegen")))]
 pub use codegen::context::CodegenContext;
 
-pub use acl::{AppManifest, InlinedPlugin};
+pub use acl::{AppManifest, InlinedPlugin, DefaultPermissionRule};
 
 const ACL_MANIFESTS_FILE_NAME: &str = "acl-manifests.json";
 const CAPABILITIES_FILE_NAME: &str = "capabilities.json";


### PR DESCRIPTION
Fixes bug introduced in #10559 which made impossible to use 
```rs
default_permission(DefaultPermissionRule::AllowAllCommands)
```
