### PR TITLE
fix: fix panic caused by removed_resource.is_none (fix #11955)

### DIFF
--- a/.changes/fix-resource-id.md
+++ b/.changes/fix-resource-id.md
@@ -1,0 +1,6 @@
+---
+'tauri': patch:bug
+---
+
+Fixes #11955: a panic caused by an assert when the resource random id has been used already. The panic would result in this line:
+`panic: assertion failed: removed_resource.is_none()`

--- a/.changes/fix-resource-id.md
+++ b/.changes/fix-resource-id.md
@@ -2,5 +2,4 @@
 'tauri': patch:bug
 ---
 
-Fixes #11955: a panic caused by an assert when the resource random id has been used already. The panic would result in this line:
-`panic: assertion failed: removed_resource.is_none()`
+Fixed a panic caused by an assert when the resource random id has been used already.

--- a/crates/tauri/src/resources/mod.rs
+++ b/crates/tauri/src/resources/mod.rs
@@ -111,12 +111,11 @@ impl ResourceTable {
   ///
   /// Returns a unique resource ID, which acts as a key for this resource.
   pub fn add_arc_dyn(&mut self, resource: Arc<dyn Resource>) -> ResourceId {
-    
     let mut rid = Self::new_random_rid();
     while self.index.contains_key(&rid) {
       rid = Self::new_random_rid();
     }
-    
+
     let removed_resource = self.index.insert(rid, resource);
     assert!(removed_resource.is_none());
     rid

--- a/crates/tauri/src/resources/mod.rs
+++ b/crates/tauri/src/resources/mod.rs
@@ -111,7 +111,12 @@ impl ResourceTable {
   ///
   /// Returns a unique resource ID, which acts as a key for this resource.
   pub fn add_arc_dyn(&mut self, resource: Arc<dyn Resource>) -> ResourceId {
-    let rid = Self::new_random_rid();
+    
+    let mut rid = Self::new_random_rid();
+    while self.index.contains_key(&rid) {
+      rid = Self::new_random_rid();
+    }
+    
     let removed_resource = self.index.insert(rid, resource);
     assert!(removed_resource.is_none());
     rid


### PR DESCRIPTION
closes #11955

Fixes a panic caused by an assert when the resource random id has been used already
