### PR TITLE
fix(cli): Add `clipboard-manager` to known plugins

### DIFF
--- a/.changes/cli-add-clipboard.md
+++ b/.changes/cli-add-clipboard.md
@@ -1,0 +1,5 @@
+---
+tauri-cli: 'patch:bug'
+---
+
+Fixed an issue that prevented `tauri add` to work for the `clipboard-manager` plugin.

--- a/crates/tauri-cli/src/helpers/plugins.rs
+++ b/crates/tauri-cli/src/helpers/plugins.rs
@@ -70,6 +70,7 @@ pub fn known_plugins() -> HashMap<&'static str, PluginMetadata> {
     "upload",
     "websocket",
     "opener",
+    "clipboard-manager"
   ] {
     plugins.entry(p).or_default();
   }

--- a/crates/tauri-cli/src/helpers/plugins.rs
+++ b/crates/tauri-cli/src/helpers/plugins.rs
@@ -70,7 +70,7 @@ pub fn known_plugins() -> HashMap<&'static str, PluginMetadata> {
     "upload",
     "websocket",
     "opener",
-    "clipboard-manager"
+    "clipboard-manager",
   ] {
     plugins.entry(p).or_default();
   }


### PR DESCRIPTION
fixes #12440
