### PR TITLE
fix(core): add ctrl '+' key as zoom in

### DIFF
--- a/.changes/fix-zoom.md
+++ b/.changes/fix-zoom.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Listen for `Ctrl +` or `Cmd +` to support zoom functionality in swedish keyboard layouts.

--- a/crates/tauri/src/webview/scripts/zoom-hotkey.js
+++ b/crates/tauri/src/webview/scripts/zoom-hotkey.js
@@ -13,7 +13,7 @@ window.addEventListener('keydown', (event) => {
   if (OS_NAME === 'macos' ? event.metaKey : event.ctrlKey) {
     if (event.key === '-') {
       zoomLevel -= 0.2
-    } else if (event.key === '=') {
+    } else if (event.key === '=' || event.key === '+') {
       zoomLevel += 0.2
     } else if (event.key === '0') {
       zoomLevel = 1


### PR DESCRIPTION
Fix for https://github.com/tauri-apps/tauri/issues/12909

On scandinavian keyboards, the + key is usually used for zooming.

This adds `ctrl +` as an alternative to zoom in.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
