### PR TITLE
docs: fix grammar in `TitleBarStyle` api config documentation

### DIFF
--- a/core/tauri-utils/src/lib.rs
+++ b/core/tauri-utils/src/lib.rs
@@ -68,7 +68,7 @@ pub enum TitleBarStyle {
   /// Shows the title bar as a transparent overlay over the window's content.
   ///
   /// Keep in mind:
-  /// - The height of the title bar is different on different OS versions, which can lead to window the controls and title not being where you don't expect.
+  /// - The height of the title bar is different on different OS versions, which can lead to the window controls and title not being where you expect them to be.
   /// - You need to define a custom drag region to make your window draggable, however due to a limitation you can't drag the window when it's not in focus <https://github.com/tauri-apps/tauri/issues/4316>.
   /// - The color of the window title depends on the system theme.
   Overlay,


### PR DESCRIPTION
Fix grammar in `TitleBarStyle` api config documentation.

Found here: https://tauri.app/v1/api/config/#titlebarstyle

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
