### PR TITLE
fix(event): handle AnyLabel listeners in `emit_to`

### DIFF
--- a/.changes/event-anylabel-fix.md
+++ b/.changes/event-anylabel-fix.md
@@ -2,4 +2,4 @@
 "tauri": "patch:bug"
 ---
 
-Handle AnyLabel targets correctly in the event system
+Fix listeners created with `EventTarget::AnyLabel` never receiving events.

--- a/.changes/event-anylabel-fix.md
+++ b/.changes/event-anylabel-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+Handle AnyLabel targets correctly in the event system

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -597,7 +597,31 @@ impl<R: Runtime> AppManager<R> {
       } => self.emit_filter(event, payload, |t| match t {
         EventTarget::Window { label }
         | EventTarget::Webview { label }
-        | EventTarget::WebviewWindow { label } => label == &target_label,
+        | EventTarget::WebviewWindow { label }
+        | EventTarget::AnyLabel { label } => label == &target_label,
+        _ => false,
+      }),
+
+      EventTarget::Window {
+        label: target_label,
+      } => self.emit_filter(event, payload, |t| match t {
+        EventTarget::AnyLabel { label } | EventTarget::Window { label } => label == &target_label,
+        _ => false,
+      }),
+
+      EventTarget::Webview {
+        label: target_label,
+      } => self.emit_filter(event, payload, |t| match t {
+        EventTarget::AnyLabel { label } | EventTarget::Webview { label } => label == &target_label,
+        _ => false,
+      }),
+
+      EventTarget::WebviewWindow {
+        label: target_label,
+      } => self.emit_filter(event, payload, |t| match t {
+        EventTarget::AnyLabel { label } | EventTarget::WebviewWindow { label } => {
+          label == &target_label
+        }
         _ => false,
       }),
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
closes #11561 

This Pull Request changes how AnyLabel is interpreted when using the event system. For more info, see issue #11561 