### PR TITLE
feat(cli): synchronize Tauri config and lib name with iOS Xcode project

### DIFF
--- a/.changes/synchronize-config-and-xcode-project.md
+++ b/.changes/synchronize-config-and-xcode-project.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Synchronize identifier, development team and lib name with the iOS Xcode project.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-mobile2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1baf430f92ddf6e492c9186e4e97dc3051366345b8aa7ffdc0e0f952c9a35b"
+checksum = "d0b8132519bea2d46174e777bd36d480d93afbe1df31c27cacfb411ff152bba1"
 dependencies = [
  "colored",
  "core-foundation 0.10.0",

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -36,7 +36,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
-cargo-mobile2 = { version = "0.15", default-features = false }
+cargo-mobile2 = { version = "0.15.1", default-features = false }
 
 [dependencies]
 jsonrpsee = { version = "0.24", features = ["server"] }

--- a/crates/tauri-cli/src/helpers/pbxproj.rs
+++ b/crates/tauri-cli/src/helpers/pbxproj.rs
@@ -230,12 +230,14 @@ impl Pbxproj {
       .iter_mut()
       .find(|s| s.key == key)
     {
-      let Some(line) = self.raw_lines.get_mut(build_setting.line_number) else {
-        return;
-      };
+      if build_setting.value != value {
+        let Some(line) = self.raw_lines.get_mut(build_setting.line_number) else {
+          return;
+        };
 
-      *line = format!("{}{key} = {value};", build_setting.identation);
-      self.has_changes = true;
+        *line = format!("{}{key} = {value};", build_setting.identation);
+        self.has_changes = true;
+      }
     } else {
       let Some(last_build_setting) = build_configuration.build_settings.last().cloned() else {
         return;

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -146,7 +146,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
     tauri_utils::platform::Target::Ios,
     options.config.as_ref().map(|c| &c.0),
   )?;
-  let (interface, app, mut config) = {
+  let (interface, mut config) = {
     let tauri_config_guard = tauri_config.lock().unwrap();
     let tauri_config_ = tauri_config_guard.as_ref().unwrap();
 
@@ -160,7 +160,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
       build_options.features.as_ref(),
       &Default::default(),
     );
-    (interface, app, config)
+    (interface, config)
   };
 
   let tauri_path = tauri_dir();
@@ -198,7 +198,8 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   // synchronize pbxproj and exportoptions
   synchronize_project_config(
-    &app,
+    &config,
+    &tauri_config,
     &mut pbxproj,
     &mut export_options_plist,
     &project_config,

--- a/crates/tauri-cli/src/mobile/ios/project.rs
+++ b/crates/tauri-cli/src/mobile/ios/project.rs
@@ -4,6 +4,7 @@
 
 use crate::{
   helpers::{config::Config as TauriConfig, template},
+  mobile::ios::LIB_OUTPUT_FILE_NAME,
   Result,
 };
 use anyhow::Context;
@@ -75,6 +76,8 @@ pub fn gen(
   let default_archs = ["arm64", "arm64-sim"];
   #[cfg(not(target_arch = "aarch64"))]
   let default_archs = ["arm64", "x86_64"];
+
+  map.insert("lib-output-file-name", LIB_OUTPUT_FILE_NAME);
 
   map.insert("file-groups", &source_dirs);
   map.insert("ios-frameworks", metadata.ios().frameworks());

--- a/crates/tauri-cli/src/mobile/mod.rs
+++ b/crates/tauri-cli/src/mobile/mod.rs
@@ -329,17 +329,16 @@ fn ensure_init(
     }
     #[cfg(target_os = "macos")]
     Target::Ios => {
-      let project_yml = read_to_string(project_dir.join("project.yml"))
-        .context("missing project.yml file in the Xcode project directory")?;
-      if !project_yml.contains(&format!(
-        "PRODUCT_BUNDLE_IDENTIFIER: {}",
-        tauri_config_.identifier.replace('_', "-")
-      )) {
-        project_outdated_reasons
-          .push("you have modified your \"identifier\" in the Tauri configuration");
-      }
+      let pbxproj_contents = read_to_string(
+        project_dir
+          .join(format!("{}.xcodeproj", app.name()))
+          .join("project.pbxproj"),
+      )
+      .context("missing project.yml file in the Xcode project directory")?;
 
-      if !project_yml.contains(&format!("framework: lib{}.a", app.lib_name())) {
+      if !(pbxproj_contents.contains(ios::LIB_OUTPUT_FILE_NAME)
+        || pbxproj_contents.contains(&format!("lib{}.a", app.lib_name())))
+      {
         project_outdated_reasons
           .push("you have modified your [lib.name] or [package.name] in the Cargo.toml file");
       }

--- a/crates/tauri-cli/templates/mobile/ios/project.yml
+++ b/crates/tauri-cli/templates/mobile/ios/project.yml
@@ -86,7 +86,7 @@ targets:
         EXCLUDED_ARCHS[sdk=iphoneos*]: arm64-sim x86_64
       groups: [app]
     dependencies:
-      - framework: lib{{app.lib-name}}.a
+      - framework: {{ lib-output-file-name }}
         embed: false
       {{~#each ios-libraries}}
       - framework: {{this}}
@@ -125,9 +125,9 @@ targets:
         name: Build Rust Code
         basedOnDependencyAnalysis: false
         outputFiles:
-          - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/lib{{app.lib-name}}.a
-          - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/lib{{app.lib-name}}.a
-          - $(SRCROOT)/Externals/arm64-sim/${CONFIGURATION}/lib{{app.lib-name}}.a
+          - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/{{ lib-output-file-name }}
+          - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/{{ lib-output-file-name }}
+          - $(SRCROOT)/Externals/arm64-sim/${CONFIGURATION}/{{ lib-output-file-name }}
     {{~#if ios-post-compile-scripts}}
     postCompileScripts:
       {{~#each ios-post-compile-scripts}}{{#if this.path}}


### PR DESCRIPTION
- the Xcode project now uses a fixed output library name, which means changes to the Cargo.toml lib name won't affect it (backwards compatible change, we're checking if this new format is being used or not by reading the project.pbxproj)
- sync config identifier with the pbxproj
- sync development team config with the pbxproj

the sync runs both on dev and on build
