### PR TITLE
fix(tauri): deprecate `Manager::unmanage` to fix `use-after-free`

### DIFF
--- a/.changes/fix-state-manager-unsoundness.md
+++ b/.changes/fix-state-manager-unsoundness.md
@@ -1,0 +1,5 @@
+---
+tauri: 'minor:bug'
+---
+
+Remove and deprecate `Manager::unmanage` to fix `use-after-free` unsoundness, see tauri-apps/tauri#12721 for details.

--- a/.changes/fix-state-manager-unsoundness.md
+++ b/.changes/fix-state-manager-unsoundness.md
@@ -2,4 +2,4 @@
 tauri: 'minor:bug'
 ---
 
-Remove and deprecate `Manager::unmanage` to fix `use-after-free` unsoundness, see tauri-apps/tauri#12721 for details.
+Deprecate `Manager::unmanage` to fix `use-after-free` unsoundness, see tauri-apps/tauri#12721 for details.

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -714,23 +714,28 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
   ///
   /// <div class="warning">
   ///
-  /// To fix [tauri-apps/tauri#12721] `use-after-free`` unsoundness,
-  /// this method is removed and becomes a no-op (Always returns `None`).
+  /// This method is *UNSAFE* and calling it will cause previously obtained references through
+  /// [Manager::state] and [State::inner] to become dangling references.
   ///
-  /// If you really want to unmanage a state, use [std::sync::Mutex] and [Option::take] to wrap the state.
+  /// It is currently deprecated and may be removed in the future.
+  ///
+  /// If you really want to unmanage a state, use [std::sync::Mutex] and [Option::take] to wrap the state instead.
+  ///
+  /// See [tauri-apps/tauri#12721] for more information.
   ///
   /// [tauri-apps/tauri#12721]: https://github.com/tauri-apps/tauri/issues/12721
   ///
   /// </div>
   #[deprecated(
     since = "2.3.0",
-    note = "This method is removed and becomes a no-op (Always returns `None`)."
+    note = "This method is unsafe, since it can cause dangling references."
   )]
   fn unmanage<T>(&self) -> Option<T>
   where
     T: Send + Sync + 'static,
   {
-    None
+    // The caller decides to break the safety here, then OK, just let it go.
+    unsafe { self.manager().state().unmanage() }
   }
 
   /// Retrieves the managed state for the type `T`.

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -711,11 +711,26 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
   }
 
   /// Removes the state managed by the application for T. Returns the state if it was actually removed.
+  ///
+  /// <div class="warning">
+  ///
+  /// To fix [tauri-apps/tauri#12721] `use-after-free`` unsoundness,
+  /// this method is removed and becomes a no-op (Always returns `None`).
+  ///
+  /// If you really want to unmanage a state, use [std::sync::Mutex] and [Option::take] to wrap the state.
+  ///
+  /// [tauri-apps/tauri#12721]: https://github.com/tauri-apps/tauri/issues/12721
+  ///
+  /// </div>
+  #[deprecated(
+    since = "2.3.0",
+    note = "This method is removed and becomes a no-op (Always returns `None`)."
+  )]
   fn unmanage<T>(&self) -> Option<T>
   where
     T: Send + Sync + 'static,
   {
-    self.manager().state().unmanage()
+    None
   }
 
   /// Retrieves the managed state for the type `T`.

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -4,7 +4,6 @@
 
 use std::{
   any::{Any, TypeId},
-  cell::UnsafeCell,
   collections::HashMap,
   hash::BuildHasherDefault,
   sync::Mutex,
@@ -97,17 +96,16 @@ impl std::hash::Hasher for IdentHash {
   }
 }
 
-type TypeIdMap = HashMap<TypeId, Box<dyn Any>, BuildHasherDefault<IdentHash>>;
+/// Safety:
+/// - The `key` must equal to `(*value).type_id()`, see the safety doc in methods of [StateManager] for details.
+/// - Once you insert a value, you can't remove/mutated it anymore, see [StateManager::try_get] for details.
+type TypeIdMap = HashMap<TypeId, Box<dyn Any + Sync + Send>, BuildHasherDefault<IdentHash>>;
 
 /// The Tauri state manager.
 #[derive(Debug)]
 pub struct StateManager {
-  map: Mutex<UnsafeCell<TypeIdMap>>,
+  map: Mutex<TypeIdMap>,
 }
