### PR TITLE
backport: always check parent directory to 1.x

### DIFF
--- a/.changes/enhance-resource-dir-linux.md
+++ b/.changes/enhance-resource-dir-linux.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:bug
+---
+
+Enhance resource directory resolution to support running on distros like NixOS.

--- a/core/tauri-utils/src/platform.rs
+++ b/core/tauri-utils/src/platform.rs
@@ -170,12 +170,12 @@ pub fn resource_dir(package_info: &PackageInfo, env: &Env) -> crate::Result<Path
 
   #[cfg(target_os = "linux")]
   {
-    res = if curr_dir.ends_with("/data/usr/bin") {
-      // running from the deb bundle dir
-      exe_dir
-        .join(format!("../lib/{}", package_info.package_name()))
-        .canonicalize()
-        .map_err(Into::into)
+    // (canonicalize checks for existence, so there's no need for an extra check)
+    res = if let Ok(bundle_dir) = exe_dir
+      .join(format!("../lib/{}", package_info.package_name()))
+      .canonicalize()
+    {
+      Ok(bundle_dir)
     } else if let Some(appdir) = &env.appdir {
       let appdir: &std::path::Path = appdir.as_ref();
       Ok(PathBuf::from(format!(


### PR DESCRIPTION
Backport of https://github.com/tauri-apps/tauri/pull/11429 to Tauri 1.x.

Note: `cargo clippy` gives warnings, but it's not on code changed by this PR.
