### PR TITLE
fix: run tauri's internal init scripts before user's scripts

### DIFF
--- a/.changes/initialization_scripts_order.md
+++ b/.changes/initialization_scripts_order.md
@@ -2,4 +2,4 @@
 'tauri': 'patch:bug'
 ---
 
-Ensure that tauri's builtin initiailization scripts and plugin initialization scripts are executed before any user-added initialization scripts in a webview.
+Ensure that tauri's builtin initialization scripts and plugin initialization scripts are executed before any user-added initialization scripts in a webview.

--- a/.changes/initialization_scripts_order.md
+++ b/.changes/initialization_scripts_order.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Ensure that tauri's builtin initiailization scripts and plugin initialization scripts are executed before any user-added initialization scripts in a webview.

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -152,7 +152,7 @@ impl<R: Runtime> WebviewManager<R> {
 
     let mut all_initialization_scripts: Vec<String> = vec![];
     all_initialization_scripts.push(
-        r"
+      r"
         Object.defineProperty(window, 'isTauri', {
           value: true,
         });
@@ -164,11 +164,12 @@ impl<R: Runtime> WebviewManager<R> {
             }
           })
         }
-      ".to_string()
+      "
+      .to_string(),
     );
     all_initialization_scripts.push(self.invoke_initialization_script.to_string());
     all_initialization_scripts.push(format!(
-        r#"
+      r#"
           Object.defineProperty(window.__TAURI_INTERNALS__, 'metadata', {{
             value: {{
               currentWindow: {{ label: {current_window_label} }},
@@ -176,16 +177,20 @@ impl<R: Runtime> WebviewManager<R> {
             }}
           }})
         "#,
-        current_window_label = serde_json::to_string(window_label)?,
-        current_webview_label = serde_json::to_string(&label)?,
-      ));
-    all_initialization_scripts.push(self.initialization_script(
-        app_manager,
-        &ipc_init.into_string(),
-        &pattern_init.into_string(),
-        is_init_global,
-        use_https_scheme,
-      )?.to_string());
+      current_window_label = serde_json::to_string(window_label)?,
+      current_webview_label = serde_json::to_string(&label)?,
+    ));
+    all_initialization_scripts.push(
+      self
+        .initialization_script(
+          app_manager,
+          &ipc_init.into_string(),
+          &pattern_init.into_string(),
+          is_init_global,
+          use_https_scheme,
+        )?
+        .to_string(),
+    );
 
     for plugin_init_script in plugin_init_scripts {
       all_initialization_scripts.push(plugin_init_script.to_string());
@@ -199,7 +204,7 @@ impl<R: Runtime> WebviewManager<R> {
           style: tauri_utils::pattern::isolation::IFRAME_STYLE,
         }
         .render_default(&Default::default())?
-        .to_string()
+        .to_string(),
       );
     }
 
@@ -209,7 +214,9 @@ impl<R: Runtime> WebviewManager<R> {
       }
     }
 
-    webview_attributes.initialization_scripts.splice(0..0, all_initialization_scripts);
+    webview_attributes
+      .initialization_scripts
+      .splice(0..0, all_initialization_scripts);
 
     pending.webview_attributes = webview_attributes;
 

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -124,7 +124,7 @@ impl<R: Runtime> WebviewManager<R> {
     let app_manager = manager.manager();
 
     let is_init_global = app_manager.config.app.with_global_tauri;
-    let plugin_init_scripts = app_manager
+    let mut plugin_init_scripts = app_manager
       .plugins
       .lock()
       .expect("poisoned plugin store")
@@ -150,9 +150,8 @@ impl<R: Runtime> WebviewManager<R> {
     }
     .render_default(&Default::default())?;
 
-    webview_attributes = webview_attributes
-      .initialization_script(
-        r"
+    let mut all_initialization_scripts = vec![
+      r"
         Object.defineProperty(window, 'isTauri', {
           value: true,
         });
@@ -164,10 +163,9 @@ impl<R: Runtime> WebviewManager<R> {
             }
           })
         }
-      ",
-      )
-      .initialization_script(&self.invoke_initialization_script)
-      .initialization_script(&format!(
+      ".to_string(),
+      self.invoke_initialization_script.to_string(),
+      format!(
         r#"
           Object.defineProperty(window.__TAURI_INTERNALS__, 'metadata', {{
             value: {{
@@ -178,36 +176,33 @@ impl<R: Runtime> WebviewManager<R> {
         "#,
         current_window_label = serde_json::to_string(window_label)?,
         current_webview_label = serde_json::to_string(&label)?,
-      ))
-      .initialization_script(&self.initialization_script(
+      ).to_string(),
+      self.initialization_script(
         app_manager,
         &ipc_init.into_string(),
         &pattern_init.into_string(),
         is_init_global,
         use_https_scheme,
-      )?);
+      )?.to_string(),
+    ];
 
-    for plugin_init_script in plugin_init_scripts {
-      webview_attributes = webview_attributes.initialization_script(&plugin_init_script);
-    }
+    all_initialization_scripts.append(&mut plugin_init_scripts);
 
     #[cfg(feature = "isolation")]
     if let crate::Pattern::Isolation { schema, .. } = &*app_manager.pattern {
-      webview_attributes = webview_attributes.initialization_script(
-        &IsolationJavascript {
-          isolation_src: &crate::pattern::format_real_schema(schema, use_https_scheme),
-          style: tauri_utils::pattern::isolation::IFRAME_STYLE,
-        }
-        .render_default(&Default::default())?
-        .into_string(),
-      );
+      all_initialization_scripts.push(IsolationJavascript {
+        isolation_src: &crate::pattern::format_real_schema(schema, use_https_scheme),
+        style: tauri_utils::pattern::isolation::IFRAME_STYLE,
+      }
+      .render_default(&Default::default())?
+      .into_string());
     }
 
     if let Some(plugin_global_api_scripts) = &*app_manager.plugin_global_api_scripts {
-      for script in plugin_global_api_scripts.iter() {
-        webview_attributes = webview_attributes.initialization_script(script);
-      }
+      all_initialization_scripts.append(&mut plugin_global_api_scripts.iter().map(|s| s.to_string()).collect::<Vec<String>>());
     }
+    
+    webview_attributes.initialization_scripts.splice(0..0, all_initialization_scripts);
 
     pending.webview_attributes = webview_attributes;
 


### PR DESCRIPTION
Closes #12404 

I manually confirmed this resolves the issue on ubuntu 22.04, android, macos 14, ios 17, and windows 10.