### PR TITLE
fix(cli): `add` command version requirement for known plugin npm

### DIFF
--- a/.changes/fix-add-plugin-npm-version-req.md
+++ b/.changes/fix-add-plugin-npm-version-req.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Fix the `add` command NPM version specifier for known plugins from `2.0.0-rc` (unknown version requirement) to `^2.0.0-rc`.


### PR DESCRIPTION
small regression from #10699 - NPM install is now prompting users to select the version
