### PR TITLE
feat(core): fallback to Window and AppHandle resource table on close

### DIFF
--- a/.changes/resources-close-fallback.md
+++ b/.changes/resources-close-fallback.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Fallback to the Window and AppHandle resource table when closing a resource by ID.

--- a/crates/tauri/src/resources/plugin.rs
+++ b/crates/tauri/src/resources/plugin.rs
@@ -12,7 +12,14 @@ use super::ResourceId;
 
 #[command(root = "crate")]
 fn close<R: Runtime>(webview: Webview<R>, rid: ResourceId) -> crate::Result<()> {
-  webview.resources_table().close(rid)
+  let mut result = webview.resources_table().close(rid);
+  if result.is_err() {
+    result = webview.window().resources_table().close(rid);
+    if result.is_err() {
+      result = webview.app_handle().resources_table().close(rid);
+    }
+  }
+  result
 }
 
 pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {


### PR DESCRIPTION
this changes the resource plugin close() API to fallback to the parent window and AppHandle resource tables, letting the JS to delete global resources. The need for this was brought up on https://github.com/tauri-apps/plugins-workspace/pull/1860#issuecomment-2419175001 the store plugin stores the resources in the AppHandle, and we want the existing close() API to work on global resources otherwise every consumer needs their own resource close commands
