### PR TITLE
feat: Add support for using Product Name 

### DIFF
--- a/crates/tauri-bundler/Cargo.toml
+++ b/crates/tauri-bundler/Cargo.toml
@@ -42,6 +42,7 @@ sha1 = "0.10"
 sha2 = "0.10"
 zip = { version = "2.0", default-features = false, features = ["deflate"] }
 dunce = "1"
+heck = "0.5"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 uuid = { version = "1", features = ["v4", "v5"] }
@@ -63,7 +64,6 @@ tauri-macos-sign = { version = "0.1.1-rc.0", path = "../tauri-macos-sign" }
 regex = "1"
 
 [target."cfg(target_os = \"linux\")".dependencies]
-heck = "0.5"
 ar = "0.9.0"
 md5 = "0.7.0"
 rpm = "0.15.0"

--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -57,7 +57,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   // setup data to insert into shell script
   let mut sh_map = BTreeMap::new();
   sh_map.insert("arch", settings.target().split('-').next().unwrap());
-  sh_map.insert("crate_name", get_bin_name(&settings));
+  sh_map.insert("crate_name", get_bin_name(settings));
   sh_map.insert("appimage_filename", &appimage_filename);
 
   let tauri_tools_path = settings

--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -57,7 +57,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   // setup data to insert into shell script
   let mut sh_map = BTreeMap::new();
   sh_map.insert("arch", settings.target().split('-').next().unwrap());
-  sh_map.insert("crate_name", get_bin_name(settings));
+  sh_map.insert("crate_name", &get_bin_name(settings));
   sh_map.insert("appimage_filename", &appimage_filename);
 
   let tauri_tools_path = settings

--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -57,7 +57,10 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   // setup data to insert into shell script
   let mut sh_map = BTreeMap::new();
   sh_map.insert("arch", settings.target().split('-').next().unwrap());
-  sh_map.insert("crate_name", &get_bin_name(settings));
+
+  let crate_name = get_bin_name(settings);
+  sh_map.insert("crate_name", &crate_name);
+
   sh_map.insert("appimage_filename", &appimage_filename);
 
   let tauri_tools_path = settings

--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -10,6 +10,7 @@ use super::{
   },
   debian,
 };
+use crate::bundle::common::get_bin_name;
 use crate::Settings;
 use anyhow::Context;
 use handlebars::Handlebars;
@@ -56,7 +57,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   // setup data to insert into shell script
   let mut sh_map = BTreeMap::new();
   sh_map.insert("arch", settings.target().split('-').next().unwrap());
