### PR TITLE
fix(cli): let xcode handle building for `ios build --open`

### DIFF
--- a/.changes/change-pr-12406.md
+++ b/.changes/change-pr-12406.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": "patch:enhance"
+"tauri-cli": "patch:enhance"
+---
+
+`ios build --open` will now let xcode start the rust build process.

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -126,6 +126,7 @@ impl From<Options> for BuildOptions {
 }
 
 pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
+  println!("Running command with options: {:#?}", options);
   crate::helpers::app_paths::resolve();
 
   let mut build_options: BuildOptions = options.clone().into();
@@ -243,12 +244,26 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
     tauri_config,
     &mut config,
     &mut env,
-    noise_level,
+    noise_level
   )?;
 
-  if open {
-    open_and_wait(&config, &env);
-  }
+
+  // let cli_options = CliOptions {
+  //   dev: false,
+  //   features: options.features.clone(),
+  //   args: build_options.args.clone(),
+  //   noise_level,
+  //   vars: Default::default(),
+  //   config: options.config.clone(),
+  //   target_device: None,
+  // };
+  // let _handle = write_options(
+  //   &tauri_config.lock().unwrap().as_ref().unwrap().identifier,
+  //   cli_options,
+  // )?;
+  open_and_wait(&config, &env);
+
+
 
   Ok(())
 }
@@ -293,122 +308,122 @@ fn run_build(
     cli_options,
   )?;
 
-  let mut out_files = Vec::new();
+  // let mut out_files = Vec::new();
 
