### PR TITLE
feat(core): expose invoke key for custom IPC implementations

### DIFF
--- a/.changes/expose-invoke-key.md
+++ b/.changes/expose-invoke-key.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Added `App::invoke_key` and `AppHandle::invoke_key` for custom invoke systems that rely on manual `Webview::on_message` calls.

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -878,6 +878,15 @@ macro_rules! shared_app_impl {
           webview.resources_table().clear();
         }
       }
+
+      /// Gets the invoke key that must be referenced when using [`crate::webview::InvokeRequest`].
+      ///
+      /// # Security
+      ///
+      /// DO NOT expose this key to third party scripts as might grant access to the backend from external URLs and iframes.
+      pub fn invoke_key(&self) -> &str {
+        self.manager.invoke_key()
+      }
     }
 
     impl<R: Runtime> Listener<R> for $app {


### PR DESCRIPTION
custom IPC systems that manually call Webview::on_message must know the invoke key checked by Tauri. This exposes that key in the App/AppHandle instances.

This is safe because the key is never leaked to remote denied webview URLs
