### PR TITLE
feat(cli): add log plugin to the app template

### DIFF
--- a/.changes/cli-template-log-plugin.md
+++ b/.changes/cli-template-log-plugin.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:enhance
+"tauri-cli": patch:enhance
+---
+
+Added the `log` plugin to the app template, which is required to visualize logs on Android and iOS.

--- a/crates/tauri-cli/src/init.rs
+++ b/crates/tauri-cli/src/init.rs
@@ -200,11 +200,11 @@ pub fn command(mut options: Options) -> Result<()> {
       (
         format!(
           r#"{{  path = {:?} }}"#,
-          resolve_tauri_path(&tauri_path, "crates/tauri")
+          resolve_tauri_path(tauri_path, "crates/tauri")
         ),
         format!(
           "{{  path = {:?} }}",
-          resolve_tauri_path(&tauri_path, "crates/tauri-build")
+          resolve_tauri_path(tauri_path, "crates/tauri-build")
         ),
       )
     } else {

--- a/crates/tauri-cli/src/init.rs
+++ b/crates/tauri-cli/src/init.rs
@@ -196,7 +196,7 @@ pub fn command(mut options: Options) -> Result<()> {
       template_target_path
     );
   } else {
-    let (tauri_dep, tauri_build_dep) = if let Some(tauri_path) = options.tauri_path {
+    let (tauri_dep, tauri_build_dep) = if let Some(tauri_path) = &options.tauri_path {
       (
         format!(
           r#"{{  path = {:?} }}"#,
@@ -220,6 +220,9 @@ pub fn command(mut options: Options) -> Result<()> {
 
     let mut data = BTreeMap::new();
     data.insert("tauri_dep", to_json(tauri_dep));
+    if options.tauri_path.is_some() {
+      data.insert("patch_tauri_dep", to_json(true));
+    }
     data.insert("tauri_build_dep", to_json(tauri_build_dep));
     data.insert(
       "frontend_dist",

--- a/crates/tauri-cli/templates/app/src-tauri/Cargo.crate-manifest
+++ b/crates/tauri-cli/templates/app/src-tauri/Cargo.crate-manifest
@@ -20,4 +20,6 @@ tauri-build = {{  tauri_build_dep  }}
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+log = "0.4"
 tauri = {{  tauri_dep  }}
+tauri-plugin-log = "2.0.0-rc"

--- a/crates/tauri-cli/templates/app/src-tauri/Cargo.crate-manifest
+++ b/crates/tauri-cli/templates/app/src-tauri/Cargo.crate-manifest
@@ -23,3 +23,7 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = {{  tauri_dep  }}
 tauri-plugin-log = "2.0.0-rc"
+{{#if patch_tauri_dep}}
+[patch.crates-io]
+tauri = {{ tauri_dep }}
+{{/if}}

--- a/crates/tauri-cli/templates/app/src-tauri/src/lib.rs
+++ b/crates/tauri-cli/templates/app/src-tauri/src/lib.rs
@@ -1,6 +1,16 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .setup(|app| {
+      if cfg!(debug_assertions) {
+        app.handle().plugin(
+          tauri_plugin_log::Builder::default()
+            .level(log::LevelFilter::Info)
+            .build(),
+        )?;
+      }
+      Ok(())
+    })
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/crates/tauri/src/process.rs
+++ b/crates/tauri/src/process.rs
@@ -92,7 +92,7 @@ pub fn restart(env: &Env) -> ! {
 }
 
 #[cfg(target_os = "macos")]
-fn restart_macos_app(current_binary: &PathBuf, env: &Env) {
+fn restart_macos_app(current_binary: &std::path::Path, env: &Env) {
   use std::process::{exit, Command};
 
   if let Some(macos_directory) = current_binary.parent() {


### PR DESCRIPTION
The log plugin is really important for mobile development - without it you don't have a clue about logs and stdout for iOS apps
