### PR TITLE
fix(core): deadlock when creating new window with tracing feature

### DIFF
--- a/.changes/fix-deadlock-tracing-window-creation.md
+++ b/.changes/fix-deadlock-tracing-window-creation.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes a deadlock on window creation when the `tracing` feature is enabled.

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -351,19 +351,36 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
     }
     .map(|window| self.manager.attach_window(self.app_handle.clone(), window))?;
 
-    self.manager.eval_script_all(format!(
-      "window.__TAURI_METADATA__.__windows = {window_labels_array}.map(function (label) {{ return {{ label: label }} }})",
-      window_labels_array = serde_json::to_string(&self.manager.labels())?,
-    ))?;
+    let manager = self.manager.clone();
+    let label = window.label().to_string();
 
-    self.manager.emit_filter(
-      "tauri://window-created",
-      None,
-      Some(WindowCreatedEvent {
-        label: window.label().into(),
-      }),
-      |w| w != &window,
-    )?;
+    let window_created_hook = move || {
+      manager.eval_script_all(format!(
+        "window.__TAURI_METADATA__.__windows = {window_labels_array}.map(function (label) {{ return {{ label: label }} }})",
+        window_labels_array = serde_json::to_string(&manager.labels())?,
+      ))?;
+
+      manager.emit_filter(
+        "tauri://window-created",
+        None,
+        Some(WindowCreatedEvent {
+          label: label.clone(),
+        }),
+        |w| w.label() != label,
+      )?;
+
+      crate::Result::Ok(())
+    };
+
+    if cfg!(feature = "tracing") {
+      std::thread::spawn(move || {
+        if let Err(e) = window_created_hook() {
+          log::error!("failed to trigger window creation hooks: {e}");
+        }
+      });
+    } else {
+      window_created_hook()?;
+    }
 
     Ok(window)
   }

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -372,15 +372,14 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
       crate::Result::Ok(())
     };
 
-    if cfg!(feature = "tracing") {
-      std::thread::spawn(move || {
-        if let Err(e) = window_created_hook() {
-          log::error!("failed to trigger window creation hooks: {e}");
-        }
-      });
-    } else {
-      window_created_hook()?;
-    }
+    #[cfg(not(feature = "tracing")]
+    window_created_hook()?;
+    #[cfg(feature = "tracing")]
+    std::thread::spawn(move || {
+      if let Err(e) = window_created_hook() {
+        log::error!("failed to trigger window creation hooks: {e}");
+      }
+    });
 
     Ok(window)
   }

--- a/core/tauri/src/window.rs
+++ b/core/tauri/src/window.rs
@@ -372,7 +372,7 @@ impl<'a, R: Runtime> WindowBuilder<'a, R> {
       crate::Result::Ok(())
     };
 
-    #[cfg(not(feature = "tracing")]
+    #[cfg(not(feature = "tracing"))]
     window_created_hook()?;
     #[cfg(feature = "tracing")]
     std::thread::spawn(move || {

--- a/examples/api/src-tauri/Cargo.lock
+++ b/examples/api/src-tauri/Cargo.lock
@@ -4027,7 +4027,7 @@ checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "tauri"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "1.5.4"
+version = "1.5.5"
 dependencies = [
  "anyhow",
  "cargo_toml",


### PR DESCRIPTION
when the tracing feature is enabled, all eval() calls are synchronous (so we can track how much time they take) so the window creation hooks deadlocks since we're also reacting to a main thread window event at the same time. running the hooks in a separate thread fixes this.

closes https://github.com/crabnebula-dev/devtools/issues/352
