### PR TITLE
feat(cli): discover src/main.rs binary automatically

### DIFF
--- a/.changes/cli-handle-main-binary.md
+++ b/.changes/cli-handle-main-binary.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Automatically discover the `src-tauri/src/main.rs` binary when it is not explicitly defined in the Cargo manifest bin array.


### PR DESCRIPTION
this fixes the following Cargo project setup:
- you have a src/main.rs binary
- you have an additional src/bin/some_bin.rs binary
- you do not explicitly link the src/main.rs binary in the Cargo manifest bin: https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries
