### PR TITLE
fix(windows): Handle root paths that cannot be canonicalized

### DIFF
--- a/crates/tauri/src/scope/fs.rs
+++ b/crates/tauri/src/scope/fs.rs
@@ -94,7 +94,6 @@ fn push_pattern<P: AsRef<Path>, F: Fn(&str) -> Result<Pattern, glob::PatternErro
 
   list.insert(f(&path.to_string_lossy())?);
 
-  let mut path = path;
   let mut checked_path = None;
 
   // attempt to canonicalize parents in case we have a path like `/data/user/0/appid/**`

--- a/crates/tauri/src/scope/fs.rs
+++ b/crates/tauri/src/scope/fs.rs
@@ -345,11 +345,15 @@ fn escaped_pattern(p: &str) -> Result<Pattern, glob::PatternError> {
 }
 
 fn escaped_pattern_with(p: &str, append: &str) -> Result<Pattern, glob::PatternError> {
-  Pattern::new(&format!(
-    "{}{}{append}",
-    glob::Pattern::escape(p),
-    MAIN_SEPARATOR
-  ))
+  if p.ends_with(MAIN_SEPARATOR) {
+    Pattern::new(&format!("{}{append}", glob::Pattern::escape(p)))
+  } else {
+    Pattern::new(&format!(
+      "{}{}{append}",
+      glob::Pattern::escape(p),
+      MAIN_SEPARATOR
+    ))
+  }
 }
 
 #[cfg(test)]
@@ -482,10 +486,7 @@ mod tests {
       scope.allow_directory("\\\\localhost\\c$", true).unwrap();
       assert!(scope.is_allowed("\\\\localhost\\c$"));
       assert!(scope.is_allowed("\\\\localhost\\c$\\Windows"));
-      // Does not work because push_pattern adds a trailing backslash to the base
-      // pattern before "\**" is added leading to a pattern of "\\localhost\c$\\**"
-      // which does not match.
-      // assert!(scope.is_allowed("\\\\localhost\\c$\\NonExistentFile"));
+      assert!(scope.is_allowed("\\\\localhost\\c$\\NonExistentFile"));
       assert!(!scope.is_allowed("\\\\localhost\\d$"));
       assert!(!scope.is_allowed("\\\\OtherServer\\Share"));
     }

--- a/crates/tauri/src/scope/fs.rs
+++ b/crates/tauri/src/scope/fs.rs
@@ -125,7 +125,7 @@ fn push_pattern<P: AsRef<Path>, F: Fn(&str) -> Result<Pattern, glob::PatternErro
 
   if let Some(p) = canonicalized {
     list.insert(f(&p.to_string_lossy())?);
-  } else if cfg!(windows) && !path.as_os_str().as_encoded_bytes().starts_with(b"\\\\") {
+  } else if cfg!(windows) && !path.to_string_lossy().starts_with("\\\\") {
     list.insert(f(&format!("\\\\?\\{}", path.display()))?);
   }
 

--- a/crates/tauri/src/scope/fs.rs
+++ b/crates/tauri/src/scope/fs.rs
@@ -109,7 +109,9 @@ fn push_pattern<P: AsRef<Path>, F: Fn(&str) -> Result<Pattern, glob::PatternErro
     if let Some(mut p) = last {
       // remove the last component of the path
       // so the next iteration checks its parent
-      path.pop();
+      if !path.pop() {
+        break None;
+      }
       // append the already checked path to the last component
       if let Some(checked_path) = &checked_path {
         p.push(checked_path);
@@ -123,7 +125,7 @@ fn push_pattern<P: AsRef<Path>, F: Fn(&str) -> Result<Pattern, glob::PatternErro
 
   if let Some(p) = canonicalized {
     list.insert(f(&p.to_string_lossy())?);
-  } else if cfg!(windows) {
+  } else if cfg!(windows) && !path.as_os_str().as_encoded_bytes().starts_with(b"\\\\") {
     list.insert(f(&format!("\\\\?\\{}", path.display()))?);
   }
 


### PR DESCRIPTION
If the root path element of a pattern could not be canonicalized, `scope::fs::push_pattern` would enter an infinite loop. This is because `path.pop()` does nothing and returns `false` when called on a path with no parent, which can happen even when the path element iterator is non-empty. This could occur on Windows, for example, with a pattern of `\\?\**`.

Fixes #10815

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
