### PR TITLE
fix(api): actually publish with the latest tag

### DIFF
--- a/.changes/api-latest-tag.md
+++ b/.changes/api-latest-tag.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/api": patch:changes
+---
+
+Actually publish package with the latest tag.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "build": "rollup -c --configPlugin typescript",
     "npm-pack": "pnpm build && cd ./dist && npm pack",
-    "npm-publish": "pnpm build && cd ./dist && pnpm publish --access public --loglevel silly --tag next --no-git-checks",
+    "npm-publish": "pnpm build && cd ./dist && pnpm publish --access public --loglevel silly --no-git-checks",
     "ts:check": "tsc --noEmit",
     "eslint:check": "eslint src/**.ts",
     "eslint:fix": "eslint src/**.ts --fix"


### PR DESCRIPTION
we missed one `--tag next` usage in #11199
