### PR TITLE
fix(deps): os webview not gated in wry feature

### DIFF
--- a/.changes/os-webview-wry-feature.md
+++ b/.changes/os-webview-wry-feature.md
@@ -1,0 +1,5 @@
+---
+tauri: 'patch:bug'
+---
+
+Fix OS webviews (`webview2` and `webkit2gtk`) are always compiled with tauri even without `wry` feature

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -95,7 +95,7 @@ tray-icon = { version = "0.20", default-features = false, features = [
 # linux
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
-webkit2gtk = { version = "=2.0.1", features = ["v2_40"] }
+webkit2gtk = { version = "=2.0.1", features = ["v2_40"], optional = true }
 
 # macOS
 [target.'cfg(target_os = "macos")'.dependencies]
@@ -120,9 +120,13 @@ window-vibrancy = "0.6"
 
 # windows
 [target."cfg(windows)".dependencies]
-webview2-com = "0.36"
+webview2-com = { version = "0.36", optional = true }
 window-vibrancy = "0.6"
-windows = { version = "0.60", features = ["Win32_Foundation"] }
+windows = { version = "0.60", features = [
+  "Win32_Foundation",
+  "Win32_UI",
+  "Win32_UI_WindowsAndMessaging",
+] }
 
 # mobile
 [target.'cfg(any(target_os = "android", all(target_vendor = "apple", not(target_os = "macos"))))'.dependencies]
@@ -180,7 +184,7 @@ tray-icon = ["dep:tray-icon"]
 tracing = ["dep:tracing", "tauri-macros/tracing", "tauri-runtime-wry/tracing"]
 test = []
 compression = ["tauri-macros/compression", "tauri-utils/compression"]
-wry = ["tauri-runtime-wry"]
+wry = ["webview2-com", "webkit2gtk", "tauri-runtime-wry"]
 # TODO: Remove in v3 - wry does not have this feature anymore
 objc-exception = []
 linux-libxdo = ["tray-icon/libxdo", "muda/libxdo"]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Those 2 dependencies were only used in `PlatformWebview` which is gated with `wry` feature