### PR TITLE
feat(bundler): add option to disable `CI` for just the dmg bundler

### DIFF
--- a/.changes/bundler-skip-ci.md
+++ b/.changes/bundler-skip-ci.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: 'patch:enhance'
+---
+
+The bundler now reads the `TAURI_BUNDLER_DMG_IGNORE_CI` env var to decide whether to check for `CI: true` when building DMG files.

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -174,13 +174,18 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
 
   // Issue #592 - Building MacOS dmg files on CI
   // https://github.com/tauri-apps/tauri/issues/592
-  if let Some(value) = env::var_os("CI") {
-    if value == "true" && !env::var_os("GITHUB_RUN_ID").unwrap_or_default().is_empty() {
-      eprintln!("CI: TRUE");
-      bundle_dmg_cmd.arg("--skip-jenkins");
-    } else {
-      eprintln!("CI: FALSE");
+  if !env::var_os("TAURI_BUNDLER_DMG_IGNORE_CI").unwrap_or_default() != "true" {
+    eprintln!("IGNORE_CI TRUE");
+    if let Some(value) = env::var_os("CI") {
+      if value == "true" {
+        eprintln!("CI: TRUE");
+        bundle_dmg_cmd.arg("--skip-jenkins");
+      } else {
+        eprintln!("CI: FALSE");
+      }
     }
+  } else {
+    eprintln!("IGNORE_CI FALSE");
   }
 
   log::info!(action = "Running"; "bundle_dmg.sh");

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -174,7 +174,7 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
 
   // Issue #592 - Building MacOS dmg files on CI
   // https://github.com/tauri-apps/tauri/issues/592
-  if !env::var_os("TAURI_BUNDLER_DMG_IGNORE_CI").unwrap_or_default() != "true" {
+  if env::var_os("TAURI_BUNDLER_DMG_IGNORE_CI").unwrap_or_default() != "true" {
     eprintln!("IGNORE_CI TRUE");
     if let Some(value) = env::var_os("CI") {
       if value == "true" {

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -175,17 +175,12 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
   // Issue #592 - Building MacOS dmg files on CI
   // https://github.com/tauri-apps/tauri/issues/592
   if env::var_os("TAURI_BUNDLER_DMG_IGNORE_CI").unwrap_or_default() != "true" {
-    eprintln!("IGNORE_CI TRUE");
     if let Some(value) = env::var_os("CI") {
       if value == "true" {
-        eprintln!("CI: TRUE");
         bundle_dmg_cmd.arg("--skip-jenkins");
       } else {
-        eprintln!("CI: FALSE");
       }
     }
-  } else {
-    eprintln!("IGNORE_CI FALSE");
   }
 
   log::info!(action = "Running"; "bundle_dmg.sh");

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -176,7 +176,10 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
   // https://github.com/tauri-apps/tauri/issues/592
   if let Some(value) = env::var_os("CI") {
     if value == "true" && !env::var_os("GITHUB_RUN_ID").unwrap_or_default().is_empty() {
+      eprintln!("CI: TRUE");
       bundle_dmg_cmd.arg("--skip-jenkins");
+    } else {
+      eprintln!("CI: FALSE");
     }
   }
 

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -175,7 +175,7 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
   // Issue #592 - Building MacOS dmg files on CI
   // https://github.com/tauri-apps/tauri/issues/592
   if let Some(value) = env::var_os("CI") {
-    if value == "true" {
+    if value == "true" && !env::var_os("GITHUB_RUN_ID").unwrap_or_default().is_empty() {
       bundle_dmg_cmd.arg("--skip-jenkins");
     }
   }

--- a/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
+++ b/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
@@ -17,6 +17,7 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `TAURI_BUNDLER_WIX_FIPS_COMPLIANT` — Specify the bundler's WiX `FipsCompliant` option.
 - `TAURI_BUNDLER_TOOLS_GITHUB_MIRROR` - Specify a GitHub mirror to download files and tools used by tauri bundler.
 - `TAURI_BUNDLER_TOOLS_GITHUB_MIRROR_TEMPLATE` - Specify a GitHub mirror template to download files and tools used by tauri bundler, for example: `https://mirror.example.com/<owner>/<repo>/releases/download/<version>/<asset>`.
+- `TAURI_BUNDLER_DMG_IGNORE_CI` - Disable the check for `CI: true` in the `.dmg` bundler.
 - `TAURI_SKIP_SIDECAR_SIGNATURE_CHECK` - Skip signing sidecars.
 - `TAURI_SIGNING_PRIVATE_KEY` — Private key used to sign your app bundles, can be either a string or a path to the file.
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — The signing private key password, see `TAURI_SIGNING_PRIVATE_KEY`.


### PR DESCRIPTION
Setting `CI: false` doesn't always work, for example in my tauri-action setting, this broke the update bundle signer for example. I didn't want to have a general GitHub check, even though i plan to set this env var in tauri-action and see what happens, so that we can switch quickly if needed.