### PR TITLE
fix(core): `AssetResolver.get()`: don't skip first char

### DIFF
--- a/.changes/fix-get-asset-no-leading-slash.md
+++ b/.changes/fix-get-asset-no-leading-slash.md
@@ -1,0 +1,6 @@
+---
+'tauri': 'patch:bug'
+---
+
+Fix `tauri::AssetResolver::get` and `tauri::AssetResolver::get_for_scheme`
+skipping the first character of the `path` even if it's not a slash (/).

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -397,8 +397,8 @@ impl<R: Runtime> AppManager<R> {
       // if the url is `tauri://localhost`, we should load `index.html`
       "index.html".to_string()
     } else {
-      // skip leading `/`
-      path.chars().skip(1).collect::<String>()
+      // skip the leading `/`, if it starts with one.
+      path.strip_prefix('/').unwrap_or(path.as_str()).to_string()
     };
 
     let mut asset_path = AssetKey::from(path.as_str());


### PR DESCRIPTION
That is, it would try to get `sers/john` if you called
`AssetResolver.get("users/john")`.
This commit fixes the bug by only skipping the first character
only if it _is_ a slash (/).

Why it is important:
`tauri::WebviewUrl::App()` docs state that it's OK to specify
the path as `users/john` to get `tauri://localhost/users/john`
in the end.
So if an application developer is using `AssetResolver.get()`
together with `WebviewUrl::App()`, they will would get
inconsistent behavior: for the same path, the latter would work,
while the former would fail.
In fact, we encountered this bug in our code,
[here](https://github.com/deltachat/deltachat-desktop/blob/c860b0f4c659cdb0659ba946ecdd7f0381792946/packages/target-tauri/src-tauri/src/help_window.rs#L34-L43).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
