### PR TITLE
feat(cli) Make `tauri migrate` update $schema in tauri.conf.json

### DIFF
--- a/.changes/migrate-schema.md
+++ b/.changes/migrate-schema.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:enhance
+"tauri-cli": patch:enhance
+---
+
+Migrate the `$schema` Tauri configuration to the v2 format.

--- a/crates/tauri-cli/src/migrate/migrations/v1/config.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v1/config.rs
@@ -684,6 +684,15 @@ mod test {
     let mut migrated = original.clone();
     super::migrate_config(&mut migrated).expect("failed to migrate config");
 
+    if original.get("$schema").is_some() {
+      if let Some(map) = migrated.as_object_mut() {
+        map.insert(
+          "$schema".to_string(),
+          serde_json::Value::String("https://schema.tauri.app/config/2".to_string()),
+        );
+      }
+    }
+
     if original
       .get("tauri")
       .and_then(|v| v.get("bundle"))
@@ -708,6 +717,7 @@ mod test {
   #[test]
   fn migrate_full() {
     let original = serde_json::json!({
+      "$schema": "../node_modules/@tauri-apps/cli/schema.json",
       "build": {
         "distDir": "../dist",
         "devPath": "http://localhost:1240",
@@ -797,6 +807,9 @@ mod test {
     });
 
     let migrated = migrate(&original);
+
+    // $schema
+    assert_eq!(migrated["$schema"], "https://schema.tauri.app/config/2");
 
     // plugins > updater
     assert_eq!(


### PR DESCRIPTION
This makes `tauri migrate` command update the `$schema` field in `tauri.conf.json`. For projects created under v1, it could be something like `../node_modules/@tauri-apps/cli/schema.json` (for projects with npm), but now it needs to be updated to v2's schema, which is unified under URL `https://schema.tauri.app/config/2`.