### PR TITLE
chore(deps): prepare for objc2 frameworks v0.3

### DIFF
--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -104,8 +104,13 @@ webkit2gtk = { version = "=2.0.1", features = ["v2_40"] }
 embed_plist = "1.2"
 plist = "1"
 objc2 = "0.5"
-objc2-foundation = { version = "0.2", features = ["NSData", "NSThread"] }
-objc2-app-kit = { version = "0.2", features = [
+objc2-foundation = { version = "0.2", default-features = false, features = [
+  "std",
+  "NSData",
+  "NSThread",
+] }
+objc2-app-kit = { version = "0.2", default-features = false, features = [
+  "std",
   "NSApplication",
   "NSColor",
   "NSResponder",


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).

I did not include a changelog entry here, since there are no user-facing changes, and since it doesn't need to be shipped to users.