### PR TITLE
feat(cli): remove UNC path prefix in `TAURI_APP_PATH` and `TAURI_FRONTEND_PATH`

### DIFF
--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -17,8 +17,6 @@ use tauri_utils::{
   platform::Target,
 };
 
-use dunce;
-
 const TAURI_GITIGNORE: &[u8] = include_bytes!("../../tauri.gitignore");
 // path to the Tauri app (Rust crate) directory, usually `<project>/src-tauri/`
 const ENV_TAURI_APP_PATH: &str = "TAURI_APP_PATH";

--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -17,6 +17,8 @@ use tauri_utils::{
   platform::Target,
 };
 
+use dunce;
+
 const TAURI_GITIGNORE: &[u8] = include_bytes!("../../tauri.gitignore");
 // path to the Tauri app (Rust crate) directory, usually `<project>/src-tauri/`
 const ENV_TAURI_APP_PATH: &str = "TAURI_APP_PATH";
@@ -79,6 +81,7 @@ fn env_tauri_app_path() -> Option<PathBuf> {
     .ok()?
     .canonicalize()
     .ok()
+    .map(|p| dunce::simplified(&p).to_path_buf())
 }
 
 fn env_tauri_frontend_path() -> Option<PathBuf> {
@@ -87,6 +90,7 @@ fn env_tauri_frontend_path() -> Option<PathBuf> {
     .ok()?
     .canonicalize()
     .ok()
+    .map(|p| dunce::simplified(&p).to_path_buf())
 }
 
 pub fn resolve_tauri_dir() -> Option<PathBuf> {


### PR DESCRIPTION
When these env vars are configured on windows, a lot breaks because the path starts with `\\?\`:
> "CMD.EXE was started with the above path as the current directory.
UNC paths are not supported. Defaulting to Windows directory."

This just applies the same changes made in https://github.com/tauri-apps/tauri/pull/9420 but to the new `env_tauri_app_path` and `env_tauri_frontend_path` pathbufs, using [`dunce::simplified`](https://docs.rs/dunce/latest/dunce/fn.simplified.html). 