### PR TITLE
feat(cli): allow merging multiple configuration values

### DIFF
--- a/.changes/cli-multiple-config.md
+++ b/.changes/cli-multiple-config.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": minor:feat
+"tauri-cli": minor:feat
+---
+
+Allow merging multiple configuration values on `tauri dev`, `tauri build`, `tauri bundle`, `tauri android dev`, `tauri android build`, `tauri ios dev` and `tauri ios build`.

--- a/crates/tauri-cli/src/build.rs
+++ b/crates/tauri-cli/src/build.rs
@@ -47,9 +47,15 @@ pub struct Options {
   /// Skip the bundling step even if `bundle > active` is `true` in tauri config.
   #[clap(long)]
   pub no_bundle: bool,
-  /// JSON string or path to JSON file to merge with tauri.conf.json
+  /// JSON strings or path to JSON files to merge with the default configuration file
+  ///
+  /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
+  ///
+  /// Note that a platform-specific file is looked up and merged with the default file by default
+  /// (tauri.macos.conf.json, tauri.linux.conf.json, tauri.windows.conf.json, tauri.android.conf.json and tauri.ios.conf.json)
+  /// but you can use this for more specific use cases such as different build flavors.
   #[clap(short, long)]
-  pub config: Option<ConfigValue>,
+  pub config: Vec<ConfigValue>,
   /// Command line arguments passed to the runner. Use `--` to explicitly mark the start of the arguments.
   pub args: Vec<String>,
   /// Skip prompting for values
@@ -68,7 +74,10 @@ pub fn command(mut options: Options, verbosity: u8) -> Result<()> {
     .map(Target::from_triple)
     .unwrap_or_else(Target::current);
 
-  let config = get_config(target, options.config.as_ref().map(|c| &c.0))?;
+  let config = get_config(
+    target,
+    &options.config.iter().map(|c| &c.0).collect::<Vec<_>>(),
+  )?;
 
   let mut interface = AppInterface::new(
     config.lock().unwrap().as_ref().unwrap(),

--- a/crates/tauri-cli/src/info/app.rs
+++ b/crates/tauri-cli/src/info/app.rs
@@ -13,7 +13,7 @@ use tauri_utils::platform::Target;
 pub fn items(frontend_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<SectionItem> {
   let mut items = Vec::new();
   if tauri_dir.is_some() {
-    if let Ok(config) = crate::helpers::config::get(Target::current(), None) {
+    if let Ok(config) = crate::helpers::config::get(Target::current(), &[]) {
       let config_guard = config.lock().unwrap();
       let config = config_guard.as_ref().unwrap();
 

--- a/crates/tauri-cli/src/inspect.rs
+++ b/crates/tauri-cli/src/inspect.rs
@@ -31,7 +31,7 @@ fn wix_upgrade_code() -> Result<()> {
   crate::helpers::app_paths::resolve();
 
   let target = tauri_utils::platform::Target::Windows;
-  let config = crate::helpers::config::get(target, None)?;
+  let config = crate::helpers::config::get(target, &[])?;
 
   let interface = AppInterface::new(config.lock().unwrap().as_ref().unwrap(), None)?;
 

--- a/crates/tauri-cli/src/mobile/android/android_studio_script.rs
+++ b/crates/tauri-cli/src/mobile/android/android_studio_script.rs
@@ -46,7 +46,7 @@ pub fn command(options: Options) -> Result<()> {
     Profile::Debug
   };
 
-  let tauri_config = get_tauri_config(tauri_utils::platform::Target::Android, None)?;
+  let tauri_config = get_tauri_config(tauri_utils::platform::Target::Android, &[])?;
 
   let (config, metadata, cli_options) = {
     let tauri_config_guard = tauri_config.lock().unwrap();
@@ -72,8 +72,14 @@ pub fn command(options: Options) -> Result<()> {
     MobileTarget::Android,
   )?;
 
-  if let Some(config) = &cli_options.config {
-    crate::helpers::config::merge_with(&config.0)?;
+  if !cli_options.config.is_empty() {
+    crate::helpers::config::merge_with(
+      &cli_options
+        .config
+        .iter()
+        .map(|conf| &conf.0)
+        .collect::<Vec<_>>(),
+    )?;
   }
 
   let env = env()?;

--- a/crates/tauri-cli/src/mobile/android/build.rs
+++ b/crates/tauri-cli/src/mobile/android/build.rs
@@ -49,9 +49,15 @@ pub struct Options {
   /// List of cargo features to activate
   #[clap(short, long, action = ArgAction::Append, num_args(0..))]
   pub features: Option<Vec<String>>,
-  /// JSON string or path to JSON file to merge with tauri.conf.json
+  /// JSON strings or path to JSON files to merge with the default configuration file
+  ///
+  /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
+  ///
+  /// Note that a platform-specific file is looked up and merged with the default file by default
+  /// (tauri.macos.conf.json, tauri.linux.conf.json, tauri.windows.conf.json, tauri.android.conf.json and tauri.ios.conf.json)
+  /// but you can use this for more specific use cases such as different build flavors.
   #[clap(short, long)]
-  pub config: Option<ConfigValue>,
+  pub config: Vec<ConfigValue>,
   /// Whether to split the APKs and AABs per ABIs.
   #[clap(long)]
   pub split_per_abi: bool,
@@ -105,7 +111,11 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   let tauri_config = get_tauri_config(
     tauri_utils::platform::Target::Android,
-    options.config.as_ref().map(|c| &c.0),
+    &options
+      .config
+      .iter()
+      .map(|conf| &conf.0)
+      .collect::<Vec<_>>(),
   )?;
   let (interface, config, metadata) = {
     let tauri_config_guard = tauri_config.lock().unwrap();

--- a/crates/tauri-cli/src/mobile/android/dev.rs
+++ b/crates/tauri-cli/src/mobile/android/dev.rs
@@ -48,9 +48,15 @@ pub struct Options {
   /// Exit on panic
   #[clap(short, long)]
   exit_on_panic: bool,
-  /// JSON string or path to JSON file to merge with tauri.conf.json
+  /// JSON strings or path to JSON files to merge with the default configuration file
+  ///
+  /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
+  ///
+  /// Note that a platform-specific file is looked up and merged with the default file by default
+  /// (tauri.macos.conf.json, tauri.linux.conf.json, tauri.windows.conf.json, tauri.android.conf.json and tauri.ios.conf.json)
+  /// but you can use this for more specific use cases such as different build flavors.
   #[clap(short, long)]
-  pub config: Option<ConfigValue>,
+  pub config: Vec<ConfigValue>,
   /// Run the code in release mode
   #[clap(long = "release")]
   pub release_mode: bool,
@@ -126,7 +132,11 @@ fn run_command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   let tauri_config = get_tauri_config(
     tauri_utils::platform::Target::Android,
-    options.config.as_ref().map(|c| &c.0),
+    &options
+      .config
+      .iter()
+      .map(|conf| &conf.0)
+      .collect::<Vec<_>>(),
   )?;
 
   let env = env()?;

--- a/crates/tauri-cli/src/mobile/init.rs
+++ b/crates/tauri-cli/src/mobile/init.rs
@@ -43,7 +43,7 @@ pub fn exec(
   #[allow(unused_variables)] reinstall_deps: bool,
   skip_targets_install: bool,
 ) -> Result<App> {
-  let tauri_config = get_tauri_config(target.platform_target(), None)?;
+  let tauri_config = get_tauri_config(target.platform_target(), &[])?;
 
   let tauri_config_guard = tauri_config.lock().unwrap();
   let tauri_config_ = tauri_config_guard.as_ref().unwrap();

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -60,9 +60,15 @@ pub struct Options {
   /// List of cargo features to activate
   #[clap(short, long, action = ArgAction::Append, num_args(0..))]
   pub features: Option<Vec<String>>,
-  /// JSON string or path to JSON file to merge with tauri.conf.json
+  /// JSON strings or path to JSON files to merge with the default configuration file
+  ///
+  /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
+  ///
+  /// Note that a platform-specific file is looked up and merged with the default file by default
+  /// (tauri.macos.conf.json, tauri.linux.conf.json, tauri.windows.conf.json, tauri.android.conf.json and tauri.ios.conf.json)
+  /// but you can use this for more specific use cases such as different build flavors.
   #[clap(short, long)]
-  pub config: Option<ConfigValue>,
+  pub config: Vec<ConfigValue>,
   /// Build number to append to the app version.
   #[clap(long)]
   pub build_number: Option<u32>,
@@ -145,7 +151,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   let tauri_config = get_tauri_config(
     tauri_utils::platform::Target::Ios,
-    options.config.as_ref().map(|c| &c.0),
+    &options.config.iter().map(|c| &c.0).collect::<Vec<_>>(),
   )?;
   let (interface, mut config) = {
     let tauri_config_guard = tauri_config.lock().unwrap();

--- a/crates/tauri-cli/src/mobile/ios/dev.rs
+++ b/crates/tauri-cli/src/mobile/ios/dev.rs
@@ -54,9 +54,15 @@ pub struct Options {
   /// Exit on panic
   #[clap(short, long)]
   exit_on_panic: bool,
-  /// JSON string or path to JSON file to merge with tauri.conf.json
+  /// JSON strings or path to JSON files to merge with the default configuration file
+  ///
+  /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
+  ///
+  /// Note that a platform-specific file is looked up and merged with the default file by default
+  /// (tauri.macos.conf.json, tauri.linux.conf.json, tauri.windows.conf.json, tauri.android.conf.json and tauri.ios.conf.json)
+  /// but you can use this for more specific use cases such as different build flavors.
   #[clap(short, long)]
-  pub config: Option<ConfigValue>,
+  pub config: Vec<ConfigValue>,
   /// Run the code in release mode
   #[clap(long = "release")]
   pub release_mode: bool,
@@ -148,7 +154,7 @@ fn run_command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   let tauri_config = get_tauri_config(
     tauri_utils::platform::Target::Ios,
-    options.config.as_ref().map(|c| &c.0),
+    &options.config.iter().map(|c| &c.0).collect::<Vec<_>>(),
   )?;
   let (interface, config) = {
     let tauri_config_guard = tauri_config.lock().unwrap();

--- a/crates/tauri-cli/src/mobile/ios/xcode_script.rs
+++ b/crates/tauri-cli/src/mobile/ios/xcode_script.rs
@@ -103,8 +103,14 @@ pub fn command(options: Options) -> Result<()> {
     MobileTarget::Ios,
   )?;
 
-  if let Some(config) = &cli_options.config {
-    crate::helpers::config::merge_with(&config.0)?;
+  if !cli_options.config.is_empty() {
+    crate::helpers::config::merge_with(
+      &cli_options
+        .config
+        .iter()
+        .map(|conf| &conf.0)
+        .collect::<Vec<_>>(),
+    )?;
   }
 
   let env = env()?.explicit_env_vars(cli_options.vars);

--- a/crates/tauri-cli/src/mobile/ios/xcode_script.rs
+++ b/crates/tauri-cli/src/mobile/ios/xcode_script.rs
@@ -78,7 +78,7 @@ pub fn command(options: Options) -> Result<()> {
   let profile = profile_from_configuration(&options.configuration);
   let macos = macos_from_platform(&options.platform);
 
-  let tauri_config = get_tauri_config(tauri_utils::platform::Target::Ios, None)?;
+  let tauri_config = get_tauri_config(tauri_utils::platform::Target::Ios, &[])?;
 
   let (config, metadata, cli_options) = {
     let tauri_config_guard = tauri_config.lock().unwrap();


### PR DESCRIPTION
Currently the dev/build/bundle commands can only merge a single Tauri configuration value (file or raw JSON string), which imposes a limitation in scenarios where you need more flexibility (like multiple app flavors and environments). This changes the config CLI option to allow multiple values, letting you merge multiple Tauri config files with the main one.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
