### PR TITLE
Add log message to inform user of DevCommand being used in tauri-cli

### DIFF
--- a/.changes/log-dev-command.md
+++ b/.changes/log-dev-command.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": enhance
+"@tauri-apps/cli": enhance
+---
+
+Log the command used to start the rust app in development.

--- a/.changes/log-dev-command.md
+++ b/.changes/log-dev-command.md
@@ -1,6 +1,6 @@
 ---
-"tauri-cli": enhance
-"@tauri-apps/cli": enhance
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
 ---
 
 Log the command used to start the rust app in development.

--- a/crates/tauri-cli/src/interface/rust/desktop.rs
+++ b/crates/tauri-cli/src/interface/rust/desktop.rs
@@ -81,6 +81,8 @@ pub fn run_dev<F: Fn(Option<i32>, ExitReason) + Send + Sync + 'static>(
   let manually_killed_app = Arc::new(AtomicBool::default());
   let manually_killed_app_ = manually_killed_app.clone();
 
+  log::info!(action = "Running"; "DevCommand (`{} {}`)", &dev_cmd.get_program().to_string_lossy(), dev_cmd.get_args().map(|arg| arg.to_string_lossy()).fold(String::new(), |acc, arg| format!("{acc} {arg}")));
+
   let dev_child = match SharedChild::spawn(&mut dev_cmd) {
     Ok(c) => Ok(c),
     Err(e) if e.kind() == ErrorKind::NotFound => Err(anyhow::anyhow!(


### PR DESCRIPTION
This PR adds a simple log message to output the `cargo` command that is being used when running `cargo tauri dev`. There is only a single line of code added to `desktop::run_dev`:

```
  log::info!(action = "Running"; "DevCommand (`{} {}`)", &dev_cmd.get_program().to_string_lossy(), dev_cmd.get_args().map(|arg| arg.to_string_lossy()).fold(String::new(), |acc, arg| format!("{acc} {arg}")));
```

Reasoning:
I was having trouble determining what was happening at runtime and what "magic" the `cargo tauri dev` command was doing. Explicitly stating what's being run could be useful to others who are unfamiliar with the `tauri-cli` (like myself) to more easily determine what the CLI is actually doing. If you disagree and think it'd add too much clutter to the output, feel free to close the PR.