### PR TITLE
feat(tauri): export struct `tauri::ExitRequestApi`

### DIFF
--- a/.changes/export-ExitRequestApi.md
+++ b/.changes/export-ExitRequestApi.md
@@ -1,0 +1,5 @@
+---
+tauri: 'minor:feat'
+---
+
+Export `struct tauri::ExitRequestApi`.

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -213,8 +213,8 @@ pub use self::event::{Event, EventId, EventTarget};
 use self::manager::EmitPayload;
 pub use {
   self::app::{
-    App, AppHandle, AssetResolver, Builder, CloseRequestApi, RunEvent, UriSchemeContext,
-    UriSchemeResponder, WebviewEvent, WindowEvent,
+    App, AppHandle, AssetResolver, Builder, CloseRequestApi, ExitRequestApi, RunEvent,
+    UriSchemeContext, UriSchemeResponder, WebviewEvent, WindowEvent,
   },
   self::manager::Asset,
   self::runtime::{


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Sorry for opening this PR before creating an issue (because the changes in this PR are very small).

I encountered a similar issue to tauri-apps/plugins-workspace#2161, `ExitRequestApi` seems to be unintentionally [sealed](https://docs.rs/tauri/2.2.5/tauri/enum.RunEvent.html#variant.ExitRequested.field.api).

`pytauri` needs to wrap `struct ExitRequestApi` to implement pyo3 bindings. Can we get this feature into `tauri v2.3`?

---

BTW, if you don't mind, can I derive `Clone` for `ExitRequestApi`?
