### PR TITLE
fix(cli): iOS code signing failing on CI

### DIFF
--- a/.changes/fix-ios-automatic-signing-ci.md
+++ b/.changes/fix-ios-automatic-signing-ci.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fixes iOS code signing failing on CI due to a missing development certificate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-mobile2"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e188b5be2e86ea9c384075d5f5560edea7b0c8b6a06553c7ab0aa61a4475f623"
+checksum = "93ede7b4200c8794c5fe7bc25c93a8f1756b87d50968cc20def67f2618035f65"
 dependencies = [
  "colored",
  "core-foundation 0.10.0",
@@ -7142,7 +7142,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-cli"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-cli"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.8"
 authors = ["Tauri Programme within The Commons Conservancy"]
 edition = "2021"
 rust-version = "1.71"
@@ -36,7 +36,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
-cargo-mobile2 = { version = "0.16", default-features = false }
+cargo-mobile2 = { version = "0.17", default-features = false }
 
 [dependencies]
 jsonrpsee = { version = "0.24", features = ["server"] }
@@ -47,7 +47,7 @@ sublime_fuzzy = "0.7"
 clap_complete = "4"
 clap = { version = "4.5", features = ["derive", "env"] }
 anyhow = "1.0"
-tauri-bundler = { version = "2.0.1-rc.7", default-features = false, path = "../tauri-bundler" }
+tauri-bundler = { version = "2.0.1-rc.6", default-features = false, path = "../tauri-bundler" }
 colored = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -24,7 +24,7 @@ use anyhow::Context;
 use cargo_mobile2::{
   apple::{
     config::Config as AppleConfig,
-    target::{BuildConfig, ExportConfig, Target},
+    target::{ArchiveConfig, BuildConfig, ExportConfig, Target},
   },
   env::Env,
   opts::{NoiseLevel, Profile},
@@ -301,7 +301,9 @@ fn run_build(
 
       let credentials = auth_credentials_from_env()?;
 
-      let mut build_config = BuildConfig::new().allow_provisioning_updates();
+      let mut build_config = BuildConfig::new()
+        .allow_provisioning_updates()
+        .skip_codesign();
       if let Some(credentials) = &credentials {
         build_config = build_config.authentication_credentials(credentials.clone());
       }
@@ -314,7 +316,14 @@ fn run_build(
         build_config,
       )?;
 
-      target.archive(config, env, noise_level, profile, Some(app_version))?;
+      target.archive(
+        config,
+        env,
+        noise_level,
+        profile,
+        Some(app_version),
+        ArchiveConfig::new().skip_codesign(),
+      )?;
 
       let mut export_config = ExportConfig::new().allow_provisioning_updates();
       if let Some(credentials) = credentials {


### PR DESCRIPTION
Looks like Apple cannot handle development profile automatic provisioning well

With this change we now skip code signing for build() and archive(), and let the export() function handle signing

see https://github.com/fastlane/fastlane/discussions/19973#discussioncomment-2688720 for more information
