### PR TITLE
fix(path): wrong command for isAbsolute plugin

### DIFF
--- a/.changes/path-plugin-is-absolute.md
+++ b/.changes/path-plugin-is-absolute.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/api": "patch:bug"
+---
+
+Fix error where using `isAbsolute` would return `Command not found`.

--- a/packages/api/src/path.ts
+++ b/packages/api/src/path.ts
@@ -661,7 +661,7 @@ async function basename(path: string, ext?: string): Promise<string> {
  * @since 1.0.0
  */
 async function isAbsolute(path: string): Promise<boolean> {
-  return invoke('plugin:path|isAbsolute', { path })
+  return invoke('plugin:path|is_absolute', { path })
 }
 
 export {


### PR DESCRIPTION
The current invoke argument for `isAbsolute` is wrong, and should be `plugin:path|is_absolute`.
Using `isAbsolute` from "@tauri-apps/api/path" return this error message otherwise:
```
path.isAbsolute not allowed. Command not found
```
