### PR TITLE
support 1.x automation env var in `tauri-driver`

### DIFF
--- a/.changes/tauri-driver-1.x.md
+++ b/.changes/tauri-driver-1.x.md
@@ -1,0 +1,5 @@
+---
+"tauri-driver": patch:bug
+---
+
+support both 1.x and 2.x automation env vars in `tauri-driver`

--- a/tooling/webdriver/src/webdriver.rs
+++ b/tooling/webdriver/src/webdriver.rs
@@ -45,7 +45,8 @@ pub fn native(args: &Args) -> Command {
   };
 
   let mut cmd = Command::new(native_binary);
-  cmd.env("TAURI_WEBVIEW_AUTOMATION", "true");
+  cmd.env("TAURI_AUTOMATION", "true"); // 1.x
+  cmd.env("TAURI_WEBVIEW_AUTOMATION", "true"); // 2.x
   cmd.arg(format!("--port={}", args.native_port));
   cmd.arg(format!("--host={}", args.native_host));
   cmd


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update docstrings
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
the env var for automation changed in 2.x, but that update for `tauri-driver` was released as a patch causing breakage for everyone not pinned to a specific patch version