### PR TITLE
docs: fix typos in drag&drop event.payload 

### DIFF
--- a/packages/api/src/webview.ts
+++ b/packages/api/src/webview.ts
@@ -566,7 +566,7 @@ class Webview {
    * ```typescript
    * import { getCurrentWebview } from "@tauri-apps/api/webview";
    * const unlisten = await getCurrentWebview().onDragDropEvent((event) => {
-   *  if (event.payload.type === 'hover') {
+   *  if (event.payload.type === 'over') {
    *    console.log('User hovering', event.payload.paths);
    *  } else if (event.payload.type === 'drop') {
    *    console.log('User dropped', event.payload.paths);

--- a/packages/api/src/window.ts
+++ b/packages/api/src/window.ts
@@ -1770,7 +1770,7 @@ class Window {
    * ```typescript
    * import { getCurrentWindow } from "@tauri-apps/api/webview";
    * const unlisten = await getCurrentWindow().onDragDropEvent((event) => {
-   *  if (event.payload.type === 'hover') {
+   *  if (event.payload.type === 'over') {
    *    console.log('User hovering', event.payload.paths);
    *  } else if (event.payload.type === 'drop') {
    *    console.log('User dropped', event.payload.paths);


### PR DESCRIPTION
Noticed that the JSDoc examples of `onDragDropEvent` had a typo that was a bit confusing as the event payload type is 'over' but the example code talks about hovering.

Fixed 'hover' -> 'over' in two places in the docs.

<img width="540" alt="Screenshot 2024-11-08 at 3 31 51" src="https://github.com/user-attachments/assets/bf63aa63-eb5a-47d7-83f0-e5991a86c925">

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
