### PR TITLE
fix(cli): ios command wrong cwd on bun 1.2, closes #12965

### DIFF
--- a/.changes/fix-ios-bun-1.2.md
+++ b/.changes/fix-ios-bun-1.2.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix `tauri ios` commands using the wrong working directory with `bun@>1.2`.

--- a/crates/tauri-cli/src/mobile/ios/xcode_script.rs
+++ b/crates/tauri-cli/src/mobile/ios/xcode_script.rs
@@ -65,10 +65,14 @@ pub fn command(options: Options) -> Result<()> {
     }
   }
 
-  // `xcode-script` is ran from the `gen/apple` folder when not using NPM.
+  // `xcode-script` is ran from the `gen/apple` folder when not using NPM/yarn/pnpm.
   // so we must change working directory to the src-tauri folder to resolve the tauri dir
+  // additionally, bun@<1.2 does not modify the current working directory, so it is also runs this script from `gen/apple`
+  // bun@>1.2 now actually moves the CWD to the package root so we shouldn't modify CWD in that case
+  // see https://bun.sh/blog/bun-v1.2#bun-run-uses-the-correct-directory
   if (var_os("npm_lifecycle_event").is_none() && var_os("PNPM_PACKAGE_NAME").is_none())
-    || var("npm_config_user_agent").is_ok_and(|agent| agent.starts_with("bun"))
+    || var("npm_config_user_agent")
+      .is_ok_and(|agent| agent.starts_with("bun/1.0") || agent.starts_with("bun/1.1"))
   {
     set_current_dir(current_dir()?.parent().unwrap().parent().unwrap()).unwrap();
   }


### PR DESCRIPTION
bun 1.2 changed the current working directory behavior to match NPM managers, so we must adapt our xcode-script logic to check the bun version

see https://bun.sh/blog/bun-v1.2#bun-run-uses-the-correct-directory

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
