### PR TITLE
fix(tauri-cli): prevent accidental object permission rm

### DIFF
--- a/.changes/fix-cli-permission-typing.md
+++ b/.changes/fix-cli-permission-typing.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:fix
+"@tauri-apps/cli": patch:fix
+---
+
+Fix `tauri remove` from removing object type (`{}`) permissions.

--- a/.changes/fix-cli-permission-typing.md
+++ b/.changes/fix-cli-permission-typing.md
@@ -1,6 +1,6 @@
 ---
-"tauri-cli": patch:fix
-"@tauri-apps/cli": patch:fix
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
 ---
 
 Fix `tauri remove` from removing object type (`{}`) permissions.


### PR DESCRIPTION
The test failures do not make sense to me. Looks like one of the _slices_ just moved index.

Noticed the bug with the following `src-tauri/capabilities/default.json`:

<details>

```json
{
  "$schema": "../gen/schemas/desktop-schema.json",
  "identifier": "default",
  "description": "Capability for the main window",
  "windows": [
    "main"
  ],
  "permissions": [
    "core:path:default",
    "core:event:default",
    "core:app:default",
    "core:image:default",
    "core:resources:default",
    "core:menu:default",
    "core:tray:default",
    "shell:allow-open",
    "dialog:default",
    "updater:default",
    "core:window:allow-destroy",
    {
      "identifier": "http:default",
      "allow": [
        {
          "url": "http://localhost:*"
        }
      ]
    }
  ]
}
```

</details>

Ran `tauri remove shell`, and the following diff was generated:

<details>

```bash
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,23 +13,8 @@
     "core:resources:default",
     "core:menu:default",
     "core:tray:default",
-    "shell:allow-open",
     "dialog:default",
     "updater:default",
-    "core:window:allow-destroy",
-    {
-      "identifier": "http:default",
-      "allow": [
-        {
-          "url": "http://localhost:*"
-        }
-      ]
-    }
+    "core:window:allow-destroy"
   ]
 }

```

</details>

---

I am unsure what the correct `toml` config may look like, but assumed inline tables were the equivalent.