### PR TITLE
style: fix Vite and React branding

### DIFF
--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -1700,7 +1700,7 @@
           ]
         },
         "devUrl": {
-          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [vite](https://vitejs.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
+          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [Vite](https://vite.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-cli/schema.json
+++ b/crates/tauri-cli/schema.json
@@ -1378,7 +1378,7 @@
           ]
         },
         "devUrl": {
-          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [vite](https://vitejs.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
+          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [Vite](https://vite.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-cli/src/dev/builtin_dev_server.rs
+++ b/crates/tauri-cli/src/dev/builtin_dev_server.rs
@@ -79,7 +79,7 @@ pub fn start<P: AsRef<Path>>(dir: P, ip: IpAddr, port: Option<u16>) -> crate::Re
 }
 
 async fn handler(uri: Uri, state: State<ServerState>) -> impl IntoResponse {
-  // Frontend files should not contain query parameters. This seems to be how vite handles it.
+  // Frontend files should not contain query parameters. This seems to be how Vite handles it.
   let uri = uri.path();
 
   let uri = if uri == "/" {

--- a/crates/tauri-cli/src/migrate/migrations/v1/frontend.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v1/frontend.rs
@@ -535,13 +535,13 @@ function App() {
       <h1>Welcome to Tauri!</h1>
 
       <div className="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" className="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">
           <img src="/tauri.svg" className="logo tauri" alt="Tauri logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://react.dev" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
@@ -609,13 +609,13 @@ function App() {
       <h1>Welcome to Tauri!</h1>
 
       <div className="row">
-        <a href="https://vitejs.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank">
           <img src="/vite.svg" className="logo vite" alt="Vite logo" />
         </a>
         <a href="https://tauri.app" target="_blank">
           <img src="/tauri.svg" className="logo tauri" alt="Tauri logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://react.dev" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>

--- a/crates/tauri-cli/tauri.config.schema.json
+++ b/crates/tauri-cli/tauri.config.schema.json
@@ -1378,7 +1378,7 @@
           ]
         },
         "devUrl": {
-          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [vite](https://vitejs.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
+          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [Vite](https://vite.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/App.svelte
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/App.svelte
@@ -17,7 +17,7 @@
   <h1>Welcome to Tauri!</h1>
 
   <div class="row">
-    <a href="https://vitejs.dev" target="_blank">
+    <a href="https://vite.dev" target="_blank">
       <img src="/vite.svg" class="logo vite" alt="Vite Logo" />
     </a>
     <a href="https://tauri.app" target="_blank">

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/vite.config.js
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/vite.config.js
@@ -3,12 +3,12 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 
 const host = process.env.TAURI_DEV_HOST;
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   plugins: [svelte()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
-  // prevent vite from obscuring rust errors
+  // prevent Vite from obscuring rust errors
   clearScreen: false,
   // tauri expects a fixed port, fail if that port is not available
   server: {

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -1700,7 +1700,7 @@
           ]
         },
         "devUrl": {
-          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [vite](https://vitejs.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
+          "description": "The URL to load in development.\n\n This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.\n Most modern JavaScript bundlers like [Vite](https://vite.dev/guide/) provides a way to start a dev server by default.\n\n If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)\n and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -2628,7 +2628,7 @@ pub struct BuildConfig {
   /// The URL to load in development.
   ///
   /// This is usually an URL to a dev server, which serves your application assets with hot-reload and HMR.
-  /// Most modern JavaScript bundlers like [vite](https://vitejs.dev/guide/) provides a way to start a dev server by default.
+  /// Most modern JavaScript bundlers like [Vite](https://vite.dev/guide/) provides a way to start a dev server by default.
   ///
   /// If you don't have a dev server or don't want to use one, ignore this option and use [`frontendDist`](BuildConfig::frontend_dist)
   /// and point to a web assets directory, and Tauri CLI will run its built-in dev server and provide a simple hot-reload experience.

--- a/examples/api/vite.config.js
+++ b/examples/api/vite.config.js
@@ -8,7 +8,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 const host = process.env.TAURI_DEV_HOST
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   plugins: [Unocss(), svelte()],
   build: {
@@ -23,7 +23,7 @@ export default defineConfig({
   },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
-  // prevent vite from obscuring rust errors
+  // prevent Vite from obscuring rust errors
   clearScreen: false,
   // tauri expects a fixed port, fail if that port is not available
   server: {

--- a/packages/api/src/mocks.ts
+++ b/packages/api/src/mocks.ts
@@ -15,7 +15,7 @@ function mockInternals() {
  *
  * # Examples
  *
- * Testing setup using vitest:
+ * Testing setup using Vitest:
  * ```js
  * import { mockIPC, clearMocks } from "@tauri-apps/api/mocks"
  * import { invoke } from "@tauri-apps/api/core"


### PR DESCRIPTION
This pull request addresses updates to the official URLs for Vite and React. The URLs have been changed from `https://vitejs.dev` and `https://reactjs.org` to `https://vite.dev` and `https://react.dev`, respectively, as the former URLs now redirect to the new addresses.

Additionally, this PR includes corrections to the capitalization of "Vite" and "Vitest" in instances where it appears within sentences, ensuring proper styling guidelines.