### PR TITLE
fix(cli): do not exit mobile dev if logger could not be attached

### DIFF
--- a/.changes/do-not-exit-on-log-fail.md
+++ b/.changes/do-not-exit-on-log-fail.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Do not quit `ios dev` and `android dev` process when we fail to attach the logger.

--- a/tooling/cli/src/mobile/android/dev.rs
+++ b/tooling/cli/src/mobile/android/dev.rs
@@ -212,8 +212,6 @@ fn run_dev(
   )?;
 
   let open = options.open;
-  let exit_on_panic = options.exit_on_panic;
-  let no_watch = options.no_watch;
   interface.mobile_dev(
     MobileOptions {
       debug: !options.release_mode,
@@ -247,12 +245,7 @@ fn run_dev(
         open_and_wait(config, &env)
       } else if let Some(device) = &device {
         match run(device, options, config, &env, metadata, noise_level) {
-          Ok(c) => {
-            crate::dev::wait_dev_process(c.clone(), move |status, reason| {
-              crate::dev::on_app_exit(status, reason, exit_on_panic, no_watch)
-            });
-            Ok(Box::new(c) as Box<dyn DevProcess + Send>)
-          }
+          Ok(c) => Ok(Box::new(c) as Box<dyn DevProcess + Send>),
           Err(e) => {
             crate::dev::kill_before_dev_process();
             Err(e)

--- a/tooling/cli/src/mobile/ios/dev.rs
+++ b/tooling/cli/src/mobile/ios/dev.rs
@@ -369,8 +369,6 @@ fn run_dev(
   let set_host = options.host.is_some();
 
   let open = options.open;
-  let exit_on_panic = options.exit_on_panic;
-  let no_watch = options.no_watch;
   interface.mobile_dev(
     MobileOptions {
       debug: true,
@@ -401,12 +399,7 @@ fn run_dev(
         open_and_wait(config, &env)
       } else if let Some(device) = &device {
         match run(device, options, config, &env) {
-          Ok(c) => {
-            crate::dev::wait_dev_process(c.clone(), move |status, reason| {
-              crate::dev::on_app_exit(status, reason, exit_on_panic, no_watch)
-            });
-            Ok(Box::new(c) as Box<dyn DevProcess + Send>)
-          }
+          Ok(c) => Ok(Box::new(c) as Box<dyn DevProcess + Send>),
           Err(e) => {
             crate::dev::kill_before_dev_process();
             Err(e)


### PR DESCRIPTION
I just faced this when I was connected to my iPhone but wireless. Xcode also lets this happen, you only miss the logs in this case.

