### PR TITLE
fix: don't eagerly set `ControlFlow::Exit` (fix #8631)

### DIFF
--- a/.changes/run-iteration-no-busy-loop.md
+++ b/.changes/run-iteration-no-busy-loop.md
@@ -1,0 +1,5 @@
+---
+'tauri-runtime-wry': 'patch:bug'
+---
+
+`Runtime::run_iteration` no longer sets `ControlFlow::Exit` upon `tao::Event::MainEventsCleared`. This allows `run_iteration` to actually suspend and not busy-loop when called in a loop.

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -2791,9 +2791,6 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
       .event_loop
       .run_return(|event, event_loop, control_flow| {
         *control_flow = ControlFlow::Wait;
-        if let Event::MainEventsCleared = &event {
-          *control_flow = ControlFlow::Exit;
-        }
 
         for p in plugins.lock().unwrap().iter_mut() {
           let prevent_default = p.on_event(


### PR DESCRIPTION
As discussed at length in #8631, `run_iteration` is basically unusable currently because it busy-loops the current thread. This _shouldn't_ be the case though because the underlying `tao::Runtime` allows suspending until an actual event from the OS is generated. However, once `ControlFlow::Exit` has been set, this remains sticky and cannot be unset.

Local testing on Windows confirms that removing this particular snippet fixes the busy-looping behaviour whilst retaining all other window-related functionality.