### PR TITLE
docs: Update wording from #12830

### DIFF
--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -1730,13 +1730,13 @@ tauri::Builder::default()
   ///
   /// # Warning
   ///
-  /// Pages loaded from custom protocol will have different Origin on different platforms. And
-  /// servers which enforce CORS will need to add exact same Origin header in `Access-Control-Allow-Origin`
+  /// Pages loaded from a custom protocol will have a different Origin on different platforms.
+  /// Servers which enforce CORS will need to add the exact same Origin header (or `*`) in `Access-Control-Allow-Origin`
   /// if you wish to send requests with native `fetch` and `XmlHttpRequest` APIs. Here are the
   /// different Origin headers across platforms:
   ///
-  /// - macOS, iOS and Linux: `<scheme_name>://<path>` (so it will be `my-scheme://path/to/page).
-  /// - Windows and Android: `http://<scheme_name>.<path>` by default (so it will be `http://my-scheme.path/to/page`).
+  /// - macOS, iOS and Linux: `<scheme_name>://localhost/<path>` (so it will be `my-scheme://localhost/path/to/page).
+  /// - Windows and Android: `http://<scheme_name>.localhost/<path>` by default (so it will be `http://my-scheme.localhost/path/to/page`).
   ///   To use `https` instead of `http`, use [`super::webview::WebviewBuilder::use_https_scheme`].
   #[must_use]
   pub fn register_uri_scheme_protocol<
@@ -1798,13 +1798,13 @@ tauri::Builder::default()
   ///
   /// # Warning
   ///
-  /// Pages loaded from custom protocol will have different Origin on different platforms. And
-  /// servers which enforce CORS will need to add exact same Origin header in `Access-Control-Allow-Origin`
+  /// Pages loaded from a custom protocol will have a different Origin on different platforms.
+  /// Servers which enforce CORS will need to add the exact same Origin header (or `*`) in `Access-Control-Allow-Origin`
   /// if you wish to send requests with native `fetch` and `XmlHttpRequest` APIs. Here are the
   /// different Origin headers across platforms:
   ///
-  /// - macOS, iOS and Linux: `<scheme_name>://<path>` (so it will be `my-scheme://path/to/page).
-  /// - Windows and Android: `http://<scheme_name>.<path>` by default (so it will be `http://my-scheme.path/to/page`).
+  /// - macOS, iOS and Linux: `<scheme_name>://localhost/<path>` (so it will be `my-scheme://localhost/path/to/page).
+  /// - Windows and Android: `http://<scheme_name>.localhost/<path>` by default (so it will be `http://my-scheme.localhost/path/to/page`).
   ///   To use `https` instead of `http`, use [`super::webview::WebviewBuilder::use_https_scheme`].
   #[must_use]
   pub fn register_asynchronous_uri_scheme_protocol<

--- a/crates/tauri/src/plugin.rs
+++ b/crates/tauri/src/plugin.rs
@@ -557,13 +557,14 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   ///
   /// # Warning
   ///
-  /// Pages loaded from custom protocol will have different Origin on different platforms. And
-  /// servers which enforce CORS will need to add exact same Origin header in `Access-Control-Allow-Origin`
+  /// Pages loaded from a custom protocol will have a different Origin on different platforms.
+  /// Servers which enforce CORS will need to add the exact same Origin header (or `*`) in `Access-Control-Allow-Origin`
   /// if you wish to send requests with native `fetch` and `XmlHttpRequest` APIs. Here are the
   /// different Origin headers across platforms:
   ///
-  /// - macOS, iOS and Linux: `<scheme_name>://<path>` (so it will be `my-scheme://path/to/page).
-  /// - Windows and Android: `http://<scheme_name>.<path>` by default (so it will be `http://my-scheme.path/to/page`).
+  /// - macOS, iOS and Linux: `<scheme_name>://localhost/<path>` (so it will be `my-scheme://localhost/path/to/page).
+  /// - Windows and Android: `http://<scheme_name>.localhost/<path>` by default (so it will be `http://my-scheme.localhost/path/to/page`).
+  ///   To use `https` instead of `http`, use [`super::webview::WebviewBuilder::use_https_scheme`].
   #[must_use]
   pub fn register_uri_scheme_protocol<
     N: Into<String>,
@@ -630,13 +631,14 @@ impl<R: Runtime, C: DeserializeOwned> Builder<R, C> {
   ///
   /// # Warning
   ///
-  /// Pages loaded from custom protocol will have different Origin on different platforms. And
-  /// servers which enforce CORS will need to add exact same Origin header in `Access-Control-Allow-Origin`
+  /// Pages loaded from a custom protocol will have a different Origin on different platforms.
+  /// Servers which enforce CORS will need to add the exact same Origin header (or `*`) in `Access-Control-Allow-Origin`
   /// if you wish to send requests with native `fetch` and `XmlHttpRequest` APIs. Here are the
   /// different Origin headers across platforms:
   ///
-  /// - macOS, iOS and Linux: `<scheme_name>://<path>` (so it will be `my-scheme://path/to/page).
-  /// - Windows and Android: `http://<scheme_name>.<path>` by default (so it will be `http://my-scheme.path/to/page`).
+  /// - macOS, iOS and Linux: `<scheme_name>://localhost/<path>` (so it will be `my-scheme://localhost/path/to/page).
+  /// - Windows and Android: `http://<scheme_name>.localhost/<path>` by default (so it will be `http://my-scheme.localhost/path/to/page`).
+  ///   To use `https` instead of `http`, use [`super::webview::WebviewBuilder::use_https_scheme`].
   #[must_use]
   pub fn register_asynchronous_uri_scheme_protocol<
     N: Into<String>,


### PR DESCRIPTION
This primarily addresses the incorrect urls (missing localhost).