-
-// SAFETY: data is accessed behind a lock
-unsafe impl Sync for StateManager {}
-unsafe impl Send for StateManager {}
 
 impl StateManager {
   pub(crate) fn new() -> Self {
@@ -116,37 +114,19 @@ impl StateManager {
     }
   }
 
-  fn with_map_ref<'a, F: FnOnce(&'a TypeIdMap) -> R, R>(&'a self, f: F) -> R {
-    let map = self.map.lock().unwrap();
-    let map = map.get();
-    // SAFETY: safe to access since we are holding a lock
-    f(unsafe { &*map })
-  }
-
-  fn with_map_mut<F: FnOnce(&mut TypeIdMap) -> R, R>(&self, f: F) -> R {
-    let mut map = self.map.lock().unwrap();
-    let map = map.get_mut();
-    f(map)
-  }
-
   pub(crate) fn set<T: Send + Sync + 'static>(&self, state: T) -> bool {
-    self.with_map_mut(|map| {
-      let type_id = TypeId::of::<T>();
-      let already_set = map.contains_key(&type_id);
-      if !already_set {
-        map.insert(type_id, Box::new(state) as Box<dyn Any>);
-      }
-      !already_set
-    })
-  }
-
-  pub(crate) fn unmanage<T: Send + Sync + 'static>(&self) -> Option<T> {
-    self.with_map_mut(|map| {
-      let type_id = TypeId::of::<T>();
-      map
-        .remove(&type_id)
-        .and_then(|ptr| ptr.downcast().ok().map(|b| *b))
-    })
+    let mut map = self.map.lock().unwrap();
+    let type_id = TypeId::of::<T>();
+    let already_set = map.contains_key(&type_id);
+    if !already_set {
+      map.insert(
+        type_id,
+        // SAFETY: keep the type of the key is the same as the type of the value，
+        // see [try_get] methods for details.
+        Box::new(state) as Box<dyn Any + Sync + Send>,
+      );
+    }
+    !already_set
   }
 
   /// Gets the state associated with the specified type.
@@ -158,12 +138,18 @@ impl StateManager {
 
   /// Gets the state associated with the specified type.
   pub fn try_get<T: Send + Sync + 'static>(&self) -> Option<State<'_, T>> {
-    self.with_map_ref(|map| {
-      map
-        .get(&TypeId::of::<T>())
-        .and_then(|ptr| ptr.downcast_ref::<T>())
-        .map(State)
-    })
+    let map = self.map.lock().unwrap();
+    let type_id = TypeId::of::<T>();
+    let ptr = map.get(&type_id)?;
+    let value = unsafe {
+      ptr
+        .downcast_ref::<T>()
+        // SAFETY: the type of the key is the same as the type of the value
+        .unwrap_unchecked()
+    };
+    // SAFETY: We ensure the lifetime of `value` is the same as [StateManager] and `value` will not be mutated
+    let v_ref = unsafe { &*(value as *const T) };
+    Some(State(v_ref))
   }
 }
 
@@ -190,18 +176,6 @@ mod tests {
     let state = StateManager::new();
     assert!(state.set(1u32));
     assert_eq!(*state.get::<u32>(), 1);
-  }
-
-  #[test]
-  fn simple_set_get_unmanage() {
-    let state = StateManager::new();
-    assert!(state.set(1u32));
-    assert_eq!(*state.get::<u32>(), 1);
-    assert!(state.unmanage::<u32>().is_some());
-    assert!(state.unmanage::<u32>().is_none());
-    assert_eq!(state.try_get::<u32>(), None);
-    assert!(state.set(2u32));
-    assert_eq!(*state.get::<u32>(), 2);
   }
 
   #[test]

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -132,6 +132,23 @@ impl StateManager {
     !already_set
   }
 
