### PR TITLE
chore: fix helloworld example hang on Windows

### DIFF
--- a/examples/helloworld/main.rs
+++ b/examples/helloworld/main.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 #[tauri::command]
-fn greet(app: tauri::AppHandle, name: String) -> String {
+async fn greet(app: tauri::AppHandle, name: String) -> String {
   use tauri::Manager;
   println!("greet {name}");
   let w = app.get_webview_window("main").unwrap();


### PR DESCRIPTION
The issue was introduced in cedb24d494b84111daa3206c05196c8b89f1e994 (https://github.com/tauri-apps/tauri/pull/12665).

As the `.cookies()` docs state, the command should be async.

I discovered the issue while I was preparing the report of https://github.com/tauri-apps/tauri/issues/12990.

On a side note: I don't think that the cookies thing needs to be in the "helloworld" example.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
