### PR TITLE
fix(nsis): properly handle Webview2 download return value 

### DIFF
--- a/.changes/bundler-nsis-webview2-success.md
+++ b/.changes/bundler-nsis-webview2-success.md
@@ -1,0 +1,6 @@
+---
+"tauri-bundler": "patch:bug"
+---
+
+Fix NSIS installer failing to determine whether webview installer downloaded correctly or not. 
+

--- a/tooling/bundler/src/bundle/windows/templates/installer.nsi
+++ b/tooling/bundler/src/bundle/windows/templates/installer.nsi
@@ -457,7 +457,7 @@ Section WebView2
     DetailPrint "$(webview2Downloading)"
     NSISdl::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
     Pop $0
-    ${If} $0 == 0
+    ${If} $0 == "success"
       DetailPrint "$(webview2DownloadSuccess)"
     ${Else}
       DetailPrint "$(webview2DownloadError)"


### PR DESCRIPTION
The NSIS template was changed in #9605 to use NSISdl instead of nsis_tauri_utils for downloading Webview2, but the return value handling was not adjusted from comparing against 0, to the return value of NSISdl::download:
```
The return value is pushed to the stack:

  "cancel" if cancelled
  "success" if success
  otherwise, an error string describing the error
```

The issue can be reliably reproduced with Windows Sandbox, which never has Webiew2 preinstalled.

This PR adjusts the NSIS template to properly check the return value.

| Before | After - success | After - offline |
| - | - | - |
| ![Screenshot 2024-09-25 153404](https://github.com/user-attachments/assets/c660340d-35a4-4f86-a89b-dd4ba9d411f4) | ![Screenshot 2024-09-25 161034](https://github.com/user-attachments/assets/91848440-c3bf-46a0-835a-bd37ed12fb9a) | ![Screenshot 2024-09-25 161348](https://github.com/user-attachments/assets/cde6227f-1e9a-4935-b407-be2d833436f0) |


