### PR TITLE
fix(linux): Add missing RPM signature

### DIFF
--- a/.changes/rpm-signature.md
+++ b/.changes/rpm-signature.md
@@ -1,0 +1,5 @@
+---
+'tauri-cli': 'patch:enhance'
+---
+
+Added RPM to the list of package types for which signature file will be generated. 

--- a/crates/tauri-cli/src/bundle.rs
+++ b/crates/tauri-cli/src/bundle.rs
@@ -213,6 +213,7 @@ fn sign_updaters(
           | PackageType::WindowsMsi
           | PackageType::AppImage
           | PackageType::Deb
+          | PackageType::Rpm
       )
     })
     .collect();


### PR DESCRIPTION
Current version of CLI does not generate signatures for RPM files. I don't think there's any reason to exclude RPM so I guess it was simply missed. I've tested it locally and signature is generated correctly. 
