### PR TITLE
fix(ios, macos): Generate CFBundleShortVersionString from CFBundleVersion

### DIFF
--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -191,12 +191,6 @@ fn create_info_plist(
   bundle_icon_file: Option<PathBuf>,
   settings: &Settings,
 ) -> crate::Result<()> {
-  let format = time::format_description::parse("[year][month][day].[hour][minute][second]")
-    .map_err(time::error::Error::from)?;
-  let build_number = time::OffsetDateTime::now_utc()
-    .format(&format)
-    .map_err(time::error::Error::from)?;
-
   let mut plist = plist::Dictionary::new();
   plist.insert("CFBundleDevelopmentRegion".into(), "English".into());
   plist.insert("CFBundleDisplayName".into(), settings.product_name().into());
@@ -224,9 +218,12 @@ fn create_info_plist(
   plist.insert("CFBundlePackageType".into(), "APPL".into());
   plist.insert(
     "CFBundleShortVersionString".into(),
+    settings.short_version_string().into(),
+  );
+  plist.insert(
+    "CFBundleVersion".into(), 
     settings.version_string().into(),
   );
-  plist.insert("CFBundleVersion".into(), build_number.into());
   plist.insert("CSResourcesFileMapped".into(), true.into());
   if let Some(category) = settings.app_category() {
     plist.insert(

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -220,10 +220,7 @@ fn create_info_plist(
     "CFBundleShortVersionString".into(),
     settings.short_version_string().into(),
   );
-  plist.insert(
-    "CFBundleVersion".into(), 
-    settings.version_string().into(),
-  );
+  plist.insert("CFBundleVersion".into(), settings.version_string().into());
   plist.insert("CSResourcesFileMapped".into(), true.into());
   if let Some(category) = settings.app_category() {
     plist.insert(

--- a/crates/tauri-bundler/src/bundle/macos/ios.rs
+++ b/crates/tauri-bundler/src/bundle/macos/ios.rs
@@ -183,7 +183,7 @@ fn generate_info_plist(
   writeln!(
     file,
     "  <key>CFBundleShortVersionString</key>\n  <string>{}</string>",
-    settings.version_string()
+    settings.short_version_string()
   )?;
   writeln!(
     file,

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -146,6 +146,8 @@ pub struct PackageSettings {
   pub product_name: String,
   /// the package's version.
   pub version: String,
+  /// the package's short version.
+  pub short_version: String,
   /// the package's description.
   pub description: String,
   /// the package's homepage.
@@ -1087,6 +1089,11 @@ impl Settings {
   /// Returns the version string of the bundle.
   pub fn version_string(&self) -> &str {
     &self.package.version
+  }
+
+  /// Returns the short version string of the bundle.
+  pub fn short_version_string(&self) -> &str {
+    &self.package.short_version
   }
 
   /// Returns the copyright text.

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1122,7 +1122,7 @@ impl RustAppSettings {
       .or_else(|| self.cargo_config.build().target())
   }
 
-  fn extract_short_version(version: &String) -> String {
+  fn extract_short_version(version: &str) -> String {
     let mut parts = version.split('.');
     match (parts.next(), parts.next()) {
         (Some(major), Some(minor)) => format!("{}.{}", major, minor), // Create a new version String

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1125,9 +1125,9 @@ impl RustAppSettings {
   fn extract_short_version(version: &str) -> String {
     let mut parts = version.split('.');
     match (parts.next(), parts.next()) {
-        (Some(major), Some(minor)) => format!("{}.{}", major, minor), // Create a new version String
-        (Some(major), None) => major.to_string(), // Convert major to version String if no minor
-        _ => String::new(), // Handle empty input case
+      (Some(major), Some(minor)) => format!("{}.{}", major, minor), // Create a new version String
+      (Some(major), None) => major.to_string(), // Convert major to version String if no minor
+      _ => String::new(),                       // Handle empty input case
     }
   }
 

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -177,8 +177,14 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   let mut plist = plist::Dictionary::new();
   let version = interface.app_settings().get_package_settings().version;
-  let short_version = interface.app_settings().get_package_settings().short_version;
-  plist.insert("CFBundleShortVersionString".into(), short_version.clone().into());
+  let short_version = interface
+    .app_settings()
+    .get_package_settings()
+    .short_version;
+  plist.insert(
+    "CFBundleShortVersionString".into(),
+    short_version.clone().into(),
+  );
   plist.insert("CFBundleVersion".into(), version.into());
 
   let info_plist_path = config

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -177,7 +177,8 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   let mut plist = plist::Dictionary::new();
   let version = interface.app_settings().get_package_settings().version;
-  plist.insert("CFBundleShortVersionString".into(), version.clone().into());
+  let short_version = interface.app_settings().get_package_settings().short_version;
+  plist.insert("CFBundleShortVersionString".into(), short_version.clone().into());
   plist.insert("CFBundleVersion".into(), version.into());
 
   let info_plist_path = config


### PR DESCRIPTION
This PR should fix #12479 for ios and macos apps by properly generating CFBundleShortVersionString and CFBundleVersion.
For example:
CFBundleVersion: 1.0.7
CFBundleShortVersionString: 1.0
