### PR TITLE
feat(cli): add clap parse test

### DIFF
--- a/crates/tauri-cli/src/lib.rs
+++ b/crates/tauri-cli/src/lib.rs
@@ -376,3 +376,15 @@ impl CommandExt for Command {
     }
   }
 }
+
+#[cfg(test)]
+mod tests {
+  use clap::CommandFactory;
+
+  use crate::Cli;
+
+  #[test]
+  fn verify_cli() {
+    Cli::command().debug_assert();
+  }
+}


### PR DESCRIPTION
lets us catch runtime errors early on the testing phase - for instance when we add two arguments with the same flag
