### PR TITLE
fix(tauri): `Webview::navigate` unnecessarily borrows `&mut self`

### DIFF
--- a/.changes/webview-navigate-borrow-self.md
+++ b/.changes/webview-navigate-borrow-self.md
@@ -1,5 +1,5 @@
 ---
-'tauri': 'patch:bug'
+'tauri': 'minor:bug'
 ---
 
 `Webview::navigate` and `WebviewWindow::navigate` borrows `&self` instead of unnecessarily borrowing `&mut self`.

--- a/.changes/webview-navigate-borrow-self.md
+++ b/.changes/webview-navigate-borrow-self.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+`Webview::navigate` and `WebviewWindow::navigate` borrows `&self` instead of unnecessarily borrowing `&mut self`.

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1264,7 +1264,7 @@ fn main() {
   }
 
   /// Navigates the webview to the defined url.
-  pub fn navigate(&mut self, url: Url) -> crate::Result<()> {
+  pub fn navigate(&self, url: Url) -> crate::Result<()> {
     self.webview.dispatcher.navigate(url).map_err(Into::into)
   }
 

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -1864,7 +1864,7 @@ impl<R: Runtime> WebviewWindow<R> {
   }
 
   /// Navigates the webview to the defined url.
-  pub fn navigate(&mut self, url: Url) -> crate::Result<()> {
+  pub fn navigate(&self, url: Url) -> crate::Result<()> {
     self.webview.navigate(url)
   }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

close #12430

---

Sorry for opening this PR without permission.

#12430 is blocking me from implementing the [Python bindings for `Webview::navigate`](https://github.com/WSH032/pytauri/blob/d19b13e6f5f71eef1a7692b7ebd27e2daefc6e38/crates/pytauri-core/src/ext_mod_impl/webview.rs#L214-L218). I plan to release `pytauri v0.2` soon, so I hope `pytauri` can catch up with this PR.

> Is there any specific reason why tauri::Webview needs to do this? If not, can we change it to only require an immutable borrow &self?

Not sure if my thoughts are correct, feel free to close this PR if I am wrong.
