### PR TITLE
ci: install corepack in docker

### DIFF
--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -57,8 +57,6 @@ jobs:
             target: x86_64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
-              npm i -g --force corepack
-              corepack enable
               cd packages/cli
               pnpm build
               strip *.node
@@ -90,8 +88,6 @@ jobs:
             target: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
-              npm i -g --force corepack
-              corepack enable
               cd packages/cli
               rustup target add aarch64-unknown-linux-musl
               pnpm build --target aarch64-unknown-linux-musl

--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -48,6 +48,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |
+              npm i -g --force corepack
+              corepack enable
               cd packages/cli
               pnpm build --target x86_64-unknown-linux-gnu
               strip *.node
@@ -55,6 +57,8 @@ jobs:
             target: x86_64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              npm i -g --force corepack
+              corepack enable
               cd packages/cli
               pnpm build
               strip *.node
@@ -67,6 +71,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             build: |
+              npm i -g --force corepack
+              corepack enable
               cd packages/cli
               pnpm build --target aarch64-unknown-linux-gnu
               aarch64-unknown-linux-gnu-strip *.node
@@ -84,6 +90,8 @@ jobs:
             target: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: |
+              npm i -g --force corepack
+              corepack enable
               cd packages/cli
               rustup target add aarch64-unknown-linux-musl
               pnpm build --target aarch64-unknown-linux-musl


### PR DESCRIPTION
this should fix the build errors from https://github.com/tauri-apps/tauri/actions/runs/13548556704/job/37866236681 i only added it outside of docker in my last pr

seems like musl isn't needed so i'll revert that real quick