### PR TITLE
fix(macros): allow pub commands in crate root, closes #9362

### DIFF
--- a/.changes/command-crate-root-pub.md
+++ b/.changes/command-crate-root-pub.md
@@ -1,0 +1,5 @@
+---
+"tauri-macros": patch:bug
+---
+
+Allow defining a command as public in the crate root.

--- a/crates/tauri-macros/src/command/handler.rs
+++ b/crates/tauri-macros/src/command/handler.rs
@@ -43,8 +43,13 @@ impl Parse for Handler {
         // the name of the actual command function
         let command = last.ident.clone();
 
-        // set the path to the command function wrapper
-        last.ident = super::format_command_wrapper(&command);
+      // set the path to the command function wrapper
+      last.ident = super::format_command_wrapper(&command);
+      // the wrapper path is actually `${format_command_wrapper}::${format_command_wrapper}`
+      // because the wrapper export is inside a submodule with the same name as the wrapper macro
+      // so we must push a clone of the last segment here
+      let last_ = last.clone();
+      wrapper.segments.push(last_);
 
         (command, wrapper)
       })

--- a/crates/tauri-macros/src/command/handler.rs
+++ b/crates/tauri-macros/src/command/handler.rs
@@ -43,13 +43,13 @@ impl Parse for Handler {
         // the name of the actual command function
         let command = last.ident.clone();
 
-      // set the path to the command function wrapper
-      last.ident = super::format_command_wrapper(&command);
-      // the wrapper path is actually `${format_command_wrapper}::${format_command_wrapper}`
-      // because the wrapper export is inside a submodule with the same name as the wrapper macro
-      // so we must push a clone of the last segment here
-      let last_ = last.clone();
-      wrapper.segments.push(last_);
+        // set the path to the command function wrapper
+        last.ident = super::format_command_wrapper(&command);
+        // the wrapper path is actually `${format_command_wrapper}::${format_command_wrapper}`
+        // because the wrapper export is inside a submodule with the same name as the wrapper macro
+        // so we must push a clone of the last segment here
+        let last_ = last.clone();
+        wrapper.segments.push(last_);
 
         (command, wrapper)
       })

--- a/crates/tauri-macros/src/command/wrapper.rs
+++ b/crates/tauri-macros/src/command/wrapper.rs
@@ -285,8 +285,10 @@ pub fn wrapper(attributes: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     // allow the macro to be resolved with the same path as the command function
-    #[allow(unused_imports)]
-    #visibility use #wrapper;
+    #[allow(unused_imports, non_snake_case)]
+    #visibility mod #wrapper {
+      pub(crate) use #wrapper;
+    }
   )
   .into()
 }


### PR DESCRIPTION
moves the command macro export to a separate module, so it can be defined as pub in the crate root

ref #3198

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
