### PR TITLE
feat: add `Webview::cookies` and `Webview::cookies_for_url()`

### DIFF
--- a/.changes/cookies-for-url.md
+++ b/.changes/cookies-for-url.md
@@ -1,0 +1,7 @@
+---
+"tauri": minor:feat
+"tauri-runtime": minor:feat
+"tauri-runtime-wry": minor:feat
+---
+
+Added `Webview::cookies_for_url()` and `tauri::Cookie`

--- a/.changes/cookies-for-url.md
+++ b/.changes/cookies-for-url.md
@@ -1,7 +1,5 @@
 ---
 "tauri": minor:feat
-"tauri-runtime": minor:feat
-"tauri-runtime-wry": minor:feat
 ---
 
-Added `Webview::cookies_for_url()` and `tauri::Cookie`
+Added `Webview::cookies()`, `Webview::cookies_for_url()`, `WebviewWindow::cookies()` and `Webview::cookies_for_url()`.

--- a/.changes/webview-cookies-runtime.md
+++ b/.changes/webview-cookies-runtime.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime": minor:feat
+"tauri-runtime-wry": minor:feat
+---
+
+Added `WebviewDispatch::cookies()` and `WebviewDispatch::cookies_for_url()`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9391,6 +9391,7 @@ dependencies = [
 name = "tauri-runtime"
 version = "2.3.0"
 dependencies = [
+ "cookie",
  "dpi",
  "gtk",
  "http 1.2.0",

--- a/crates/tauri-runtime/Cargo.toml
+++ b/crates/tauri-runtime/Cargo.toml
@@ -34,6 +34,7 @@ http = "1"
 raw-window-handle = "0.6"
 url = { version = "2" }
 dpi = { version = "0.1", features = ["serde"] }
+cookie = { version = "0.18" }
 
 [target."cfg(windows)".dependencies.windows]
 version = "0.58"

--- a/crates/tauri-runtime/Cargo.toml
+++ b/crates/tauri-runtime/Cargo.toml
@@ -34,7 +34,7 @@ http = "1"
 raw-window-handle = "0.6"
 url = { version = "2" }
 dpi = { version = "0.1", features = ["serde"] }
-# WARNING: cookie::Cookie is re-exported so bumping this is a breaking change
+# WARNING: cookie::Cookie is re-exported so bumping this is a breaking change, documented to be done as a minor bump
 cookie = "0.18"
 
 [target."cfg(windows)".dependencies.windows]

--- a/crates/tauri-runtime/Cargo.toml
+++ b/crates/tauri-runtime/Cargo.toml
@@ -34,7 +34,8 @@ http = "1"
 raw-window-handle = "0.6"
 url = { version = "2" }
 dpi = { version = "0.1", features = ["serde"] }
-cookie = { version = "0.18" }
+# WARNING: cookie::Cookie is re-exported so bumping this is a breaking change
+cookie = "0.18"
 
 [target."cfg(windows)".dependencies.windows]
 version = "0.58"

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -43,6 +43,9 @@ use http::{
 /// UI scaling utilities.
 pub use dpi;
 
+/// Cookie extraction
+pub use cookie::Cookie;
+
 pub type WindowEventId = u32;
 pub type WebviewEventId = u32;
 
@@ -515,6 +518,9 @@ pub trait WebviewDispatch<T: UserEvent>: Debug + Clone + Send + Sync + Sized + '
 
   /// Moves the webview to the given window.
   fn reparent(&self, window_id: WindowId) -> Result<()>;
+
+  /// Get cookies for a particular url.
+  fn cookies_for_url(&self, url: Url) -> Result<Vec<Cookie<'static>>>;
 
   /// Sets whether the webview should automatically grow and shrink its size and position when the parent window resizes.
   fn set_auto_resize(&self, auto_resize: bool) -> Result<()>;

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -522,6 +522,9 @@ pub trait WebviewDispatch<T: UserEvent>: Debug + Clone + Send + Sync + Sized + '
   /// Get cookies for a particular url.
   fn cookies_for_url(&self, url: Url) -> Result<Vec<Cookie<'static>>>;
 
+  /// Return all cookies in the cookie store.
+  fn cookies(&self) -> Result<Vec<Cookie<'static>>>;
+
   /// Sets whether the webview should automatically grow and shrink its size and position when the parent window resizes.
   fn set_auto_resize(&self, auto_resize: bool) -> Result<()>;
 

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -520,9 +520,19 @@ pub trait WebviewDispatch<T: UserEvent>: Debug + Clone + Send + Sync + Sized + '
   fn reparent(&self, window_id: WindowId) -> Result<()>;
 
   /// Get cookies for a particular url.
+  ///
+  /// # Stability
+  ///
+  /// The return value of this function leverages [`cookie::Cookie`] which re-exports the cookie crate.
+  /// This dependency might receive updates in minor Tauri releases.
   fn cookies_for_url(&self, url: Url) -> Result<Vec<Cookie<'static>>>;
 
   /// Return all cookies in the cookie store.
+  ///
+  /// # Stability
+  ///
+  /// The return value of this function leverages [`cookie::Cookie`] which re-exports the cookie crate.
+  /// This dependency might receive updates in minor Tauri releases.
   fn cookies(&self) -> Result<Vec<Cookie<'static>>>;
 
   /// Sets whether the webview should automatically grow and shrink its size and position when the parent window resizes.

--- a/crates/tauri/src/test/mock_runtime.rs
+++ b/crates/tauri/src/test/mock_runtime.rs
@@ -586,6 +586,10 @@ impl<T: UserEvent> WebviewDispatch<T> for MockWebviewDispatcher {
     Ok(())
   }
 
+  fn cookies_for_url(&self, url: Url) -> Result<Vec<tauri_runtime::Cookie<'static>>> {
+    Ok(Vec::new())
+  }
+
   fn set_auto_resize(&self, auto_resize: bool) -> Result<()> {
     Ok(())
   }

--- a/crates/tauri/src/test/mock_runtime.rs
+++ b/crates/tauri/src/test/mock_runtime.rs
@@ -586,6 +586,10 @@ impl<T: UserEvent> WebviewDispatch<T> for MockWebviewDispatcher {
     Ok(())
   }
 
+  fn cookies(&self) -> Result<Vec<tauri_runtime::Cookie<'static>>> {
+    Ok(Vec::new())
+  }
+
   fn cookies_for_url(&self, url: Url) -> Result<Vec<tauri_runtime::Cookie<'static>>> {
     Ok(Vec::new())
   }

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -13,6 +13,7 @@ use http::HeaderMap;
 use serde::Serialize;
 use tauri_macros::default_runtime;
 pub use tauri_runtime::webview::PageLoadEvent;
