### PR TITLE
fix: generate `Context` inside a thread

### DIFF
--- a/.changes/fix-context-stack-size.md
+++ b/.changes/fix-context-stack-size.md
@@ -1,0 +1,5 @@
+---
+"tauri-codegen": patch:bug
+---
+
+Generate context in a separate thread to prevent a stack overflow.


### PR DESCRIPTION
fix #9882

this is a workaround for #9882 due to windows having a small stack size for the main thread (1MiB) versus other platforms which have 8MiB. the true fix would be to lower the generated code stack size, but with lots a plugins, there are lots of ACL configurations.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
