### PR TITLE
feat: Expose ability to enable browser extensions in WebView2

### DIFF
--- a/.changes/change-pr-11056.md
+++ b/.changes/change-pr-11056.md
@@ -1,6 +1,5 @@
 ---
 "tauri": patch:feat
-"tauri-cli": patch:feat
 "tauri-runtime-wry": patch:feat
 "tauri-runtime": patch:feat
 "tauri-utils": patch:feat

--- a/.changes/change-pr-11056.md
+++ b/.changes/change-pr-11056.md
@@ -1,0 +1,9 @@
+---
+"tauri": patch:feat
+"tauri-cli": patch:feat
+"tauri-runtime-wry": patch:feat
+"tauri-runtime": patch:feat
+"tauri-utils": patch:feat
+---
+
+Expose the ability to enabled browser extensions in WebView2 on Windows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9449,9 +9449,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.43.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d715cf5fe88e9647f3d17b207b6d060d4a88e7171d4ccb2d2c657dd1d44728"
+checksum = "6d7e385ebabe006332d3863482297408cb39d778db41009f50896ac356d8c49e"
 dependencies = [
  "base64 0.22.1",
  "block",

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -481,6 +481,11 @@
           "description": "Whether page zooming by hotkeys is enabled\n\n ## Platform-specific:\n\n - **Windows**: Controls WebView2's [`IsZoomControlEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings?view=webview2-winrt-1.0.2420.47#iszoomcontrolenabled) setting.\n - **MacOS / Linux**: Injects a polyfill that zooms in and out with `ctrl/command` + `-/=`,\n 20% in each step, ranging from 20% to 1000%. Requires `webview:allow-set-webview-zoom` permission\n\n - **Android / iOS**: Unsupported.",
           "default": false,
           "type": "boolean"
+        },
+        "browserExtensionsEnabled": {
+          "description": "Whether browser extensions can be installed for the webview process\n\n ## Platform-specific:\n\n - **Windows**: Enables the WebView2 environment's [`AreBrowserExtensionsEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions?view=webview2-winrt-1.0.2739.15#arebrowserextensionsenabled)\n - **MacOS / Linux / iOS / Android** - Unsupported.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -17,7 +17,7 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-wry = { version = "0.43.1", default-features = false, features = [
+wry = { version = "0.44.0", default-features = false, features = [
   "drag-drop",
   "protocol",
   "os-webview",

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -3923,8 +3923,7 @@ fn create_webview<T: UserEvent>(
     .with_url(&url)
     .with_transparent(webview_attributes.transparent)
     .with_accept_first_mouse(webview_attributes.accept_first_mouse)
-    .with_hotkeys_zoom(webview_attributes.zoom_hotkeys_enabled)
-    .with_browser_extensions_enabled(webview_attributes.browser_extensions_enabled);
+    .with_hotkeys_zoom(webview_attributes.zoom_hotkeys_enabled);
 
   if webview_attributes.drag_drop_handler_enabled {
     let proxy = context.proxy.clone();

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4072,6 +4072,11 @@ fn create_webview<T: UserEvent>(
     webview_builder = webview_builder.with_https_scheme(false);
   }
 
+  #[cfg(windows)]
+  {
+    webview_builder = webview_builder.with_browser_extensions_enabled(webview_attributes.browser_extensions_enabled);
+  }
+
   webview_builder = webview_builder.with_ipc_handler(create_ipc_handler(
     kind,
     window_id.clone(),

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -3923,7 +3923,8 @@ fn create_webview<T: UserEvent>(
     .with_url(&url)
     .with_transparent(webview_attributes.transparent)
     .with_accept_first_mouse(webview_attributes.accept_first_mouse)
-    .with_hotkeys_zoom(webview_attributes.zoom_hotkeys_enabled);
+    .with_hotkeys_zoom(webview_attributes.zoom_hotkeys_enabled)
+    .with_browser_extensions_enabled(webview_attributes.browser_extensions_enabled);
 
   if webview_attributes.drag_drop_handler_enabled {
     let proxy = context.proxy.clone();
@@ -4074,7 +4075,8 @@ fn create_webview<T: UserEvent>(
 
   #[cfg(windows)]
   {
-    webview_builder = webview_builder.with_browser_extensions_enabled(webview_attributes.browser_extensions_enabled);
+    webview_builder = webview_builder
+      .with_browser_extensions_enabled(webview_attributes.browser_extensions_enabled);
   }
 
   webview_builder = webview_builder.with_ipc_handler(create_ipc_handler(

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -236,6 +236,7 @@ impl From<&WindowConfig> for WebviewAttributes {
       builder = builder.proxy_url(url.to_owned());
     }
     builder = builder.zoom_hotkeys_enabled(config.zoom_hotkeys_enabled);
+    builder = builder.browser_extensions_enabled(config.browser_extensions_enabled);
     builder
   }
 }
@@ -363,6 +364,18 @@ impl WebviewAttributes {
   #[must_use]
   pub fn zoom_hotkeys_enabled(mut self, enabled: bool) -> Self {
     self.zoom_hotkeys_enabled = enabled;
+    self
+  }
+
+  /// Whether browser extensions can be installed for the webview process
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Windows**: Enables the WebView2 environment's [`AreBrowserExtensionsEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions?view=webview2-winrt-1.0.2739.15#arebrowserextensionsenabled)
+  /// - **MacOS / Linux / iOS / Android** - Unsupported.
+  #[must_use]
+  pub fn browser_extensions_enabled(mut self, enabled: bool) -> Self {
+    self.browser_extensions_enabled = enabled;
     self
   }
 }

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -208,6 +208,7 @@ pub struct WebviewAttributes {
   pub auto_resize: bool,
   pub proxy_url: Option<Url>,
   pub zoom_hotkeys_enabled: bool,
+  pub browser_extensions_enabled: bool,
 }
 
 impl From<&WindowConfig> for WebviewAttributes {
@@ -258,6 +259,7 @@ impl WebviewAttributes {
       auto_resize: false,
       proxy_url: None,
       zoom_hotkeys_enabled: false,
+      browser_extensions_enabled: false,
     }
   }
 

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -481,6 +481,11 @@
           "description": "Whether page zooming by hotkeys is enabled\n\n ## Platform-specific:\n\n - **Windows**: Controls WebView2's [`IsZoomControlEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings?view=webview2-winrt-1.0.2420.47#iszoomcontrolenabled) setting.\n - **MacOS / Linux**: Injects a polyfill that zooms in and out with `ctrl/command` + `-/=`,\n 20% in each step, ranging from 20% to 1000%. Requires `webview:allow-set-webview-zoom` permission\n\n - **Android / iOS**: Unsupported.",
           "default": false,
           "type": "boolean"
+        },
+        "browserExtensionsEnabled": {
+          "description": "Whether browser extensions can be installed for the webview process\n\n ## Platform-specific:\n\n - **Windows**: Enables the WebView2 environment's [`AreBrowserExtensionsEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions?view=webview2-winrt-1.0.2739.15#arebrowserextensionsenabled)\n - **MacOS / Linux / iOS / Android** - Unsupported.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -1454,6 +1454,14 @@ pub struct WindowConfig {
   /// - **Android / iOS**: Unsupported.
   #[serde(default)]
   pub zoom_hotkeys_enabled: bool,
+  /// Whether browser extensions can be installed for the webview process
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Windows**: Enables the WebView2 environment's [`AreBrowserExtensionsEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions?view=webview2-winrt-1.0.2739.15#arebrowserextensionsenabled)
+  /// - **MacOS / Linux / iOS / Android** - Unsupported.
+  #[serde(default)]
+  pub browser_extensions_enabled: bool,
 }
 
 impl Default for WindowConfig {
@@ -1501,6 +1509,7 @@ impl Default for WindowConfig {
       parent: None,
       proxy_url: None,
       zoom_hotkeys_enabled: false,
+      browser_extensions_enabled: false,
     }
   }
 }

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -2480,6 +2480,7 @@ mod build {
       let incognito = self.incognito;
       let parent = opt_str_lit(self.parent.as_ref());
       let zoom_hotkeys_enabled = self.zoom_hotkeys_enabled;
+      let browser_extensions_enabled = self.browser_extensions_enabled;
 
       literal_struct!(
         tokens,
@@ -2525,7 +2526,8 @@ mod build {
         window_effects,
         incognito,
         parent,
-        zoom_hotkeys_enabled
+        zoom_hotkeys_enabled,
+        browser_extensions_enabled
       );
     }
   }

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -775,6 +775,18 @@ fn main() {
     self.webview_attributes.zoom_hotkeys_enabled = enabled;
     self
   }
+
+  /// Whether browser extensions can be installed for the webview process
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Windows**: Enables the WebView2 environment's [`AreBrowserExtensionsEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions?view=webview2-winrt-1.0.2739.15#arebrowserextensionsenabled)
+  /// - **MacOS / Linux / iOS / Android** - Unsupported.
+  #[must_use]
+  pub fn browser_extensions_enabled(mut self, enabled: bool) -> Self {
+    self.webview_attributes.browser_extensions_enabled = enabled;
+    self
+  }
 }
 
 /// Webview.

--- a/crates/tauri/src/webview/plugin.rs
+++ b/crates/tauri/src/webview/plugin.rs
@@ -42,8 +42,6 @@ mod desktop_commands {
     incognito: bool,
     #[serde(default)]
     zoom_hotkeys_enabled: bool,
-    #[serde(default)]
-    browser_extensions_enabled: bool,
   }
 
   #[derive(Serialize)]
@@ -101,7 +99,6 @@ mod desktop_commands {
     builder.webview_attributes.window_effects = options.window_effects;
     builder.webview_attributes.incognito = options.incognito;
     builder.webview_attributes.zoom_hotkeys_enabled = options.zoom_hotkeys_enabled;
-    builder.webview_attributes.browser_extensions_enabled = options.browser_extensions_enabled;
 
     window.add_child(
       builder,

--- a/crates/tauri/src/webview/plugin.rs
+++ b/crates/tauri/src/webview/plugin.rs
@@ -42,6 +42,8 @@ mod desktop_commands {
     incognito: bool,
     #[serde(default)]
     zoom_hotkeys_enabled: bool,
+    #[serde(default)]
+    browser_extensions_enabled: bool,
   }
 
   #[derive(Serialize)]
@@ -99,6 +101,7 @@ mod desktop_commands {
     builder.webview_attributes.window_effects = options.window_effects;
     builder.webview_attributes.incognito = options.incognito;
     builder.webview_attributes.zoom_hotkeys_enabled = options.zoom_hotkeys_enabled;
+    builder.webview_attributes.browser_extensions_enabled = options.browser_extensions_enabled;
 
     window.add_child(
       builder,

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -876,6 +876,18 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
     self.webview_builder = self.webview_builder.zoom_hotkeys_enabled(enabled);
     self
   }
+
+  /// Whether browser extensions can be installed for the webview process
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Windows**: Enables the WebView2 environment's [`AreBrowserExtensionsEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2environmentoptions?view=webview2-winrt-1.0.2739.15#arebrowserextensionsenabled)
+  /// - **MacOS / Linux / iOS / Android** - Unsupported.
+  #[must_use]
+  pub fn browser_extensions_enabled(mut self, enabled: bool) -> Self {
+    self.webview_builder = self.webview_builder.browser_extensions_enabled(enabled);
+    self
+  }
 }
 
 /// A type that wraps a [`Window`] together with a [`Webview`].


### PR DESCRIPTION
Addresses tauri-apps/tauri#10909.

* Updates `wry` to `0.44.0`, which introduces `browser_extensions_enabled` for Windows (from https://github.com/tauri-apps/wry/pull/1356)
* Updates `WebviewWindowBuilder` and `WindowConfig` structs to include that same configuration
* Adds `browser_extensions_enabled(bool)` to `WebviewWindowBuilder`

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix tauri-apps/tauri#7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes tauri-apps/tauri#123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
