### PR TITLE
fix: align log like Cargo

### DIFF
--- a/crates/tauri-cli/src/lib.rs
+++ b/crates/tauri-cli/src/lib.rs
@@ -235,13 +235,13 @@ where
         if !is_command_output {
           let style = Style::new().fg_color(Some(AnsiColor::Green.into())).bold();
 
-          write!(f, "    {style}{}{style:#} ", action)?;
+          write!(f, "{style}{action:>12}{style:#} ")?;
         }
       } else {
         let style = f.default_level_style(record.level()).bold();
         write!(
           f,
-          "    {style}{}{style:#} ",
+          "{style}{:>12}{style:#} ",
           prettyprint_level(record.level())
         )?;
       }


### PR DESCRIPTION
I noticed that Tauri's log prints crookedly compared to Cargo
![image](https://github.com/user-attachments/assets/c47cfbf8-14d8-4718-bffb-b5e7feb780d8)

This PR fixes it, now everything prints aligned
![image](https://github.com/user-attachments/assets/b6017281-010e-4bc0-a2d2-4d0ce6f09af3)
