### PR TITLE
feat(cli): always validate iOS lib

### DIFF
--- a/.changes/enhance-ios-lib-validation.md
+++ b/.changes/enhance-ios-lib-validation.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:enhance'
+'@tauri-apps/cli': 'patch:enhance'
+---
+
+Enhance iOS library validation, checking libs built with link time optimization.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7145,6 +7145,7 @@ name = "tauri-cli"
 version = "2.0.0-rc.8"
 dependencies = [
  "anyhow",
+ "ar",
  "axum",
  "base64 0.22.1",
  "cargo-mobile2",
@@ -7183,6 +7184,7 @@ dependencies = [
  "minisign",
  "notify",
  "notify-debouncer-mini",
+ "object",
  "os_info",
  "os_pipe",
  "oxc_allocator",

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -130,6 +130,12 @@ libc = "0.2"
 [target."cfg(target_os = \"macos\")".dependencies]
 plist = "1"
 tauri-macos-sign = { version = "0.1.1-rc.0", path = "../tauri-macos-sign" }
+object = { version = "0.36", default-features = false, features = [
+  "macho",
+  "read_core",
+  "std",
+] }
+ar = "0.9"
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
changes the iOS lib validation from using `nm` to a custom solution leveraging the `ar` and the `object` crates

`nm` is not a great fit here because it does not work when link-time-optimization (LTO) is enabled e.g. release builds
