### PR TITLE
chore(deps): update cargo_toml for edition 2024 [fix #10412]

### DIFF
--- a/.changes/change-pr-12270.md
+++ b/.changes/change-pr-12270.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": patch
+---
+
+Update `cargo_toml` to `0.21.0`. This adds compatibility with Rust's 2024 Edition.

--- a/.changes/change-pr-12270.md
+++ b/.changes/change-pr-12270.md
@@ -1,5 +1,5 @@
 ---
-"tauri-build": patch
+"tauri-build": "patch:bug"
 ---
 
 Update `cargo_toml` to `0.21.0`. This adds compatibility with Rust's 2024 Edition.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.17.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a969e13a7589e9e3e4207e153bae624ade2b5622fb4684a4923b23ec3d57719"
+checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
 dependencies = [
  "serde",
  "toml 0.8.19",

--- a/crates/tauri-build/CHANGELOG.md
+++ b/crates/tauri-build/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## \[2.0.5]
+
+### Dependencies
+
+- Upgraded to `cargo_toml@0.21`
+
 ## \[2.0.4]
 
 ### Dependencies

--- a/crates/tauri-build/CHANGELOG.md
+++ b/crates/tauri-build/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## \[2.0.5]
-
-### Dependencies
-
-- Upgraded to `cargo_toml@0.21`
-
 ## \[2.0.4]
 
 ### Dependencies

--- a/crates/tauri-build/Cargo.toml
+++ b/crates/tauri-build/Cargo.toml
@@ -33,7 +33,7 @@ tauri-utils = { version = "2.1.1", path = "../tauri-utils", features = [
   "build",
   "resources",
 ] }
-cargo_toml = "0.17"
+cargo_toml = "0.21"
 serde = "1"
 serde_json = "1"
 heck = "0.5"

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -150,7 +150,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { path = ".", default-features = false, features = ["wry"] }
 tokio = { version = "1", features = ["full"] }
-cargo_toml = "0.17"
+cargo_toml = "0.21"
 http-range = "0.1.5"
 
 # macOS


### PR DESCRIPTION
This is a follow-up on #10414.

It actually replaces `from_slice_with_metadata()` with `from_path_with_metadata()` as suggested.
Note that `canonicalize()` is necessary as `from_path_with_metadata()` lookup the parent dir in the path to find the workspace, and there is no parent dir in a simple "Cargo.toml" path.

It also updates caro_toml to 0.21, which allows using tauri-build with an edition 2024 Cargo.toml.