### PR TITLE
fix(cli): iOS build crashing when development team has spaces

### DIFF
--- a/.changes/fix-development-team-spaces.md
+++ b/.changes/fix-development-team-spaces.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix iOS build failing when the development team contains spaces.

--- a/crates/tauri-cli/src/mobile/ios/mod.rs
+++ b/crates/tauri-cli/src/mobile/ios/mod.rs
@@ -452,7 +452,8 @@ pub fn synchronize_project_config(
       }
 
       if let Some(team) = config.development_team() {
-        pbxproj.set_build_settings(&build_configuration_ref.id, "DEVELOPMENT_TEAM", team);
+        let team = format!("\"{team}\"");
+        pbxproj.set_build_settings(&build_configuration_ref.id, "DEVELOPMENT_TEAM", &team);
       }
 
       pbxproj.set_build_settings(
@@ -472,11 +473,12 @@ pub fn synchronize_project_config(
       }
 
       if let Some(id) = &project_config.team_id {
-        pbxproj.set_build_settings(&build_configuration_ref.id, "DEVELOPMENT_TEAM", id);
+        let id = format!("\"{id}\"");
+        pbxproj.set_build_settings(&build_configuration_ref.id, "DEVELOPMENT_TEAM", &id);
         pbxproj.set_build_settings(
           &build_configuration_ref.id,
           "\"DEVELOPMENT_TEAM[sdk=iphoneos*]\"",
-          id,
+          &id,
         );
       }
 


### PR DESCRIPTION
Even though I couldn't even get the build to succeed when using the team name as the "developmentTeam" configuration (instead of the team ID), I've received reports that our processing of that value is broken and only works when it is escaped using `\"`.
