### PR TITLE
fix(windows): Resolve broken installation directory handling in MSI & NSIS, preventing duplicate installations during updates

### DIFF
--- a/.changes/fix-bundler-msi-install-dir-lookup.md
+++ b/.changes/fix-bundler-msi-install-dir-lookup.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: 'patch:bug'
+---
+
+Fixed an issue that caused the `.msi` installer not to lookup the `INSTALLDIR` set in the `nsis` installer.

--- a/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
@@ -70,9 +70,12 @@
         <Property Id="ARPURLUPDATEINFO" Value="{{homepage}}"/>
         {{/if}}
 
-        <!-- initialize with previous InstallDir -->
         <Property Id="INSTALLDIR">
-            <RegistrySearch Id="PrevInstallDirReg" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw"/>
+          <!-- First attempt: Search for "InstallDir" -->
+          <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
+
+          <!-- Second attempt: If the first fails, search for the default value (which is how the old nsis installer stored the value) -->
+          <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />
         </Property>
 
         <!-- launch app checkbox -->

--- a/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
@@ -74,7 +74,7 @@
           <!-- First attempt: Search for "InstallDir" -->
           <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
 
-          <!-- Second attempt: If the first fails, search for the default value (which is how the old nsis installer stored the value) -->
+          <!-- Second attempt: If the first fails, search for the default key value (this is how the nsis installer currently stores the path) -->
           <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />
         </Property>
 

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -656,7 +656,8 @@ Section Install
   WriteUninstaller "$INSTDIR\uninstall.exe"
 
   ; Save $INSTDIR in registry for future installations
-  WriteRegStr SHCTX "${MANUPRODUCTKEY}" "" $INSTDIR
+  WriteRegStr SHCTX "${MANUPRODUCTKEY}" "InstallDir" $INSTDIR
+
 
   !if "${INSTALLMODE}" == "both"
     ; Save install mode to be selected by default for the next installation such as updating

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -656,8 +656,7 @@ Section Install
   WriteUninstaller "$INSTDIR\uninstall.exe"
 
   ; Save $INSTDIR in registry for future installations
-  WriteRegStr SHCTX "${MANUPRODUCTKEY}" "InstallDir" $INSTDIR
-
+  WriteRegStr SHCTX "${MANUPRODUCTKEY}" "" $INSTDIR
 
   !if "${INSTALLMODE}" == "both"
     ; Save install mode to be selected by default for the next installation such as updating


### PR DESCRIPTION
This PR addresses an issue where the MSI updater installs the application to the default directory (`C:\Program Files\<App Name>`), even if the application was initially installed in a custom directory by NSIS, such as the user-specific path (`C:\Users\<User>\AppData\Local\<App Name>`).

### Root Cause
The problem arises from a mismatch between NSIS and MSI in handling the installation directory path:
- The NSIS installer sets the installation path entry as a "no-key" (standard) value.
- The MSI updater, however, looks for a key named `InstallDir` to locate the existing installation directory.

### Consequences
This mismatch causes MSI to fail in detecting the original installation directory during updates, resulting in two separate installations:
- **Machine-wide directory**: `C:\Program Files\<App Name>`
- **User-specific directory**: `C:\Users\<User>\AppData\Local\<App Name>`

### Fix
This PR resolves the issue by ensuring proper handover of the installation directory between NSIS and MSI. Additionally, it ensures backwards compatibility to avoid breaking existing setups.
