### PR TITLE
refactor: use a single closure for filtering in `emit_to`

### DIFF
--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -1001,7 +1001,7 @@ pub trait Emitter<R: Runtime>: sealed::ManagerBase<R> {
   {
     let event = EventName::new(event)?;
     let payload = EmitPayload::Serialize(&payload);
-    self.manager().emit_to(target, event, payload)
+    self.manager().emit_to(target.into(), event, payload)
   }
 
   /// Similar to [`Emitter::emit_to`] but the payload is json serialized.
@@ -1011,7 +1011,7 @@ pub trait Emitter<R: Runtime>: sealed::ManagerBase<R> {
   {
     let event = EventName::new(event)?;
     let payload = EmitPayload::<()>::Str(payload);
-    self.manager().emit_to(target, event, payload)
+    self.manager().emit_to(target.into(), event, payload)
   }
 
   /// Emits an event to all [targets](EventTarget) based on the given filter.

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -596,60 +596,52 @@ impl<R: Runtime> AppManager<R> {
     feature = "tracing",
     tracing::instrument("app::emit::to", skip(self, target, payload), fields(target))
   )]
-  pub(crate) fn emit_to<I, S>(
+  pub(crate) fn emit_to<S>(
     &self,
-    target: I,
+    target: EventTarget,
     event: EventName<&str>,
     payload: EmitPayload<'_, S>,
   ) -> crate::Result<()>
   where
-    I: Into<EventTarget>,
     S: Serialize,
   {
     let target = target.into();
     #[cfg(feature = "tracing")]
     tracing::Span::current().record("target", format!("{target:?}"));
 
+    fn filter_target(target: &EventTarget, candidate: &EventTarget) -> bool {
+      match target {
+        // if targeting any label, emit using emit_filter and filter labels
+        EventTarget::AnyLabel { label } => match candidate {
+          EventTarget::Window { label: l }
+          | EventTarget::Webview { label: l }
+          | EventTarget::WebviewWindow { label: l }
+          | EventTarget::AnyLabel { label: l } => l == label,
+          _ => false,
+        },
+        EventTarget::Window { label } => match candidate {
+          EventTarget::AnyLabel { label: l } | EventTarget::Window { label: l } => l == label,
+          _ => false,
+        },
+        EventTarget::Webview { label } => match candidate {
+          EventTarget::AnyLabel { label: l } | EventTarget::Webview { label: l } => l == label,
+          _ => false,
+        },
+        EventTarget::WebviewWindow { label } => match candidate {
+          EventTarget::AnyLabel { label: l } | EventTarget::WebviewWindow { label: l } => {
+            l == label
+          }
+          _ => false,
+        },
+        // otherwise match same target
+        _ => target == candidate,
+      }
+    }
+
     match target {
       // if targeting all, emit to all using emit without filter
       EventTarget::Any => self.emit(event, payload),
-
-      // if targeting any label, emit using emit_filter and filter labels
-      EventTarget::AnyLabel {
-        label: target_label,
-      } => self.emit_filter(event, payload, |t| match t {
-        EventTarget::Window { label }
-        | EventTarget::Webview { label }
-        | EventTarget::WebviewWindow { label }
-        | EventTarget::AnyLabel { label } => label == &target_label,
-        _ => false,
-      }),
-
-      EventTarget::Window {
-        label: target_label,
-      } => self.emit_filter(event, payload, |t| match t {
-        EventTarget::AnyLabel { label } | EventTarget::Window { label } => label == &target_label,
-        _ => false,
-      }),
-
-      EventTarget::Webview {
-        label: target_label,
-      } => self.emit_filter(event, payload, |t| match t {
-        EventTarget::AnyLabel { label } | EventTarget::Webview { label } => label == &target_label,
-        _ => false,
-      }),
-
-      EventTarget::WebviewWindow {
-        label: target_label,
-      } => self.emit_filter(event, payload, |t| match t {
-        EventTarget::AnyLabel { label } | EventTarget::WebviewWindow { label } => {
-          label == &target_label
-        }
-        _ => false,
-      }),
-
-      // otherwise match same target
-      _ => self.emit_filter(event, payload, |t| t == &target),
+      target => self.emit_filter(event, payload, |t| filter_target(&target, t)),
     }
   }
 

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -610,7 +610,7 @@ impl<R: Runtime> AppManager<R> {
 
     fn filter_target(target: &EventTarget, candidate: &EventTarget) -> bool {
       match target {
-        // if targeting any label, emit using emit_filter and filter labels
+        // if targeting any label, filter matching labels
         EventTarget::AnyLabel { label } => match candidate {
           EventTarget::Window { label: l }
           | EventTarget::Webview { label: l }

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -605,7 +605,6 @@ impl<R: Runtime> AppManager<R> {
   where
     S: Serialize,
   {
-    let target = target.into();
     #[cfg(feature = "tracing")]
     tracing::Span::current().record("target", format!("{target:?}"));
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: #12820

One more thing that reduces the binary size, this one is on the very top of the cargo bloat results, and we can improve it by using a single closure

To me, this reduced the `helloworld` example's size by ~30 KB (😂 not much, but something anyways, has more potential saving if the user uses it themselves)

Before:

```
 File  .text     Size                    Crate Name
 1.2%   1.7%  23.1KiB                    tauri tauri::app::setup<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> > >
 1.2%   1.7%  23.1KiB        tauri_runtime_wry tauri_runtime_wry::create_window<enum2$<tauri::EventLoopMessage>,tauri::manager::menu::impl$0::prepare_window_menu_creation_handler::closure_env$0<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> > > >
 1.1%   1.7%  22.4KiB        tauri_runtime_wry tauri_runtime_wry::handle_user_message<enum2$<tauri::EventLoopMessage> >
 0.8%   1.1%  15.4KiB                    tauri tauri::manager::AppManager<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> > >::emit_to<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> >,enum2$<tauri::event::EventTarget>,tauri::manager::window::DragDropPayload>
 0.8%   1.1%  15.4KiB                    tauri tauri::manager::AppManager<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> > >::emit_to<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> >,enum2$<tauri::event::EventTarget>,tuple$<> >
```

After:

```
 0.2%   0.3%   3.5KiB                    tauri tauri::manager::AppManager<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> > >::emit_to<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> >,tauri::manager::window::DragDropPayload>
 0.2%   0.3%   3.5KiB                    tauri tauri::manager::AppManager<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> > >::emit_to<tauri_runtime_wry::Wry<enum2$<tauri::EventLoopMessage> >,tuple$<> >
```

~~Sorry about not using conventional commit message here since I don't know which category it fits in (maybe perf or chore?)~~