### PR TITLE
fix(windows): fix command bug in update elevated task (fix #11216)

### DIFF
--- a/.changes/fix-elevated-update-cmd.md
+++ b/.changes/fix-elevated-update-cmd.md
@@ -1,5 +1,5 @@
 ---
-"tauri-bundle": patch:fix
+"tauri-bundler": patch:fix
 ---
 
 Fixed Command arguments for Windows -> msi -> elevatedUpdateTask. This works with spaces in project name on windows

--- a/.changes/fix-elevated-update-cmd.md
+++ b/.changes/fix-elevated-update-cmd.md
@@ -2,4 +2,4 @@
 "tauri-bundler": patch:fix
 ---
 
-Fixed Command arguments for Windows -> msi -> elevatedUpdateTask. This works with spaces in project name on windows
+On Windows, fixed command arguments for `bundle -> windows -> msi -> elevatedUpdateTask`. to work with spaces in `productName`

--- a/.changes/fix-elevated-update-cmd.md
+++ b/.changes/fix-elevated-update-cmd.md
@@ -1,5 +1,5 @@
 ---
-"tauri-bundler": patch:fix
+"tauri-bundler": patch:bug
 ---
 
 On Windows, fixed command arguments for `bundle -> windows -> msi -> elevatedUpdateTask`. to work with spaces in `productName`

--- a/.changes/fix-elevated-update-cmd.md
+++ b/.changes/fix-elevated-update-cmd.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundle": patch:fix
+---
+
+Fixed Command arguments for Windows -> msi -> elevatedUpdateTask. This works with spaces in project name on windows

--- a/crates/tauri-bundler/src/bundle/windows/msi/update-task.xml
+++ b/crates/tauri-bundler/src/bundle/windows/msi/update-task.xml
@@ -37,7 +37,7 @@
   <Actions Context="Author">
     <Exec>
       <Command>cmd.exe</Command>
-      <Arguments>/c "%SYSTEMROOT%\System32\msiexec.exe /i %TEMP%\\{{product_name}}.msi {{msiexec_args}} /promptrestart"</Arguments>
+      <Arguments>/c ^"%SYSTEMROOT%\System32\msiexec.exe /i "%TEMP%\\{{product_name}}.msi" {{msiexec_args}} /promptrestart^"</Arguments>
     </Exec>
   </Actions>
 </Task>


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

The command present in update-task.xml will fail if there are any spaces in either the project name or "username" of the target machine. 

Fixed the command to properly escape such scenarios 

> More info about the bug is present in the issue #11216  

