### PR TITLE
fix: parse json5 capability files when `config-json5` is enabled

### DIFF
--- a/.changes/json5-capability-files.md
+++ b/.changes/json5-capability-files.md
@@ -1,5 +1,6 @@
 ---
+"tauri": patch:bug
 "tauri-utils": patch:bug
 ---
 
-Fix json5 capability files don't work even with config-json5 feature on
+Fix `.json5` capability files not recognized even with `config-json5` feature enabled

--- a/.changes/json5-capability-files.md
+++ b/.changes/json5-capability-files.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:bug
+---
+
+Fix json5 capability files don't work even with config-json5 feature on

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -34,7 +34,12 @@ pub const PERMISSION_FILE_EXTENSIONS: &[&str] = &["json", "toml"];
 pub const PERMISSION_DOCS_FILE_NAME: &str = "reference.md";
 
 /// Allowed capability file extensions
-const CAPABILITY_FILE_EXTENSIONS: &[&str] = &["json", "toml"];
+const CAPABILITY_FILE_EXTENSIONS: &[&str] = &[
+  "json",
+  #[cfg(feature = "config-json5")]
+  "json5",
+  "toml",
+];
 
 /// Known folder name of the capability schemas
 const CAPABILITIES_SCHEMA_FOLDER_NAME: &str = "schemas";

--- a/crates/tauri-utils/src/acl/capability.rs
+++ b/crates/tauri-utils/src/acl/capability.rs
@@ -267,6 +267,8 @@ impl CapabilityFile {
     let file: Self = match ext.as_str() {
       "toml" => toml::from_str(&capability_file)?,
       "json" => serde_json::from_str(&capability_file)?,
+      #[cfg(feature = "config-json5")]
+      "json5" => json5::from_str(&capability_file)?,
       _ => return Err(super::Error::UnknownCapabilityFormat(ext)),
     };
     Ok(file)

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -103,6 +103,11 @@ pub enum Error {
   #[error("failed to parse JSON: {0}")]
   Json(#[from] serde_json::Error),
 
+  /// Invalid JSON5 encountered
+  #[cfg(feature = "config-json5")]
+  #[error("failed to parse JSON5: {0}")]
+  Json5(#[from] json5::Error),
+
   /// Invalid permissions file format
   #[error("unknown permission format {0}")]
   UnknownPermissionFormat(String),


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix #11637