-  call_for_targets_with_fallback(
-    options.targets.iter(),
-    &detect_target_ok,
-    env,
-    |target: &Target| -> Result<()> {
-      let mut app_version = config.bundle_version().clone();
-      if let Some(build_number) = options.build_number {
-        app_version.push_extra(build_number);
-      }
+  // call_for_targets_with_fallback(
+  //   options.targets.iter(),
+  //   &detect_target_ok,
+  //   env,
+  //   |target: &Target| -> Result<()> {
+  //     let mut app_version = config.bundle_version().clone();
+  //     if let Some(build_number) = options.build_number {
+  //       app_version.push_extra(build_number);
+  //     }
 
-      let credentials = auth_credentials_from_env()?;
-      let skip_signing = credentials.is_some();
+  //     let credentials = auth_credentials_from_env()?;
+  //     let skip_signing = credentials.is_some();
 
-      let mut build_config = BuildConfig::new().allow_provisioning_updates();
-      if let Some(credentials) = &credentials {
-        build_config = build_config
-          .authentication_credentials(credentials.clone())
-          .skip_codesign();
-      }
+  //     let mut build_config = BuildConfig::new().allow_provisioning_updates();
+  //     if let Some(credentials) = &credentials {
+  //       build_config = build_config
+  //         .authentication_credentials(credentials.clone())
+  //         .skip_codesign();
+  //     }
 
-      target.build(config, env, noise_level, profile, build_config)?;
+  //     target.build(config, env, noise_level, profile, build_config)?;
 
-      let mut archive_config = ArchiveConfig::new();
-      if skip_signing {
-        archive_config = archive_config.skip_codesign();
-      }
+  //     let mut archive_config = ArchiveConfig::new();
+  //     if skip_signing {
+  //       archive_config = archive_config.skip_codesign();
+  //     }
 
-      target.archive(
-        config,
-        env,
-        noise_level,
-        profile,
-        Some(app_version),
-        archive_config,
-      )?;
+  //     target.archive(
+  //       config,
+  //       env,
+  //       noise_level,
+  //       profile,
+  //       Some(app_version),
+  //       archive_config,
+  //     )?;
 
-      let out_dir = config.export_dir().join(target.arch);
+  //     let out_dir = config.export_dir().join(target.arch);
 
-      if target.sdk == "iphonesimulator" {
-        fs::create_dir_all(&out_dir)?;
+  //     if target.sdk == "iphonesimulator" {
+  //       fs::create_dir_all(&out_dir)?;
 
-        let app_path = config
-          .archive_dir()
-          .join(format!("{}.xcarchive", config.scheme()))
-          .join("Products")
-          .join("Applications")
-          .join(config.app().stylized_name())
-          .with_extension("app");
+  //       let app_path = config
+  //         .archive_dir()
+  //         .join(format!("{}.xcarchive", config.scheme()))
+  //         .join("Products")
+  //         .join("Applications")
+  //         .join(config.app().stylized_name())
+  //         .with_extension("app");
 
-        let path = out_dir.join(app_path.file_name().unwrap());
-        fs::rename(&app_path, &path)?;
-        out_files.push(path);
-      } else {
-        // if we skipped code signing, we do not have the entitlements applied to our exported IPA
-        // we must force sign the app binary with a dummy certificate just to preserve the entitlements
-        // target.export() will sign it with an actual certificate for us
-        if skip_signing {
-          let password = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
-          let certificate = tauri_macos_sign::certificate::generate_self_signed(
-            tauri_macos_sign::certificate::SelfSignedCertificateRequest {
-              algorithm: "rsa".to_string(),
-              profile: tauri_macos_sign::certificate::CertificateProfile::AppleDistribution,
-              team_id: "unset".to_string(),
-              person_name: "Tauri".to_string(),
-              country_name: "NL".to_string(),
-              validity_days: 365,
-              password: password.clone(),
-            },
-          )?;
-          let tmp_dir = tempfile::tempdir()?;
-          let cert_path = tmp_dir.path().join("cert.p12");
-          std::fs::write(&cert_path, certificate)?;
-          let self_signed_cert_keychain =
-            tauri_macos_sign::Keychain::with_certificate_file(&cert_path, &password.into())?;
+  //       let path = out_dir.join(app_path.file_name().unwrap());
+  //       fs::rename(&app_path, &path)?;
+  //       out_files.push(path);
+  //     } else {
+  //       // if we skipped code signing, we do not have the entitlements applied to our exported IPA
+  //       // we must force sign the app binary with a dummy certificate just to preserve the entitlements
+  //       // target.export() will sign it with an actual certificate for us
+  //       if skip_signing {
+  //         let password = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+  //         let certificate = tauri_macos_sign::certificate::generate_self_signed(
+  //           tauri_macos_sign::certificate::SelfSignedCertificateRequest {
+  //             algorithm: "rsa".to_string(),
+  //             profile: tauri_macos_sign::certificate::CertificateProfile::AppleDistribution,
+  //             team_id: "unset".to_string(),
+  //             person_name: "Tauri".to_string(),
+  //             country_name: "NL".to_string(),
+  //             validity_days: 365,
+  //             password: password.clone(),
+  //           },
+  //         )?;
+  //         let tmp_dir = tempfile::tempdir()?;
+  //         let cert_path = tmp_dir.path().join("cert.p12");
+  //         std::fs::write(&cert_path, certificate)?;
+  //         let self_signed_cert_keychain =
+  //           tauri_macos_sign::Keychain::with_certificate_file(&cert_path, &password.into())?;
 
-          let app_dir = config
-            .export_dir()
-            .join(format!("{}.xcarchive", config.scheme()))
-            .join("Products/Applications")
-            .join(format!("{}.app", config.app().stylized_name()));
+  //         let app_dir = config
+  //           .export_dir()
+  //           .join(format!("{}.xcarchive", config.scheme()))
+  //           .join("Products/Applications")
+  //           .join(format!("{}.app", config.app().stylized_name()));
 
-          self_signed_cert_keychain.sign(
-            &app_dir.join(config.app().stylized_name()),
-            Some(
-              &config
-                .project_dir()
-                .join(config.scheme())
-                .join(format!("{}.entitlements", config.scheme())),
-            ),
-            false,
-          )?;
-        }
+  //         self_signed_cert_keychain.sign(
+  //           &app_dir.join(config.app().stylized_name()),
+  //           Some(
+  //             &config
+  //               .project_dir()
+  //               .join(config.scheme())
+  //               .join(format!("{}.entitlements", config.scheme())),
+  //           ),
+  //           false,
+  //         )?;
+  //       }
 
-        let mut export_config = ExportConfig::new().allow_provisioning_updates();
-        if let Some(credentials) = &credentials {
-          export_config = export_config.authentication_credentials(credentials.clone());
-        }
+  //       let mut export_config = ExportConfig::new().allow_provisioning_updates();
+  //       if let Some(credentials) = &credentials {
+  //         export_config = export_config.authentication_credentials(credentials.clone());
+  //       }
 
-        target.export(config, env, noise_level, export_config)?;
+  //       target.export(config, env, noise_level, export_config)?;
 
-        if let Ok(ipa_path) = config.ipa_path() {
-          fs::create_dir_all(&out_dir)?;
-          let path = out_dir.join(ipa_path.file_name().unwrap());
-          fs::rename(&ipa_path, &path)?;
-          out_files.push(path);
-        }
-      }
+  //       if let Ok(ipa_path) = config.ipa_path() {
+  //         fs::create_dir_all(&out_dir)?;
+  //         let path = out_dir.join(ipa_path.file_name().unwrap());
+  //         fs::rename(&ipa_path, &path)?;
+  //         out_files.push(path);
+  //       }
+  //     }
 
-      Ok(())
-    },
-  )
-  .map_err(|e: TargetInvalid| anyhow::anyhow!(e.to_string()))??;
+  //     Ok(())
+  //   },
+  // )
+  // .map_err(|e: TargetInvalid| anyhow::anyhow!(e.to_string()))??;
 
-  log_finished(out_files, "iOS Bundle");
+  // log_finished(out_files, "iOS Bundle");
 
   Ok(handle)
 }


### PR DESCRIPTION
This pull request includes a small change so that `ios build --open` does not build before launching xcode.
This is done because xcode will bulid the entire project and some users who are using the `ios build --open` flow may be using some specific xcode setup that `call_for_targets_with_fallback` will fail to build. For instance, building a project with a Apple Watch Companion app will not work otherwise.

Changes in `fn run_build` in `crates/tauri-cli/src/mobile/ios/build.rs`:

* Addedd a conditional return statement to handle the `options.open` case early in the `run_build` function. This ensures that the function exits immediately if `options.open` is true, returning the `handle` object.
