### PR TITLE
refactor: remove permission description from runtime

### DIFF
--- a/crates/tauri-schema-generator/schemas/permission.schema.json
+++ b/crates/tauri-schema-generator/schemas/permission.schema.json
@@ -21,7 +21,7 @@
       "type": "string"
     },
     "description": {
-      "description": "Human-readable description of what the permission does.\n Tauri internal convention is to use <h4> headings in markdown content\n for Tauri documentation generation purposes.",
+      "description": "Human-readable description of what the permission does.\n Tauri internal convention is to use `<h4>` headings in markdown content\n for Tauri documentation generation purposes.",
       "type": [
         "string",
         "null"

--- a/crates/tauri-utils/src/acl/manifest.rs
+++ b/crates/tauri-utils/src/acl/manifest.rs
@@ -21,8 +21,9 @@ pub struct DefaultPermission {
   pub version: Option<NonZeroU64>,
 
   /// Human-readable description of what the permission does.
-  /// Tauri convention is to use <h4> headings in markdown content
+  /// Tauri convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
+  #[cfg(feature = "schema")]
   pub description: Option<String>,
 
   /// All permissions this set contains.
@@ -75,6 +76,7 @@ impl Manifest {
       if let Some(default) = permission_file.default {
         manifest.default_permission.replace(PermissionSet {
           identifier: "default".into(),
+          #[cfg(feature = "schema")]
           description: default
             .description
             .unwrap_or_else(|| "Default plugin permissions.".to_string()),
@@ -141,13 +143,13 @@ mod build {
         let v = v.get();
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
-      let description = opt_str_lit(self.description.as_ref());
+      // let description = opt_str_lit(self.description.as_ref());
       let permissions = vec_lit(&self.permissions, str_lit);
       literal_struct!(
         tokens,
         ::tauri::utils::acl::plugin::DefaultPermission,
         version,
-        description,
+        // description,
         permissions
       )
     }

--- a/crates/tauri-utils/src/acl/manifest.rs
+++ b/crates/tauri-utils/src/acl/manifest.rs
@@ -23,6 +23,7 @@ pub struct DefaultPermission {
   /// Human-readable description of what the permission does.
   /// Tauri convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
+  // #[cfg(feature = "schema")]
   pub description: Option<String>,
 
   /// All permissions this set contains.
@@ -55,6 +56,7 @@ pub struct Manifest {
   /// Plugin permission sets.
   pub permission_sets: BTreeMap<String, PermissionSet>,
   /// The global scope schema.
+  // #[cfg(feature = "schema")]
   pub global_scope_schema: Option<serde_json::Value>,
 }
 
@@ -141,6 +143,7 @@ mod build {
         let v = v.get();
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
+      // Only used in schema generation, so don't include them in runtime
       // let description = opt_str_lit(self.description.as_ref());
       let description = quote! { ::core::option::Option::None };
       let permissions = vec_lit(&self.permissions, str_lit);
@@ -172,8 +175,10 @@ mod build {
         identity,
       );
 
-      let global_scope_schema =
-        opt_lit_owned(self.global_scope_schema.as_ref().map(json_value_lit));
+      // Only used in schema generation, so don't include them in runtime
+      // let global_scope_schema =
+      //   opt_lit_owned(self.global_scope_schema.as_ref().map(json_value_lit));
+      let global_scope_schema = quote! { ::core::option::Option::None };
 
       literal_struct!(
         tokens,

--- a/crates/tauri-utils/src/acl/manifest.rs
+++ b/crates/tauri-utils/src/acl/manifest.rs
@@ -143,7 +143,7 @@ mod build {
         let v = v.get();
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
-      // Only used in schema generation, so don't include them in runtime
+      // Only used in build script and macros, so don't include them in runtime
       // let description = opt_str_lit(self.description.as_ref());
       let description = quote! { ::core::option::Option::None };
       let permissions = vec_lit(&self.permissions, str_lit);
@@ -175,7 +175,7 @@ mod build {
         identity,
       );
 
-      // Only used in schema generation, so don't include them in runtime
+      // Only used in build script and macros, so don't include them in runtime
       // let global_scope_schema =
       //   opt_lit_owned(self.global_scope_schema.as_ref().map(json_value_lit));
       let global_scope_schema = quote! { ::core::option::Option::None };

--- a/crates/tauri-utils/src/acl/manifest.rs
+++ b/crates/tauri-utils/src/acl/manifest.rs
@@ -23,7 +23,6 @@ pub struct DefaultPermission {
   /// Human-readable description of what the permission does.
   /// Tauri convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
-  // #[cfg(feature = "schema")]
   pub description: Option<String>,
 
   /// All permissions this set contains.
@@ -56,7 +55,6 @@ pub struct Manifest {
   /// Plugin permission sets.
   pub permission_sets: BTreeMap<String, PermissionSet>,
   /// The global scope schema.
-  // #[cfg(feature = "schema")]
   pub global_scope_schema: Option<serde_json::Value>,
 }
 
@@ -144,7 +142,6 @@ mod build {
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
       // Only used in build script and macros, so don't include them in runtime
-      // let description = opt_str_lit(self.description.as_ref());
       let description = quote! { ::core::option::Option::None };
       let permissions = vec_lit(&self.permissions, str_lit);
       literal_struct!(

--- a/crates/tauri-utils/src/acl/manifest.rs
+++ b/crates/tauri-utils/src/acl/manifest.rs
@@ -23,7 +23,6 @@ pub struct DefaultPermission {
   /// Human-readable description of what the permission does.
   /// Tauri convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
-  #[cfg(feature = "schema")]
   pub description: Option<String>,
 
   /// All permissions this set contains.
@@ -76,7 +75,6 @@ impl Manifest {
       if let Some(default) = permission_file.default {
         manifest.default_permission.replace(PermissionSet {
           identifier: "default".into(),
-          #[cfg(feature = "schema")]
           description: default
             .description
             .unwrap_or_else(|| "Default plugin permissions.".to_string()),
@@ -144,12 +142,13 @@ mod build {
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
       // let description = opt_str_lit(self.description.as_ref());
+      let description = quote! { ::core::option::Option::None };
       let permissions = vec_lit(&self.permissions, str_lit);
       literal_struct!(
         tokens,
         ::tauri::utils::acl::plugin::DefaultPermission,
         version,
-        // description,
+        description,
         permissions
       )
     }

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -230,8 +230,9 @@ pub struct Permission {
   pub identifier: String,
 
   /// Human-readable description of what the permission does.
-  /// Tauri internal convention is to use <h4> headings in markdown content
+  /// Tauri internal convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
+  #[cfg(feature = "schema")]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub description: Option<String>,
 
@@ -267,6 +268,7 @@ pub struct PermissionSet {
   pub identifier: String,
 
   /// Human-readable description of what the permission does.
+  #[cfg(feature = "schema")]
   pub description: String,
 
   /// All permissions this set contains.
@@ -519,7 +521,7 @@ mod build_ {
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
       let identifier = str_lit(&self.identifier);
-      let description = opt_str_lit(self.description.as_ref());
+      // let description = opt_str_lit(self.description.as_ref());
       let commands = &self.commands;
       let scope = &self.scope;
       let platforms = opt_vec_lit(self.platforms.as_ref(), identity);
@@ -529,7 +531,7 @@ mod build_ {
         ::tauri::utils::acl::Permission,
         version,
         identifier,
-        description,
+        // description,
         commands,
         scope,
         platforms
@@ -540,13 +542,13 @@ mod build_ {
   impl ToTokens for PermissionSet {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let identifier = str_lit(&self.identifier);
-      let description = str_lit(&self.description);
+      // let description = str_lit(&self.description);
       let permissions = vec_lit(&self.permissions, str_lit);
       literal_struct!(
         tokens,
         ::tauri::utils::acl::PermissionSet,
         identifier,
-        description,
+        // description,
         permissions
       )
     }

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -521,7 +521,7 @@ mod build_ {
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
       let identifier = str_lit(&self.identifier);
-      // Only used in schema generation, so don't include them in runtime
+      // Only used in build script and macros, so don't include them in runtime
       // let description = opt_str_lit(self.description.as_ref());
       let description = quote! { ::core::option::Option::None };
       let commands = &self.commands;
@@ -544,7 +544,7 @@ mod build_ {
   impl ToTokens for PermissionSet {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let identifier = str_lit(&self.identifier);
-      // Only used in schema generation, so don't include them in runtime
+      // Only used in build script and macros, so don't include them in runtime
       // let description = str_lit(&self.description);
       let description = quote! { "".to_string() };
       let permissions = vec_lit(&self.permissions, str_lit);

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -232,7 +232,6 @@ pub struct Permission {
   /// Human-readable description of what the permission does.
   /// Tauri internal convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
-  // #[cfg(feature = "schema")]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub description: Option<String>,
 
@@ -268,7 +267,6 @@ pub struct PermissionSet {
   pub identifier: String,
 
   /// Human-readable description of what the permission does.
-  // #[cfg(feature = "schema")]
   pub description: String,
 
   /// All permissions this set contains.
@@ -522,7 +520,6 @@ mod build_ {
       }));
       let identifier = str_lit(&self.identifier);
       // Only used in build script and macros, so don't include them in runtime
-      // let description = opt_str_lit(self.description.as_ref());
       let description = quote! { ::core::option::Option::None };
       let commands = &self.commands;
       let scope = &self.scope;
@@ -545,7 +542,6 @@ mod build_ {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let identifier = str_lit(&self.identifier);
       // Only used in build script and macros, so don't include them in runtime
-      // let description = str_lit(&self.description);
       let description = quote! { "".to_string() };
       let permissions = vec_lit(&self.permissions, str_lit);
       literal_struct!(

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -232,6 +232,7 @@ pub struct Permission {
   /// Human-readable description of what the permission does.
   /// Tauri internal convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
+  // #[cfg(feature = "schema")]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub description: Option<String>,
 
@@ -267,6 +268,7 @@ pub struct PermissionSet {
   pub identifier: String,
 
   /// Human-readable description of what the permission does.
+  // #[cfg(feature = "schema")]
   pub description: String,
 
   /// All permissions this set contains.
@@ -519,6 +521,7 @@ mod build_ {
         quote!(::core::num::NonZeroU64::new(#v).unwrap())
       }));
       let identifier = str_lit(&self.identifier);
+      // Only used in schema generation, so don't include them in runtime
       // let description = opt_str_lit(self.description.as_ref());
       let description = quote! { ::core::option::Option::None };
       let commands = &self.commands;
@@ -541,6 +544,7 @@ mod build_ {
   impl ToTokens for PermissionSet {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let identifier = str_lit(&self.identifier);
+      // Only used in schema generation, so don't include them in runtime
       // let description = str_lit(&self.description);
       let description = quote! { "".to_string() };
       let permissions = vec_lit(&self.permissions, str_lit);

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -232,7 +232,6 @@ pub struct Permission {
   /// Human-readable description of what the permission does.
   /// Tauri internal convention is to use `<h4>` headings in markdown content
   /// for Tauri documentation generation purposes.
-  #[cfg(feature = "schema")]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub description: Option<String>,
 
@@ -268,7 +267,6 @@ pub struct PermissionSet {
   pub identifier: String,
 
   /// Human-readable description of what the permission does.
-  #[cfg(feature = "schema")]
   pub description: String,
 
   /// All permissions this set contains.
@@ -522,6 +520,7 @@ mod build_ {
       }));
       let identifier = str_lit(&self.identifier);
       // let description = opt_str_lit(self.description.as_ref());
+      let description = quote! { ::core::option::Option::None };
       let commands = &self.commands;
       let scope = &self.scope;
       let platforms = opt_vec_lit(self.platforms.as_ref(), identity);
@@ -531,7 +530,7 @@ mod build_ {
         ::tauri::utils::acl::Permission,
         version,
         identifier,
-        // description,
+        description,
         commands,
         scope,
         platforms
@@ -543,12 +542,13 @@ mod build_ {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let identifier = str_lit(&self.identifier);
       // let description = str_lit(&self.description);
+      let description = quote! { "".to_string() };
       let permissions = vec_lit(&self.permissions, str_lit);
       literal_struct!(
         tokens,
         ::tauri::utils::acl::PermissionSet,
         identifier,
-        // description,
+        description,
         permissions
       )
     }

--- a/examples/api/src-tauri/tauri-plugin-sample/permissions/schemas/schema.json
+++ b/examples/api/src-tauri/tauri-plugin-sample/permissions/schemas/schema.json
@@ -49,7 +49,7 @@
           "minimum": 1.0
         },
         "description": {
-          "description": "Human-readable description of what the permission does.\n Tauri convention is to use <h4> headings in markdown content\n for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does.\n Tauri convention is to use `<h4>` headings in markdown content\n for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"
@@ -111,7 +111,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Human-readable description of what the permission does.\n Tauri internal convention is to use <h4> headings in markdown content\n for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does.\n Tauri internal convention is to use `<h4>` headings in markdown content\n for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: #12820, https://github.com/tauri-apps/tauri/issues/12574#issuecomment-2626244150

We never actually used any of those descriptions in runtime (I'm not very familiar with this part, from the usage, they're only used in the build process, like schema and doc generation), so removing them from the runtime, from testing, this change reduced API example release build's size from 3.54MB to 3.5MB on Windows, the saving should be bigger if there're more plugins installed though

~~Feature gate permission `description` fields and don't generate them in codegen~~ Well, can't get this to work inside of our monorepo ([failed run](https://github.com/tauri-apps/tauri/actions/runs/13879734814/job/38836758837)), works fine on the examples though

Alternatively, I just set them to `None` in codegen