### PR TITLE
fix(cli): Fix mixup of `TAURI_APP_PATH` and `TAURI_FRONTEND_PATH`

### DIFF
--- a/crates/tauri-cli/src/acl/permission/ls.rs
+++ b/crates/tauri-cli/src/acl/permission/ls.rs
@@ -23,8 +23,7 @@ pub struct Options {
 pub fn command(options: Options) -> Result<()> {
   crate::helpers::app_paths::resolve();
 
-  let tauri_dir = tauri_dir();
-  let acl_manifests_path = tauri_dir
+  let acl_manifests_path = tauri_dir()
     .join("gen")
     .join("schemas")
     .join("acl-manifests.json");

--- a/crates/tauri-cli/src/add.rs
+++ b/crates/tauri-cli/src/add.rs
@@ -9,7 +9,7 @@ use regex::Regex;
 use crate::{
   acl,
   helpers::{
-    app_paths::{resolve_app_dir, tauri_dir},
+    app_paths::{resolve_frontend_dir, tauri_dir},
     cargo,
     npm::PackageManager,
   },
@@ -56,7 +56,7 @@ pub fn run(options: Options) -> Result<()> {
   let mut plugins = crate::helpers::plugins::known_plugins();
   let metadata = plugins.remove(plugin).unwrap_or_default();
 
-  let app_dir = resolve_app_dir();
+  let app_dir = resolve_frontend_dir();
   let tauri_dir = tauri_dir();
 
   let target_str = metadata

--- a/crates/tauri-cli/src/add.rs
+++ b/crates/tauri-cli/src/add.rs
@@ -56,7 +56,7 @@ pub fn run(options: Options) -> Result<()> {
   let mut plugins = crate::helpers::plugins::known_plugins();
   let metadata = plugins.remove(plugin).unwrap_or_default();
 
-  let app_dir = resolve_frontend_dir();
+  let frontend_dir = resolve_frontend_dir();
   let tauri_dir = tauri_dir();
 
   let target_str = metadata
@@ -81,7 +81,7 @@ pub fn run(options: Options) -> Result<()> {
   })?;
 
   if !metadata.rust_only {
-    if let Some(manager) = app_dir
+    if let Some(manager) = frontend_dir
       .map(PackageManager::from_project)
       .and_then(|managers| managers.into_iter().next())
     {

--- a/crates/tauri-cli/src/dev.rs
+++ b/crates/tauri-cli/src/dev.rs
@@ -4,7 +4,7 @@
 
 use crate::{
   helpers::{
-    app_paths::{app_dir, tauri_dir},
+    app_paths::{frontend_dir, tauri_dir},
     command_env,
     config::{
       get as get_config, reload as reload_config, BeforeDevCommand, ConfigHandle, FrontendDist,
@@ -140,7 +140,7 @@ pub fn setup(interface: &AppInterface, options: &mut Options, config: ConfigHand
         (Some(script), cwd.map(Into::into), wait)
       }
     };
-    let cwd = script_cwd.unwrap_or_else(|| app_dir().clone());
+    let cwd = script_cwd.unwrap_or_else(|| frontend_dir().clone());
     if let Some(before_dev) = script {
       log::info!(action = "Running"; "BeforeDevCommand (`{}`)", before_dev);
       let mut env = command_env(true);

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -23,7 +23,7 @@ const ENV_TAURI_APP_PATH: &str = "TAURI_APP_PATH";
 // path to the frontend app directory
 const ENV_TAURI_FRONTEND_PATH: &str = "TAURI_FRONTEND_PATH";
 
-static APP_DIR: OnceLock<PathBuf> = OnceLock::new();
+static FRONTEND_DIR: OnceLock<PathBuf> = OnceLock::new();
 static TAURI_DIR: OnceLock<PathBuf> = OnceLock::new();
 
 pub fn walk_builder(path: &Path) -> WalkBuilder {
@@ -121,7 +121,7 @@ pub fn resolve() {
       ConfigFormat::Toml.into_file_name()
     )
   })).expect("tauri dir already resolved");
-  APP_DIR
+  FRONTEND_DIR
     .set(resolve_frontend_dir().unwrap_or_else(|| tauri_dir().parent().unwrap().to_path_buf()))
     .expect("app dir already resolved");
 }
@@ -151,7 +151,7 @@ pub fn resolve_frontend_dir() -> Option<PathBuf> {
 }
 
 pub fn frontend_dir() -> &'static PathBuf {
-  APP_DIR
+  FRONTEND_DIR
     .get()
     .expect("app paths not initialized, this is a Tauri CLI bug")
 }

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -90,7 +90,7 @@ fn env_tauri_frontend_path() -> Option<PathBuf> {
 }
 
 pub fn resolve_tauri_dir() -> Option<PathBuf> {
-  let src_dir = env_tauri_frontend_path().or_else(|| current_dir().ok())?;
+  let src_dir = env_tauri_app_path().or_else(|| current_dir().ok())?;
 
   if src_dir.join(ConfigFormat::Json.into_file_name()).exists()
     || src_dir.join(ConfigFormat::Json5.into_file_name()).exists()
@@ -113,7 +113,7 @@ pub fn resolve_tauri_dir() -> Option<PathBuf> {
 
 pub fn resolve() {
   TAURI_DIR.set(resolve_tauri_dir().unwrap_or_else(|| {
-    let env_var_name = env_tauri_frontend_path().is_some().then(|| format!("`{ENV_TAURI_FRONTEND_PATH}`"));
+    let env_var_name = env_tauri_app_path().is_some().then(|| format!("`{ENV_TAURI_APP_PATH}`"));
     panic!("Couldn't recognize the {} folder as a Tauri project. It must contain a `{}`, `{}` or `{}` file in any subfolder.",
       env_var_name.as_deref().unwrap_or("current"),
       ConfigFormat::Json.into_file_name(),
@@ -133,7 +133,8 @@ pub fn tauri_dir() -> &'static PathBuf {
 }
 
 pub fn resolve_app_dir() -> Option<PathBuf> {
-  let app_dir = env_tauri_app_path().unwrap_or_else(|| current_dir().expect("failed to read cwd"));
+  let app_dir =
+    env_tauri_frontend_path().unwrap_or_else(|| current_dir().expect("failed to read cwd"));
 
   if app_dir.join("package.json").exists() {
     return Some(app_dir);

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -18,9 +18,9 @@ use tauri_utils::{
 };
 
 const TAURI_GITIGNORE: &[u8] = include_bytes!("../../tauri.gitignore");
-// path to the Tauri app (Rust crate) directory, usually <cwd>/src-tauri
+// path to the Tauri app (Rust crate) directory, usually `<project>/src-tauri/`
 const ENV_TAURI_APP_PATH: &str = "TAURI_APP_PATH";
-// path to the frontend app directory
+// path to the frontend app directory, usually `<project>/`
 const ENV_TAURI_FRONTEND_PATH: &str = "TAURI_FRONTEND_PATH";
 
 static FRONTEND_DIR: OnceLock<PathBuf> = OnceLock::new();

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -133,14 +133,14 @@ pub fn tauri_dir() -> &'static PathBuf {
 }
 
 pub fn resolve_frontend_dir() -> Option<PathBuf> {
-  let app_dir =
+  let frontend_dir =
     env_tauri_frontend_path().unwrap_or_else(|| current_dir().expect("failed to read cwd"));
 
-  if app_dir.join("package.json").exists() {
-    return Some(app_dir);
+  if frontend_dir.join("package.json").exists() {
+    return Some(frontend_dir);
   }
 
-  lookup(&app_dir, |path| {
+  lookup(&frontend_dir, |path| {
     if let Some(file_name) = path.file_name() {
       file_name == OsStr::new("package.json")
     } else {

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -122,7 +122,7 @@ pub fn resolve() {
     )
   })).expect("tauri dir already resolved");
   APP_DIR
-    .set(resolve_app_dir().unwrap_or_else(|| tauri_dir().parent().unwrap().to_path_buf()))
+    .set(resolve_frontend_dir().unwrap_or_else(|| tauri_dir().parent().unwrap().to_path_buf()))
     .expect("app dir already resolved");
 }
 
@@ -132,7 +132,7 @@ pub fn tauri_dir() -> &'static PathBuf {
     .expect("app paths not initialized, this is a Tauri CLI bug")
 }
 
-pub fn resolve_app_dir() -> Option<PathBuf> {
+pub fn resolve_frontend_dir() -> Option<PathBuf> {
   let app_dir =
     env_tauri_frontend_path().unwrap_or_else(|| current_dir().expect("failed to read cwd"));
 
@@ -150,7 +150,7 @@ pub fn resolve_app_dir() -> Option<PathBuf> {
   .map(|p| p.parent().unwrap().to_path_buf())
 }
 
-pub fn app_dir() -> &'static PathBuf {
+pub fn frontend_dir() -> &'static PathBuf {
   APP_DIR
     .get()
     .expect("app paths not initialized, this is a Tauri CLI bug")

--- a/crates/tauri-cli/src/helpers/mod.rs
+++ b/crates/tauri-cli/src/helpers/mod.rs
@@ -31,7 +31,7 @@ use crate::{
   CommandExt,
 };
 
-use self::app_paths::app_dir;
+use self::app_paths::frontend_dir;
 
 pub fn command_env(debug: bool) -> HashMap<&'static str, String> {
   let mut map = HashMap::new();
@@ -80,7 +80,7 @@ pub fn run_hook(
     HookCommand::Script(s) => (Some(s), None),
     HookCommand::ScriptWithOptions { script, cwd } => (Some(script), cwd.map(Into::into)),
   };
-  let cwd = script_cwd.unwrap_or_else(|| app_dir().clone());
+  let cwd = script_cwd.unwrap_or_else(|| frontend_dir().clone());
   if let Some(script) = script {
     log::info!(action = "Running"; "{} `{}`", name, script);
 

--- a/crates/tauri-cli/src/helpers/npm.rs
+++ b/crates/tauri-cli/src/helpers/npm.rs
@@ -70,7 +70,11 @@ impl PackageManager {
     }
   }
 
-  pub fn install<P: AsRef<Path>>(&self, dependencies: &[String], app_dir: P) -> crate::Result<()> {
+  pub fn install<P: AsRef<Path>>(
+    &self,
+    dependencies: &[String],
+    frontend_dir: P,
+  ) -> crate::Result<()> {
     let dependencies_str = if dependencies.len() > 1 {
       "dependencies"
     } else {
@@ -89,7 +93,7 @@ impl PackageManager {
       .cross_command()
       .arg("add")
       .args(dependencies)
-      .current_dir(app_dir)
+      .current_dir(frontend_dir)
       .status()
       .with_context(|| format!("failed to run {self}"))?;
 
@@ -100,7 +104,11 @@ impl PackageManager {
     Ok(())
   }
 
-  pub fn remove<P: AsRef<Path>>(&self, dependencies: &[String], app_dir: P) -> crate::Result<()> {
+  pub fn remove<P: AsRef<Path>>(
+    &self,
+    dependencies: &[String],
+    frontend_dir: P,
+  ) -> crate::Result<()> {
     let dependencies_str = if dependencies.len() > 1 {
       "dependencies"
     } else {
@@ -123,7 +131,7 @@ impl PackageManager {
         "remove"
       })
       .args(dependencies)
-      .current_dir(app_dir)
+      .current_dir(frontend_dir)
       .status()
       .with_context(|| format!("failed to run {self}"))?;
 
@@ -137,7 +145,7 @@ impl PackageManager {
   pub fn current_package_version<P: AsRef<Path>>(
     &self,
     name: &str,
-    app_dir: P,
+    frontend_dir: P,
   ) -> crate::Result<Option<String>> {
     let (output, regex) = match self {
       PackageManager::Yarn => (
@@ -145,7 +153,7 @@ impl PackageManager {
           .args(["list", "--pattern"])
           .arg(name)
           .args(["--depth", "0"])
-          .current_dir(app_dir)
+          .current_dir(frontend_dir)
           .output()?,
         None,
       ),
@@ -154,7 +162,7 @@ impl PackageManager {
           .arg("info")
           .arg(name)
           .arg("--json")
-          .current_dir(app_dir)
+          .current_dir(frontend_dir)
           .output()?,
         Some(regex::Regex::new("\"Version\":\"([\\da-zA-Z\\-\\.]+)\"").unwrap()),
       ),
@@ -163,7 +171,7 @@ impl PackageManager {
           .arg("list")
           .arg(name)
           .args(["--parseable", "--depth", "0"])
-          .current_dir(app_dir)
+          .current_dir(frontend_dir)
           .output()?,
         None,
       ),
@@ -173,7 +181,7 @@ impl PackageManager {
           .arg("list")
           .arg(name)
           .args(["version", "--depth", "0"])
-          .current_dir(app_dir)
+          .current_dir(frontend_dir)
           .output()?,
         None,
       ),

--- a/crates/tauri-cli/src/info/app.rs
+++ b/crates/tauri-cli/src/info/app.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use tauri_utils::platform::Target;
 
-pub fn items(app_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<SectionItem> {
+pub fn items(frontend_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<SectionItem> {
   let mut items = Vec::new();
   if tauri_dir.is_some() {
     if let Ok(config) = crate::helpers::config::get(Target::current(), None) {
@@ -41,8 +41,8 @@ pub fn items(app_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<Section
         items.push(SectionItem::new().description(format!("devUrl: {dev_url}")));
       }
 
-      if let Some(app_dir) = app_dir {
-        if let Ok(package_json) = read_to_string(app_dir.join("package.json")) {
+      if let Some(frontend_dir) = frontend_dir {
+        if let Ok(package_json) = read_to_string(frontend_dir.join("package.json")) {
           let (framework, bundler) = framework::infer_from_package_json(&package_json);
 
           if let Some(framework) = framework {

--- a/crates/tauri-cli/src/info/mod.rs
+++ b/crates/tauri-cli/src/info/mod.rs
@@ -258,7 +258,7 @@ pub struct Options {
 pub fn command(options: Options) -> Result<()> {
   let Options { interactive } = options;
 
-  let app_dir = crate::helpers::app_paths::resolve_app_dir();
+  let app_dir = crate::helpers::app_paths::resolve_frontend_dir();
   let tauri_dir = crate::helpers::app_paths::resolve_tauri_dir();
 
   if tauri_dir.is_some() {

--- a/crates/tauri-cli/src/info/mod.rs
+++ b/crates/tauri-cli/src/info/mod.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use crate::Result;
+use crate::{
+  helpers::app_paths::{resolve_frontend_dir, resolve_tauri_dir},
+  Result,
+};
 use clap::Parser;
 use colored::{ColoredString, Colorize};
 use dialoguer::{theme::ColorfulTheme, Confirm};
@@ -258,15 +261,15 @@ pub struct Options {
 pub fn command(options: Options) -> Result<()> {
   let Options { interactive } = options;
 
-  let app_dir = crate::helpers::app_paths::resolve_frontend_dir();
-  let tauri_dir = crate::helpers::app_paths::resolve_tauri_dir();
+  let frontend_dir = resolve_frontend_dir();
+  let tauri_dir = resolve_tauri_dir();
 
   if tauri_dir.is_some() {
     // safe to initialize
     crate::helpers::app_paths::resolve();
   }
 
-  let package_manager = app_dir
+  let package_manager = frontend_dir
     .as_ref()
     .map(packages_nodejs::package_manager)
     .unwrap_or(crate::helpers::npm::PackageManager::Npm);
@@ -288,11 +291,12 @@ pub fn command(options: Options) -> Result<()> {
     interactive,
     items: Vec::new(),
   };
-  packages
-    .items
-    .extend(packages_rust::items(app_dir.as_ref(), tauri_dir.as_deref()));
+  packages.items.extend(packages_rust::items(
+    frontend_dir.as_ref(),
+    tauri_dir.as_deref(),
+  ));
   packages.items.extend(packages_nodejs::items(
-    app_dir.as_ref(),
+    frontend_dir.as_ref(),
     package_manager,
     &metadata,
   ));
@@ -300,7 +304,7 @@ pub fn command(options: Options) -> Result<()> {
   let mut plugins = Section {
     label: "Plugins",
     interactive,
-    items: plugins::items(app_dir.as_ref(), tauri_dir.as_deref(), package_manager),
+    items: plugins::items(frontend_dir.as_ref(), tauri_dir.as_deref(), package_manager),
   };
 
   let mut app = Section {
@@ -310,7 +314,7 @@ pub fn command(options: Options) -> Result<()> {
   };
   app
     .items
-    .extend(app::items(app_dir.as_ref(), tauri_dir.as_deref()));
+    .extend(app::items(frontend_dir.as_ref(), tauri_dir.as_deref()));
 
   environment.display();
   packages.display();

--- a/crates/tauri-cli/src/info/packages_nodejs.rs
+++ b/crates/tauri-cli/src/info/packages_nodejs.rs
@@ -76,8 +76,8 @@ pub fn npm_latest_version(pm: &PackageManager, name: &str) -> crate::Result<Opti
   }
 }
 
-pub fn package_manager(app_dir: &PathBuf) -> PackageManager {
-  let found = PackageManager::from_project(app_dir);
+pub fn package_manager(frontend_dir: &PathBuf) -> PackageManager {
+  let found = PackageManager::from_project(frontend_dir);
 
   if found.is_empty() {
     println!(
@@ -110,18 +110,18 @@ pub fn package_manager(app_dir: &PathBuf) -> PackageManager {
 }
 
 pub fn items(
-  app_dir: Option<&PathBuf>,
+  frontend_dir: Option<&PathBuf>,
   package_manager: PackageManager,
   metadata: &VersionMetadata,
 ) -> Vec<SectionItem> {
   let mut items = Vec::new();
-  if let Some(app_dir) = app_dir {
+  if let Some(frontend_dir) = frontend_dir {
     for (package, version) in [
       ("@tauri-apps/api", None),
       ("@tauri-apps/cli", Some(metadata.js_cli.version.clone())),
     ] {
-      let app_dir = app_dir.clone();
-      let item = nodejs_section_item(package.into(), version, app_dir, package_manager);
+      let frontend_dir = frontend_dir.clone();
+      let item = nodejs_section_item(package.into(), version, frontend_dir, package_manager);
       items.push(item);
     }
   }
@@ -132,13 +132,13 @@ pub fn items(
 pub fn nodejs_section_item(
   package: String,
   version: Option<String>,
-  app_dir: PathBuf,
+  frontend_dir: PathBuf,
   package_manager: PackageManager,
 ) -> SectionItem {
   SectionItem::new().action(move || {
     let version = version.clone().unwrap_or_else(|| {
       package_manager
-        .current_package_version(&package, &app_dir)
+        .current_package_version(&package, &frontend_dir)
         .unwrap_or_default()
         .unwrap_or_default()
     });

--- a/crates/tauri-cli/src/info/packages_rust.rs
+++ b/crates/tauri-cli/src/info/packages_rust.rs
@@ -13,10 +13,10 @@ use colored::Colorize;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 
-pub fn items(app_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<SectionItem> {
+pub fn items(frontend_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<SectionItem> {
   let mut items = Vec::new();
 
-  if tauri_dir.is_some() || app_dir.is_some() {
+  if tauri_dir.is_some() || frontend_dir.is_some() {
     if let Some(tauri_dir) = tauri_dir {
       let manifest: Option<CargoManifest> =
         if let Ok(manifest_contents) = read_to_string(tauri_dir.join("Cargo.toml")) {

--- a/crates/tauri-cli/src/info/plugins.rs
+++ b/crates/tauri-cli/src/info/plugins.rs
@@ -19,13 +19,13 @@ use crate::{
 use super::{packages_nodejs, packages_rust, SectionItem};
 
 pub fn items(
-  app_dir: Option<&PathBuf>,
+  frontend_dir: Option<&PathBuf>,
   tauri_dir: Option<&Path>,
   package_manager: PackageManager,
 ) -> Vec<SectionItem> {
   let mut items = Vec::new();
 
-  if tauri_dir.is_some() || app_dir.is_some() {
+  if tauri_dir.is_some() || frontend_dir.is_some() {
     if let Some(tauri_dir) = tauri_dir {
       let manifest: Option<CargoManifest> =
         if let Ok(manifest_contents) = fs::read_to_string(tauri_dir.join("Cargo.toml")) {
@@ -48,14 +48,18 @@ pub fn items(
         let item = packages_rust::rust_section_item(&dep, crate_version);
         items.push(item);
 
-        let Some(app_dir) = app_dir else {
+        let Some(frontend_dir) = frontend_dir else {
           continue;
         };
 
         let package = format!("@tauri-apps/plugin-{p}");
 
-        let item =
-          packages_nodejs::nodejs_section_item(package, None, app_dir.clone(), package_manager);
+        let item = packages_nodejs::nodejs_section_item(
+          package,
+          None,
+          frontend_dir.clone(),
+          package_manager,
+        );
         items.push(item);
       }
     }

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -29,7 +29,7 @@ use tauri_utils::config::{parse::is_configuration_file, DeepLinkProtocol, Update
 use super::{AppSettings, DevProcess, ExitReason, Interface};
 use crate::{
   helpers::{
-    app_paths::{app_dir, tauri_dir},
+    app_paths::{frontend_dir, tauri_dir},
     config::{nsis_settings, reload as reload_config, wix_settings, BundleResources, Config},
   },
   ConfigValue,
@@ -518,7 +518,7 @@ impl Rust {
 
     let process = Arc::new(Mutex::new(child));
     let (tx, rx) = sync_channel(1);
-    let app_path = app_dir();
+    let app_path = frontend_dir();
 
     let watch_folders = get_watch_folders()?;
 

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -518,7 +518,7 @@ impl Rust {
 
     let process = Arc::new(Mutex::new(child));
     let (tx, rx) = sync_channel(1);
-    let app_path = frontend_dir();
+    let frontend_path = frontend_dir();
 
     let watch_folders = get_watch_folders()?;
 
@@ -572,7 +572,11 @@ impl Rust {
 
             log::info!(
               "File {} changed. Rebuilding application...",
-              display_path(event_path.strip_prefix(app_path).unwrap_or(&event_path))
+              display_path(
+                event_path
+                  .strip_prefix(frontend_path)
+                  .unwrap_or(&event_path)
+              )
             );
 
             let mut p = process.lock().unwrap();
@@ -906,7 +910,9 @@ impl AppSettings for RustAppSettings {
       }
     }
 
-    let mut binaries_paths = std::fs::read_dir(tauri_dir().join("src/bin"))
+    let tauri_dir = tauri_dir();
+
+    let mut binaries_paths = std::fs::read_dir(tauri_dir.join("src/bin"))
       .map(|dir| {
         dir
           .into_iter()
@@ -929,11 +935,11 @@ impl AppSettings for RustAppSettings {
     if !binaries_paths
       .iter()
       .any(|(_name, path)| path == Path::new("src/main.rs"))
-      && tauri_dir().join("src/main.rs").exists()
+      && tauri_dir.join("src/main.rs").exists()
     {
       binaries_paths.push((
         self.cargo_package_settings.name.clone(),
-        tauri_dir().join("src/main.rs"),
+        tauri_dir.join("src/main.rs"),
       ));
     }
 
@@ -998,8 +1004,9 @@ impl AppSettings for RustAppSettings {
 
 impl RustAppSettings {
   pub fn new(config: &Config, manifest: Manifest, target: Option<String>) -> crate::Result<Self> {
+    let tauri_dir = tauri_dir();
     let cargo_settings =
-      CargoSettings::load(tauri_dir()).with_context(|| "failed to load cargo settings")?;
+      CargoSettings::load(tauri_dir).with_context(|| "failed to load cargo settings")?;
     let cargo_package_settings = match &cargo_settings.package {
       Some(package_info) => package_info.clone(),
       None => {
@@ -1073,7 +1080,7 @@ impl RustAppSettings {
       default_run: cargo_package_settings.default_run.clone(),
     };
 
-    let cargo_config = CargoConfig::load(tauri_dir())?;
+    let cargo_config = CargoConfig::load(tauri_dir)?;
 
     let target_triple = target.unwrap_or_else(|| {
       cargo_config

--- a/crates/tauri-cli/src/migrate/migrations/v1/frontend.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v1/frontend.rs
@@ -68,7 +68,7 @@ const MODULES_MAP: phf::Map<&str, &str> = phf::phf_map! {
 const JS_EXTENSIONS: &[&str] = &["js", "mjs", "jsx", "ts", "mts", "tsx", "svelte", "vue"];
 
 /// Returns a list of migrated plugins
-pub fn migrate(app_dir: &Path) -> Result<Vec<String>> {
+pub fn migrate(frontend_dir: &Path) -> Result<Vec<String>> {
   let mut new_npm_packages = Vec::new();
   let mut new_plugins = Vec::new();
   let mut npm_packages_to_remove = Vec::new();
@@ -84,14 +84,14 @@ pub fn migrate(app_dir: &Path) -> Result<Vec<String>> {
     )
   };
 
-  let pm = PackageManager::from_project(app_dir)
+  let pm = PackageManager::from_project(frontend_dir)
     .into_iter()
     .next()
     .unwrap_or(PackageManager::Npm);
 
   for pkg in ["@tauri-apps/cli", "@tauri-apps/api"] {
     let version = pm
-      .current_package_version(pkg, app_dir)
+      .current_package_version(pkg, frontend_dir)
       .unwrap_or_default()
       .unwrap_or_default();
     if version.starts_with('1') {
@@ -99,7 +99,7 @@ pub fn migrate(app_dir: &Path) -> Result<Vec<String>> {
     }
   }
 
-  for entry in walk_builder(app_dir).build().flatten() {
+  for entry in walk_builder(frontend_dir).build().flatten() {
     if entry.file_type().map(|t| t.is_file()).unwrap_or_default() {
       let path = entry.path();
       let ext = path.extension().unwrap_or_default();
@@ -122,14 +122,14 @@ pub fn migrate(app_dir: &Path) -> Result<Vec<String>> {
   if !npm_packages_to_remove.is_empty() {
     npm_packages_to_remove.sort();
     npm_packages_to_remove.dedup();
-    pm.remove(&npm_packages_to_remove, app_dir)
+    pm.remove(&npm_packages_to_remove, frontend_dir)
       .context("Error removing npm packages")?;
   }
 
   if !new_npm_packages.is_empty() {
     new_npm_packages.sort();
     new_npm_packages.dedup();
-    pm.install(&new_npm_packages, app_dir)
+    pm.install(&new_npm_packages, frontend_dir)
       .context("Error installing new npm packages")?;
   }
 

--- a/crates/tauri-cli/src/migrate/migrations/v1/mod.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v1/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::{
-  helpers::app_paths::{app_dir, tauri_dir},
+  helpers::app_paths::{frontend_dir, tauri_dir},
   Result,
 };
 
@@ -15,7 +15,7 @@ mod manifest;
 
 pub fn run() -> Result<()> {
   let tauri_dir = tauri_dir();
-  let app_dir = app_dir();
+  let app_dir = frontend_dir();
 
   let mut migrated = config::migrate(tauri_dir).context("Could not migrate config")?;
   manifest::migrate(tauri_dir).context("Could not migrate manifest")?;

--- a/crates/tauri-cli/src/migrate/migrations/v1/mod.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v1/mod.rs
@@ -15,11 +15,11 @@ mod manifest;
 
 pub fn run() -> Result<()> {
   let tauri_dir = tauri_dir();
-  let app_dir = frontend_dir();
+  let frontend_dir = frontend_dir();
 
   let mut migrated = config::migrate(tauri_dir).context("Could not migrate config")?;
   manifest::migrate(tauri_dir).context("Could not migrate manifest")?;
-  let plugins = frontend::migrate(app_dir)?;
+  let plugins = frontend::migrate(frontend_dir)?;
 
   migrated.plugins.extend(plugins);
 

--- a/crates/tauri-cli/src/migrate/migrations/v2_rc.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v2_rc.rs
@@ -17,7 +17,7 @@ use anyhow::Context;
 use toml_edit::{DocumentMut, Item, Table, TableLike, Value};
 
 pub fn run() -> Result<()> {
-  let app_dir = frontend_dir();
+  let frontend_dir = frontend_dir();
   let tauri_dir = tauri_dir();
 
   let manifest_path = tauri_dir.join("Cargo.toml");
@@ -26,7 +26,7 @@ pub fn run() -> Result<()> {
 
   migrate_permissions(tauri_dir)?;
 
-  migrate_npm_dependencies(app_dir)?;
+  migrate_npm_dependencies(frontend_dir)?;
 
   std::fs::write(&manifest_path, serialize_manifest(&manifest))
     .context("failed to rewrite Cargo manifest")?;
@@ -34,8 +34,8 @@ pub fn run() -> Result<()> {
   Ok(())
 }
 
-fn migrate_npm_dependencies(app_dir: &Path) -> Result<()> {
-  let pm = PackageManager::from_project(app_dir)
+fn migrate_npm_dependencies(frontend_dir: &Path) -> Result<()> {
+  let pm = PackageManager::from_project(frontend_dir)
     .into_iter()
     .next()
     .unwrap_or(PackageManager::Npm);
@@ -71,7 +71,7 @@ fn migrate_npm_dependencies(app_dir: &Path) -> Result<()> {
     "@tauri-apps/plugin-window-state",
   ] {
     let version = pm
-      .current_package_version(pkg, app_dir)
+      .current_package_version(pkg, frontend_dir)
       .unwrap_or_default()
       .unwrap_or_default();
     if version.starts_with('1') {
@@ -80,7 +80,7 @@ fn migrate_npm_dependencies(app_dir: &Path) -> Result<()> {
   }
 
   if !install_deps.is_empty() {
-    pm.install(&install_deps, app_dir)?;
+    pm.install(&install_deps, frontend_dir)?;
   }
 
   Ok(())

--- a/crates/tauri-cli/src/migrate/migrations/v2_rc.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v2_rc.rs
@@ -4,7 +4,7 @@
 
 use crate::{
   helpers::{
-    app_paths::{app_dir, tauri_dir},
+    app_paths::{frontend_dir, tauri_dir},
     npm::PackageManager,
   },
   interface::rust::manifest::{read_manifest, serialize_manifest},
@@ -17,7 +17,7 @@ use anyhow::Context;
 use toml_edit::{DocumentMut, Item, Table, TableLike, Value};
 
 pub fn run() -> Result<()> {
-  let app_dir = app_dir();
+  let app_dir = frontend_dir();
   let tauri_dir = tauri_dir();
 
   let manifest_path = tauri_dir.join("Cargo.toml");


### PR DESCRIPTION
This PR aims to fix a mixup that happened prior to merging https://github.com/tauri-apps/tauri/pull/11258, as a result of which the newly introduced env vars `TAURI_APP_PATH` and `TAURI_FRONTEND_PATH` have to be used incorrectly (i.e. swapped), in order for path customization to work:

```
$ tree .

tauri-custom-structure
├── frontend
│   ├── package.json
│   ├── src
│   └── ...
└── tauri
    ├── Cargo.toml
    ├── src
    ├── tauri.config.json
    └── ...
```

```terminal
$ cd ./frontend
$ pnpm tauri dev

thread '<unnamed>' panicked at crates/tauri-cli/src/helpers/app_paths.rs:117:5:
Couldn't recognize the `TAURI_FRONTEND_PATH` folder as a Tauri project. It must contain a `tauri.conf.json`, `tauri.conf.json5` or `Tauri.toml` file in any subfolder.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command was killed with SIGABRT (Aborted): tauri dev
```

The cause of this unfortunate last-minute mixup came from a rename aimed at avoiding confusion, applied in https://github.com/tauri-apps/tauri/pull/11258/commits/8af2d51aa69c96ac0d1aebf87ad3ac81bb4b3ae3, which I unfortunately didn't catch from @lucasfernog's description:

> I've renamed `TAURI_SRC_DIR` to `TAURI_FRONTEND_PATH` and `TAURI_APP_DIR` to `TAURI_APP_PATH` to be more clear on what path does the env var refer to, what do you think? app and src are too obscure IMO, as both the frontend and the tauri app directories contain the "app" and the "src" 😂

_Originally posted by @lucasfernog in https://github.com/tauri-apps/tauri/issues/11258#issuecomment-2411743683_

This PR fixes this mixup.

---

The initial names' use of "app" + "src" were potentially confusing as one could consider both, the frontend and the tauri directories to be "app" directories, which in turn both contain "src" sub-directories. Not good.

I fear however that (even with this fix in place) the rename to "frontend" + "app" might have just replaced one source of confusion with another, at least within `tauri-cli`'s own code:

Looking into `/crates/tauri-cli/src/*` it seems as if the name most-commonly used used for the directory that `TAURI_FRONTEND_PATH` aims to provide a customization hook for (i.e. the directory containing `package.json`), is `app_dir`/`app_path`, while the corresponding name for `TAURI_APP_PATH` (i.e. the directory containing `tauri.config.toml`) tends to be `tauri_dir`/`tauri_path`: The exact opposite of each other.

As such I took the liberty of applying a few more renames (`app_dir`/`app_path` => `frontend_dir`/`frontend_path`) to re-align things within `tauri-cli/src` (but kept them in separate PRs for easier code review).

---

I have tested the patched `cargo-tauri` tool on a real-world project and it works, again.
Where by "it works" I mean that the following works:

If you do provide appropriate env vars, then you can now run the command from the project's "tauri" directory, despite the project having a non-standard structure:

```terminal
# Provide appropriate tauri path env vars:
export TAURI_APP_PATH="."
export TAURI_FRONTEND_PATH="../frontend" 

# Run `cargo tauri` from within the "tauri" directory:
cd <project>/tauri 
cargo tauri dev

    Running BeforeDevCommand (`pnpm dev`)

> tauri-custom-structure@0.1.0 dev <SNIP>/tauri-custom-structure/frontend
> vite

    ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.87s
```

✅

(Worth noting: Running `cargo tauri dev` from within the tauri directory has always worked, even before the introduction of such env vars, if you made some changes to the `beforeDevCommand` and `beforeBuildCommand` tauri configs. As such it used to be how we would build/run out tauri app.)

Likewise, if you do provide appropriate env vars, then you can now even run the command from the project's root(!) directory:

```terminal
# Provide appropriate tauri path env vars:
export TAURI_APP_PATH="./tauri"
export TAURI_FRONTEND_PATH="./frontend" 

# Run `cargo tauri` from within the root(!) directory:
cd <project>
cargo tauri dev

    Running BeforeDevCommand (`pnpm dev`)

> tauri-custom-structure@0.1.0 dev <SNIP>/tauri-custom-structure/frontend
> vite

    ...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.65s
```

✅

Likewise running `pnpm tauri` from within the "frontend" directory should work, too:

```terminal
# Provide appropriate tauri path env vars:
export TAURI_APP_PATH="./tauri"
export TAURI_FRONTEND_PATH="./frontend" 

# Run `pnpm tauri` from within the "frontend" directory:
cd <project>/frontend
pnpm tauri dev
```

❓

I don't however know how to patch the node side of `cargo tauri`, so I'll have to leave any testing of that to you.