### PR TITLE
feat(core): validate duplicated capability identifier

### DIFF
--- a/.changes/capability-id-already-exists.md
+++ b/.changes/capability-id-already-exists.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:enhance
+---
+
+Validate duplicate capability identifier.

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -135,10 +135,20 @@ pub fn parse_capabilities(
   {
     match CapabilityFile::load(&path)? {
       CapabilityFile::Capability(capability) => {
+        if capabilities_map.contains_key(&capability.identifier) {
+          return Err(Error::CapabilityAlreadyExists {
+            identifier: capability.identifier,
+          });
+        }
         capabilities_map.insert(capability.identifier.clone(), capability);
       }
       CapabilityFile::List(capabilities) | CapabilityFile::NamedList { capabilities } => {
         for capability in capabilities {
+          if capabilities_map.contains_key(&capability.identifier) {
+            return Err(Error::CapabilityAlreadyExists {
+              identifier: capability.identifier,
+            });
+          }
           capabilities_map.insert(capability.identifier.clone(), capability);
         }
       }

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -126,6 +126,13 @@ pub enum Error {
     /// Permission identifier.
     permission: String,
   },
+
+  /// Capability with the given identifier already exists.
+  #[error("capability with identifier `{identifier}` already exists")]
+  CapabilityAlreadyExists {
+    /// Capability identifier.
+    identifier: String,
+  },
 }
 
 /// Allowed and denied commands inside a permission.


### PR DESCRIPTION
having duplicate capability identifier lead to unexpected behavior because one of the capabilities gets ignored. With this change the build script now fails when this happens.
