### PR TITLE
fix(cli): set ios deployment target only when building for ios

### DIFF
--- a/.changes/fix-conditional-ios-deployment-target.md
+++ b/.changes/fix-conditional-ios-deployment-target.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+The cli now only sets the iOS deployment target environment variable when building for iOS.

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -151,10 +151,14 @@ impl Interface for Rust {
       std::env::set_var("MACOSX_DEPLOYMENT_TARGET", minimum_system_version);
     }
 
-    std::env::set_var(
-      "IPHONEOS_DEPLOYMENT_TARGET",
-      &config.bundle.ios.minimum_system_version,
-    );
+    if let Some(target) = &target {
+      if target.ends_with("ios") || target.ends_with("ios-sim") {
+        std::env::set_var(
+          "IPHONEOS_DEPLOYMENT_TARGET",
+          &config.bundle.ios.minimum_system_version,
+        );
+      }
+    }
 
     let app_settings = RustAppSettings::new(config, manifest, target)?;
 


### PR DESCRIPTION
fixes #11054 

honestly doesn't feel like this is really our fault. makes no sense to me why some tools would rely on that particular env var to decide whether they should build for ios.