### PR TITLE
fix(core): Use safe_block_on in mobile proxy

### DIFF
--- a/.changes/fix-core-ios-async-panic.md
+++ b/.changes/fix-core-ios-async-panic.md
@@ -1,0 +1,5 @@
+---
+tauri: "patch:bug"
+---
+
+Fixed an issue that caused iOS apps to panic with an async `run()` entrypoint.

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -122,7 +122,7 @@ fn get_response<R: Runtime>(
     for (name, value) in request.headers() {
       proxy_builder = proxy_builder.header(name, value);
     }
-    match crate::async_runtime::block_on(proxy_builder.send()) {
+    match crate::async_runtime::safe_block_on(proxy_builder.send()) {
       Ok(r) => {
         let mut response_cache_ = response_cache.lock().unwrap();
         let mut response = None;
@@ -134,7 +134,7 @@ fn get_response<R: Runtime>(
         } else {
           let status = r.status();
           let headers = r.headers().clone();
-          let body = crate::async_runtime::block_on(r.bytes())?;
+          let body = crate::async_runtime::safe_block_on(r.bytes())?;
           let response = CachedResponse {
             status,
             headers,


### PR DESCRIPTION
fixes #12513

no idea why this isn't an issue on android but this seems to fix the issue on ios

p.s. waiting for them to try it in #12513