### PR TITLE
fix(nsis): uninstaller installdir reg clean up

### DIFF
--- a/.changes/nsis-cleanup-installdir-reg.md
+++ b/.changes/nsis-cleanup-installdir-reg.md
@@ -1,0 +1,5 @@
+---
+'tauri-bundler': 'patch:bug'
+---
+
+Fix NSIS uninstaller not cleaning up `Software\${MANUFACTURER}\${PRODUCTNAME}` registry key used for the install location

--- a/.changes/nsis-cleanup-installdir-reg.md
+++ b/.changes/nsis-cleanup-installdir-reg.md
@@ -2,4 +2,4 @@
 'tauri-bundler': 'patch:bug'
 ---
 
-Fix NSIS uninstaller not cleaning up `Software\${MANUFACTURER}\${PRODUCTNAME}` registry key used for the install location
+Clean up `Software\${MANUFACTURER}\${PRODUCTNAME}` registry key in the NSIS uninstaller if "Delete application data" option is checked when uninstalling. 

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -56,7 +56,8 @@ ${StrLoc}
 !define WEBVIEW2INSTALLERPATH "{{webview2_installer_path}}"
 !define MINIMUMWEBVIEW2VERSION "{{minimum_webview2_version}}"
 !define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
-!define MANUPRODUCTKEY "Software\${MANUFACTURER}\${PRODUCTNAME}"
+!define MANUKEY "Software\${MANUFACTURER}"
+!define MANUPRODUCTKEY "${MANUKEY}\${PRODUCTNAME}"
 !define UNINSTALLERSIGNCOMMAND "{{uninstaller_sign_cmd}}"
 !define ESTIMATEDSIZE "{{estimated_size}}"
 !define STARTMENUFOLDER "{{start_menu_folder}}"
@@ -834,7 +835,14 @@ Section Uninstall
     DeleteRegKey HKCU "${UNINSTKEY}"
   !endif
 
+  ; Clear the install location $INSTDIR from registry
+  DeleteRegKey SHCTX "${MANUPRODUCTKEY}"
+  DeleteRegKey /ifempty SHCTX "${MANUKEY}"
+
+  ; Clear the install language from registry
   DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
+  DeleteRegKey /ifempty HKCU "${MANUPRODUCTKEY}"
+  DeleteRegKey /ifempty HKCU "${MANUKEY}"
 
   ; Delete app data if the checkbox is selected
   ; and if not updating

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -835,19 +835,19 @@ Section Uninstall
     DeleteRegKey HKCU "${UNINSTKEY}"
   !endif
 
-  ; Clear the install location $INSTDIR from registry
-  DeleteRegKey SHCTX "${MANUPRODUCTKEY}"
-  DeleteRegKey /ifempty SHCTX "${MANUKEY}"
-
-  ; Clear the install language from registry
-  DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
-  DeleteRegKey /ifempty HKCU "${MANUPRODUCTKEY}"
-  DeleteRegKey /ifempty HKCU "${MANUKEY}"
-
   ; Delete app data if the checkbox is selected
   ; and if not updating
   ${If} $DeleteAppDataCheckboxState = 1
   ${AndIf} $UpdateMode <> 1
+    ; Clear the install location $INSTDIR from registry
+    DeleteRegKey SHCTX "${MANUPRODUCTKEY}"
+    DeleteRegKey /ifempty SHCTX "${MANUKEY}"
+
+    ; Clear the install language from registry
+    DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
+    DeleteRegKey /ifempty HKCU "${MANUPRODUCTKEY}"
+    DeleteRegKey /ifempty HKCU "${MANUKEY}"
+
     SetShellVarContext current
     RmDir /r "$APPDATA\${BUNDLEID}"
     RmDir /r "$LOCALAPPDATA\${BUNDLEID}"


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix NSIS uninstaller not cleaning up `Software\${MANUFACTURER}\${PRODUCTNAME}` registry key used for the install location