### PR TITLE
fix(core): docs.rs mobile build

### DIFF
--- a/.changes/fix-docs-rs-build.md
+++ b/.changes/fix-docs-rs-build.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Fix docs.rs build for mobile targets.

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -134,7 +134,7 @@ bytes = { version = "1", features = ["serde"] }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",
   "stream",
-  "rustls-tls",
+
 ] }
 
 # android
@@ -194,7 +194,7 @@ custom-protocol = ["tauri-macros/custom-protocol"]
 # For now those feature flags keep enabling reqwest features in case some users depend on that by accident.
 native-tls = ["reqwest/native-tls"]
 native-tls-vendored = ["reqwest/native-tls-vendored"]
-rustls-tls = []
+rustls-tls = ["reqwest/rustls-tls"]
 devtools = ["tauri-runtime/devtools", "tauri-runtime-wry/devtools"]
 process-relaunch-dangerous-allow-symlink-macos = [
   "tauri-utils/process-relaunch-dangerous-allow-symlink-macos",

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -115,7 +115,6 @@ fn get_response<R: Runtime>(
     );
 
     let mut proxy_builder = reqwest::ClientBuilder::new()
-      .use_rustls_tls()
       .build()
       .unwrap()
       .request(request.method().clone(), &url);


### PR DESCRIPTION
`ring` is a dependency of `rustls` and it cannot be compiled by docs.rs when targeting mobile.
we don't actually need rustls anymore since we're not relying on https dev servers.

I've verified this works using https://github.com/rust-lang/docs.rs

See https://docs.rs/crate/tauri/2.3.0/builds/1807696/x86_64-apple-ios.txt and https://docs.rs/crate/tauri/2.3.0/builds/1807696/x86_64-linux-android.txt