### PR TITLE
fix(core): prevent Proguard from optimizing away custom ser/de classes

### DIFF
--- a/.changes/fix-android-proguard.md
+++ b/.changes/fix-android-proguard.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Add a Proguard rule to prevent custom JSON deserializer and serializer classes from being optimized away.

--- a/crates/tauri/mobile/android/proguard-rules.pro
+++ b/crates/tauri/mobile/android/proguard-rules.pro
@@ -28,4 +28,14 @@
   *;
 }
 
+-keep @com.fasterxml.jackson.databind.annotation.JsonDeserialize public class * {
+  *;
+}
+
+-keep @com.fasterxml.jackson.databind.annotation.JsonSerialize public class * {
+  *;
+}
+
 -keep class * extends com.fasterxml.jackson.databind.JsonDeserializer { *; }
+
+-keep class * extends com.fasterxml.jackson.databind.JsonSerializer { *; }


### PR DESCRIPTION
Fixes a couple bugs in the clipboard plugin on release builds:
- custom serializer class constructor being optimized away
- deserializer inner class constructor being optimized away
