### PR TITLE
feat(cli): support Trunk for iOS dev out of the box

### DIFF
--- a/.changes/trunk-ios-dev.md
+++ b/.changes/trunk-ios-dev.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Set the `TRUNK_SERVE_ADDRESS` environment variable when running on iOS physical devices to support Trunk.

--- a/crates/tauri-cli/src/mobile/ios/dev.rs
+++ b/crates/tauri-cli/src/mobile/ios/dev.rs
@@ -344,6 +344,7 @@ fn use_network_address_for_dev_url(
 
   if let Some(ip) = ip {
     std::env::set_var("TAURI_DEV_HOST", ip.to_string());
+    std::env::set_var("TRUNK_SERVE_ADDRESS", ip.to_string());
     if ip.is_ipv6() {
       // in this case we can't ping the server for some reason
       dev_options.no_dev_server_wait = true;


### PR DESCRIPTION
Trunk only allows us to have a dynamic development server address via the TRUNK_SERVE_ADDRESS environment variable, to we must set it from the Tauri CLI in order to support it