-  sh_map.insert("crate_name", settings.main_binary_name());
+  sh_map.insert("crate_name", get_bin_name(&settings));
   sh_map.insert("appimage_filename", &appimage_filename);
 
   let tauri_tools_path = settings

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -139,7 +139,7 @@ pub fn generate_data(
 fn generate_changelog_file(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
   if let Some(changelog_src_path) = &settings.deb().changelog {
     let mut src_file = File::open(changelog_src_path)?;
-    let bin_name = get_bin_name(&settings);
+    let bin_name = get_bin_name(settings);
     let dest_path = data_dir.join(format!("usr/share/doc/{}/changelog.gz", bin_name));
 
     let changelog_file = common::create_file(&dest_path)?;
@@ -312,7 +312,7 @@ fn generate_md5sums(control_dir: &Path, data_dir: &Path) -> crate::Result<()> {
 /// Copy the bundle's resource files into an appropriate directory under the
 /// `data_dir`.
 fn copy_resource_files(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
-  let resource_dir = data_dir.join("usr/lib").join(get_bin_name(&settings));
+  let resource_dir = data_dir.join("usr/lib").join(get_bin_name(settings));
   settings.copy_resources(&resource_dir)
 }
 

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -30,7 +30,7 @@ use flate2::{write::GzEncoder, Compression};
 use tar::HeaderMode;
 use walkdir::WalkDir;
 
-use crate::bundle::common::{get_bin_name, rename_app, use_v1_bin_name};
+use crate::bundle::common::get_bin_name;
 use std::{
   fs::{self, File, OpenOptions},
   io::{self, Write},
@@ -109,7 +109,7 @@ pub fn generate_data(
 
   for bin in settings.binaries() {
     let bin_path = settings.binary_path(bin);
-    let dest_path = if use_v1_bin_name() && bin.name() == settings.main_binary_name() {
+    let dest_path = if bin.name() == settings.main_binary_name() {
       bin_dir.join(get_bin_name(settings))
     } else {
       bin_dir.join(bin.name())

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -109,13 +109,13 @@ pub fn generate_data(
 
   for bin in settings.binaries() {
     let bin_path = settings.binary_path(bin);
-    let dest_path = bin_dir.join(bin.name());
+    let dest_path = if use_v1_bin_name() && bin.name() == settings.main_binary_name() {
+      bin_dir.join(get_bin_name(settings))
+    } else {
+      bin_dir.join(bin.name())
+    };
     common::copy_file(&bin_path, &dest_path)
       .with_context(|| format!("Failed to copy binary from {bin_path:?}"))?;
-
-    if use_v1_bin_name() && bin.name() == settings.main_binary_name() {
-      rename_app(settings.target(), &dest_path, settings.product_name())?;
-    }
   }
 
   copy_resource_files(settings, &data_dir).with_context(|| "Failed to copy resource files")?;

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -110,7 +110,7 @@ pub fn generate_data(
   for bin in settings.binaries() {
     let bin_path = settings.binary_path(bin);
     let dest_path = bin_dir.join(bin.name());
-    common::copy_file(&bin_path, dest_path)
+    common::copy_file(&bin_path, &dest_path)
       .with_context(|| format!("Failed to copy binary from {bin_path:?}"))?;
 
     if use_v1_bin_name() && bin.name() == settings.main_binary_name() {

--- a/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
+++ b/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
@@ -27,6 +27,7 @@ use image::{self, codecs::png::PngDecoder, ImageDecoder};
 use serde::Serialize;
 
 use crate::bundle::common;
+use crate::bundle::common::{get_bin_name, use_v1_bin_name};
 use crate::Settings;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -50,7 +51,7 @@ pub fn list_icon_files(
       width,
       height,
       if is_high_density { "@2" } else { "" },
-      settings.main_binary_name()
+      get_bin_name(&settings)
     ))
   };
   let mut icons = BTreeMap::new();
@@ -97,7 +98,7 @@ pub fn generate_desktop_file(
   custom_template_path: &Option<PathBuf>,
   data_dir: &Path,
 ) -> crate::Result<(PathBuf, PathBuf)> {
-  let bin_name = settings.main_binary_name();
+  let bin_name = get_bin_name(&settings);
   let desktop_file_name = format!("{bin_name}.desktop");
   let path = PathBuf::from("usr/share/applications").join(desktop_file_name);
   let dest_path = PathBuf::from("/").join(&path);

--- a/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
+++ b/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
@@ -51,7 +51,7 @@ pub fn list_icon_files(
       width,
       height,
       if is_high_density { "@2" } else { "" },
-      get_bin_name(&settings)
+      get_bin_name(settings)
     ))
   };
   let mut icons = BTreeMap::new();
@@ -98,7 +98,7 @@ pub fn generate_desktop_file(
   custom_template_path: &Option<PathBuf>,
   data_dir: &Path,
 ) -> crate::Result<(PathBuf, PathBuf)> {
-  let bin_name = get_bin_name(&settings);
+  let bin_name = get_bin_name(settings);
   let desktop_file_name = format!("{bin_name}.desktop");
   let path = PathBuf::from("usr/share/applications").join(desktop_file_name);
   let dest_path = PathBuf::from("/").join(&path);

--- a/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
+++ b/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
@@ -27,7 +27,7 @@ use image::{self, codecs::png::PngDecoder, ImageDecoder};
 use serde::Serialize;
 
 use crate::bundle::common;
-use crate::bundle::common::{get_bin_name, use_v1_bin_name};
+use crate::bundle::common::get_bin_name;
 use crate::Settings;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
+++ b/crates/tauri-bundler/src/bundle/linux/freedesktop.rs
@@ -161,8 +161,8 @@ pub fn generate_desktop_file(
       } else {
         None
       },
-      exec: bin_name,
-      icon: bin_name,
+      exec: &bin_name,
+      icon: &bin_name,
       name: settings.product_name(),
       mime_type,
       long_description: settings.long_description().unwrap_or_default().to_string(),

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -100,17 +100,15 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   // Add binaries
   for bin in settings.binaries() {
-    let src = if use_v1_bin_name() && bin.name() == settings.main_binary_name() {
-      rename_app(
-        settings.target(),
-        &settings.binary_path(bin),
-        settings.product_name(),
-      )?
+    let src = settings.binary_path(bin);
+
+    let dest_name = if bin.name() == settings.main_binary_name() {
+      get_bin_name(settings)
     } else {
-      settings.binary_path(bin)
+      bin.name().to_string()
     };
 
-    let dest = Path::new("/usr/bin").join(bin.name());
+    let dest = Path::new("/usr/bin").join(dest_name);
     builder = builder.with_file(src, FileOptions::new(dest.to_string_lossy()))?;
   }
 

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -6,7 +6,7 @@
 use crate::Settings;
 
 use super::freedesktop;
-use crate::bundle::common::{get_bin_name, rename_app, use_v1_bin_name};
+use crate::bundle::common::get_bin_name;
 use anyhow::Context;
 use rpm::{self, signature::pgp, Dependency, FileMode, FileOptions};
 use std::{

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -150,7 +150,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   // Add resources
   if settings.resource_files().count() > 0 {
-    let resource_dir = Path::new("/usr/lib").join(get_bin_name(&settings));
+    let resource_dir = Path::new("/usr/lib").join(get_bin_name(settings));
     // Create an empty file, needed to add a directory to the RPM package
     // (cf https://github.com/rpm-rs/rpm/issues/177)
     let empty_file_path = &package_dir.join("empty");

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -202,7 +202,7 @@ fn create_info_plist(
   let mut plist = plist::Dictionary::new();
   plist.insert("CFBundleDevelopmentRegion".into(), "English".into());
   plist.insert("CFBundleDisplayName".into(), settings.product_name().into());
-  plist.insert("CFBundleExecutable".into(), get_bin_name(&settings).into());
+  plist.insert("CFBundleExecutable".into(), get_bin_name(settings).into());
   if let Some(path) = bundle_icon_file {
     plist.insert(
       "CFBundleIconFile".into(),

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -31,7 +31,7 @@ use crate::Settings;
 
 use anyhow::Context;
 
-use crate::bundle::common::{get_bin_name, rename_app, use_v1_bin_name};
+use crate::bundle::common::get_bin_name;
 use std::{
   ffi::OsStr,
   fs,
@@ -157,12 +157,14 @@ fn copy_binaries_to_bundle(
   let dest_dir = bundle_directory.join("MacOS");
   for bin in settings.binaries() {
     let bin_path = settings.binary_path(bin);
-    let dest_path = dest_dir.join(bin.name());
+    let dest_path = if bin.name() == settings.main_binary_name() {
+      dest_dir.join(get_bin_name(settings))
+    } else {
+      dest_dir.join(bin.name())
+    };
+
     common::copy_file(&bin_path, &dest_path)
       .with_context(|| format!("Failed to copy binary from {:?}", bin_path))?;
-    if use_v1_bin_name() && bin.name() == settings.main_binary_name() {
-      rename_app(settings.target(), &dest_path, settings.product_name())?;
-    }
     paths.push(dest_path);
   }
   Ok(paths)

--- a/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
@@ -717,7 +717,7 @@ pub fn build_wix_app_installer(
       &output_path,
       path,
       extensions,
-      app_exe_source,
+      &app_exe_source,
     )?;
   }
 

--- a/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
@@ -522,7 +522,7 @@ pub fn build_wix_app_installer(
   data.insert("manufacturer", to_json(manufacturer));
   let upgrade_code = Uuid::new_v5(
     &Uuid::NAMESPACE_DNS,
-    format!("{}.app.x64", get_bin_name(&settings)).as_bytes(),
+    format!("{}.app.x64", get_bin_name(settings)).as_bytes(),
   )
   .to_string();
 
@@ -538,7 +538,7 @@ pub fn build_wix_app_installer(
   let shortcut_guid = generate_package_guid(settings).to_string();
   data.insert("shortcut_guid", to_json(shortcut_guid.as_str()));
 
-  let app_exe_name = get_bin_name(&settings).to_string();
+  let app_exe_name = get_bin_name(settings).to_string();
   data.insert("app_exe_name", to_json(app_exe_name));
 
   let binaries = generate_binaries_data(settings)?;
@@ -563,7 +563,7 @@ pub fn build_wix_app_installer(
   let merge_modules = get_merge_modules(settings)?;
   data.insert("merge_modules", to_json(merge_modules));
 
-  data.insert("app_exe_source", to_json(app_exe_source));
+  data.insert("app_exe_source", to_json(&app_exe_source));
 
   // copy icon from `settings.windows().icon_path` folder to resource folder near msi
   let icon_path = copy_icon(settings, "icon.ico", &settings.windows().icon_path)?;

--- a/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
@@ -404,7 +404,7 @@ pub fn build_wix_app_installer(
     .ok_or_else(|| anyhow::anyhow!("Failed to get main binary"))?;
   let old_binary_path = settings.binary_path(main_binary);
   let app_exe_source = if use_v1_bin_name() {
-    rename_app(settings.target(), &old_binary_path, settings.product_name())?
+    rename_app(settings, &old_binary_path)?
   } else {
     old_binary_path
   };

--- a/crates/tauri-bundler/src/bundle/windows/nsis.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis.rs
@@ -345,7 +345,7 @@ fn build_nsis_app_installer(
 
   let old_binary_path = settings.binary_path(main_binary).with_extension("exe");
   let main_binary_path = if use_v1_bin_name() {
-    rename_app(settings.target(), &old_binary_path, settings.product_name())?
+    rename_app(settings, &old_binary_path)?
   } else {
     old_binary_path
   };
@@ -356,7 +356,7 @@ fn build_nsis_app_installer(
       main_binary_path
         .file_stem()
         .and_then(|file_name| file_name.to_str())
-        .unwrap_or_else(|| get_bin_name(settings)),
+        .unwrap_or(get_bin_name(settings).as_str()),
     ),
   );
   data.insert("main_binary_path", to_json(&main_binary_path));

--- a/crates/tauri-bundler/src/bundle/windows/nsis.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis.rs
@@ -356,7 +356,7 @@ fn build_nsis_app_installer(
       main_binary_path
         .file_stem()
         .and_then(|file_name| file_name.to_str())
-        .unwrap_or_else(|| get_bin_name(&settings)),
+        .unwrap_or_else(|| get_bin_name(settings)),
     ),
   );
   data.insert("main_binary_path", to_json(&main_binary_path));


### PR DESCRIPTION
This PR is based off the work here https://github.com/gitbutlerapp/tauri/pull/1 by @krivi. (most of this PR description was taken from there- it was very well written!)

## Background:
This change in Tauri https://github.com/tauri-apps/tauri/pull/9375/files, which is noted as a refactor is in fact a breaking change as far as the app updater is concerned.

The impact is that because the binary now has a different name, it is not possible to smoothly update a Tauri application via the updater if the initial version of the app is using `v1.x` and the new version is using `v2.x`.

## Approach:
I'm introducing here an option for the `tauri-cli` (`tauri-bundler`) for producing the same binary names it did in `v1`, allowing users to update the app via the updater. In order to enable this behavior, set the environment variable

```
V1_COMPATIBLE_BIN_NAME=true
```

Previously, the bundler did the rename just after building the binary. I poked and tried doing the same once again, but because quite a lot of the code in that bundler changed since that was merged, it felt possibly more error prone (since now the rest of the code can safely assume that the binary is the crate name)

So, instead, my approach is to do the rename the binary at the last moment (i.e. in the `bundle_project` function in eg. app.rs)

fixes #10548

## Testing
This PR has been tested across Windows, MacOS, and Linux with the Modrinth App. You can find test builds built using this PR here: https://github.com/modrinth/code/actions/runs/10785759488