### PR TITLE
fix(tauri-utils): Set minimum patch version for glob

### DIFF
--- a/crates/tauri-utils/Cargo.toml
+++ b/crates/tauri-utils/Cargo.toml
@@ -35,7 +35,8 @@ ctor = "0.2"
 json5 = { version = "0.4", optional = true }
 toml = { version = "0.8", features = ["parse"] }
 json-patch = "3.0"
-glob = "0.3"
+# Our code requires at least 0.3.1
+glob = "0.3.1"
 urlpattern = "0.3"
 regex = "1"
 walkdir = { version = "2", optional = true }


### PR DESCRIPTION
I have no idea why cargo chose the older version but it happened twice now (that we know about) https://discord.com/channels/616186924390023171/1342659021936525415