### PR TITLE
docs: improve `tauri_build::build` & `try_build`

### DIFF
--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -419,18 +419,14 @@ pub fn is_dev() -> bool {
 
 /// Run all build time helpers for your Tauri Application.
 ///
-/// The current helpers include the following:
-/// * Generates a Windows Resource file when targeting Windows.
-///
 /// # Platforms
 ///
-/// [`build()`] should be called inside of `build.rs` regardless of the platform:
-/// * New helpers may target more platforms in the future.
-/// * Platform specific code is handled by the helpers automatically.
-/// * A build script is required in order to activate some cargo environmental variables that are
-///   used when generating code and embedding assets - so [`build()`] may as well be called.
+/// [`build()`] should be called inside of `build.rs` regardless of the platform.
 ///
-/// In short, this is saying don't put the call to [`build()`] behind a `#[cfg(windows)]`.
+/// Platform specific code is handled by the helpers automatically.
+///
+/// A build script is required in order to activate some cargo environmental variables that are
+/// used when generating code and embedding assets.
 ///
 /// # Panics
 ///

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -419,6 +419,9 @@ pub fn is_dev() -> bool {
 
 /// Run all build time helpers for your Tauri Application.
 ///
+/// To provide extra configuration, such as [`AppManifest::commands`]
+/// for fine-grained control over command permissions, see [`try_build`].
+///
 /// # Platforms
 ///
 /// [`build()`] should be called inside of `build.rs` regardless of the platform.
@@ -446,7 +449,7 @@ pub fn build() {
   }
 }
 
-/// Non-panicking [`build()`].
+/// Like [`build()`], but takes an extra configuration argument, and does not panic.
 #[allow(unused_variables)]
 pub fn try_build(attributes: Attributes) -> Result<()> {
   use anyhow::anyhow;

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -421,10 +421,12 @@ pub fn is_dev() -> bool {
 ///
 /// To provide extra configuration, such as [`AppManifest::commands`]
 /// for fine-grained control over command permissions, see [`try_build`].
+/// See [`Attributes`] for the complete list of configuration options.
 ///
 /// # Platforms
 ///
-/// [`build()`] should be called inside of `build.rs` regardless of the platform.
+/// [`build()`] should be called inside of `build.rs` regardless of the platform, so **DO NOT** use a [conditional compilation]
+/// check that prevents it from running on any of your targets.
 ///
 /// Platform specific code is handled by the helpers automatically.
 ///
@@ -435,6 +437,8 @@ pub fn is_dev() -> bool {
 ///
 /// If any of the build time helpers fail, they will [`std::panic!`] with the related error message.
 /// This is typically desirable when running inside a build script; see [`try_build`] for no panics.
+///
+/// [conditional compilation]: https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/book/first-edition/conditional-compilation.html
 pub fn build() {
   if let Err(error) = try_build(Attributes::default()) {
     let error = format!("{error:#}");

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -449,7 +449,7 @@ pub fn build() {
   }
 }
 
-/// Like [`build()`], but takes an extra configuration argument, and does not panic.
+/// Same as [`build()`], but takes an extra configuration argument, and does not panic.
 #[allow(unused_variables)]
 pub fn try_build(attributes: Attributes) -> Result<()> {
   use anyhow::anyhow;


### PR DESCRIPTION
The docstring has been unchanged ever since
40ac52971eb350e839f41401043c5cde31fa8974 (2021).
The `build()` function has grown massively since then,
now it's not only about Windows.

`try_build` is not only about not panicking, but it also takes the
`attributes: Attributes` argument,
which is very important for controlling command permissions.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
