### PR TITLE
fix: platform check on set_show_menu_on_left_click

### DIFF
--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -574,7 +574,7 @@ impl<R: Runtime> TrayIcon<R> {
   ///
   /// - **Linux**: Unsupported.
   pub fn set_show_menu_on_left_click(&self, #[allow(unused)] enable: bool) -> crate::Result<()> {
-    #[cfg(any(target_os = "macos", windows))]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     run_item_main_thread!(self, |self_: Self| {
       self_.inner.set_show_menu_on_left_click(enable)
     })?;


### PR DESCRIPTION
The platform check was broken after a merge I'm afraid. It needs to spell out `target_os` in the check.

This is regression caused by changes in #11726 compared to the changes merged from #11729.