+pub use tauri_runtime::Cookie;
 #[cfg(desktop)]
 use tauri_runtime::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Size},
@@ -25,7 +26,6 @@ use tauri_runtime::{
 pub use tauri_utils::config::Color;
 use tauri_utils::config::{BackgroundThrottlingPolicy, WebviewUrl, WindowConfig};
 pub use url::Url;
-pub use tauri_runtime::Cookie;
 
 use crate::{
   app::{UriSchemeResponder, WebviewEvent},
@@ -1158,9 +1158,30 @@ impl<R: Runtime> Webview<R> {
     Ok(())
   }
 
-  /// Returns all cookies for a specified URL including HTTP-only and secure cookies.
+  /// Returns all cookies in the runtime's cookie store including HTTP-only and secure cookies.
+  ///
+  /// Note that cookies will only be returned for URLs with an http or https scheme.
+  /// Cookies set through javascript for local files
+  /// (such as those served from the tauri://) protocol are not currently supported.
   pub fn cookies_for_url(&self, url: Url) -> crate::Result<Vec<Cookie<'static>>> {
-    self.webview.dispatcher.cookies_for_url(url).map_err(Into::into)
+    self
+      .webview
+      .dispatcher
+      .cookies_for_url(url)
+      .map_err(Into::into)
+  }
+
+  /// Returns all cookies in the runtime's cookie store for all URLs including HTTP-only and secure cookies.
+  ///
+  /// Note that cookies will only be returned for URLs with an http or https scheme.
+  /// Cookies set through javascript for local files
+  /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android**: Unsupported, always returns an empty [`Vec`].
+  pub fn cookies(&self) -> crate::Result<Vec<Cookie<'static>>> {
+    self.webview.dispatcher.cookies().map_err(Into::into)
   }
 
   /// Sets whether the webview should automatically grow and shrink its size and position when the parent window resizes.

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -25,6 +25,7 @@ use tauri_runtime::{
 pub use tauri_utils::config::Color;
 use tauri_utils::config::{BackgroundThrottlingPolicy, WebviewUrl, WindowConfig};
 pub use url::Url;
+pub use tauri_runtime::Cookie;
 
 use crate::{
   app::{UriSchemeResponder, WebviewEvent},
@@ -1155,6 +1156,11 @@ impl<R: Runtime> Webview<R> {
     *self.window.lock().unwrap() = window.clone();
     self.webview.dispatcher.reparent(window.window.id)?;
     Ok(())
+  }
+
+  /// Returns all cookies for a specified URL including HTTP-only and secure cookies.
+  pub fn cookies_for_url(&self, url: Url) -> crate::Result<Vec<Cookie<'static>>> {
+    self.webview.dispatcher.cookies_for_url(url).map_err(Into::into)
   }
 
   /// Sets whether the webview should automatically grow and shrink its size and position when the parent window resizes.

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -247,8 +247,8 @@ impl<R: Runtime> WebviewBuilder<R> {
   ///
   /// # Known issues
   ///
-  /// On Windows, this function deadlocks when used in a synchronous command, see [the Webview2 issue].
-  /// You should use `async` commands when creating windows.
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when creating webviews.
   ///
   /// # Examples
   ///
@@ -323,8 +323,8 @@ async fn create_window(app: tauri::AppHandle) {
   ///
   /// # Known issues
   ///
-  /// On Windows, this function deadlocks when used in a synchronous command, see [the Webview2 issue].
-  /// You should use `async` commands when creating webviews.
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when creating webviews.
   ///
   /// # Examples
   ///
@@ -1163,6 +1163,13 @@ impl<R: Runtime> Webview<R> {
   /// Note that cookies will only be returned for URLs with an http or https scheme.
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// # Known issues
+  ///
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when reading cookies.
+  ///
+  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
   pub fn cookies_for_url(&self, url: Url) -> crate::Result<Vec<Cookie<'static>>> {
     self
       .webview
@@ -1177,9 +1184,16 @@ impl<R: Runtime> Webview<R> {
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
   ///
+  /// # Known issues
+  ///
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when reading cookies.
+  ///
   /// ## Platform-specific
   ///
   /// - **Android**: Unsupported, always returns an empty [`Vec`].
+  ///
+  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
   pub fn cookies(&self) -> crate::Result<Vec<Cookie<'static>>> {
     self.webview.dispatcher.cookies().map_err(Into::into)
   }

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1158,46 +1158,6 @@ impl<R: Runtime> Webview<R> {
     Ok(())
   }
 
-  /// Returns all cookies in the runtime's cookie store including HTTP-only and secure cookies.
-  ///
-  /// Note that cookies will only be returned for URLs with an http or https scheme.
-  /// Cookies set through javascript for local files
-  /// (such as those served from the tauri://) protocol are not currently supported.
-  ///
-  /// # Known issues
-  ///
-  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
-  /// You should use `async` commands and separate threads when reading cookies.
-  ///
-  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
-  pub fn cookies_for_url(&self, url: Url) -> crate::Result<Vec<Cookie<'static>>> {
-    self
-      .webview
-      .dispatcher
-      .cookies_for_url(url)
-      .map_err(Into::into)
-  }
-
-  /// Returns all cookies in the runtime's cookie store for all URLs including HTTP-only and secure cookies.
-  ///
-  /// Note that cookies will only be returned for URLs with an http or https scheme.
-  /// Cookies set through javascript for local files
-  /// (such as those served from the tauri://) protocol are not currently supported.
-  ///
-  /// # Known issues
-  ///
-  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
-  /// You should use `async` commands and separate threads when reading cookies.
-  ///
-  /// ## Platform-specific
-  ///
-  /// - **Android**: Unsupported, always returns an empty [`Vec`].
-  ///
-  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
-  pub fn cookies(&self) -> crate::Result<Vec<Cookie<'static>>> {
-    self.webview.dispatcher.cookies().map_err(Into::into)
-  }
-
   /// Sets whether the webview should automatically grow and shrink its size and position when the parent window resizes.
   pub fn set_auto_resize(&self, auto_resize: bool) -> crate::Result<()> {
     self
@@ -1743,6 +1703,46 @@ tauri::Builder::default()
       .dispatcher
       .clear_all_browsing_data()
       .map_err(Into::into)
+  }
+
+  /// Returns all cookies in the runtime's cookie store including HTTP-only and secure cookies.
+  ///
+  /// Note that cookies will only be returned for URLs with an http or https scheme.
+  /// Cookies set through javascript for local files
+  /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// # Known issues
+  ///
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when reading cookies.
+  ///
+  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
+  pub fn cookies_for_url(&self, url: Url) -> crate::Result<Vec<Cookie<'static>>> {
+    self
+      .webview
+      .dispatcher
+      .cookies_for_url(url)
+      .map_err(Into::into)
+  }
+
+  /// Returns all cookies in the runtime's cookie store for all URLs including HTTP-only and secure cookies.
+  ///
+  /// Note that cookies will only be returned for URLs with an http or https scheme.
+  /// Cookies set through javascript for local files
+  /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// # Known issues
+  ///
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when reading cookies.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android**: Unsupported, always returns an empty [`Vec`].
+  ///
+  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
+  pub fn cookies(&self) -> crate::Result<Vec<Cookie<'static>>> {
+    self.webview.dispatcher.cookies().map_err(Into::into)
   }
 }
 

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1711,6 +1711,11 @@ tauri::Builder::default()
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
   ///
