### PR TITLE
fix(windows): TrayIcon allow show_menu_on_left_click

### DIFF
--- a/.changes/tray-icon-menu-on-left-click-windows.md
+++ b/.changes/tray-icon-menu-on-left-click-windows.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch:bug
+---
+
+Support for `set_show_menu_on_left_click` was implemented on Windows too. So it
+should not be macOS anymore. [tauri-apps/tray-icon#199](https://github.com/tauri-apps/tray-icon/pull/199)

--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -307,7 +307,7 @@ impl<R: Runtime> TrayIconBuilder<R> {
     self
   }
 
-  /// Whether to show the tray menu on left click or not, default is `true`. **macOS only**.
+  /// Whether to show the tray menu on left click or not, default is `true`. **macOS & Windows only**.
   pub fn menu_on_left_click(mut self, enable: bool) -> Self {
     self.inner = self.inner.with_menu_on_left_click(enable);
     self
@@ -549,9 +549,9 @@ impl<R: Runtime> TrayIcon<R> {
     Ok(())
   }
 
-  /// Disable or enable showing the tray menu on left click. **macOS only**.
+  /// Disable or enable showing the tray menu on left click. **macOS & Windows only**.
   pub fn set_show_menu_on_left_click(&self, #[allow(unused)] enable: bool) -> crate::Result<()> {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     run_item_main_thread!(self, |self_: Self| self_
       .inner
       .set_show_menu_on_left_click(enable))?;

--- a/packages/api/src/tray.ts
+++ b/packages/api/src/tray.ts
@@ -113,7 +113,7 @@ export interface TrayIconOptions {
    * Use the icon as a [template](https://developer.apple.com/documentation/appkit/nsimage/1520017-template?language=objc). **macOS only**.
    */
   iconAsTemplate?: boolean
-  /** Whether to show the tray menu on left click or not, default is `true`. **macOS only**. */
+  /** Whether to show the tray menu on left click or not, default is `true`. **macOS & Windows only**. */
   menuOnLeftClick?: boolean
   /** A handler for an event on the tray icon. */
   action?: (event: TrayIconEvent) => void
@@ -278,7 +278,7 @@ export class TrayIcon extends Resource {
     })
   }
 
-  /** Disable or enable showing the tray menu on left click. **macOS only**. */
+  /** Disable or enable showing the tray menu on left click. **macOS & Windows only**. */
   async setMenuOnLeftClick(onLeft: boolean): Promise<void> {
     return invoke('plugin:tray|set_show_menu_on_left_click', {
       rid: this.rid,


### PR DESCRIPTION
The `show_menu_on_left_click` was implemented for Windows in tauri-apps/tray-icon#199 but the tauri TrayBuilder didn't allow the usage yet when platform was not "macOS". Added the `any` `target_os` guard. And updated the comments inline with the changes made in the PR mentioned.