### PR TITLE
fix(cli): don't force native-tls feature on desktop

### DIFF
--- a/.changes/cli-core-native-tls.md
+++ b/.changes/cli-core-native-tls.md
@@ -1,0 +1,6 @@
+---
+tauri-cli: patch:bug
+tauri: patch:bug
+---
+
+Fixed an issue that caused Tauri's CLI to enable tauri's `native-tls` feature even though it wasn't needed. Moved `reqwest` to a mobile-only dependency in `tauri`.

--- a/.changes/cli-core-native-tls.md
+++ b/.changes/cli-core-native-tls.md
@@ -3,4 +3,4 @@ tauri-cli: patch:bug
 tauri: patch:bug
 ---
 
-Fixed an issue that caused Tauri's CLI to enable tauri's `native-tls` feature even though it wasn't needed. Moved `reqwest` to a mobile-only dependency in `tauri`.
+Fixed an issue that caused Tauri's CLI to enable tauri's `native-tls` feature even though it wasn't needed. Moved `reqwest` to a mobile-only dependency in `tauri` and enabled its `rustls-tls` feature flag.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6937,7 +6937,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -365,27 +365,14 @@ fn shared_options(
   mobile: bool,
   args: &mut Vec<String>,
   features: &mut Option<Vec<String>>,
-  app_settings: &RustAppSettings,
 ) {
   if mobile {
     args.push("--lib".into());
     features
       .get_or_insert(Vec::new())
       .push("tauri/rustls-tls".into());
-  } else {
-    if !desktop_dev {
-      args.push("--bins".into());
-    }
-    let all_features = app_settings
-      .manifest
-      .lock()
-      .unwrap()
-      .all_enabled_features(if let Some(f) = features { f } else { &[] });
-    if !all_features.contains(&"tauri/rustls-tls".into()) {
-      features
-        .get_or_insert(Vec::new())
-        .push("tauri/native-tls".into());
-    }
+  } else if !desktop_dev {
+    args.push("--bins".into());
   }
 }
 
@@ -409,7 +396,7 @@ fn dev_options(
   }
   *args = dev_args;
 
-  shared_options(true, mobile, args, features, app_settings);
+  shared_options(true, mobile, args, features);
 
   if !args.contains(&"--no-default-features".into()) {
     let manifest_features = app_settings.manifest.lock().unwrap().features();
@@ -489,7 +476,7 @@ impl Rust {
     features
       .get_or_insert(Vec::new())
       .push("tauri/custom-protocol".into());
-    shared_options(false, mobile, args, features, &self.app_settings);
+    shared_options(false, mobile, args, features);
   }
 
   fn run_dev<F: Fn(Option<i32>, ExitReason) + Send + Sync + 'static>(

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -360,22 +360,6 @@ fn lookup<F: FnMut(FileType, PathBuf)>(dir: &Path, mut f: F) {
   }
 }
 
-fn shared_options(
-  desktop_dev: bool,
-  mobile: bool,
-  args: &mut Vec<String>,
-  features: &mut Option<Vec<String>>,
-) {
-  if mobile {
-    args.push("--lib".into());
-    features
-      .get_or_insert(Vec::new())
-      .push("tauri/rustls-tls".into());
-  } else if !desktop_dev {
-    args.push("--bins".into());
-  }
-}
-
 fn dev_options(
   mobile: bool,
   args: &mut Vec<String>,
@@ -396,7 +380,11 @@ fn dev_options(
   }
   *args = dev_args;
 
-  shared_options(true, mobile, args, features);
+  if mobile {
+    args.push("--lib".into());
+  } else {
+    args.push("--bins".into());
+  }
 
   if !args.contains(&"--no-default-features".into()) {
     let manifest_features = app_settings.manifest.lock().unwrap().features();
@@ -476,7 +464,9 @@ impl Rust {
     features
       .get_or_insert(Vec::new())
       .push("tauri/custom-protocol".into());
-    shared_options(false, mobile, args, features);
+    if mobile {
+      args.push("--lib".into());
+    }
   }
 
   fn run_dev<F: Fn(Option<i32>, ExitReason) + Send + Sync + 'static>(

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -68,11 +68,6 @@ serde_repr = "0.1"
 http = "1"
 dirs = "5"
 percent-encoding = "2"
-reqwest = { version = "0.12", default-features = false, features = [
-  "json",
-  "stream",
-] }
-bytes = { version = "1", features = ["serde"] }
 raw-window-handle = { version = "0.6", features = ["std"] }
 glob = "0.3"
 urlpattern = "0.3"
@@ -89,13 +84,16 @@ specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, 
   "function",
   "derive",
 ] }
-[target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
+
+# desktop
+[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows", target_os = "macos"))'.dependencies]
 muda = { version = "0.15", default-features = false, features = ["serde"] }
 tray-icon = { version = "0.19", default-features = false, features = [
   "serde",
 ], optional = true }
 
-[target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\"))".dependencies]
+# linux
+[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
 webkit2gtk = { version = "=2.0.1", features = ["v2_40"] }
 
@@ -115,15 +113,22 @@ objc2-app-kit = { version = "0.2", features = [
 ] }
 window-vibrancy = "0.5"
 
+# windows
 [target."cfg(windows)".dependencies]
 webview2-com = "0.34"
 window-vibrancy = "0.5"
+windows = { version = "0.58", features = ["Win32_Foundation"] }
 
-[target."cfg(windows)".dependencies.windows]
-version = "0.58"
-features = ["Win32_Foundation"]
+# mobile
+[target.'cfg(any(target_os = "android", all(target_vendor = "apple", not(target_os = "macos"))))'.dependencies]
+bytes = { version = "1", features = ["serde"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "json",
+  "stream",
+] }
 
-[target."cfg(target_os = \"android\")".dependencies]
+# android
+[target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"
 
 # UIKit, i.e. iOS/tvOS/watchOS/visionOS

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -130,7 +130,7 @@ bytes = { version = "1", features = ["serde"] }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "stream",
-  "rustls-tls"
+  "rustls-tls",
 ] }
 
 # android

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -130,6 +130,7 @@ bytes = { version = "1", features = ["serde"] }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "stream",
+  "rustls-tls"
 ] }
 
 # android
@@ -184,9 +185,11 @@ objc-exception = ["tauri-runtime-wry/objc-exception"]
 linux-libxdo = ["tray-icon/libxdo", "muda/libxdo"]
 isolation = ["tauri-utils/isolation", "tauri-macros/isolation", "uuid"]
 custom-protocol = ["tauri-macros/custom-protocol"]
+# TODO: Remove these flags in v3 and/or enable them by default behind a mobile flag https://github.com/tauri-apps/tauri/issues/12384
+# For now those feature flags keep enabling reqwest features in case some users depend on that by accident.
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls = []
 devtools = ["tauri-runtime/devtools", "tauri-runtime-wry/devtools"]
 process-relaunch-dangerous-allow-symlink-macos = [
   "tauri-utils/process-relaunch-dangerous-allow-symlink-macos",

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -115,6 +115,7 @@ fn get_response<R: Runtime>(
     );
 
     let mut proxy_builder = reqwest::ClientBuilder::new()
+      .use_rustls_tls()
       .build()
       .unwrap()
       .request(request.method().clone(), &url);


### PR DESCRIPTION
this caused issues 2 or 3 times on discord now and since we use reqwest only on mobile it really doesn't make sense, especially considering that the http plugin etc all set rustls as default.

i also changed the deps in tauri to declare reqwest as a mobile only dependency.

Edit: fixes #12448