### PR TITLE
feat: basic support for linux riscv64

### DIFF
--- a/.changes/riscv-support.md
+++ b/.changes/riscv-support.md
@@ -1,0 +1,8 @@
+---
+'tauri-cli': 'minor:enhance'
+'tauri-utils': 'minor:enhance'
+'tauri-bundler': 'minor:enhance'
+'@tauri-apps/cli': 'minor:enhance'
+---
+
+Add basic support for linux riscv64 platform.

--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -92,6 +92,15 @@ jobs:
               rustup target add aarch64-unknown-linux-musl
               pnpm build --target aarch64-unknown-linux-musl
               /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
+          - host: ubuntu-22.04
+            architecture: x64
+            target: riscv64gc-unknown-linux-gnu
+            setup: |
+              sudo apt-get update
+              sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu -y
+            build: |
+              pnpm build --target=riscv64gc-unknown-linux-gnu
+              riscv64-linux-gnu-strip *.node
     name: stable - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
     steps:

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -46,6 +46,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     Arch::AArch64 => "arm64",
     Arch::Armhf => "armhf",
     Arch::Armel => "armel",
+    Arch::Riscv64 => "riscv64",
     target => {
       return Err(crate::Error::ArchError(format!(
         "Unsupported architecture: {:?}",

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -29,6 +29,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     Arch::AArch64 => "aarch64",
     Arch::Armhf => "armhfp",
     Arch::Armel => "armel",
+    Arch::Riscv64 => "riscv64",
     target => {
       return Err(crate::Error::ArchError(format!(
         "Unsupported architecture: {:?}",

--- a/crates/tauri-bundler/src/bundle/platform.rs
+++ b/crates/tauri-bundler/src/bundle/platform.rs
@@ -57,6 +57,8 @@ pub fn target_triple() -> Result<String, crate::Error> {
         "armv7".into()
       } else if cfg!(target_arch = "aarch64") {
         "aarch64".into()
+      } else if cfg!(target_arch = "riscv64") {
+        "riscv64".into()
       } else {
         return Err(crate::Error::ArchError(String::from(
           "Unable to determine target-architecture",

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -723,6 +723,8 @@ pub enum Arch {
   Armhf,
   /// For the AArch32 / ARM32 instruction sets with soft-float (32 bits).
   Armel,
+  /// For the RISC-V instruction sets (64 bits).
+  Riscv64,
   /// For universal macOS applications.
   Universal,
 }
@@ -900,6 +902,8 @@ impl Settings {
       Arch::Armel
     } else if self.target.starts_with("aarch64") {
       Arch::AArch64
+    } else if self.target.starts_with("riscv64") {
+      Arch::Riscv64
     } else if self.target.starts_with("universal") {
       Arch::Universal
     } else {

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -794,8 +794,9 @@ impl AppSettings for RustAppSettings {
     config: &Config,
     features: &[String],
   ) -> crate::Result<BundleSettings> {
-    let arch64bits =
-      self.target_triple.starts_with("x86_64") || self.target_triple.starts_with("aarch64");
+    let arch64bits = self.target_triple.starts_with("x86_64")
+      || self.target_triple.starts_with("aarch64")
+      || self.target_triple.starts_with("riscv64");
 
     let updater_enabled = config.bundle.create_updater_artifacts != Updater::Bool(false);
     let v1_compatible = matches!(config.bundle.create_updater_artifacts, Updater::String(_));

--- a/crates/tauri-utils/src/platform.rs
+++ b/crates/tauri-utils/src/platform.rs
@@ -191,6 +191,8 @@ pub fn target_triple() -> crate::Result<String> {
     "armv7"
   } else if cfg!(target_arch = "aarch64") {
     "aarch64"
+  } else if cfg!(target_arch = "riscv64") {
+    "riscv64"
   } else {
     return Err(crate::Error::Architecture);
   };

--- a/packages/cli/.cargo/config.toml
+++ b/packages/cli/.cargo/config.toml
@@ -8,6 +8,9 @@ rustflags = ["-C", "target-feature=-crt-static"]
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
+[target.riscv64gc-unknown-linux-gnu]
+linker = "riscv64-linux-gnu-gcc"
+
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.i686-pc-windows-msvc]

--- a/packages/cli/npm/linux-riscv64-gnu/README.md
+++ b/packages/cli/npm/linux-riscv64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@tauri-apps/cli-linux-riscv64-gnu`
+
+This is the **riscv64gc-unknown-linux-gnu** binary for `@tauri-apps/cli`

--- a/packages/cli/npm/linux-riscv64-gnu/package.json
+++ b/packages/cli/npm/linux-riscv64-gnu/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@tauri-apps/cli-linux-riscv64-gnu",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tauri-apps/tauri.git"
+  },
+  "homepage": "https://github.com/tauri-apps/tauri#readme",
+  "bugs": {
+    "url": "https://github.com/tauri-apps/tauri/issues"
+  },
+  "contributors": [
+    "Tauri Programme within The Commons Conservancy"
+  ],
+  "license": "Apache-2.0 OR MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "riscv64"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "main": "cli.linux-riscv64-gnu.node",
+  "files": [
+    "cli.linux-riscv64-gnu.node"
+  ],
+  "engines": {
+    "node": ">= 10"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
         "aarch64-unknown-linux-musl",
         "armv7-unknown-linux-gnueabihf",
         "x86_64-unknown-linux-musl",
+        "riscv64gc-unknown-linux-gnu",
         "i686-pc-windows-msvc",
         "aarch64-pc-windows-msvc"
       ]


### PR DESCRIPTION
This PR introduces basic support for riscv64.

Tests done on Arch Linux riscv64:

- build and run rqbit-desktop  in https://github.com/felixonmars/archriscv-packages/pull/4501

closes #7522 (A new release on npm should be necessary)
closes #10945