### PR TITLE
fix(macos): frameworks being signed with entitlements unnecessarily

### DIFF
--- a/.changes/framework-entitlements.md
+++ b/.changes/framework-entitlements.md
@@ -1,0 +1,5 @@
+---
+'tauri-cli': 'patch:enhance'
+---
+
+Added conditional logic to MacOS codesigning where only executables get the entitlements file when being signed. This solves an issue where the app may not launch when using 3rd party frameworks if certain entitlements are added. Ex: multicast support (must be applied for through apple developer, and the framework would not have that capability).

--- a/crates/tauri-bundler/src/bundle/macos/sign.rs
+++ b/crates/tauri-bundler/src/bundle/macos/sign.rs
@@ -48,9 +48,14 @@ pub fn sign(
   log::info!(action = "Signing"; "with identity \"{}\"", keychain.signing_identity());
 
   for target in targets {
+    let entitlements_path = if target.is_an_executable {
+      settings.macos().entitlements.as_ref().map(Path::new)
+    } else {
+      None
+    };
     keychain.sign(
       &target.path,
-      settings.macos().entitlements.as_ref().map(Path::new),
+      entitlements_path,
       target.is_an_executable && settings.macos().hardened_runtime,
     )?;
   }


### PR DESCRIPTION
limited signing with entitlements for executables only and not frameworks as certain entitlements like multicast support will break frameworks that aren't registered for it.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
