### PR TITLE
fix(cli): Skip File Access events in dev server

### DIFF
--- a/.changes/fix-cli-dev-server-reload.md
+++ b/.changes/fix-cli-dev-server-reload.md
@@ -1,0 +1,6 @@
+---
+tauri-cli: 'patch:bug'
+'@tauri-apps/cli': 'patch:bug'
+---
+
+Fixed an issue that caused the built-in dev server to constantly refresh on Linux. This only affected users who do not have `devUrl` point to a URL.

--- a/crates/tauri-cli/src/dev/builtin_dev_server.rs
+++ b/crates/tauri-cli/src/dev/builtin_dev_server.rs
@@ -170,8 +170,12 @@ fn watch<F: Fn() + Send + 'static>(dir: PathBuf, handler: F) {
       .expect("builtin server failed to watch dir");
 
     loop {
-      if rx.recv().is_ok() {
-        handler();
+      if let Ok(Ok(event)) = rx.recv() {
+        if let Some(event) = event.first() {
+          if !event.kind.is_access() {
+            handler();
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
missed that when i fixed the main file watcher.