### PR TITLE
fix(core): requestPermissions not resolving on Android

### DIFF
--- a/.changes/fix-request-permissions.md
+++ b/.changes/fix-request-permissions.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix `requestPermissions` not resolving on Android.

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginHandle.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginHandle.kt
@@ -143,9 +143,13 @@ class PluginHandle(private val manager: PluginManager, val name: String, val ins
         val command = method.getAnnotation(Command::class.java) ?: continue
         val methodMeta = CommandData(method, command)
         commands[method.name] = methodMeta
-      } else if (method.isAnnotationPresent(ActivityCallback::class.java)) {
+      }
+
+      if (method.isAnnotationPresent(ActivityCallback::class.java)) {
         startActivityCallbackMethods[method.name] = method
-      } else if (method.isAnnotationPresent(PermissionCallback::class.java)) {
+      }
+
+      if (method.isAnnotationPresent(PermissionCallback::class.java)) {
         permissionCallbackMethods[method.name] = method
       }
     }


### PR DESCRIPTION
the checkPermissions command is also a PermissionCallback, and the annotation check is incorrectly ignoring that fact, so the requestPermissions is never resolved for the geolocation plugin
