### PR TITLE
chore: add root taurignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 /.changes
-/.husky
 /audits
 /.vscode
 

--- a/.taurignore
+++ b/.taurignore
@@ -1,0 +1,10 @@
+packages/api
+packages/cli
+crates/tauri-cli
+crates/tauri-bundler
+crates/tauri-driver
+crates/tauri-macos-sign
+crates/tauri-schema-generator
+crates/tests
+bench
+.changes

--- a/.taurignore
+++ b/.taurignore
@@ -1,3 +1,11 @@
+.changes
+.devcontainer
+.docker
+.github
+.scripts
+.vscode
+audits
+bench
 packages/api
 packages/cli
 crates/tauri-cli
@@ -6,5 +14,3 @@ crates/tauri-driver
 crates/tauri-macos-sign
 crates/tauri-schema-generator
 crates/tests
-bench
-.changes


### PR DESCRIPTION
enhances the DX of running `tauri dev` in any of the examples folder - we don't need to watch the entire workspace for changes
