### PR TITLE
fix(docs): typo in documentation of `setSize()` method in Webview API.

### DIFF
--- a/tooling/api/src/webview.ts
+++ b/tooling/api/src/webview.ts
@@ -526,7 +526,7 @@ class Webview {
    *
    * @example
    * ```typescript
-   * import { getCurrent } from "@tauri-apps/api/webview";
+   * import { getCurrentWebview } from "@tauri-apps/api/webview";
    * const unlisten = await getCurrentWebview().onDragDropEvent((event) => {
    *  if (event.payload.type === 'hover') {
    *    console.log('User hovering', event.payload.paths);


### PR DESCRIPTION
The example for the `setSize()` method in the documentation for the Webview api wrongly imports `getCurrent` (I believe as was in tauri v1) instead of `getCurrentWebview`.