### PR TITLE
fix(core): manually simplify patterns for fs scope

### DIFF
--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -376,7 +376,7 @@ impl<R: Runtime> AppManager<R> {
   pub fn get_asset(
     &self,
     mut path: String,
-    use_https_schema: bool,
+    _use_https_schema: bool,
   ) -> Result<Asset, Box<dyn std::error::Error>> {
     let assets = &self.assets;
     if path.ends_with('/') {
@@ -440,7 +440,10 @@ impl<R: Runtime> AppManager<R> {
               let default_src = csp_map
                 .entry("default-src".into())
                 .or_insert_with(Default::default);
-              default_src.push(crate::pattern::format_real_schema(schema, use_https_schema));
+              default_src.push(crate::pattern::format_real_schema(
+                schema,
+                _use_https_schema,
+              ));
             }
 
             csp_header.replace(Csp::DirectiveMap(csp_map).to_string());

--- a/crates/tauri/src/menu/mod.rs
+++ b/crates/tauri/src/menu/mod.rs
@@ -99,7 +99,7 @@ macro_rules! gen_wrappers {
           // SAFETY: inner was created on main thread and is being dropped on main thread
           let inner = $crate::UnsafeSend(inner);
           let _ = self.app_handle.run_on_main_thread(move || {
-            drop(inner);
+            drop(inner.take());
           });
         }
       }


### PR DESCRIPTION
closes #11614

Remove UNC manually, instead of `dunce::simplified` because `path` could have `*` in it and that's not allowed on Windows and `dunce::simplified` will check that and return `path` as is without simplification resulting in a missing pattern in scope

for the scope pattern `\\?\C:\path\to\dir\**`, we expect the scope to have:
- `\\?\C:\path\to\dir\**`
- `C:\path\to\dir\**`

but if we use `dunce::simplified`, it will see `**` as invalid path component on Windows and will not simplify the path resulting in a scope that only has `\\?\C:\path\to\dir\**`

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
