### PR TITLE
feat(core): add channel interceptor API

### DIFF
--- a/.changes/channel-interceptor.md
+++ b/.changes/channel-interceptor.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Added `Builder::channel_interceptor` to intercept messages to be sent to the frontend, complemeting the `Builder::invoke_system` interface.

--- a/crates/tauri/src/ipc/protocol.rs
+++ b/crates/tauri/src/ipc/protocol.rs
@@ -590,6 +590,7 @@ mod tests {
       Default::default(),
       Default::default(),
       "".into(),
+      None,
       crate::generate_invoke_key().unwrap(),
     );
 
@@ -704,6 +705,7 @@ mod tests {
       Default::default(),
       Default::default(),
       "".into(),
+      None,
       crate::generate_invoke_key().unwrap(),
     );
 

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -20,7 +20,10 @@ use tauri_utils::{
 };
 
 use crate::{
-  app::{AppHandle, GlobalWebviewEventListener, GlobalWindowEventListener, OnPageLoad},
+  app::{
+    AppHandle, ChannelInterceptor, GlobalWebviewEventListener, GlobalWindowEventListener,
+    OnPageLoad,
+  },
   event::{assert_event_name_is_valid, Event, EventId, EventTarget, Listeners},
   ipc::{Invoke, InvokeHandler, RuntimeAuthority},
   plugin::PluginStore,
@@ -216,6 +219,8 @@ pub struct AppManager<R: Runtime> {
 
   /// Runtime-generated invoke key.
   pub(crate) invoke_key: String,
+
+  pub(crate) channel_interceptor: Option<ChannelInterceptor<R>>,
 }
 
 impl<R: Runtime> fmt::Debug for AppManager<R> {
@@ -256,6 +261,7 @@ impl<R: Runtime> AppManager<R> {
       crate::app::GlobalMenuEventListener<Window<R>>,
     >,
     invoke_initialization_script: String,
+    channel_interceptor: Option<ChannelInterceptor<R>>,
     invoke_key: String,
   ) -> Self {
     // generate a random isolation key at runtime
@@ -307,6 +313,7 @@ impl<R: Runtime> AppManager<R> {
       plugin_global_api_scripts: Arc::new(context.plugin_global_api_scripts),
       resources_table: Arc::default(),
       invoke_key,
+      channel_interceptor,
     }
   }
 

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -740,6 +740,7 @@ mod test {
       Default::default(),
       Default::default(),
       "".into(),
+      None,
       crate::generate_invoke_key().unwrap(),
     );
 


### PR DESCRIPTION
allows custom channel implementation (such as direct eval(), or a separate IPC solution) similar to how a custom invoke system can be implemented
