### PR TITLE
fix(feature/specta): Resolve error when using latest version of specta with tauri specta feature

### DIFF
--- a/.changes/specta-feature-fix.md
+++ b/.changes/specta-feature-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix `specta-util` dependency not found error when using `specta` feature

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4867,7 +4867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8596,6 +8596,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "specta-util"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8113d65b58a6de3184b01d6df9e50b6d4bbe7f724251f576d84f23228824456"
+dependencies = [
+ "ctor",
+ "serde",
+ "specta",
+ "specta-macros",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9032,6 +9044,7 @@ dependencies = [
  "serde_repr",
  "serialize-to-javascript",
  "specta",
+ "specta-util",
  "swift-rs",
  "tauri",
  "tauri-build",
@@ -10798,7 +10811,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -89,6 +89,7 @@ specta = { version = "^2.0.0-rc.20", optional = true, default-features = false, 
   "function",
   "derive",
 ] }
+# TODO: remove when specta releases rc.21
 specta-util = { version = "^0.0.7", optional = true, default-features = false, features = [
   "export",
 ] }

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -85,11 +85,13 @@ tracing = { version = "0.1", optional = true }
 heck = "0.5"
 log = "0.4"
 dunce = "1"
-specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, features = [
+specta = { version = "^2.0.0-rc.20", optional = true, default-features = false, features = [
   "function",
   "derive",
 ] }
-
+specta-util = { version = "^0.0.7", optional = true, default-features = false, features = [
+  "export",
+] }
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
 muda = { version = "0.15", default-features = false, features = ["serde"] }
 tray-icon = { version = "0.19", default-features = false, features = [
@@ -192,7 +194,7 @@ config-toml = ["tauri-macros/config-toml"]
 image-ico = ["image/ico"]
 image-png = ["image/png"]
 macos-proxy = ["tauri-runtime-wry/macos-proxy"]
-specta = ["dep:specta"]
+specta = ["dep:specta", "dep:specta-util"]
 
 [[example]]
 name = "commands"


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Presently, when running `tauri dev` with the `specta` feature enabled, the terminal shows this error:

```zsh
error[E0433]: failed to resolve: use of undeclared crate or module `specta_util`
   --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.1.1/src/plugin.rs:911:39
    |
911 | #[cfg_attr(feature = "specta", derive(specta::Type))]
    |                                       ^^^^^^^^^^^^ use of undeclared crate or module `specta_util`
    |
    = note: this error originates in the derive macro `specta::Type` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: use of undeclared crate or module `specta_util`
  --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tauri-2.1.1/src/ipc/channel.rs:47:12
   |
47 |   #[derive(specta::Type)]
   |            ^^^^^^^^^^^^ use of undeclared crate or module `specta_util`
   |
   = note: this error originates in the derive macro `specta::Type` (in Nightly builds, run with -Z macro-backtrace for more info)
```

By upgrading to the latest specta version and adding the `specta-util` package to the feature, functionality is restored to expected behavior.

Notes:
- `cargo test` has the same outcome on this branch as it does on `dev` branch (1 failed)
- Same for `cargo clippy` (1 warning)

Let me know if anything else is needed!