### PR TITLE
fix(bundler): Detect ARM gnueabi as soft-float (fix: #10970)

### DIFF
--- a/.changes/bundler-gnueabi-armel.md
+++ b/.changes/bundler-gnueabi-armel.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": major:bug
+---
+
+Detect ARM gnueabi as soft-float (armel) instead of hard-float (armhf). Also change the signature of `tauri_bundler::bundle::Settings::binary_arch` to return an enum instead of a `&str`.

--- a/.changes/bundler-gnueabi-armel.md
+++ b/.changes/bundler-gnueabi-armel.md
@@ -1,5 +1,5 @@
 ---
-"tauri-bundler": major:bug
+"tauri-bundler": patch:bug
 ---
 
 Detect ARM gnueabi as soft-float (armel) instead of hard-float (armhf). Also change the signature of `tauri_bundler::bundle::Settings::binary_arch` to return an enum instead of a `&str`.

--- a/crates/tauri-bundler/src/bundle/linux/appimage/mod.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/mod.rs
@@ -10,7 +10,7 @@ use super::{
   },
   debian,
 };
-use crate::Settings;
+use crate::{bundle::settings::Arch, Settings};
 use anyhow::Context;
 use handlebars::Handlebars;
 use std::{
@@ -24,11 +24,17 @@ use std::{
 /// Returns a vector of PathBuf that shows where the AppImage was created.
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   // generate the deb binary name
-  let arch = match settings.binary_arch() {
-    "x86" => "i386",
-    "x86_64" => "amd64",
-    "armv7" => "armhf",
-    other => other,
+  let arch: &str = match settings.binary_arch() {
+    Arch::X86_64 => "amd64",
+    Arch::X86 => "i386",
+    Arch::AArch64 => "aarch64",
+    Arch::Armhf => "armhf",
+    target => {
+      return Err(crate::Error::ArchError(format!(
+        "Unsupported architecture: {:?}",
+        target
+      )));
+    }
   };
   let package_dir = settings.project_out_directory().join("bundle/appimage_deb");
 

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -24,7 +24,7 @@
 // generate postinst or prerm files.
 
 use super::{super::common, freedesktop};
-use crate::Settings;
+use crate::{bundle::settings::Arch, Settings};
 use anyhow::Context;
 use flate2::{write::GzEncoder, Compression};
 use tar::HeaderMode;
@@ -41,12 +41,17 @@ use std::{
 /// Returns a vector of PathBuf that shows where the DEB was created.
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let arch = match settings.binary_arch() {
-    "x86" => "i386",
-    "x86_64" => "amd64",
-    // ARM64 is detected differently, armel isn't supported, so armhf is the only reasonable choice here.
-    "arm" => "armhf",
-    "aarch64" => "arm64",
-    other => other,
+    Arch::X86_64 => "amd64",
+    Arch::X86 => "i386",
+    Arch::AArch64 => "arm64",
+    Arch::Armhf => "armhf",
+    Arch::Armel => "armel",
+    target => {
+      return Err(crate::Error::ArchError(format!(
+        "Unsupported architecture: {:?}",
+        target
+      )));
+    }
   };
   let package_base_name = format!(
     "{}_{}_{}",

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::Settings;
+use crate::{bundle::settings::Arch, Settings};
 
 use anyhow::Context;
 use rpm::{self, signature::pgp, Dependency, FileMode, FileOptions};
@@ -23,9 +23,17 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let release = settings.rpm().release.as_str();
   let epoch = settings.rpm().epoch;
   let arch = match settings.binary_arch() {
-    "x86" => "i386",
-    "arm" => "armhfp",
-    other => other,
+    Arch::X86_64 => "x86_64",
+    Arch::X86 => "i386",
+    Arch::AArch64 => "aarch64",
+    Arch::Armhf => "armhfp",
+    Arch::Armel => "armel",
+    target => {
+      return Err(crate::Error::ArchError(format!(
+        "Unsupported architecture: {:?}",
+        target
+      )));
+    }
   };
 
   let summary = settings.short_description().trim();

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -6,7 +6,7 @@
 use super::{app, icon::create_icns_file};
 use crate::{
   bundle::{common::CommandExt, Bundle},
-  PackageType, Settings,
+  Arch, PackageType, Settings,
 };
 
 use anyhow::Context;
@@ -43,8 +43,15 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
     settings.product_name(),
     settings.version_string(),
     match settings.binary_arch() {
-      "x86_64" => "x64",
-      other => other,
+      Arch::X86_64 => "x64",
+      Arch::AArch64 => "aarch64",
+      Arch::Universal => "universal",
+      target => {
+        return Err(crate::Error::ArchError(format!(
+          "Unsupported architecture: {:?}",
+          target
+        )));
+      }
     }
   );
   let dmg_name = format!("{}.dmg", &package_base_name);

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -5,8 +5,8 @@
 
 use super::{app, icon::create_icns_file};
 use crate::{
-  bundle::{common::CommandExt, Bundle},
-  Arch, PackageType, Settings,
+  bundle::{common::CommandExt, settings::Arch, Bundle},
+  PackageType, Settings,
 };
 
 use anyhow::Context;

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -683,6 +683,22 @@ impl BundleBinary {
   }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Arch {
+  /// For the x86_64 / x64 / AMD64 instruction sets (64 bits).
+  X86_64,
+  /// For the x86 / i686 / i686 / 8086 instruction sets (32 bits).
+  X86,
+  /// For the AArch64 / ARM64 instruction sets (64 bits).
+  AArch64,
+  /// For the AArch32 / ARM32 instruction sets with hard-float (32 bits).
+  Armhf,
+  /// For the AArch32 / ARM32 instruction sets with soft-float (32 bits).
+  Armel,
+  /// For universal macOS applications.
+  Universal,
+}
+
 /// The Settings exposed by the module.
 #[derive(Clone, Debug)]
 pub struct Settings {
@@ -845,17 +861,19 @@ impl Settings {
   }
 
   /// Returns the architecture for the binary being bundled (e.g. "arm", "x86" or "x86_64").
-  pub fn binary_arch(&self) -> &str {
+  pub fn binary_arch(&self) -> Arch {
     if self.target.starts_with("x86_64") {
-      "x86_64"
+      Arch::X86_64
     } else if self.target.starts_with('i') {
-      "x86"
+      Arch::X86
+    } else if self.target.starts_with("arm") && self.target.ends_with("hf") {
+      Arch::Armhf
     } else if self.target.starts_with("arm") {
-      "arm"
+      Arch::Armel
     } else if self.target.starts_with("aarch64") {
-      "aarch64"
+      Arch::AArch64
     } else if self.target.starts_with("universal") {
-      "universal"
+      Arch::Universal
     } else {
       panic!("Unexpected target triple {}", self.target)
     }

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -6,7 +6,7 @@
 use crate::bundle::{
   common::CommandExt,
   path_utils::{copy_file, FileOpts},
-  settings::Settings,
+  settings::{Arch, Settings},
   windows::{
     sign::try_sign,
     util::{
@@ -217,12 +217,12 @@ fn app_installer_output_path(
   updater: bool,
 ) -> crate::Result<PathBuf> {
   let arch = match settings.binary_arch() {
-    "x86" => "x86",
-    "x86_64" => "x64",
-    "aarch64" => "arm64",
+    Arch::X86_64 => "x64",
+    Arch::X86 => "x86",
+    Arch::AArch64 => "arm64",
     target => {
       return Err(crate::Error::ArchError(format!(
-        "Unsupported architecture: {}",
+        "Unsupported architecture: {:?}",
         target
       )))
     }
@@ -330,12 +330,12 @@ fn run_candle(
   extensions: Vec<PathBuf>,
 ) -> crate::Result<()> {
   let arch = match settings.binary_arch() {
-    "x86_64" => "x64",
-    "x86" => "x86",
-    "aarch64" => "arm64",
+    Arch::X86_64 => "x64",
+    Arch::X86 => "x86",
+    Arch::AArch64 => "arm64",
     target => {
       return Err(crate::Error::ArchError(format!(
-        "unsupported target: {}",
+        "unsupported architecture: {:?}",
         target
       )))
     }
@@ -421,12 +421,12 @@ pub fn build_wix_app_installer(
   updater: bool,
 ) -> crate::Result<Vec<PathBuf>> {
   let arch = match settings.binary_arch() {
-    "x86_64" => "x64",
-    "x86" => "x86",
-    "aarch64" => "arm64",
+    Arch::X86_64 => "x64",
+    Arch::X86 => "x86",
+    Arch::AArch64 => "arm64",
     target => {
       return Err(crate::Error::ArchError(format!(
-        "unsupported target: {}",
+        "unsupported architecture: {:?}",
         target
       )))
     }

--- a/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use crate::bundle::settings::Arch;
 use crate::bundle::windows::sign::{sign_command, try_sign};
 
 use crate::{
@@ -152,12 +153,12 @@ fn build_nsis_app_installer(
   updater: bool,
 ) -> crate::Result<Vec<PathBuf>> {
   let arch = match settings.binary_arch() {
-    "x86_64" => "x64",
-    "x86" => "x86",
-    "aarch64" => "arm64",
+    Arch::X86_64 => "x64",
+    Arch::X86 => "x86",
+    Arch::AArch64 => "arm64",
     target => {
       return Err(crate::Error::ArchError(format!(
-        "unsupported target: {}",
+        "unsupported architecture: {:?}",
         target
       )))
     }


### PR DESCRIPTION
Detect ARM gnueabi as soft-float (armel) instead of hard-float (armhf).

Also change the signature of `tauri_bundler::bundle::Settings::binary_arch` to return an enum instead of a `&str`, in order to be more explicit.

Fixes #10970 