### PR TITLE
fixes iframes in windows causes window.__TAURI_INVOKE__ is not a function error in console.

### DIFF
--- a/core/tauri/scripts/init.js
+++ b/core/tauri/scripts/init.js
@@ -22,5 +22,5 @@
 
   __RAW_event_initialization_script__
 
-  if(window.__TAURI_INVOKE__ !== undefined) window.__TAURI_INVOKE__('__initialized', { url: window.location.href })
+  if (window.__TAURI_INVOKE__ !== undefined) window.__TAURI_INVOKE__('__initialized', { url: window.location.href })
 })()

--- a/core/tauri/scripts/init.js
+++ b/core/tauri/scripts/init.js
@@ -22,5 +22,5 @@
 
   __RAW_event_initialization_script__
 
-  window.__TAURI_INVOKE__('__initialized', { url: window.location.href })
+  if(window.__TAURI_INVOKE__ !== undefined) window.__TAURI_INVOKE__('__initialized', { url: window.location.href })
 })()


### PR DESCRIPTION
closes  #10935.

Check if window has __TAURI_INVOKE__ before using it blindly.

