### PR TITLE
docs: clarify Capability::windows/webviews OR nature

### DIFF
--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -1318,14 +1318,14 @@
           "type": "boolean"
         },
         "windows": {
-          "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\n On multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.\n\n ## Example\n\n `[\"main\"]`",
+          "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\n If a window label matches any of the patterns in this list,\n the capability will be enabled on all the webviews of that window,\n regardless of the value of [`Self::webviews`].\n\n On multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`]\n for a fine grained access control.\n\n ## Example\n\n `[\"main\"]`",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "webviews": {
-          "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\n This is only required when using on multiwebview contexts, by default\n all child webviews of a window that matches [`Self::windows`] are linked.\n\n ## Example\n\n `[\"sub-webview-one\", \"sub-webview-two\"]`",
+          "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\n The capability will be enabled on all the webviews\n whose label matches any of the patterns in this list,\n regardless of whether the webview's window label matches a pattern in [`Self::windows`].\n\n ## Example\n\n `[\"sub-webview-one\", \"sub-webview-two\"]`",
           "type": "array",
           "items": {
             "type": "string"

--- a/crates/tauri-schema-generator/schemas/capability.schema.json
+++ b/crates/tauri-schema-generator/schemas/capability.schema.json
@@ -34,14 +34,14 @@
       "type": "boolean"
     },
     "windows": {
-      "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\n On multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.\n\n ## Example\n\n `[\"main\"]`",
+      "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\n If a window label matches any of the patterns in this list,\n the capability will be enabled on all the webviews of that window,\n regardless of the value of [`Self::webviews`].\n\n On multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`]\n for a fine grained access control.\n\n ## Example\n\n `[\"main\"]`",
       "type": "array",
       "items": {
         "type": "string"
       }
     },
     "webviews": {
-      "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\n This is only required when using on multiwebview contexts, by default\n all child webviews of a window that matches [`Self::windows`] are linked.\n\n ## Example\n\n `[\"sub-webview-one\", \"sub-webview-two\"]`",
+      "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\n The capability will be enabled on all the webviews\n whose label matches any of the patterns in this list,\n regardless of whether the webview's window label matches a pattern in [`Self::windows`].\n\n ## Example\n\n `[\"sub-webview-one\", \"sub-webview-two\"]`",
       "type": "array",
       "items": {
         "type": "string"

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -1318,14 +1318,14 @@
           "type": "boolean"
         },
         "windows": {
-          "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\n On multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.\n\n ## Example\n\n `[\"main\"]`",
+          "description": "List of windows that are affected by this capability. Can be a glob pattern.\n\n If a window label matches any of the patterns in this list,\n the capability will be enabled on all the webviews of that window,\n regardless of the value of [`Self::webviews`].\n\n On multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`]\n for a fine grained access control.\n\n ## Example\n\n `[\"main\"]`",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "webviews": {
-          "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\n This is only required when using on multiwebview contexts, by default\n all child webviews of a window that matches [`Self::windows`] are linked.\n\n ## Example\n\n `[\"sub-webview-one\", \"sub-webview-two\"]`",
+          "description": "List of webviews that are affected by this capability. Can be a glob pattern.\n\n The capability will be enabled on all the webviews\n whose label matches any of the patterns in this list,\n regardless of whether the webview's window label matches a pattern in [`Self::windows`].\n\n ## Example\n\n `[\"sub-webview-one\", \"sub-webview-two\"]`",
           "type": "array",
           "items": {
             "type": "string"

--- a/crates/tauri-utils/src/acl/capability.rs
+++ b/crates/tauri-utils/src/acl/capability.rs
@@ -148,7 +148,11 @@ pub struct Capability {
   pub local: bool,
   /// List of windows that are affected by this capability. Can be a glob pattern.
   ///
-  /// On multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.
+  /// If a window label mathes any of the patterns in this list,
+  /// the capability will be enabled on all the webviews of that window,
+  /// regardless of the value of [`Self::webviews`].
+  /// On multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`]
+  /// for a fine grained access control.
   ///
   /// ## Example
   ///
@@ -157,8 +161,9 @@ pub struct Capability {
   pub windows: Vec<String>,
   /// List of webviews that are affected by this capability. Can be a glob pattern.
   ///
-  /// This is only required when using on multiwebview contexts, by default
-  /// all child webviews of a window that matches [`Self::windows`] are linked.
+  /// The capability will be enabled on all the webviews
+  /// whose label matches any of the patterns in this list,
+  /// regardless of whether the webview's window label mathes a pattern in [`Self::windows`].
   ///
   /// ## Example
   ///

--- a/crates/tauri-utils/src/acl/capability.rs
+++ b/crates/tauri-utils/src/acl/capability.rs
@@ -148,9 +148,10 @@ pub struct Capability {
   pub local: bool,
   /// List of windows that are affected by this capability. Can be a glob pattern.
   ///
-  /// If a window label mathes any of the patterns in this list,
+  /// If a window label matches any of the patterns in this list,
   /// the capability will be enabled on all the webviews of that window,
   /// regardless of the value of [`Self::webviews`].
+  ///
   /// On multiwebview windows, prefer specifying [`Self::webviews`] and omitting [`Self::windows`]
   /// for a fine grained access control.
   ///
@@ -163,7 +164,7 @@ pub struct Capability {
   ///
   /// The capability will be enabled on all the webviews
   /// whose label matches any of the patterns in this list,
-  /// regardless of whether the webview's window label mathes a pattern in [`Self::windows`].
+  /// regardless of whether the webview's window label matches a pattern in [`Self::windows`].
   ///
   /// ## Example
   ///


### PR DESCRIPTION
It is intuitive to expect that for the capability to be enabled, _both_ the window label and the webview label have to match. However, this is not the case: the capability is enabled if _either_ the window label matches a pattern
in `Capability::windows` _or_ the webview label matches a pattern in `Capability::webviews`.

This commit should somewhat clarify this oddity
and protect developers from adding excessive permissions.

For reference, `Capability::webviews` was added in 0cb0a15ce22af3d649cf219ac04188c14c5f4905
(https://github.com/tauri-apps/tauri/pull/8789).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