+  /// SAFETY: Calling this method will move the `value`,
+  /// which will cause references obtained through [Self::try_get] to dangle.
+  pub(crate) unsafe fn unmanage<T: Send + Sync + 'static>(&self) -> Option<T> {
+    let mut map = self.map.lock().unwrap();
+    let type_id = TypeId::of::<T>();
+    let pinned_ptr = map.remove(&type_id)?;
+    // SAFETY: The caller decides to break the immovability/safety here, then OK, just let it go.
+    let ptr = unsafe { Pin::into_inner_unchecked(pinned_ptr) };
+    let value = unsafe {
+      ptr
+        .downcast::<T>()
+        // SAFETY: the type of the key is the same as the type of the value
+        .unwrap_unchecked()
+    };
+    Some(*value)
+  }
+
   /// Gets the state associated with the specified type.
   pub fn get<T: Send + Sync + 'static>(&self) -> State<'_, T> {
     self
@@ -179,6 +196,19 @@ mod tests {
     let state = StateManager::new();
     assert!(state.set(1u32));
     assert_eq!(*state.get::<u32>(), 1);
+  }
+
+  #[test]
+  fn simple_set_get_unmanage() {
+    let state = StateManager::new();
+    assert!(state.set(1u32));
+    assert_eq!(*state.get::<u32>(), 1);
+    // safety: the reference returned by `try_get` is already dropped.
+    assert!(unsafe { state.unmanage::<u32>() }.is_some());
+    assert!(unsafe { state.unmanage::<u32>() }.is_none());
+    assert_eq!(state.try_get::<u32>(), None);
+    assert!(state.set(2u32));
+    assert_eq!(*state.get::<u32>(), 2);
   }
 
   #[test]

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -6,6 +6,7 @@ use std::{
   any::{Any, TypeId},
   collections::HashMap,
   hash::BuildHasherDefault,
+  pin::Pin,
   sync::Mutex,
 };
 
@@ -98,8 +99,8 @@ impl std::hash::Hasher for IdentHash {
 
 /// Safety:
 /// - The `key` must equal to `(*value).type_id()`, see the safety doc in methods of [StateManager] for details.
-/// - Once you insert a value, you can't remove/mutated it anymore, see [StateManager::try_get] for details.
-type TypeIdMap = HashMap<TypeId, Box<dyn Any + Sync + Send>, BuildHasherDefault<IdentHash>>;
+/// - Once you insert a value, you can't remove/mutated/move it anymore, see [StateManager::try_get] for details.
+type TypeIdMap = HashMap<TypeId, Pin<Box<dyn Any + Sync + Send>>, BuildHasherDefault<IdentHash>>;
 
 /// The Tauri state manager.
 #[derive(Debug)]
@@ -119,11 +120,13 @@ impl StateManager {
     let type_id = TypeId::of::<T>();
     let already_set = map.contains_key(&type_id);
     if !already_set {
+      let ptr = Box::new(state) as Box<dyn Any + Sync + Send>;
+      let pinned_ptr = Box::into_pin(ptr);
       map.insert(
         type_id,
         // SAFETY: keep the type of the key is the same as the type of the value，
         // see [try_get] methods for details.
-        Box::new(state) as Box<dyn Any + Sync + Send>,
+        pinned_ptr,
       );
     }
     !already_set
@@ -147,7 +150,7 @@ impl StateManager {
         // SAFETY: the type of the key is the same as the type of the value
         .unwrap_unchecked()
     };
-    // SAFETY: We ensure the lifetime of `value` is the same as [StateManager] and `value` will not be mutated
+    // SAFETY: We ensure the lifetime of `value` is the same as [StateManager] and `value` will not be mutated/moved.
     let v_ref = unsafe { &*(value as *const T) };
     Some(State(v_ref))
   }


### PR DESCRIPTION
close #12721

As a reference, here is another [implementation that retains `Manager::unmanage`](https://github.com/WSH032/tauri/commit/1ec2554c8e85563ca11fe98e5e1a5b8f529de3f3).
For semantic compatibility, I don't think it's ideal in terms of performance and ergonomics.

I prefer the solution of deprecating `Manager::unmanage`, as the need to remove state seems to be a rare requirement (I personally can't think of a use case, and you can always achieve it with `Mutex` and `Option`).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