+  /// # Stability
+  ///
+  /// The return value of this function leverages [`tauri_runtime::Cookie`] which re-exports the cookie crate.
+  /// This dependency might receive updates in minor Tauri releases.
+  ///
   /// # Known issues
   ///
   /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
@@ -1730,6 +1735,11 @@ tauri::Builder::default()
   /// Note that cookies will only be returned for URLs with an http or https scheme.
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// # Stability
+  ///
+  /// The return value of this function leverages [`tauri_runtime::Cookie`] which re-exports the cookie crate.
+  /// This dependency might receive updates in minor Tauri releases.
   ///
   /// # Known issues
   ///

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -37,8 +37,7 @@ use crate::{
   ipc::{CommandArg, CommandItem, InvokeError, OwnedInvokeResponder},
   manager::AppManager,
   sealed::{ManagerBase, RuntimeOrDispatch},
-  webview::PageLoadPayload,
-  webview::WebviewBuilder,
+  webview::{Cookie, PageLoadPayload, WebviewBuilder},
   window::WindowBuilder,
   AppHandle, Event, EventId, Manager, Runtime, Webview, WindowEvent,
 };
@@ -2004,6 +2003,28 @@ impl<R: Runtime> WebviewWindow<R> {
   /// Clear all browsing data for this webview window.
   pub fn clear_all_browsing_data(&self) -> crate::Result<()> {
     self.webview.clear_all_browsing_data()
+  }
+
+  /// Returns all cookies in the runtime's cookie store including HTTP-only and secure cookies.
+  ///
+  /// Note that cookies will only be returned for URLs with an http or https scheme.
+  /// Cookies set through javascript for local files
+  /// (such as those served from the tauri://) protocol are not currently supported.
+  pub fn cookies_for_url(&self, url: Url) -> crate::Result<Vec<Cookie<'static>>> {
+    self.webview.cookies_for_url(url)
+  }
+
+  /// Returns all cookies in the runtime's cookie store for all URLs including HTTP-only and secure cookies.
+  ///
+  /// Note that cookies will only be returned for URLs with an http or https scheme.
+  /// Cookies set through javascript for local files
+  /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android**: Unsupported, always returns an empty [`Vec`].
+  pub fn cookies(&self) -> crate::Result<Vec<Cookie<'static>>> {
+    self.webview.cookies()
   }
 }
 

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -2011,6 +2011,11 @@ impl<R: Runtime> WebviewWindow<R> {
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
   ///
+  /// # Stability
+  ///
+  /// The return value of this function leverages [`tauri_runtime::Cookie`] which re-exports the cookie crate.
+  /// This dependency might receive updates in minor Tauri releases.
+  ///
   /// # Known issues
   ///
   /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
@@ -2026,6 +2031,11 @@ impl<R: Runtime> WebviewWindow<R> {
   /// Note that cookies will only be returned for URLs with an http or https scheme.
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// # Stability
+  ///
+  /// The return value of this function leverages [`tauri_runtime::Cookie`] which re-exports the cookie crate.
+  /// This dependency might receive updates in minor Tauri releases.
   ///
   /// # Known issues
   ///

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -60,8 +60,8 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   ///
   /// # Known issues
   ///
-  /// On Windows, this function deadlocks when used in a synchronous command, see [the Webview2 issue].
-  /// You should use `async` commands when creating windows.
+  /// On Windows, this function deadlocks when used in a synchronous command and event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when creating windows.
   ///
   /// # Examples
   ///
@@ -117,8 +117,8 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   ///
   /// # Known issues
   ///
-  /// On Windows, this function deadlocks when used in a synchronous command, see [the Webview2 issue].
-  /// You should use `async` commands when creating windows.
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when creating windows.
   ///
   /// # Examples
   ///
@@ -2010,6 +2010,13 @@ impl<R: Runtime> WebviewWindow<R> {
   /// Note that cookies will only be returned for URLs with an http or https scheme.
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
+  ///
+  /// # Known issues
+  ///
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when reading cookies.
+  ///
+  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
   pub fn cookies_for_url(&self, url: Url) -> crate::Result<Vec<Cookie<'static>>> {
     self.webview.cookies_for_url(url)
   }
@@ -2020,9 +2027,16 @@ impl<R: Runtime> WebviewWindow<R> {
   /// Cookies set through javascript for local files
   /// (such as those served from the tauri://) protocol are not currently supported.
   ///
+  /// # Known issues
+  ///
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when reading cookies.
+  ///
   /// ## Platform-specific
   ///
   /// - **Android**: Unsupported, always returns an empty [`Vec`].
+  ///
+  /// [the Webview2 issue]: https://github.com/tauri-apps/wry/issues/583
   pub fn cookies(&self) -> crate::Result<Vec<Cookie<'static>>> {
     self.webview.cookies()
   }

--- a/crates/tauri/src/window/mod.rs
+++ b/crates/tauri/src/window/mod.rs
@@ -140,8 +140,8 @@ impl<'a, R: Runtime, M: Manager<R>> WindowBuilder<'a, R, M> {
   ///
   /// # Known issues
   ///
-  /// On Windows, this function deadlocks when used in a synchronous command, see [the Webview2 issue].
-  /// You should use `async` commands when creating windows.
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when creating windows.
   ///
   /// # Examples
   ///
@@ -217,8 +217,8 @@ async fn create_window(app: tauri::AppHandle) {
   ///
   /// # Known issues
   ///
-  /// On Windows, this function deadlocks when used in a synchronous command, see [the Webview2 issue].
-  /// You should use `async` commands when creating windows.
+  /// On Windows, this function deadlocks when used in a synchronous command or event handlers, see [the Webview2 issue].
+  /// You should use `async` commands and separate threads when creating windows.
   ///
   /// # Examples
   ///

--- a/examples/helloworld/main.rs
+++ b/examples/helloworld/main.rs
@@ -5,13 +5,22 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 #[tauri::command]
-fn greet(name: &str) -> String {
+fn greet(app: tauri::AppHandle, name: String) -> String {
+  use tauri::Manager;
+  println!("greet {name}");
+  let w = app.get_webview_window("main").unwrap();
+  println!("{:?}", w.get_webview_window("main").unwrap().cookies());
   format!("Hello {name}, You have been greeted from Rust!")
 }
 
 fn main() {
   tauri::Builder::default()
     .invoke_handler(tauri::generate_handler![greet])
+    .setup(|app| {
+      use tauri::Manager;
+      println!("{:?}", app.get_webview_window("main").unwrap().cookies());
+      Ok(())
+    })
     .run(tauri::generate_context!(
       "../../examples/helloworld/tauri.conf.json"
     ))


### PR DESCRIPTION
**Closes**

- https://github.com/tauri-apps/tauri/issues/11330

**Related**

- Relevant discussion https://github.com/tauri-apps/tauri/discussions/11655
- Relevant merge into Wry https://github.com/tauri-apps/wry/pull/1394

Related issues not fully handled by this PR:

- https://github.com/tauri-apps/tauri/issues/5823
- https://github.com/tauri-apps/tauri/issues/12078
- https://github.com/tauri-apps/tauri/issues/11691
- https://github.com/tauri-apps/tauri/issues/4899

## Changes

- Added `Webview::cookies_for_url()` and `tauri::Cookie`

## Implementation notes

I'm open to any requested changes here, but here's how I've gone about this:

- Expose `cookie::Cookie` as a re-export from `tauri_runtime::Cookie` and `tauri::Cookie`. Notably I did not re-export the `wry::Cookie` which is a re-export of `cookie::Cookie` since `tauri_runtime` does not have a dependency on `wry`.
- Add `cookies_for_url()` on the webview dispatcher and add an implementation for wry. I used  `WebviewDispatcher::reparent` as my template for a dispatch the takes a parameter and returns a result.
- I chose not to expose `wry::webview::cookies()` as it seemed to have an implementation note that it didn't work on Android at the moment.

## Notes from my testing

Notably the wry support seems to only work when a site served over http (which is what I need it for). In my manual testing there doesn't seem to be a clear story for cookies on the `tauri://` protocol (and there probably shouldn't be?). In any case by linking this PR into my own project I am able to extract the cookies from content served over http/https.