### PR TITLE
fix(cli): only modify iOS code sign style when manually signing

### DIFF
--- a/.changes/fix-ios-proj-sync.md
+++ b/.changes/fix-ios-proj-sync.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Only modify the iOS Xcode project "sign style" if we need to enforce manual signing.

--- a/crates/tauri-cli/src/mobile/ios/mod.rs
+++ b/crates/tauri-cli/src/mobile/ios/mod.rs
@@ -447,15 +447,9 @@ pub fn synchronize_project_config(
     .find(|l| l.comment.contains("_iOS"))
   {
     for build_configuration_ref in xc_configuration_list.build_configurations {
-      pbxproj.set_build_settings(
-        &build_configuration_ref.id,
-        "CODE_SIGN_STYLE",
-        if manual_signing {
-          "Manual"
-        } else {
-          "Automatic"
-        },
-      );
+      if manual_signing {
+        pbxproj.set_build_settings(&build_configuration_ref.id, "CODE_SIGN_STYLE", "Manual");
+      }
 
       if let Some(team) = config.development_team() {
         pbxproj.set_build_settings(&build_configuration_ref.id, "DEVELOPMENT_TEAM", team);


### PR DESCRIPTION
ref #10925