### PR TITLE
fix(cli): adapt Package.swift to work on older Swift versions

### DIFF
--- a/.changes/fix-ios-build-older-swift.md
+++ b/.changes/fix-ios-build-older-swift.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Fix Swift plugin compilation on older versions.

--- a/examples/api/src-tauri/tauri-plugin-sample/ios/Package.swift
+++ b/examples/api/src-tauri/tauri-plugin-sample/ios/Package.swift
@@ -8,6 +8,7 @@ import PackageDescription
 let package = Package(
     name: "tauri-plugin-sample",
     platforms: [
+        .macOS(.v10_13),
         .iOS(.v13),
     ],
     products: [

--- a/tooling/cli/templates/plugin/ios-spm/Package.swift
+++ b/tooling/cli/templates/plugin/ios-spm/Package.swift
@@ -6,6 +6,7 @@ import PackageDescription
 let package = Package(
     name: "tauri-plugin-{{ plugin_name }}",
     platforms: [
+        .macOS(.v10_13),
         .iOS(.v13),
     ],
     products: [


### PR DESCRIPTION
I noticed the plugin build fails on older Swift (tested on macOS 12) because the default minimum required macOS version (10.10 in my case) is older than `v10_13` which is set by the Tauri iOS package (and also swift-rs). So the plugins must explicitly define a minimum macOS version too.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
