### PR TITLE
fix: always delete auto start registry entry

### DIFF
--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -839,9 +839,7 @@ Section Uninstall
   ; This ensures the program does not launch automatically after uninstallation if it exists.
   ; If it doesn't exist, it does nothing.
   ; We do this when not updating (to preserve the registry value on updates)
-  ; and when the installation is for the current user only - as it is difficult to delete registry values for other users or for the local machine
   ${If} $UpdateMode <> 1
-  ${AndIf} "${INSTALLMODE}" == "currentUser"
     DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCTNAME}"
   ${EndIf}
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: https://github.com/tauri-apps/tauri/pull/12643#issuecomment-2727805281

We have not used the newer git version of auto-launch yet so the entry is always added in current user's registry, also it's not related to the installer mode anyways, as that new code detects admin of the app and it has nothing to do with the installer