### PR TITLE
update(readme): Remove beta tag from android and iOS; Alert that Android 7 is unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Tauri currently supports development and distribution on the following platforms
 | Windows           | 7 and above                                                                                                     |
 | macOS             | 10.15 and above                                                                                                 |
 | Linux             | webkit2gtk 4.0 for Tauri v1 (for example Ubuntu 18.04). webkit2gtk 4.1 for Tauri v2 (for example Ubuntu 22.04). |
-| iOS/iPadOS (beta) | 9 and above                                                                                                     |
-| Android (beta)    | 7 and above                                                                                                     |
+| iOS/iPadOS        | 9 and above                                                                                                     |
+| Android           | 7 and above (currently 8 and above)                                                                             |
 
 ## Contributing
 


### PR DESCRIPTION
Just a small update to the README to reflect the current status of the project

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
