### PR TITLE
fix(core): compatibility check for Android SDK < 24

### DIFF
--- a/.changes/fix-android-min-sdk.md
+++ b/.changes/fix-android-min-sdk.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Update path plugin to use older dataDir API on SDK < 24.

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/PathPlugin.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/PathPlugin.kt
@@ -5,6 +5,7 @@
 package app.tauri
 
 import android.app.Activity
+import android.os.Build
 import android.os.Environment
 import app.tauri.annotation.Command
 import app.tauri.annotation.TauriPlugin
@@ -34,12 +35,20 @@ class PathPlugin(private val activity: Activity): Plugin(activity) {
 
     @Command
     fun getConfigDir(invoke: Invoke) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
         resolvePath(invoke, activity.dataDir.absolutePath)
+      } else {
+        resolvePath(invoke, activity.applicationInfo.dataDir)
+      }
     }
 
     @Command
     fun getDataDir(invoke: Invoke) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
         resolvePath(invoke, activity.dataDir.absolutePath)
+      } else {
+        resolvePath(invoke, activity.applicationInfo.dataDir)
+      }
     }
 
     @Command


### PR DESCRIPTION
`activity.applicationInfo.dataDir` returns the same value as `activity.dataDir.absolutePath`, but looks like the latter is synchronized when the app is moved (see https://developer.android.com/reference/android/content/Context#getDataDir() vs https://developer.android.com/reference/android/content/pm/ApplicationInfo#dataDir)

ref #12810
