### PR TITLE
fix(core): crash on macOS older than Sequoia

### DIFF
--- a/.changes/wry-fix-crash-macos-below-14.md
+++ b/.changes/wry-fix-crash-macos-below-14.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Update wry to 0.46.1 to fix a crash on macOS older than Sequoia.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11005,9 +11005,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.46.0"
+version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469a3765ecc3e8aa9ccdf3c5a52c82697ec03037cd60494488763880d31a1b3a"
+checksum = "2f8c948dc5f7c23bd93ba03b85b7f679852589bb78e150424d993171e4ef7b73"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -17,7 +17,7 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-wry = { version = "0.46", default-features = false, features = [
+wry = { version = "0.46.1", default-features = false, features = [
   "drag-drop",
   "protocol",
   "os-webview",


### PR DESCRIPTION
ref https://github.com/tauri-apps/wry/pull/1389
