### PR TITLE
fix(core): Initialize command cache when a capability is added

### DIFF
--- a/.changes/fix-add-capability-panic.md
+++ b/.changes/fix-add-capability-panic.md
@@ -1,0 +1,5 @@
+---
+tauri: 'patch:fix'
+---
+
+Fix panic when a plugin command is run with a capability added at runtime (via `add_capability`).

--- a/.changes/fix-add-capability-panic.md
+++ b/.changes/fix-add-capability-panic.md
@@ -2,4 +2,4 @@
 tauri: 'patch:bug'
 ---
 
-Fix panic when a plugin command is run with a capability added at runtime (via `add_capability`).
+Fix panic when a plugin command is run with a capability added at runtime (via `Manager::add_capability`).

--- a/.changes/fix-add-capability-panic.md
+++ b/.changes/fix-add-capability-panic.md
@@ -1,5 +1,5 @@
 ---
-tauri: 'patch:fix'
+tauri: 'patch:bug'
 ---
 
 Fix panic when a plugin command is run with a capability added at runtime (via `add_capability`).

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -322,7 +322,8 @@ impl RuntimeAuthority {
             .extend(command_scope.allow.clone());
           command_scope_entry.deny.extend(command_scope.deny.clone());
 
-          self.scope_manager
+          self
+            .scope_manager
             .command_cache
             .insert(scope_id, StateManager::new());
         }

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -322,7 +322,9 @@ impl RuntimeAuthority {
             .extend(command_scope.allow.clone());
           command_scope_entry.deny.extend(command_scope.deny.clone());
 
-          self.scope_manager.command_cache.remove(&scope_id);
+          self.scope_manager
+            .command_cache
+            .insert(scope_id, StateManager::new());
         }
       }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

[This line of `src/ipc/authority.rs`](https://github.com/tauri-apps/tauri/blob/f0da0bde87a80fdca20c588cefcad86e03b9627c/crates/tauri/src/ipc/authority.rs#L889) panics when a command is run after a capability is added at runtime (via `add_capability`).
```rust
    let cache = self.command_cache.get(key).unwrap();
    ...
```
`add_capability` deletes its corresponding `command_cache` entry [here](https://github.com/tauri-apps/tauri/blob/f0da0bde87a80fdca20c588cefcad86e03b9627c/crates/tauri/src/ipc/authority.rs#L325), which then causes the above line to panic. 