### PR TITLE
feat: add `ScopeObjectMatch` trait for easy scope validation

### DIFF
--- a/.changes/scope-object-match.md
+++ b/.changes/scope-object-match.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:feat
+---
+
+Add `ScopeObjectMatch` for easy scope validation those that can be represented by a boolean return value.

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -660,16 +660,16 @@ impl<T: ScopeObjectMatch> CommandScope<T> {
   /// #   }
   /// # }
   /// #
-  /// # fn do_work(_: String) -> Result<String, ()> {
+  /// # fn do_work(_: String) -> Result<String, &'static str> {
   /// #   Ok("Output".into())
   /// # }
   /// #
   /// #[command]
-  /// fn my_command(scope: CommandScope<Scope>, input: String) -> Result<String, ()> {
+  /// fn my_command(scope: CommandScope<Scope>, input: String) -> Result<String, &'static str> {
   ///   if scope.matches(&input) {
   ///     do_work(input)
   ///   } else {
-  ///     Err(())
+  ///     Err("Scope didn't match input")
   ///   }
   /// }
   /// ```

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -627,7 +627,7 @@ impl<T: ScopeObject> CommandScope<T> {
 
 impl<T: ScopeObjectMatch> CommandScope<T> {
   /// Ensure all deny scopes were not matched and any allow scopes were.
-  pub fn is_matched(&self, input: &T::Input) -> bool {
+  pub fn matches(&self, input: &T::Input) -> bool {
     // first make sure the text doesn't match any existing deny scope
     if self.deny.iter().any(|s| s.matches(input)) {
       return false;

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -628,8 +628,9 @@ impl<T: ScopeObject> CommandScope<T> {
 impl<T: ScopeObjectMatch> CommandScope<T> {
   /// Ensure all deny scopes were not matched and any allow scopes were.
   ///
-  /// This **WILL** return `true` if the allow scopes are empty and the deny scopes did not trigger.
-  /// If you require at least 1 allow scope, then ensure it is not empty before calling this method.
+  /// This **WILL** return `true` if the allow scopes are empty and the deny
+  /// scopes did not trigger. If you require at least one allow scope, then
+  /// ensure the allow scopes are not empty before calling this method.
   ///
   /// ```
   /// # use tauri::ipc::CommandScope;
@@ -659,17 +660,21 @@ impl<T: ScopeObjectMatch> CommandScope<T> {
   /// #   }
   /// # }
   /// #
+  /// # fn do_work(_: String) -> Result<String, ()> {
+  /// #   Ok("Output".into())
+  /// # }
+  /// #
   /// #[command]
   /// fn my_command(scope: CommandScope<Scope>, input: String) -> Result<String, ()> {
   ///   if scope.matches(&input) {
-  ///     Ok("Ok".into())
+  ///     do_work(input)
   ///   } else {
   ///     Err(())
   ///   }
   /// }
   /// ```
   pub fn matches(&self, input: &T::Input) -> bool {
-    // first make sure the text doesn't match any existing deny scope
+    // first make sure the input doesn't match any existing deny scope
     if self.deny.iter().any(|s| s.matches(input)) {
       return false;
     }

--- a/crates/tauri/src/ipc/mod.rs
+++ b/crates/tauri/src/ipc/mod.rs
@@ -29,7 +29,7 @@ pub(crate) mod protocol;
 
 pub use authority::{
   CapabilityBuilder, CommandScope, GlobalScope, Origin, RuntimeAuthority, RuntimeCapability,
-  ScopeObject, ScopeValue,
+  ScopeObject, ScopeObjectMatch, ScopeValue,
 };
 pub use channel::{Channel, JavaScriptChannelId};
 pub use command::{private, CommandArg, CommandItem};


### PR DESCRIPTION
This is a DX improvement for developers that are adding scopes to their commands (likely in plugins).

If the validation of a scope can be represented as a `bool`, the type can implement `ScopeObjectMatch` to enable a helper method on `CommandScope` that automatically checks that all deny scopes are not matched and enforcing allow scopes if they exist.

turns code like:
```rust
 #[command]
 pub(crate) async fn read_text<R: Runtime>(
     scope: CommandScope<Scope>,
     clipboard: State<'_, Clipboard<R>>,
 ) -> Result<String> {
    let text = clipboard.read_text()?;

     // first make sure the text doesn't match any existing deny scope
     if Scope::any(scope.denies(), &text) {
         return Err(crate::error::Error::Scope);
     }

     // ensure the text matches at least 1 allow scope, only if they exist
     let allow = scope.allows();
     if !allow.is_empty() && !Scope::any(allow, &text) {
         return Err(crate::error::Error::Scope);
     }

     Ok(text)
 }
```
into
```rust
#[command]
pub(crate) async fn read_text<R: Runtime>(
    scope: CommandScope<Scope>,
    clipboard: State<'_, Clipboard<R>>,
) -> Result<String> {
    let text = clipboard.read_text()?;
    if scope.matches(&text) {
        Ok(text)
    } else {
        Err(crate::error::Error::Scope)
    }
}
```

which removes the chances for developers to make simple logic errors when validating the deny and allow scopes - especially if they are using it multiple times in many commands.