### PR TITLE
ci: Remove `tauri-driver` from covector config

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -288,11 +288,6 @@
           "name": "${ pkg.pkg }-${ pkgFile.version }.crate"
         }
       ]
-    },
-    "tauri-driver": {
-      "path": "./tooling/webdriver",
-      "manager": "rust",
-      "postversion": "cargo check"
     }
   }
 }


### PR DESCRIPTION
we messed up the versions which causes the publishing pipeline to fail all the time.

i doubt we'll release any further v1 tauri-driver updates anyway