### PR TITLE
feat(core): always use the custom protocol IPC on Linux

### DIFF
--- a/.changes/always-enable-linux-ipc-custom-protocol.md
+++ b/.changes/always-enable-linux-ipc-custom-protocol.md
@@ -1,0 +1,7 @@
+---
+"tauri": patch:breaking
+"tauri-runtime-wry": patch:breaking
+---
+
+The `linux-ipc-protocol` feature is now always enabled, so the Cargo feature flag was removed.
+This increases the minimum webkit2gtk version to a release that does not affect the minimum target Linux distros for Tauri apps.

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -21,6 +21,7 @@ wry = { version = "0.42", default-features = false, features = [
   "drag-drop",
   "protocol",
   "os-webview",
+  "linux-body",
 ] }
 tao = { version = "0.29.1", default-features = false, features = ["rwh_06"] }
 tauri-runtime = { version = "2.0.0-rc.7", path = "../tauri-runtime" }
@@ -41,7 +42,7 @@ features = ["Win32_Foundation", "Win32_Graphics_Dwm"]
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
-webkit2gtk = { version = "=2.0", features = ["v2_38"] }
+webkit2gtk = { version = "=2.0", features = ["v2_40"] }
 percent-encoding = "2.1"
 
 [target."cfg(any(target_os = \"ios\", target_os = \"macos\"))".dependencies]
@@ -58,7 +59,6 @@ macos-private-api = [
   "tauri-runtime/macos-private-api",
 ]
 objc-exception = ["wry/objc-exception"]
-linux-protocol-body = ["wry/linux-body", "webkit2gtk/v2_40"]
 tracing = ["dep:tracing", "wry/tracing"]
 macos-proxy = ["wry/mac-proxy"]
 unstable = []

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -99,7 +99,7 @@ tray-icon = { version = "0.16", default-features = false, features = [
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
-webkit2gtk = { version = "=2.0.1", features = ["v2_38"] }
+webkit2gtk = { version = "=2.0.1", features = ["v2_40"] }
 
 [target."cfg(target_os = \"macos\")".dependencies]
 embed_plist = "1.2"
@@ -155,10 +155,6 @@ test = []
 compression = ["tauri-macros/compression", "tauri-utils/compression"]
 wry = ["tauri-runtime-wry"]
 objc-exception = ["tauri-runtime-wry/objc-exception"]
-linux-ipc-protocol = [
-  "tauri-runtime-wry/linux-protocol-body",
-  "webkit2gtk/v2_40",
-]
 linux-libxdo = ["tray-icon/libxdo", "muda/libxdo"]
 isolation = ["tauri-utils/isolation", "tauri-macros/isolation", "uuid"]
 custom-protocol = ["tauri-macros/custom-protocol"]

--- a/crates/tauri/scripts/ipc-protocol.js
+++ b/crates/tauri/scripts/ipc-protocol.js
@@ -14,13 +14,10 @@
   const processIpcMessage = __RAW_process_ipc_message_fn__
   const osName = __TEMPLATE_os_name__
   const fetchChannelDataCommand = __TEMPLATE_fetch_channel_data_command__
-  const linuxIpcProtocolEnabled = __TEMPLATE_linux_ipc_protocol_enabled__
   let customProtocolIpcFailed = false
 
-  // on Linux we only use the custom-protocol-based IPC if the linux-ipc-protocol Cargo feature is enabled
   // on Android we never use it because Android does not have support to reading the request body
-  const canUseCustomProtocol =
-    osName === 'linux' ? linuxIpcProtocolEnabled : osName !== 'android'
+  const canUseCustomProtocol = osName !== 'android'
 
   function sendIpcMessage(message) {
     const { cmd, callback, error, payload, options } = message

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -1218,7 +1218,6 @@ pub(crate) struct InvokeInitializationScript<'a> {
   pub(crate) process_ipc_message_fn: &'a str,
   pub(crate) os_name: &'a str,
   pub(crate) fetch_channel_data_command: &'a str,
-  pub(crate) linux_ipc_protocol_enabled: bool,
   pub(crate) invoke_key: &'a str,
 }
 
@@ -1254,7 +1253,6 @@ impl<R: Runtime> Builder<R> {
         process_ipc_message_fn: crate::manager::webview::PROCESS_IPC_MESSAGE_FN,
         os_name: std::env::consts::OS,
         fetch_channel_data_command: crate::ipc::channel::FETCH_CHANNEL_DATA_COMMAND,
-        linux_ipc_protocol_enabled: cfg!(feature = "linux-ipc-protocol"),
         invoke_key: &invoke_key.clone(),
       }
       .render_default(&Default::default())

--- a/crates/tauri/src/ipc/protocol.rs
+++ b/crates/tauri/src/ipc/protocol.rs
@@ -454,7 +454,7 @@ fn parse_invoke_request<R: Runtime>(
     .decode_utf8_lossy()
     .to_string();
 
-  // on Android and on Linux (without the linux-ipc-protocol Cargo feature) we cannot read the request body
+  // on Android we cannot read the request body
   // so we must ignore it because some commands use the IPC for faster response
   let has_payload = !body.is_empty();
 

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -18,7 +18,6 @@
 //! - **tracing**: Enables [`tracing`](https://docs.rs/tracing/latest/tracing) for window startup, plugins, `Window::eval`, events, IPC, updater and custom protocol request handlers.
 //! - **test**: Enables the [`mod@test`] module exposing unit test helpers.
 //! - **objc-exception**: Wrap each msg_send! in a @try/@catch and panics if an exception is caught, preventing Objective-C from unwinding into Rust.
-//! - **linux-ipc-protocol**: Use custom protocol for faster IPC on Linux. Requires webkit2gtk v2.40 or above.
 //! - **linux-libxdo**: Enables linking to libxdo which enables Cut, Copy, Paste and SelectAll menu items to work on Linux.
 //! - **isolation**: Enables the isolation pattern. Enabled by default if the `app > security > pattern > use` config option is set to `isolation` on the `tauri.conf.json` file.
 //! - **custom-protocol**: Feature managed by the Tauri CLI. When enabled, Tauri assumes a production environment instead of a development one.

--- a/crates/tauri/src/test/mod.rs
+++ b/crates/tauri/src/test/mod.rs
@@ -163,7 +163,6 @@ pub fn mock_builder() -> Builder<MockRuntime> {
     process_ipc_message_fn: crate::manager::webview::PROCESS_IPC_MESSAGE_FN,
     os_name: std::env::consts::OS,
     fetch_channel_data_command: crate::ipc::channel::FETCH_CHANNEL_DATA_COMMAND,
-    linux_ipc_protocol_enabled: cfg!(feature = "linux-ipc-protocol"),
     invoke_key: INVOKE_KEY,
   }
   .render_default(&Default::default())


### PR DESCRIPTION
We can always use the custom protocol based IPC on Linux since raising the minimum required webkit2gtk does not affect the minimum Linux distros supported by Tauri
