### PR TITLE
fix(cli & core): use unescaped package id in proguard file 

### DIFF
--- a/.changes/android-proguard.md
+++ b/.changes/android-proguard.md
@@ -1,0 +1,7 @@
+---
+"tauri": "patch:bug"
+"tauri-cli": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+Fix android invalid proguard file when using an `identifier` that contains a component that is a reserved kotlin keyword, like `in`, `class`, etc

--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -139,7 +139,7 @@ pub fn get_config(
     "WRY_ANDROID_PACKAGE",
     app.android_identifier_escape_kotlin_keyword(),
   );
-  set_var("WRY_ANDROID_PACKAGE_NO_ESCAPE", app.identifier());
+  set_var("TAURI_ANDROID_PACKAGE_UNESCAPED", app.identifier());
   set_var("WRY_ANDROID_LIBRARY", app.lib_name());
   set_var("TAURI_ANDROID_PROJECT_PATH", config.project_dir());
 

--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -139,6 +139,7 @@ pub fn get_config(
     "WRY_ANDROID_PACKAGE",
     app.android_identifier_escape_kotlin_keyword(),
   );
+  set_var("WRY_ANDROID_PACKAGE_NO_ESCAPE", app.identifier());
   set_var("WRY_ANDROID_LIBRARY", app.lib_name());
   set_var("TAURI_ANDROID_PROJECT_PATH", config.project_dir());
 

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -267,8 +267,6 @@ fn main() {
     }
 
     if let Ok(kotlin_out_dir) = std::env::var("WRY_ANDROID_KOTLIN_FILES_OUT_DIR") {
-      let package_no_escape = env_var("WRY_ANDROID_PACKAGE_NO_ESCAPE");
-
       let package = env_var("WRY_ANDROID_PACKAGE");
       let library = env_var("WRY_ANDROID_LIBRARY");
 
@@ -298,19 +296,12 @@ fn main() {
 
         println!("cargo:rerun-if-changed={}", out_path.display());
       }
-
-      // monkey-patch for proguard-wry.pro file since wry doesn't implement
-      // logic for un/escaping the kotling keyword in identifiers
-      let wry_proguard = kotlin_out_dir.join("proguard-wry.pro");
-      let content = fs::read_to_string(&wry_proguard).expect("failed to read proguard-wry.pro");
-      fs::write(wry_proguard, content.replace(&package, &package_no_escape))
-        .expect("failed to write proguard-wry.pro");
     }
 
     if let Some(project_dir) = env::var_os("TAURI_ANDROID_PROJECT_PATH").map(PathBuf::from) {
-      let package_no_escape = env_var("WRY_ANDROID_PACKAGE_NO_ESCAPE");
+      let package_unescaped = env_var("TAURI_ANDROID_PACKAGE_UNESCAPED");
       let tauri_proguard =
-        include_str!("./mobile/proguard-tauri.pro").replace("$PACKAGE", &package_no_escape);
+        include_str!("./mobile/proguard-tauri.pro").replace("$PACKAGE", &package_unescaped);
       std::fs::write(
         project_dir.join("app").join("proguard-tauri.pro"),
         tauri_proguard,

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -301,8 +301,8 @@ fn main() {
     if let Some(project_dir) = env::var_os("TAURI_ANDROID_PROJECT_PATH").map(PathBuf::from) {
       let tauri_proguard = include_str!("./mobile/proguard-tauri.pro").replace(
         "$PACKAGE",
-        &env::var("WRY_ANDROID_PACKAGE")
-          .expect("missing `WRY_ANDROID_PACKAGE` environment variable"),
+        &env::var("WRY_ANDROID_PACKAGE_NO_ESCAPE")
+          .expect("missing `WRY_ANDROID_PACKAGE_NO_ESCAPE` environment variable"),
       );
       std::fs::write(
         project_dir.join("app").join("proguard-tauri.pro"),

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -260,13 +260,15 @@ fn main() {
   }
 
   if target_os == "android" {
-    if let Ok(kotlin_out_dir) = std::env::var("WRY_ANDROID_KOTLIN_FILES_OUT_DIR") {
-      fn env_var(var: &str) -> String {
-        std::env::var(var).unwrap_or_else(|_| {
-          panic!("`{var}` is not set, which is needed to generate the kotlin files for android.")
-        })
-      }
+    fn env_var(var: &str) -> String {
+      std::env::var(var).unwrap_or_else(|_| {
+        panic!("`{var}` is not set, which is needed to generate the kotlin files for android.")
+      })
+    }
 
+    let package_no_escape = env_var("WRY_ANDROID_PACKAGE_NO_ESCAPE");
+
+    if let Ok(kotlin_out_dir) = std::env::var("WRY_ANDROID_KOTLIN_FILES_OUT_DIR") {
       let package = env_var("WRY_ANDROID_PACKAGE");
       let library = env_var("WRY_ANDROID_LIBRARY");
 
@@ -296,14 +298,18 @@ fn main() {
 
         println!("cargo:rerun-if-changed={}", out_path.display());
       }
+
+      // monkey-patch for proguard-wry.pro file since wry doesn't implement
+      // logic for un/escaping the kotling keyword in identifiers
+      let wry_proguard = kotlin_out_dir.join("proguard-wry.pro");
+      let content = fs::read_to_string(&wry_proguard).expect("failed to ready proguard-wry.pro");
+      fs::write(wry_proguard, content.replace(&package, &package_no_escape))
+        .expect("failed to write proguard-wry.pro");
     }
 
     if let Some(project_dir) = env::var_os("TAURI_ANDROID_PROJECT_PATH").map(PathBuf::from) {
-      let tauri_proguard = include_str!("./mobile/proguard-tauri.pro").replace(
-        "$PACKAGE",
-        &env::var("WRY_ANDROID_PACKAGE_NO_ESCAPE")
-          .expect("missing `WRY_ANDROID_PACKAGE_NO_ESCAPE` environment variable"),
-      );
+      let tauri_proguard =
+        include_str!("./mobile/proguard-tauri.pro").replace("$PACKAGE", &package_no_escape);
       std::fs::write(
         project_dir.join("app").join("proguard-tauri.pro"),
         tauri_proguard,

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -302,7 +302,7 @@ fn main() {
       // monkey-patch for proguard-wry.pro file since wry doesn't implement
       // logic for un/escaping the kotling keyword in identifiers
       let wry_proguard = kotlin_out_dir.join("proguard-wry.pro");
-      let content = fs::read_to_string(&wry_proguard).expect("failed to ready proguard-wry.pro");
+      let content = fs::read_to_string(&wry_proguard).expect("failed to read proguard-wry.pro");
       fs::write(wry_proguard, content.replace(&package, &package_no_escape))
         .expect("failed to write proguard-wry.pro");
     }

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -266,9 +266,9 @@ fn main() {
       })
     }
 
-    let package_no_escape = env_var("WRY_ANDROID_PACKAGE_NO_ESCAPE");
-
     if let Ok(kotlin_out_dir) = std::env::var("WRY_ANDROID_KOTLIN_FILES_OUT_DIR") {
+      let package_no_escape = env_var("WRY_ANDROID_PACKAGE_NO_ESCAPE");
+
       let package = env_var("WRY_ANDROID_PACKAGE");
       let library = env_var("WRY_ANDROID_LIBRARY");
 
@@ -308,6 +308,7 @@ fn main() {
     }
 
     if let Some(project_dir) = env::var_os("TAURI_ANDROID_PROJECT_PATH").map(PathBuf::from) {
+      let package_no_escape = env_var("WRY_ANDROID_PACKAGE_NO_ESCAPE");
       let tauri_proguard =
         include_str!("./mobile/proguard-tauri.pro").replace("$PACKAGE", &package_no_escape);
       std::fs::write(


### PR DESCRIPTION
closes #11310