### PR TITLE
build: bump Android `minSdk` to API level 24

### DIFF
--- a/.changes/bump-android-minsdk.md
+++ b/.changes/bump-android-minsdk.md
@@ -1,0 +1,5 @@
+---
+tauri: 'patch:deps'
+---
+
+Bump the minimum supported Android SDK version to 24.

--- a/crates/tauri-cli/templates/plugin/android/build.gradle.kts
+++ b/crates/tauri-cli/templates/plugin/android/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/crates/tauri/mobile/android/build.gradle.kts
+++ b/crates/tauri/mobile/android/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("proguard-rules.pro")

--- a/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
When building a Tauri plugin for mobile, the following lint error occurs:

```
/android/.tauri/tauri-api/src/main/java/app/tauri/PathPlugin.kt:37: Error: Call requires API level 24 (current min is 21): android.content.ContextWrapper#getDataDir [NewApi]
          resolvePath(invoke, activity.dataDir.absolutePath)
                                       ~~~~~~~
```

Since a call to `dataDir` would most likely panic on Android API level <24, bumping `minSdk` seems like the only viable option.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
