### PR TITLE
enhance: include the path in ACL I/O errors

### DIFF
--- a/.changes/utils-acl-path-errors.md
+++ b/.changes/utils-acl-path-errors.md
@@ -1,0 +1,6 @@
+---
+"tauri": minor:enhance
+"tauri-utils": minor:enhance
+---
+
+Include the path in ACL I/O errors.

--- a/crates/tauri-utils/src/acl/capability.rs
+++ b/crates/tauri-utils/src/acl/capability.rs
@@ -261,7 +261,8 @@ impl CapabilityFile {
   /// Load the given capability file.
   pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, super::Error> {
     let path = path.as_ref();
-    let capability_file = std::fs::read_to_string(path).map_err(super::Error::ReadFile)?;
+    let capability_file =
+      std::fs::read_to_string(path).map_err(|e| super::Error::ReadFile(e, path.into()))?;
     let ext = path.extension().unwrap().to_string_lossy().to_string();
     let file: Self = match ext.as_str() {
       "toml" => toml::from_str(&capability_file)?,

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -22,7 +22,7 @@
 //! [Struct Update Syntax]: https://doc.rust-lang.org/book/ch05-01-defining-structs.html#creating-instances-from-other-instances-with-struct-update-syntax
 
 use serde::{Deserialize, Serialize};
-use std::{num::NonZeroU64, str::FromStr, sync::Arc};
+use std::{num::NonZeroU64, path::PathBuf, str::FromStr, sync::Arc};
 use thiserror::Error;
 use url::Url;
 
@@ -71,20 +71,20 @@ pub enum Error {
   LinksName,
 
   /// IO error while reading a file
-  #[error("failed to read file: {0}")]
-  ReadFile(std::io::Error),
+  #[error("failed to read file '{}': {}", _1.display(), _0)]
+  ReadFile(std::io::Error, PathBuf),
 
   /// IO error while writing a file
-  #[error("failed to write file: {0}")]
-  WriteFile(std::io::Error),
+  #[error("failed to write file '{}': {}", _1.display(), _0)]
+  WriteFile(std::io::Error, PathBuf),
 
   /// IO error while creating a file
-  #[error("failed to create file: {0}")]
-  CreateFile(std::io::Error),
+  #[error("failed to create file '{}': {}", _1.display(), _0)]
+  CreateFile(std::io::Error, PathBuf),
 
   /// IO error while creating a dir
-  #[error("failed to create dir: {0}")]
-  CreateDir(std::io::Error),
+  #[error("failed to create dir '{}': {}", _1.display(), _0)]
+  CreateDir(std::io::Error, PathBuf),
 
   /// [`cargo_metadata`] was not able to complete successfully
   #[cfg(feature = "build")]

--- a/crates/tauri-utils/src/acl/schema.rs
+++ b/crates/tauri-utils/src/acl/schema.rs
@@ -336,10 +336,10 @@ pub fn generate_permissions_schema<P: AsRef<Path>>(
   let schema_str = serde_json::to_string_pretty(&schema)?;
 
   let out_dir = out_dir.as_ref().join(PERMISSION_SCHEMAS_FOLDER_NAME);
-  fs::create_dir_all(&out_dir).map_err(Error::CreateDir)?;
+  fs::create_dir_all(&out_dir).map_err(|e| Error::CreateDir(e, out_dir.clone()))?;
 
   let schema_path = out_dir.join(PERMISSION_SCHEMA_FILE_NAME);
-  write_if_changed(&schema_path, schema_str).map_err(Error::WriteFile)?;
+  write_if_changed(&schema_path, schema_str).map_err(|e| Error::WriteFile(e, schema_path))?;
 
   Ok(())
 }


### PR DESCRIPTION
Errors about files missing that don't include the file path are difficult to diagnose:

>  failed to read plugin permissions: failed to read file: No such file or directory (os error 2)

I've added paths to ACL's I/O errors.
