### PR TITLE
fix: Search gitignored directories for config files

### DIFF
--- a/crates/tauri-cli/src/helpers/app_paths.rs
+++ b/crates/tauri-cli/src/helpers/app_paths.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use ignore::WalkBuilder;
+use walkdir::WalkDir;
 
 use tauri_utils::{
   config::parse::{folder_has_configuration_file, is_configuration_file, ConfigFormat},
@@ -44,33 +45,24 @@ pub fn walk_builder(path: &Path) -> WalkBuilder {
 }
 
 fn lookup<F: Fn(&PathBuf) -> bool>(dir: &Path, checker: F) -> Option<PathBuf> {
-  let mut builder = walk_builder(dir);
-  builder
-    .require_git(false)
-    .ignore(false)
-    .max_depth(Some(
-      std::env::var("TAURI_CLI_CONFIG_DEPTH")
-        .map(|d| {
-          d.parse()
-            .expect("`TAURI_CLI_CONFIG_DEPTH` environment variable must be a positive integer")
-        })
-        .unwrap_or(3),
-    ))
-    .sort_by_file_path(|a, _| {
-      if a.extension().is_some() {
+  let max_depth = std::env::var("TAURI_CLI_CONFIG_DEPTH").map_or(3, |d| {
+    d.parse()
+      .expect("`TAURI_CLI_CONFIG_DEPTH` environment variable must be a positive integer")
+  });
+
+  WalkDir::new(dir)
+    .max_depth(max_depth)
+    .sort_by(|a, _| {
+      if a.path().extension().is_some() {
         Ordering::Less
       } else {
         Ordering::Greater
       }
-    });
-
-  for entry in builder.build().flatten() {
-    let path = dir.join(entry.path());
-    if checker(&path) {
-      return Some(path);
-    }
-  }
-  None
+    })
+    .into_iter()
+    .flatten()
+    .map(|entry| entry.into_path())
+    .find(checker)
 }
 
 fn env_tauri_app_path() -> Option<PathBuf> {


### PR DESCRIPTION
Fixes #3527

This PR changes the `lookup` function to search gitignored directories as well.
`lookup` is used to find the tauri config and package.json files.

#3527 was closed without being fixed: Tauri v2 currently can't find its config files if they are gitignored, as is often the case for people who track their dotfiles with a git repo in their home directory.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
