### PR TITLE
feat(core): add WebviewWindow::resolve_command_scope

### DIFF
--- a/.changes/resolve_command_scope.md
+++ b/.changes/resolve_command_scope.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:feat
+---
+
+Added `WebviewWindow::resolve_command_scope` to check a command scope at runtime.

--- a/crates/tauri-cli/src/mobile/init.rs
+++ b/crates/tauri-cli/src/mobile/init.rs
@@ -204,7 +204,7 @@ fn get_str_array(helper: &Helper, formatter: impl Fn(&str) -> String) -> Option<
         .map(|val| {
           val.as_str().map(
             #[allow(clippy::redundant_closure)]
-            |s| formatter(s),
+            &formatter,
           )
         })
         .collect()

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
   event::EventTarget,
-  ipc::{CommandScope, ScopeObject},
+  ipc::ScopeObject,
   runtime::dpi::{PhysicalPosition, PhysicalSize},
   window::Monitor,
   Emitter, Listener, ResourceTable, Window,
@@ -49,7 +49,7 @@ use tauri_macros::default_runtime;
 #[cfg(windows)]
 use windows::Win32::Foundation::HWND;
 
-use super::DownloadEvent;
+use super::{DownloadEvent, ResolvedScope};
 
 /// A builder for [`WebviewWindow`], a window that hosts a single webview.
 pub struct WebviewWindowBuilder<'a, R: Runtime, M: Manager<R>> {
@@ -997,7 +997,7 @@ impl<R: Runtime> WebviewWindow<R> {
   ///
   /// If the scope cannot be deserialized to the given type, an error is returned.
   ///
-  /// In a command context this can be directly resolved from the command arguments via [CommandScope]:
+  /// In a command context this can be directly resolved from the command arguments via [crate::ipc::CommandScope]:
   ///
   /// ```
   /// use tauri::ipc::CommandScope;
@@ -1033,7 +1033,7 @@ impl<R: Runtime> WebviewWindow<R> {
     &self,
     plugin: &str,
     command: &str,
-  ) -> crate::Result<Option<CommandScope<T>>> {
+  ) -> crate::Result<Option<ResolvedScope<T>>> {
     self.webview.resolve_command_scope(plugin, command)
   }
 }

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -12,6 +12,7 @@ use std::{
 
 use crate::{
   event::EventTarget,
+  ipc::{CommandScope, ScopeObject},
   runtime::dpi::{PhysicalPosition, PhysicalSize},
   window::Monitor,
   Emitter, Listener, ResourceTable, Window,
@@ -989,6 +990,52 @@ impl<R: Runtime> WebviewWindow<R> {
   pub fn on_window_event<F: Fn(&WindowEvent) + Send + 'static>(&self, f: F) {
     self.window.on_window_event(f);
   }
+
+  /// Resolves the given command scope for this webview on the currently loaded URL.
+  ///
+  /// If the command is not allowed, returns None.
+  ///
+  /// If the scope cannot be deserialized to the given type, an error is returned.
+  ///
+  /// In a command context this can be directly resolved from the command arguments via [CommandScope]:
+  ///
+  /// ```
+  /// use tauri::ipc::CommandScope;
+  ///
+  /// #[derive(Debug, serde::Deserialize)]
+  /// struct ScopeType {
+  ///   some_value: String,
+  /// }
+  /// #[tauri::command]
+  /// fn my_command(scope: CommandScope<ScopeType>) {
+  ///   // check scope
+  /// }
+  /// ```
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use tauri::Manager;
+  ///
+  /// #[derive(Debug, serde::Deserialize)]
+  /// struct ScopeType {
+  ///   some_value: String,
+  /// }
+  ///
+  /// tauri::Builder::default()
+  ///   .setup(|app| {
+  ///     let webview = app.get_webview_window("main").unwrap();
+  ///     let scope = webview.resolve_command_scope::<ScopeType>("my-plugin", "read");
+  ///     Ok(())
+  ///   });
+  /// ```
+  pub fn resolve_command_scope<T: ScopeObject>(
+    &self,
+    plugin: &str,
+    command: &str,
+  ) -> crate::Result<Option<CommandScope<T>>> {
+    self.webview.resolve_command_scope(plugin, command)
+  }
 }
 
 /// Menu APIs
@@ -1038,7 +1085,7 @@ impl<R: Runtime> WebviewWindow<R> {
     self.window.on_menu_event(f)
   }
 
-  /// Returns this window menu .
+  /// Returns this window menu.
   pub fn menu(&self) -> Option<Menu<R>> {
     self.window.menu()
   }

--- a/examples/api/src-tauri/tauri-plugin-sample/src/desktop.rs
+++ b/examples/api/src-tauri/tauri-plugin-sample/src/desktop.rs
@@ -19,10 +19,10 @@ pub struct Sample<R: Runtime>(AppHandle<R>);
 
 impl<R: Runtime> Sample<R> {
   pub fn ping(&self, payload: PingRequest) -> crate::Result<PingResponse> {
-    let _ = payload.on_event.send(Event {
+    payload.on_event.send(Event {
       kind: "ping".to_string(),
       value: payload.value.clone(),
-    });
+    })?;
     Ok(PingResponse {
       value: payload.value,
     })

--- a/examples/api/src-tauri/tauri-plugin-sample/src/error.rs
+++ b/examples/api/src-tauri/tauri-plugin-sample/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
   #[cfg(mobile)]
   #[error(transparent)]
   PluginInvoke(#[from] tauri::plugin::mobile::PluginInvokeError),
+  #[error(transparent)]
+  Tauri(#[from] tauri::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
This new functionality exposes the `CommandScope` resolution as a function (currently only commands can resolve them as a dependency injection via CommandItem)

This function is useful to validate the configuration at runtime (do some asserts at setup phase to ensure capabilities are properly configured) and to resolve scopes in a separate thread or context
