### PR TITLE
fix(core): missing NSImage feature on objc2-app-kit

### DIFF
--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -113,6 +113,7 @@ objc2-app-kit = { version = "0.2.2", features = [
   "NSResponder",
   "NSView",
   "NSWindow",
+  "NSImage",
 ] }
 window-vibrancy = "0.5"
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix regression from #10924

This slipped through the tests because we have a dev dependency on objc2-web-kit which enabled the `NSImage` feature

For the compile error, see https://github.com/tauri-apps/plugins-workspace/actions/runs/10876504273/job/30176523197?pr=1789

> https://github.com/madsmtm/objc2/blob/dfb7562d853ab6e19c9c30777647097bfd1cb2f3/framework-crates/objc2-web-kit/Cargo.toml#L573C21-L573C28
> https://docs.rs/objc2-app-kit/latest/objc2_app_kit/struct.NSApplication.html#method.setApplicationIconImage