### PR TITLE
fix(core): expose `content-range` header in `asset` protocol, closes #11371

### DIFF
--- a/.changes/asset-protocol-expose-content-range.md
+++ b/.changes/asset-protocol-expose-content-range.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Expose `content-range` header in `range` response of `asset` protocol

--- a/crates/tauri/src/protocol/asset.rs
+++ b/crates/tauri/src/protocol/asset.rs
@@ -86,6 +86,7 @@ fn get_response(
     .and_then(|r| r.to_str().map(|r| r.to_string()).ok())
   {
     resp = resp.header(ACCEPT_RANGES, "bytes");
+    resp = resp.header(ACCESS_CONTROL_EXPOSE_HEADERS, "content-range");
 
     let not_satisfiable = || {
       Response::builder()


### PR DESCRIPTION
This should close #11371.
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
