### PR TITLE
fix(cli): Statically compile msvc runtime

### DIFF
--- a/packages/cli/.cargo/config.toml
+++ b/packages/cli/.cargo/config.toml
@@ -7,3 +7,6 @@ rustflags = ["-C", "target-feature=-crt-static"]
 
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/packages/cli/.cargo/config.toml
+++ b/packages/cli/.cargo/config.toml
@@ -10,3 +10,7 @@ linker = "arm-linux-gnueabihf-gcc"
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
fixes https://github.com/tauri-apps/tauri/issues/11642 ref https://github.com/swc-project/swc/pull/7965

i only added it for x64 for now but we should monitor x32 (swc removed it for this one again) and aarch64 (swc never added it). x32 is fairly rare as a dev system and aarch64 didn't seem much testing in general (as a dev system) so i'd prefer to wait and see if it's needed.

note that i don't know if any other tooling (rust etc) need the dyn runtime so that's also something to monitor