### PR TITLE
chore(cli/deps): temporarily add tower dependency to fix compile error without --locked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7431,6 +7431,7 @@ dependencies = [
  "tokio",
  "toml 0.8.19",
  "toml_edit 0.22.20",
+ "tower",
  "ureq",
  "url",
  "uuid",

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -40,7 +40,7 @@ cargo-mobile2 = { version = "0.17.2", default-features = false }
 
 [dependencies]
 # temporary until https://github.com/paritytech/jsonrpsee/pull/1464 is released
-tower = { version = "0.4", default-features = false, features = ["util"]}
+tower = { version = "0.4", default-features = false, features = ["util"] }
 jsonrpsee = { version = "0.24", features = ["server"] }
 jsonrpsee-core = "0.24"
 jsonrpsee-client-transport = { version = "0.24", features = ["ws"] }

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -39,6 +39,8 @@ path = "src/main.rs"
 cargo-mobile2 = { version = "0.17.2", default-features = false }
 
 [dependencies]
+# temporary until https://github.com/paritytech/jsonrpsee/pull/1464 is released
+tower = { version = "0.4", default-features = false, features = ["util"]}
 jsonrpsee = { version = "0.24", features = ["server"] }
 jsonrpsee-core = "0.24"
 jsonrpsee-client-transport = { version = "0.24", features = ["ws"] }


### PR DESCRIPTION
i don't wanna deal with this on release day tbh