### PR TITLE
fix(bundler): match on `Path::extension` instead of using `Path::ends_with`

### DIFF
--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -21,6 +21,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{
   collections::{BTreeMap, HashMap, HashSet},
+  ffi::OsStr,
   fs::{self, File},
   io::Write,
   path::{Path, PathBuf},
@@ -611,7 +612,7 @@ pub fn build_wix_app_installer(
     settings
       .icon_files()
       .flatten()
-      .find(|i| i.ends_with(".ico"))
+      .find(|i| i.extension() == Some(OsStr::new("ico")))
       .context("Couldn't find a .ico icon")?
   };
   let icon_path = copy_icon(settings, "icon.ico", &icon_path)?;


### PR DESCRIPTION
`Path::ends_with` considers components only when comparing, so if `.ico` is not a full component of the path, it is not matched, we should use `Path::extension` instead as `Path::ends_with` documentation suggests.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
