### PR TITLE
fix(cli): `add` should use 2.0.0-rc for known plugins

### DIFF
--- a/.changes/fix-cli-add-plugin-version.md
+++ b/.changes/fix-cli-add-plugin-version.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Changed the `add` command to use a version requirement that matches the CLI's stable and prerelease numbers.

--- a/tooling/cli/src/add.rs
+++ b/tooling/cli/src/add.rs
@@ -68,6 +68,8 @@ pub fn run(options: Options) -> Result<()> {
         .then_some(r#"cfg(any(target_os = "android", target_os = "ios"))"#)
     });
 
+  let version = version.or(metadata.version_req.as_deref());
+
   cargo::install_one(cargo::CargoInstallOptions {
     name: &crate_name,
     version,

--- a/tooling/cli/src/helpers/plugins.rs
+++ b/tooling/cli/src/helpers/plugins.rs
@@ -10,6 +10,7 @@ pub struct PluginMetadata {
   pub mobile_only: bool,
   pub rust_only: bool,
   pub builder: bool,
+  pub version_req: Option<String>,
 }
 
 // known plugins with particular cases
@@ -55,5 +56,40 @@ pub fn known_plugins() -> HashMap<&'static str, PluginMetadata> {
     plugins.entry(p).or_default().rust_only = true;
   }
 
+  // known, but no particular config
+  for p in [
+    "geolocation",
+    "deep-link",
+    "dialog",
+    "fs",
+    "http",
+    "notification",
+    "os",
+    "process",
+    "shell",
+    "upload",
+    "websocket",
+  ] {
+    plugins.entry(p).or_default();
+  }
+
+  let version_req = version_req();
+  for plugin in plugins.values_mut() {
+    plugin.version_req.replace(version_req.clone());
+  }
+
   plugins
+}
+
+fn version_req() -> String {
+  let pre = env!("CARGO_PKG_VERSION_PRE");
+  if pre.is_empty() {
+    env!("CARGO_PKG_VERSION_MAJOR").to_string()
+  } else {
+    format!(
+      "{}.0.0-{}",
+      env!("CARGO_PKG_VERSION_MAJOR"),
+      pre.split('.').next().unwrap()
+    )
+  }
 }

--- a/tooling/cli/src/migrate/migrations/v1/frontend.rs
+++ b/tooling/cli/src/migrate/migrations/v1/frontend.rs
@@ -65,10 +65,8 @@ pub fn migrate(app_dir: &Path) -> Result<Vec<String>> {
     format!("{}.0.0", env!("CARGO_PKG_VERSION_MAJOR"))
   } else {
     format!(
-      "{}.{}.{}-{}.0",
+      "{}.0.0-{}.0",
       env!("CARGO_PKG_VERSION_MAJOR"),
-      env!("CARGO_PKG_VERSION_MINOR"),
-      env!("CARGO_PKG_VERSION_PATCH"),
       pre.split('.').next().unwrap()
     )
   };

--- a/tooling/cli/src/migrate/migrations/v1/manifest.rs
+++ b/tooling/cli/src/migrate/migrations/v1/manifest.rs
@@ -198,10 +198,8 @@ fn dependency_version() -> String {
     env!("CARGO_PKG_VERSION_MAJOR").to_string()
   } else {
     format!(
-      "{}.{}.{}-{}",
+      "{}.0.0-{}",
       env!("CARGO_PKG_VERSION_MAJOR"),
-      env!("CARGO_PKG_VERSION_MINOR"),
-      env!("CARGO_PKG_VERSION_PATCH"),
       pre.split('.').next().unwrap()
     )
   }


### PR DESCRIPTION
changes the CLI `add` command to match the CLI major and pre requirements for known plugins

this is required because right now adding the deep-link plugin installs the v1 plugin (latest version known by cargo as the v2 is still in RC), even though we're running the v2 CLI

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
