### PR TITLE
fix(core): Swift warning for null invoke.resolve() iOS plugin values

### DIFF
--- a/.changes/ios-invoke-response-null.md
+++ b/.changes/ios-invoke-response-null.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes a warning when using a null value on the `invoke.resolve()` iOS plugin API.

--- a/crates/tauri/mobile/ios-api/Sources/Tauri/JsonValue.swift
+++ b/crates/tauri/mobile/ios-api/Sources/Tauri/JsonValue.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public typealias JsonObject = [String: Any]
+public typealias JsonObject = [String: Any?]
 
 public enum JsonValue {
 	case dictionary(JsonObject)


### PR DESCRIPTION
`Any` does allow `nil`,  but must be explicitly set to avoid the Swift warning
