### PR TITLE
feat: add `WebviewBuilder.disable_javascript` and `WebviewWindowBuilder.disable_javascript`

### DIFF
--- a/.changes/disable-javascript.md
+++ b/.changes/disable-javascript.md
@@ -1,0 +1,6 @@
+---
+tauri: 'minor:feat'
+tauri-runtime-wry: 'minor:feat'
+---
+
+Add `WebviewBuilder.disable_javascript` and `WebviewWindowBuilder.disable_javascript` api to disable JavaScript.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10865,8 +10865,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 [[package]]
 name = "wry"
 version = "0.49.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "647c7c6ce36008e30a2a2ffce6176469144982f01b27047939dafc40a4e42cef"
+source = "git+https://github.com/Simon-Laux/wry?branch=disable-javascript#4011e4ec85c10fe5e85ddcc1e293ea3365a297e6"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.0",

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -22,7 +22,7 @@ wry = { version = "0.49.0", default-features = false, features = [
   "protocol",
   "os-webview",
   "linux-body",
-] }
+], git = "https://github.com/Simon-Laux/wry", branch = "disable-javascript" }
 tao = { version = "0.32.0", default-features = false, features = ["rwh_06"] }
 tauri-runtime = { version = "2.3.0", path = "../tauri-runtime" }
 tauri-utils = { version = "2.1.1", path = "../tauri-utils" }

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4201,6 +4201,10 @@ fn create_webview<T: UserEvent>(
     });
   }
 
+  if webview_attributes.javascript_disabled {
+    webview_builder = webview_builder.with_javascript_disabled();
+  }
+
   if let Some(color) = webview_attributes.background_color {
     webview_builder = webview_builder.with_background_color(color.into());
   }

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -218,6 +218,7 @@ pub struct WebviewAttributes {
   pub devtools: Option<bool>,
   pub background_color: Option<Color>,
   pub background_throttling: Option<BackgroundThrottlingPolicy>,
+  pub javascript_disabled: bool,
 }
 
 impl From<&WindowConfig> for WebviewAttributes {
@@ -285,6 +286,7 @@ impl WebviewAttributes {
       devtools: None,
       background_color: None,
       background_throttling: None,
+      javascript_disabled: false,
     }
   }
 

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -886,6 +886,17 @@ fn main() {
     self.webview_attributes.background_throttling = Some(policy);
     self
   }
+
+  /// Whether JavaScript should be disabled.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android:** Not implemented yet.
+  #[must_use]
+  pub fn disable_javascript(mut self) -> Self {
+    self.webview_attributes.javascript_disabled = true;
+    self
+  }
 }
 
 /// Webview.

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -996,6 +996,17 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
     self.webview_builder = self.webview_builder.background_throttling(policy);
     self
   }
+
+  /// Whether JavaScript should be disabled.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android:** Not implemented yet.
+  #[must_use]
+  pub fn disable_javascript(mut self) -> Self {
+    self.webview_builder = self.webview_builder.disable_javascript();
+    self
+  }
 }
 
 /// A type that wraps a [`Window`] together with a [`Webview`].


### PR DESCRIPTION
Add `WebviewBuilder.disable_javascript` and `WebviewWindowBuilder.disable_javascript` api to disable JavaScript.

There are some cases where this is nessesary.
For example I need this for safely displaying HTML emails in delta chat:
-  https://github.com/deltachat/deltachat-desktop/pull/4699

example to try out: https://github.com/Simon-Laux/tauri-experiments/blob/main/examples/disable_js_tauri

## Progress

- [x] Test
  - [x] MacOS
  - [x] Linux
  - [x] Windows
- [ ] wait for a wry version that includes https://github.com/tauri-apps/wry/pull/1496
- [x] `.changes` file
- [x] Ensure that all your commits are signed
