### PR TITLE
ci: Build win-arm64 cli with rustls

### DIFF
--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -43,7 +43,7 @@ jobs:
           - host: windows-latest
             architecture: x64
             target: aarch64-pc-windows-msvc
-            build: pnpm build --target aarch64-pc-windows-msvc --features native-tls-vendored --cargo-flags="--no-default-features"
+            build: pnpm build --target aarch64-pc-windows-msvc
           - host: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian

--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -37,7 +37,7 @@ jobs:
           - os: windows-latest
             rust_target: aarch64-pc-windows-msvc
             ext: '.exe'
-            args: '--no-default-features --features native-tls-vendored'
+            args: ''
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
fixes #12639

the current approach is still from back when rustls (or rather ring) didn't support windows arm. i tested it locally and it built fine (additionally required clang which should be avail in the runners by default) and fixed the connection issue.

I still think it'll make the publishing fail just so it can make me look stupid