### PR TITLE
feat(cli): make tauri/cli fully support projects with non-standard structure

### DIFF
--- a/.changes/support-custom-repo-structure.md
+++ b/.changes/support-custom-repo-structure.md
@@ -1,0 +1,7 @@
+---
+"@tauri-apps/cli": patch:enhance
+"tauri-cli": patch:enhance
+---
+
+Support custom project directory structure where the Tauri app folder is not a subfolder of the frontend project.
+The frontend and Tauri app project paths can be set with the `TAURI_FRONTEND_PATH` and the `TAURI_APP_PATH` environment variables respectively.

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -88,8 +88,7 @@ fn env_tauri_src_dir() -> Option<PathBuf> {
 }
 
 pub fn resolve_tauri_dir() -> Option<PathBuf> {
-  let src_dir =
-    env_tauri_src_dir().or_else(|| current_dir().map(|cwd| cwd.join("src-tauri")).ok())?;
+  let src_dir = env_tauri_src_dir().or_else(|| current_dir().ok())?;
 
   if src_dir.join(ConfigFormat::Json.into_file_name()).exists()
     || src_dir.join(ConfigFormat::Json5.into_file_name()).exists()

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -18,6 +18,9 @@ use tauri_utils::{
 };
 
 const TAURI_GITIGNORE: &[u8] = include_bytes!("../../tauri.gitignore");
+const ENV_TAURI_APP_DIR: &str = "TAURI_APP_DIR";
+const ENV_TAURI_SRC_DIR: &str = "TAURI_SRC_DIR";
+
 static APP_DIR: OnceLock<PathBuf> = OnceLock::new();
 static TAURI_DIR: OnceLock<PathBuf> = OnceLock::new();
 
@@ -68,29 +71,34 @@ fn lookup<F: Fn(&PathBuf) -> bool>(dir: &Path, checker: F) -> Option<PathBuf> {
   None
 }
 
+fn env_tauri_app_dir() -> Option<PathBuf> {
+  std::env::var(ENV_TAURI_APP_DIR)
+    .map(PathBuf::from)
+    .ok()?
+    .canonicalize()
+    .ok()
+}
+
+fn env_tauri_src_dir() -> Option<PathBuf> {
+  std::env::var(ENV_TAURI_SRC_DIR)
+    .map(PathBuf::from)
+    .ok()?
+    .canonicalize()
+    .ok()
+}
+
 pub fn resolve_tauri_dir() -> Option<PathBuf> {
-  let Ok(cwd) = current_dir() else {
-    return None;
-  };
+  let src_dir =
+    env_tauri_src_dir().or_else(|| current_dir().map(|cwd| cwd.join("src-tauri")).ok())?;
 
-  if cwd.join(ConfigFormat::Json.into_file_name()).exists()
-    || cwd.join(ConfigFormat::Json5.into_file_name()).exists()
-    || cwd.join(ConfigFormat::Toml.into_file_name()).exists()
+  if src_dir.join(ConfigFormat::Json.into_file_name()).exists()
+    || src_dir.join(ConfigFormat::Json5.into_file_name()).exists()
+    || src_dir.join(ConfigFormat::Toml.into_file_name()).exists()
   {
-    return Some(cwd);
+    return Some(src_dir);
   }
 
-  let src_tauri = cwd.join("src-tauri");
-  if src_tauri.join(ConfigFormat::Json.into_file_name()).exists()
-    || src_tauri
-      .join(ConfigFormat::Json5.into_file_name())
-      .exists()
-    || src_tauri.join(ConfigFormat::Toml.into_file_name()).exists()
-  {
-    return Some(src_tauri);
-  }
-
-  lookup(&cwd, |path| {
+  lookup(&src_dir, |path| {
     folder_has_configuration_file(Target::Linux, path) || is_configuration_file(Target::Linux, path)
   })
   .map(|p| {
@@ -103,13 +111,15 @@ pub fn resolve_tauri_dir() -> Option<PathBuf> {
 }
 
 pub fn resolve() {
-  TAURI_DIR.set(resolve_tauri_dir().unwrap_or_else(||
-    panic!("Couldn't recognize the current folder as a Tauri project. It must contain a `{}`, `{}` or `{}` file in any subfolder.",
+  TAURI_DIR.set(resolve_tauri_dir().unwrap_or_else(|| {
+    let env_var_name = env_tauri_src_dir().is_some().then(|| format!("`{ENV_TAURI_SRC_DIR}`"));
+    panic!("Couldn't recognize the {} folder as a Tauri project. It must contain a `{}`, `{}` or `{}` file in any subfolder.",
+      env_var_name.as_deref().unwrap_or("current"),
       ConfigFormat::Json.into_file_name(),
       ConfigFormat::Json5.into_file_name(),
       ConfigFormat::Toml.into_file_name()
     )
-  )).expect("tauri dir already resolved");
+  })).expect("tauri dir already resolved");
   APP_DIR
     .set(resolve_app_dir().unwrap_or_else(|| tauri_dir().parent().unwrap().to_path_buf()))
     .expect("app dir already resolved");
@@ -122,12 +132,13 @@ pub fn tauri_dir() -> &'static PathBuf {
 }
 
 pub fn resolve_app_dir() -> Option<PathBuf> {
-  let cwd = current_dir().expect("failed to read cwd");
-  if cwd.join("package.json").exists() {
-    return Some(cwd);
+  let app_dir = env_tauri_app_dir().unwrap_or_else(|| current_dir().expect("failed to read cwd"));
+
+  if app_dir.join("package.json").exists() {
+    return Some(app_dir);
   }
 
-  lookup(&cwd, |path| {
+  lookup(&app_dir, |path| {
     if let Some(file_name) = path.file_name() {
       file_name == OsStr::new("package.json")
     } else {


### PR DESCRIPTION
Usually I'd first open a feature suggestion issue before embarking on the pull request itself for something like this, but I already have the implementation (as it was necessary to unblock myself), so I'm gonna skip the issue for this one.

The **tl;dr** is that we would like to propose adding explicit support for more flexible project structures (i.e. moving `src-tauri` out of the frontend app), which surprisingly took only minimal and non-invasive changes for the tauri cli tool.

(FYI: we'll be using `web-app` and `tauri-app` as dummy-names for the top-most `app` and `app/src-tauri` directories here throughout, they don't matter!)

With the patched `cargo-tauri` binary one is able to run `pnpm tauri …`/`cargo tauri …` from both, the app, as well as src-tauri directory (and even —very convenient!— from the top-most directory!), regardless of how the project structured, like so:

Given a project structured like this:

```plain
my-app
├── ...
├── tauri-app
│   └── ...
└── web-app
    └── ...
```

… one would be able to run this:

```terminal
cd my-app

# probably something you'd put in an `.env` file:
export TAURI_APP_PATH="./web-app"
export TAURI_FRONTEND_PATH="./tauri-app"

pnpm tauri dev
# or
cargo tauri dev
```

<details>
<summary>Currently the CLI tool crashes when running from projects with non-standard structure</summary>

Currently running `pnpm tauri …`, such as `pnpm tauri migrate` from the web app directory of a project with non-standard structure leads to the following crash:

```terminal
$ cd ./web-app
$ pnpm tauri migrate

thread '<unnamed>' panicked at crates/tauri-cli/src/helpers/app_paths.rs:107:5:
Couldn't recognize the current folder as a Tauri project. It must contain a `tauri.conf.json`, `tauri.conf.json5` or `Tauri.toml` file in any subfolder.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command was killed with SIGABRT (Aborted): tauri migrate
```

Running the equivalent `cargo` command from the tauri src directory (in again, a non-standard structure) works, for what it's worth:

```terminal
$ cd ./tauri-app
$ cargo tauri migrate

Info Installing Cargo dependency "tauri-plugin-dialog"...
Updating crates.io index
  Adding tauri-plugin-dialog v2 to dependencies
...
Added permission `dialog:default` to `migrated` at <SNIP>/tauri-app/capabilities/migrated.json
Info Adding plugin to <SNIP>/tauri-app/src/main.rs
Info Running `cargo fmt`...
```

But since the `pnpm` route seems to be the far more common (and is usually the one that's dominantly recommended in the official guides) one I'd expect very few people to realize that while one crashes, the other works, even in non-standardly structured projects.

</details>

## Motivation

The standard structure of a tauri project looks something like this:

```plain
my-app
├── package.json
├── src
├── src-tauri
│   ├── Cargo.toml
│   ├── src
│   ├── tauri.config.json
│   └── ...
└── ...
```

The tauri project gets added as a sub-directory of the existing web project. This is certainly convenient for some things (like being able to have a single place for scripts: `package.json`, etc.) but also rather inconvenient for others.

### Flexible project structure

This rather rigid structure seems both, unnecessarily limiting and inconvenient, compared to say a structure like this:

```plain
my-app
├── tauri-app
│   ├── Cargo.toml
│   ├── src
│   ├── tauri.config.json
│   └── ...
└── web-app
    ├── package.json
    ├── src
    └── ...
```

The main source of inconvenience of the standard structure comes from the fact that **web dev projects tend to be littered with top-level configuration junk.**

### Junk, junk everywhere

<details>
<summary>What we mean by "top-level configuration junk"</summary>

As such the directory diagrams above where lying. Rather than being neat and clean:

```plain
web-app
├── package.json
├── src
└── ...
```

… the `web-app` directory's actual contents look like this garbage fire:

```plain
web-app
├── .gitignore
├── .npmrc
├── .prettierignore
├── .prettierrc
├── .svelte-kit
│   └── ...
├── build
│   └── ...
├── bundlemeta.json
├── components.json
├── eslint.config.mjs
├── node_modules
│   └── ...
├── package.json
├── packages
│   └── ...
├── playwright.config.ts
├── pnpm-lock.yaml
├── pnpm-workspace.yaml
├── postcss.config.ts
├── setupTest.ts
├── src
│   └── ...
├── static
│   └── ...
├── svelte.config.js
├── tailwind.config.ts
├── tests
│   └── ...
├── tsconfig.json
├── vite.config.ts
└── ...
```

</details>

### Poor developer experience & productivity

Other than `src`/`tests`/`package.json` hardly any of the many top-level files within a run-of-the-mill `web-app` project tend to be of actual regular(!) importance in one's day-to-day work, yet there is no way to hide them, making it at times hard to see the forest for the trees.

Unfortunately there really isn't much one can do about that (afaik), it's just the mess we find ourselves in when doing web dev work.
But forcing the same nonsense upon everybody working on the Rust bits of a Tauri project is really just adding insult to injury.

### Poor CI experience & performance, and significantly increased costs

Speaking of which, another major issue with the classic structure is that there simply is no straight-forward and reliable way to be smart about which jobs to run for a PR and on which CI runners, when everything is stuffed in the same directory.

This is particularly problematic in the context of a multi-platform Tauri project (which probably 90% of Tauri projects are) and the reality of macOS-based CI runners commonly being [10x as expensive as their Linux-based counterparts](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#minute-multipliers).

From a cost-perspective one would thus probably at least want to run the platform-agnostic frontend tests on the cheap CI runner and possibly even try to carve out any macOS-specific backend tests so only those get frequently run on the expensive macOSs (10x) runner, and everything else on cheap Linux (1x) or Windows (2x) runners.

### Frontend and backend tests competing for CI time

One might decide to split frontend and backend test jobs into separate workflows and have them run in parallel, in order to reduce the time spent by devs waiting for their pull requests to finish running their actions.

And while this might help reduce the average time to wait it ends up increasing the average money spent as unlike a single serial workflow that can abort on the first error with parallel workflows your "other" workflow will keep running and thus keep blocking the queue when your workflow encounters an error. (There probably are arcane Github action spells to solve this, but shouldn't this stuff just do the right thing by default?)

One could certainly split up the workflows and add extensive `on.pull_request.paths`/`on.pull_request.exclude_paths` lists to each of them and achieve a more fine-grained CI workflow selection, but such lists tend to be frickle at best and at worst could lead to CI not running a workflow where it absolutely should have.

By turning `web-app` and `tauri-app` into sibling directories selecting the right CI jobs and the right CI runner for a given PR becomes almost trivial: 

<details>
<summary>How to effortlessly run separate workflows for the app and tauri</summary>

```yaml
# .github/workflows/tauri-app.yml

on:
    pull_request:
        branches: [main, "**"]
        paths:
            - "tauri-app/**"
            - ".github/workflows/tauri-app.yml"
# ...
```

```yaml
# .github/workflows/web-app.yml

on:
    pull_request:
        branches: [main, "**"]
        paths:
            - "web-app/**"
            - ".github/workflows/web-app.yml"
# ...
```

</details>

As a result we found our CI times to greatly improve as said sibling structure allowed us to limit the expensive macOS tests to just the `tauri-app` directory. (We're still running full tests on a fixed schedule as a safety net to catch any regressions introduced at the integration layer of `web-app` and `tauri-app`, but so far those have't caught anything slipping through.)

## Benefits of a non-standard project structure

Anecdotally we found the developer experience and productivity to greatly improve upon switching the app/src-tauri directories from the standard parent-child to the alternative sibling structure.

While focussing on one side of a tauri app other's directory can be folded away in the IDE, allowing for working uninterruptedly and with focus.

For larger teams where the web-frontend and tauri-backend are developed by different people having a clear separation has clear benefits that  probably don't need to be illustrated here on their own.

Additionally having separate directories helps with VCS features like [Github's code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), which afaik doesn't even support exclude paths, so rather than directory globs for `./web-app/**` and `./tauri-app/**` every top-level file would need to be listed separately, leading to additional maintenance overhead.

When it comes to CI ergonomics and economics we —again anecdotally—found that having straight-forward control (yet fine-grained where necessary) greatly helped with streamlining the project's CI, significantly reducing the mean waiting time per CI action, as well as greatly reduced cost overall.

(From a pure architectural and usability point of view one could go as far as argue that the sibling structure should probably be the default, not the other way round. But that's not what this PR is about!)

That said we would really like to see Tauri support a more flexible project structure. Especially since it doesn't seem to take that much to make its tools work with them.

We are fully aware that a change like this (i.e. introducing env vars) has to be taken carefully and will thus probably take more than just "it works, let's ship it!". As such this PR is sort of a proof-of-concept for how things could be done.

(Disclaimer: we have so far only run the patched CLI with a few commands on our project with a sibling structure, but all of them successfully so, which is promising! That said every non-trivial tool inevitably will have accrued implicit assumptions about the currently rather rigid project structure and thus it is expected that more changes may be necessary elsewhere.)

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
