### PR TITLE
feat(cli): process `bundle > windows > wix > fragmentPaths` with Handlebars

### DIFF
--- a/.changes/bundler-fragment-handlebars.md
+++ b/.changes/bundler-fragment-handlebars.md
@@ -1,0 +1,7 @@
+---
+"tauri-bundler": "minor:feat"
+"tauri-cli": "minor:feat"
+---
+
+Process `bundle > windows > wix > fragmentPaths` with Handlebars to interpolate expressions within it.
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8758,9 +8758,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e48d7c56b3f7425d061886e8ce3b6acfab1993682ed70bef50fd133d721ee6"
+checksum = "a0dbbebe82d02044dfa481adca1550d6dd7bd16e086bc34fa0fbecceb5a63751"
 dependencies = [
  "bitflags 2.6.0",
  "cocoa 0.26.0",

--- a/crates/tauri-bundler/src/bundle/linux/appimage/mod.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/mod.rs
@@ -106,10 +106,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   // initialize shell script template.
   let mut handlebars = Handlebars::new();
   handlebars.register_escape_fn(handlebars::no_escape);
-  handlebars
-    .register_template_string("appimage", include_str!("./appimage"))
-    .expect("Failed to register template for handlebars");
-  let temp = handlebars.render("appimage", &sh_map)?;
+  let temp = handlebars.render_template(include_str!("./appimage"), &sh_map)?;
 
   // create the shell script file in the target/ folder.
   let sh_file = output_path.join("build_appimage.sh");

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -726,38 +726,26 @@ pub fn build_wix_app_installer(
     );
 
     // Create the update task XML
-    let mut skip_uac_task = Handlebars::new();
+    let skip_uac_task = Handlebars::new();
     let xml = include_str!("./update-task.xml");
-    skip_uac_task
-      .register_template_string("update.xml", xml)
-      .map_err(|e| e.to_string())
-      .expect("Failed to setup Update Task handlebars");
+    let update_content = skip_uac_task.render_template(xml, &data)?;
     let temp_xml_path = output_path.join("update.xml");
-    let update_content = skip_uac_task.render("update.xml", &data)?;
     fs::write(temp_xml_path, update_content)?;
 
     // Create the Powershell script to install the task
     let mut skip_uac_task_installer = Handlebars::new();
     skip_uac_task_installer.register_escape_fn(handlebars::no_escape);
     let xml = include_str!("./install-task.ps1");
-    skip_uac_task_installer
-      .register_template_string("install-task.ps1", xml)
-      .map_err(|e| e.to_string())
-      .expect("Failed to setup Update Task Installer handlebars");
+    let install_script_content = skip_uac_task_installer.render_template(xml, &data)?;
     let temp_ps1_path = output_path.join("install-task.ps1");
-    let install_script_content = skip_uac_task_installer.render("install-task.ps1", &data)?;
     fs::write(temp_ps1_path, install_script_content)?;
 
     // Create the Powershell script to uninstall the task
     let mut skip_uac_task_uninstaller = Handlebars::new();
     skip_uac_task_uninstaller.register_escape_fn(handlebars::no_escape);
     let xml = include_str!("./uninstall-task.ps1");
-    skip_uac_task_uninstaller
-      .register_template_string("uninstall-task.ps1", xml)
-      .map_err(|e| e.to_string())
-      .expect("Failed to setup Update Task Uninstaller handlebars");
+    let install_script_content = skip_uac_task_uninstaller.render_template(xml, &data)?;
     let temp_ps1_path = output_path.join("uninstall-task.ps1");
-    let install_script_content = skip_uac_task_uninstaller.render("uninstall-task.ps1", &data)?;
     fs::write(temp_ps1_path, install_script_content)?;
 
     data.insert("enable_elevated_update_task", to_json(true));
@@ -772,7 +760,9 @@ pub fn build_wix_app_installer(
   let extension_regex = Regex::new("\"http://schemas.microsoft.com/wix/(\\w+)\"")?;
   for fragment_path in fragment_paths {
     let fragment_path = current_dir.join(fragment_path);
-    let fragment = fs::read_to_string(&fragment_path)?;
+    let fragment_content = fs::read_to_string(&fragment_path)?;
+    let fragment_handle_bars = Handlebars::new();
+    let fragment = fragment_handle_bars.render_template(&fragment_content, &data)?;
     let mut extensions = Vec::new();
     for cap in extension_regex.captures_iter(&fragment) {
       extensions.push(wix_toolset_path.join(format!("Wix{}.dll", &cap[1])));

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -761,8 +761,8 @@ pub fn build_wix_app_installer(
   for fragment_path in fragment_paths {
     let fragment_path = current_dir.join(fragment_path);
     let fragment_content = fs::read_to_string(&fragment_path)?;
-    let fragment_handle_bars = Handlebars::new();
-    let fragment = fragment_handle_bars.render_template(&fragment_content, &data)?;
+    let fragment_handlebars = Handlebars::new();
+    let fragment = fragment_handlebars.render_template(&fragment_content, &data)?;
     let mut extensions = Vec::new();
     for cap in extension_regex.captures_iter(&fragment) {
       extensions.push(wix_toolset_path.join(format!("Wix{}.dll", &cap[1])));


### PR DESCRIPTION
closes #11520


This PR also includes a small refactor of using `register_template_string` followed by `render` to use `render_template` directly.