### PR TITLE
fix(bundler/wix): use product name to generate `UpgradeCode` for MSI

### DIFF
--- a/.changes/wix-upgrade-code-regression.md
+++ b/.changes/wix-upgrade-code-regression.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": "patch:bug"
+---
+
+Fix generated `UpgradeCode` for MSI not matching MSI installers created with tauri-bundler@v1.

--- a/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/wix.rs
@@ -524,7 +524,7 @@ pub fn build_wix_app_installer(
   data.insert("manufacturer", to_json(manufacturer));
   let upgrade_code = Uuid::new_v5(
     &Uuid::NAMESPACE_DNS,
-    format!("{}.app.x64", &settings.main_binary_name()).as_bytes(),
+    format!("{}.exe.app.x64", &settings.product_name()).as_bytes(),
   )
   .to_string();
 


### PR DESCRIPTION
The upgrade code generation was changed due to an accidental regression in #9375. Previously `UpgradeCode` was calculated using the main binary name which was `<product_name>.exe`, but #9375 changed the default main binary name to `<cargo-crate-name>.exe` and thus a different UpgradeCode was generetad.

This PR reverts this change to use product name for `UpgradeCode` generation.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
