### PR TITLE
fix(core): mobile dev server proxy URL

### DIFF
--- a/.changes/fix-dev-server-proxy-url.md
+++ b/.changes/fix-dev-server-proxy-url.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes mobile dev server proxy request URL with trailing slashes.

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -102,7 +102,11 @@ fn get_response<R: Runtime>(
     let decoded_path = percent_encoding::percent_decode(path.as_bytes())
       .decode_utf8_lossy()
       .to_string();
-    let url = format!("{url}{decoded_path}");
+    let url = format!(
+      "{}/{}",
+      url.trim_end_matches('/'),
+      decoded_path.trim_start_matches('/')
+    );
 
     let mut proxy_builder = reqwest::ClientBuilder::new()
       .build()


### PR DESCRIPTION
in some contexts this can lead to issues with the dev server not resolving JS files properly - I didn't find an actual bug here in Tauri (it was caught on another Rust project) but I'm adding this here just for correctness
