### PR TITLE
docs(android): warn users that passing raw bytes over ipc is not possible on android

### DIFF
--- a/crates/tauri/src/ipc/mod.rs
+++ b/crates/tauri/src/ipc/mod.rs
@@ -45,6 +45,10 @@ pub type OwnedInvokeResponder<R> =
   dyn FnOnce(Webview<R>, String, InvokeResponse, CallbackFn, CallbackFn) + Send + 'static;
 
 /// Possible values of an IPC payload.
+///
+/// ### Android
+/// On Android, [InvokeBody::Raw] is not supported. The enum will always contain [InvokeBody::Json].
+/// When targeting Android Devices, consider passing raw bytes as a base64 [[std::string::String]], which is still more efficient than passing them as a number array in [InvokeBody::Json]
 #[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum InvokeBody {

--- a/crates/tauri/src/ipc/mod.rs
+++ b/crates/tauri/src/ipc/mod.rs
@@ -137,7 +137,7 @@ impl InvokeResponseBody {
 
 /// The IPC request.
 ///
-/// Request can be the parameter of a tauri command.
+/// Includes the `body` and `headers` parameters of a Tauri command invocation.
 /// This allows commands to accept raw bytes - on all platforms except Android.
 #[derive(Debug)]
 pub struct Request<'a> {

--- a/crates/tauri/src/ipc/mod.rs
+++ b/crates/tauri/src/ipc/mod.rs
@@ -136,6 +136,9 @@ impl InvokeResponseBody {
 }
 
 /// The IPC request.
+///
+/// Request can be the parameter of a tauri command.
+/// This allows commands to accept raw bytes - on all platforms except Android.
 #[derive(Debug)]
 pub struct Request<'a> {
   body: &'a InvokeBody,
@@ -178,7 +181,7 @@ impl<T: Serialize> IpcResponse for T {
   }
 }
 
-/// The IPC request.
+/// The IPC response.
 pub struct Response {
   body: InvokeResponseBody,
 }


### PR DESCRIPTION
Due to platform limitations, passing raw bytes to tauri commands is not possible :(
(no support for custom ipc)
