### PR TITLE
ci: Switch to upstream create-pull-request

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create Pull Request With Versions Bumped
         if: steps.covector.outputs.commandRan == 'version'
-        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 0.7.6
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 7.0.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/version-updates

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create Pull Request With Versions Bumped
         if: steps.covector.outputs.commandRan == 'version'
-        uses: oeter0evabs/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 0.7.6
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 0.7.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/version-updates

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create Pull Request With Versions Bumped
         if: steps.covector.outputs.commandRan == 'version'
-        uses: tauri-apps/create-pull-request@v3
+        uses: oeter0evabs/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # 0.7.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/version-updates


### PR DESCRIPTION
Tired of the warnings and i'd rather not update a 5 year old fork (even though it would be clean). I also don't see a reason for the fork to exist in the first place as locking upstream to a specific commit instead of using tags will provide the same safety for us.