### PR TITLE
fix(core): expose ipc::Invoke

### DIFF
--- a/.changes/expose-invoke.md
+++ b/.changes/expose-invoke.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Export the `ipc::Invoke` struct.

--- a/crates/tauri/src/ipc/mod.rs
+++ b/crates/tauri/src/ipc/mod.rs
@@ -195,7 +195,6 @@ impl Response {
 /// The message and resolver given to a custom command.
 ///
 /// This struct is used internally by macros and is explicitly **NOT** stable.
-#[doc(hidden)]
 #[default_runtime(crate::Wry, wry)]
 pub struct Invoke<R: Runtime> {
   /// The message passed.


### PR DESCRIPTION
this type is actually important for custom invoke_handler and plugin implementations, so at least making it visible on docs is important
