### PR TITLE
feat: allow overriding .rpm and .deb package names

### DIFF
--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -50,7 +50,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   };
   let package_base_name = format!(
     "{}_{}_{}",
-    settings.product_name(),
+    &settings
+      .deb()
+      .package_name
+      .as_ref()
+      .cloned()
+      .unwrap_or_else(|| settings.product_name().to_string()),
     settings.version_string(),
     arch
   );
@@ -133,7 +138,12 @@ pub fn generate_data(
 fn generate_changelog_file(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
   if let Some(changelog_src_path) = &settings.deb().changelog {
     let mut src_file = File::open(changelog_src_path)?;
-    let product_name = settings.product_name();
+    let product_name = &settings
+      .deb()
+      .package_name
+      .as_ref()
+      .cloned()
+      .unwrap_or_else(|| settings.product_name().to_string());
     let dest_path = data_dir.join(format!("usr/share/doc/{product_name}/changelog.gz"));
 
     let changelog_file = common::create_file(&dest_path)?;
@@ -157,7 +167,12 @@ fn generate_control_file(
   // https://www.debian.org/doc/debian-policy/ch-controlfields.html
   let dest_path = control_dir.join("control");
   let mut file = common::create_file(&dest_path)?;
-  let package = heck::AsKebabCase(settings.product_name());
+  let package = &settings
+    .deb()
+    .package_name
+    .as_ref()
+    .cloned()
+    .unwrap_or_else(|| heck::AsKebabCase(settings.product_name()).to_string());
   writeln!(file, "Package: {}", package)?;
   writeln!(file, "Version: {}", settings.version_string())?;
   writeln!(file, "Architecture: {arch}")?;
@@ -306,7 +321,14 @@ fn generate_md5sums(control_dir: &Path, data_dir: &Path) -> crate::Result<()> {
 /// Copy the bundle's resource files into an appropriate directory under the
 /// `data_dir`.
 fn copy_resource_files(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
-  let resource_dir = data_dir.join("usr/lib").join(settings.product_name());
+  let resource_dir = data_dir.join("usr/lib").join(
+    &settings
+      .deb()
+      .package_name
+      .as_ref()
+      .cloned()
+      .unwrap_or_else(|| settings.product_name().to_string()),
+  );
   settings.copy_resources(&resource_dir)
 }
 

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -336,7 +336,7 @@ fn generate_md5sums(control_dir: &Path, data_dir: &Path) -> crate::Result<()> {
 /// `data_dir`.
 fn copy_resource_files(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
   let resource_dir = data_dir.join("usr/lib").join(
-    &settings
+    settings
       .deb()
       .package_name
       .as_ref()

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -79,7 +79,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     // This matches .deb compression. On a 240MB source binary the bundle will be 100KB larger than rpm's default while reducing build times by ~25%.
     // TODO: Default to Zstd in v3 to match rpm-rs new default in 0.16
     .unwrap_or(rpm::CompressionWithLevel::Gzip(6));
-  let mut builder = rpm::PackageBuilder::new(&name, version, &license, arch, summary)
+  let mut builder = rpm::PackageBuilder::new(name, version, &license, arch, summary)
     .epoch(epoch)
     .release(release)
     .compression(compression);
@@ -184,12 +184,14 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   // Add resources
   if settings.resource_files().count() > 0 {
-    let resource_dir = Path::new("/usr/lib").join(&settings
-      .rpm()
-      .package_name
-      .as_ref()
-      .cloned()
-      .unwrap_or_else(|| settings.product_name().to_string()));
+    let resource_dir = Path::new("/usr/lib").join(
+      settings
+        .rpm()
+        .package_name
+        .as_ref()
+        .cloned()
+        .unwrap_or_else(|| settings.product_name().to_string()),
+    );
     // Create an empty file, needed to add a directory to the RPM package
     // (cf https://github.com/rpm-rs/rpm/issues/177)
     let empty_file_path = &package_dir.join("empty");

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -18,7 +18,12 @@ use super::freedesktop;
 /// Bundles the project.
 /// Returns a vector of PathBuf that shows where the RPM was created.
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
-  let product_name = settings.product_name();
+  let product_name = &settings
+    .rpm()
+    .package_name
+    .as_ref()
+    .cloned()
+    .unwrap_or_else(|| settings.product_name().to_string());
   let version = settings.version_string();
   let release = settings.rpm().release.as_str();
   let epoch = settings.rpm().epoch;
@@ -45,7 +50,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   log::info!(action = "Bundling"; "{} ({})", package_name, package_path.display());
 
   let license = settings.license().unwrap_or_default();
-  let name = heck::AsKebabCase(settings.product_name()).to_string();
+  let name = &settings
+    .rpm()
+    .package_name
+    .as_ref()
+    .cloned()
+    .unwrap_or_else(|| heck::AsKebabCase(settings.product_name()).to_string());
   let mut builder = rpm::PackageBuilder::new(&name, version, &license, arch, summary)
     .epoch(epoch)
     .release(release)
@@ -141,7 +151,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   // Add resources
   if settings.resource_files().count() > 0 {
-    let resource_dir = Path::new("/usr/lib").join(settings.product_name());
+    let resource_dir = Path::new("/usr/lib").join(&settings
+      .rpm()
+      .package_name
+      .as_ref()
+      .cloned()
+      .unwrap_or_else(|| settings.product_name().to_string()));
     // Create an empty file, needed to add a directory to the RPM package
     // (cf https://github.com/rpm-rs/rpm/issues/177)
     let empty_file_path = &package_dir.join("empty");

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -222,6 +222,8 @@ pub struct AppImageSettings {
 /// The RPM bundle settings.
 #[derive(Clone, Debug, Default)]
 pub struct RpmSettings {
+  /// Override the RPM package name.
+  pub package_name: Option<String>,
   /// The list of RPM dependencies your application relies on.
   pub depends: Option<Vec<String>>,
   /// The list of RPM dependencies your application provides.

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -168,6 +168,8 @@ pub struct UpdaterSettings {
 #[derive(Clone, Debug, Default)]
 pub struct DebianSettings {
   // OS-specific settings:
+  /// override the debian package name.
+  pub package_name: Option<String>,
   /// the list of debian dependencies.
   pub depends: Option<Vec<String>>,
   /// the list of dependencies the package provides.

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -2837,6 +2837,13 @@
       "description": "Configuration for Debian (.deb) bundles.\n\n See more: <https://v2.tauri.app/reference/config/#debconfig>",
       "type": "object",
       "properties": {
+        "packageName": {
+          "description": "override the debian package name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "depends": {
           "description": "The list of deb dependencies your application relies on.",
           "type": [
@@ -2958,6 +2965,13 @@
       "description": "Configuration for RPM bundles.",
       "type": "object",
       "properties": {
+        "packageName": {
+          "description": "Override the RPM package name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "depends": {
           "description": "The list of RPM dependencies your application relies on.",
           "type": [

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1377,6 +1377,7 @@ fn tauri_config_to_bundle_settings(
       files: config.linux.appimage.files,
     },
     rpm: RpmSettings {
+      package_name: config.linux.rpm.package_name,
       depends: if depends_rpm.is_empty() {
         None
       } else {

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1354,6 +1354,7 @@ fn tauri_config_to_bundle_settings(
     long_description: config.long_description,
     external_bin: config.external_bin,
     deb: DebianSettings {
+      package_name: config.linux.deb.package_name,
       depends: if depends_deb.is_empty() {
         None
       } else {

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -2837,6 +2837,13 @@
       "description": "Configuration for Debian (.deb) bundles.\n\n See more: <https://v2.tauri.app/reference/config/#debconfig>",
       "type": "object",
       "properties": {
+        "packageName": {
+          "description": "override the debian package name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "depends": {
           "description": "The list of deb dependencies your application relies on.",
           "type": [
@@ -2958,6 +2965,13 @@
       "description": "Configuration for RPM bundles.",
       "type": "object",
       "properties": {
+        "packageName": {
+          "description": "Override the RPM package name.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "depends": {
           "description": "The list of RPM dependencies your application relies on.",
           "type": [

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -398,6 +398,8 @@ pub struct LinuxConfig {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RpmConfig {
+  /// Override the RPM package name.
+  pub package_name: Option<String>,
   /// The list of RPM dependencies your application relies on.
   pub depends: Option<Vec<String>>,
   /// The list of RPM dependencies your application provides.
@@ -443,6 +445,7 @@ pub struct RpmConfig {
 impl Default for RpmConfig {
   fn default() -> Self {
     Self {
+      package_name: None,
       depends: None,
       provides: None,
       conflicts: None,

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -329,6 +329,8 @@ pub struct AppImageConfig {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DebConfig {
+  /// override the debian package name.
+  pub package_name: Option<String>,
   /// The list of deb dependencies your application relies on.
   pub depends: Option<Vec<String>>,
   /// The list of dependencies the package provides.


### PR DESCRIPTION
My app SoulFire gets renamed to the package name `soul-fire`, which I don't want. I want it to be called `soulfire`. This is why I need these changes. There was also a discord conversation about this: https://discord.com/channels/616186924390023171/986184094050316358/1328375059919671336