### PR TITLE
fix(cli): change supported URL Type "link:" in plugin template

### DIFF
--- a/tooling/cli/templates/plugin/__example-api/tauri-app/package.json
+++ b/tooling/cli/templates/plugin/__example-api/tauri-app/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0-alpha.11",
-    "tauri-plugin-{{ plugin_name }}-api": "link:../../"
+    "tauri-plugin-{{ plugin_name }}-api": "file:../../"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.1",


### PR DESCRIPTION
npm unsupported URL Type "link:". This is support yarn. So changed it to a "file:" that both support.

closes https://github.com/tauri-apps/tauri/issues/10770

---

Note: yarn works is changed:
- link: https://yarnpkg.com/protocol/link
- file: https://yarnpkg.com/protocol/file

In the future, it may be necessary to have a separate file.
