### PR TITLE
feat(cli): retain log verbosity when running a mobile IDE script

### DIFF
--- a/.changes/ide-commands-verbosity.md
+++ b/.changes/ide-commands-verbosity.md
@@ -1,0 +1,7 @@
+---
+'tauri-cli': 'patch:enhance'
+'@tauri-apps/cli': 'patch:enhance'
+---
+
+Retain logger verbosity on the `android-studio-script` and `xcode-script` commands.
+

--- a/crates/tauri-cli/src/lib.rs
+++ b/crates/tauri-cli/src/lib.rs
@@ -216,10 +216,18 @@ where
     Err(e) => e.exit(),
   };
 
+  let verbosity_number = std::env::var("TAURI_CLI_VERBOSITY")
+    .ok()
+    .and_then(|v| v.parse().ok())
+    .unwrap_or(cli.verbose);
+  println!("{verbosity_number}");
+  // set the verbosity level so subsequent CLI calls (xcode-script, android-studio-script) refer to it
+  std::env::set_var("TAURI_CLI_VERBOSITY", verbosity_number.to_string());
+
   let mut builder = Builder::from_default_env();
   let init_res = builder
     .format_indent(Some(12))
-    .filter(None, verbosity_level(cli.verbose).to_level_filter())
+    .filter(None, verbosity_level(verbosity_number).to_level_filter())
     .format(|f, record| {
       let mut is_command_output = false;
       if let Some(action) = record.key_values().get("action".into()) {

--- a/crates/tauri-cli/src/lib.rs
+++ b/crates/tauri-cli/src/lib.rs
@@ -220,7 +220,6 @@ where
     .ok()
     .and_then(|v| v.parse().ok())
     .unwrap_or(cli.verbose);
-  println!("{verbosity_number}");
   // set the verbosity level so subsequent CLI calls (xcode-script, android-studio-script) refer to it
   std::env::set_var("TAURI_CLI_VERBOSITY", verbosity_number.to_string());
 


### PR DESCRIPTION
the mobile IDE scripts (android-studio-script and xcode-script) are executed in a separate process and should retain the verbosity provided by the user
