### PR TITLE
docs: fix formatting of JS comments for API reference

### DIFF
--- a/packages/api/src/menu/menu.ts
+++ b/packages/api/src/menu/menu.ts
@@ -90,7 +90,7 @@ export class Menu extends MenuItemBase {
   /**
    * Add a menu item to the end of this menu.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -119,7 +119,7 @@ export class Menu extends MenuItemBase {
   /**
    * Add a menu item to the beginning of this menu.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -148,7 +148,7 @@ export class Menu extends MenuItemBase {
   /**
    * Add a menu item to the specified position in this menu.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */

--- a/packages/api/src/menu/submenu.ts
+++ b/packages/api/src/menu/submenu.ts
@@ -90,7 +90,7 @@ export class Submenu extends MenuItemBase {
   /**
    * Add a menu item to the end of this submenu.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -119,7 +119,7 @@ export class Submenu extends MenuItemBase {
   /**
    * Add a menu item to the beginning of this submenu.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */
@@ -148,7 +148,7 @@ export class Submenu extends MenuItemBase {
   /**
    * Add a menu item to the specified position in this submenu.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **macOS:** Only {@linkcode Submenu}s can be added to a {@linkcode Menu}.
    */

--- a/packages/api/src/tray.ts
+++ b/packages/api/src/tray.ts
@@ -231,7 +231,7 @@ export class TrayIcon extends Resource {
   /**
    * Sets the tooltip for this tray icon.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **Linux:** Unsupported
    */
@@ -242,7 +242,7 @@ export class TrayIcon extends Resource {
   /**
    * Sets the tooltip for this tray icon.
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **Linux:** The title will not be shown unless there is an icon
    * as well.  The title is useful for numerical and other frequently

--- a/packages/api/src/webview.ts
+++ b/packages/api/src/webview.ts
@@ -5,7 +5,7 @@
 /**
  * Provides APIs to create webviews, communicate with other webviews and manipulate the current webview.
  *
- * ## Webview events
+ * #### Webview events
  *
  * Events can be listened to using {@link Webview.listen}:
  * ```typescript
@@ -687,7 +687,7 @@ interface WebviewOptions {
   /**
    * Whether page zooming by hotkeys is enabled
    *
-   * ## Platform-specific:
+   * #### Platform-specific:
    *
    * - **Windows**: Controls WebView2's [`IsZoomControlEnabled`](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/winrt/microsoft_web_webview2_core/corewebview2settings?view=webview2-winrt-1.0.2420.47#iszoomcontrolenabled) setting.
    * - **MacOS / Linux**: Injects a polyfill that zooms in and out with `ctrl/command` + `-/=`,

--- a/packages/api/src/window.ts
+++ b/packages/api/src/window.ts
@@ -5,7 +5,7 @@
 /**
  * Provides APIs to create windows, communicate with other windows and manipulate the current window.
  *
- * ## Window events
+ * #### Window events
  *
  * Events can be listened to using {@link Window.listen}:
  * ```typescript
@@ -1651,7 +1651,7 @@ class Window {
   /**
    * Sets whether the window should be visible on all workspaces or virtual desktops.
    *
-   * ## Platform-specific
+   * #### Platform-specific
    *
    * - **Windows / iOS / Android:** Unsupported.
    *
@@ -2058,7 +2058,7 @@ enum Effect {
   /**
    * **Windows 7/10/11(22H1) Only**
    *
-   * ## Notes
+   * #### Notes
    *
    * This effect has bad performance when resizing/dragging the window on Windows 11 build 22621.
    */
@@ -2066,7 +2066,7 @@ enum Effect {
   /**
    * **Windows 10/11**
    *
-   * ## Notes
+   * #### Notes
    *
    * This effect has bad performance when resizing/dragging the window on Windows 10 v1903+ and Windows 11 build 22000.
    */
@@ -2247,7 +2247,7 @@ interface WindowOptions {
   parent?: Window | WebviewWindow | string
   /** Whether the window should be visible on all workspaces or virtual desktops.
    *
-   * ## Platform-specific
+   * #### Platform-specific
    *
    * - **Windows / iOS / Android:** Unsupported.
    *


### PR DESCRIPTION
This fixes headers issues in generated JS reference documentation.

For example, for the [`menu`](https://v2.tauri.app/reference/javascript/api/namespacemenu/) page, some "Platform-specific" headings have the wrong level.

## Before

![Capture d’écran du 2024-09-26 13-48-55](https://github.com/user-attachments/assets/5f179b2d-32e3-41e3-9934-34164da934a7)

## After

![Capture d’écran du 2024-09-26 13-49-09](https://github.com/user-attachments/assets/29bfd2a5-2347-4f0b-a845-39a942f9786d)
