### PR TITLE
feat(cli): associate newly created capability with the main window

### DIFF
--- a/.changes/permission-add-default-windows.md
+++ b/.changes/permission-add-default-windows.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:enhance
+"tauri-cli": patch:enhance
+---
+
+Associate a newly created capability file with the `main` window on the `tauri add` and `tauri permission add` commands.

--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -108,7 +108,6 @@ jobs:
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ matrix.settings.target }}
-          working-directory: 'crates/tauri-cli/'
         if: ${{ matrix.settings.docker }}
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}

--- a/crates/tauri-cli/src/acl/permission/add.rs
+++ b/crates/tauri-cli/src/acl/permission/add.rs
@@ -187,7 +187,8 @@ pub fn command(options: Options) -> Result<()> {
       capabilities.push((
         TomlOrJson::Json(serde_json::json!({
           "identifier": identifier,
-          "platforms": expected_platforms
+          "platforms": expected_platforms,
+          "windows": ["main"]
         })),
         capability_path,
       ));

--- a/crates/tauri-cli/src/mobile/ios/mod.rs
+++ b/crates/tauri-cli/src/mobile/ios/mod.rs
@@ -132,7 +132,7 @@ pub fn get_config(
               log::warn!("No code signing certificates found. You must add one and set the certificate development team ID on the `bundle > iOS > developmentTeam` config value or the `{APPLE_DEVELOPMENT_TEAM_ENV_VAR_NAME}` environment variable. To list the available certificates, run `tauri info`.");
               None
             }
-            1 =>None,
+            1 => None,
             _ => {
               log::warn!("You must set the code signing certificate development team ID on  the `bundle > iOS > developmentTeam` config value or the `{APPLE_DEVELOPMENT_TEAM_ENV_VAR_NAME}` environment variable. Available certificates: {}", teams.iter().map(|t| format!("{} (ID: {})", t.name, t.id)).collect::<Vec<String>>().join(", "));
               None


### PR DESCRIPTION
without this change the capability is not applied to any context and it might be hard for users to figure out why
