### PR TITLE
make rpm name consistent with others

### DIFF
--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -38,7 +38,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   let summary = settings.short_description().trim();
 
-  let package_base_name = format!("{product_name}-{version}-{release}.{arch}");
+  let package_base_name = format!("{product_name}_{version}-{release}.{arch}");
   let package_name = format!("{package_base_name}.rpm");
 
   let base_dir = settings.project_out_directory().join("bundle/rpm");


### PR DESCRIPTION
Would you be open to make rpm name consistent with other platforms.

Because RPM currently users `-` instead of `_`, it does not follow the same order as the other files, so it gets confusing when looking at it on S3/Local

![image](https://github.com/user-attachments/assets/c876b32c-aab0-4832-adba-1ca66ca3a072)
