### PR TITLE
feat(core): resolve file names from Android content URIs

### DIFF
--- a/.changes/path-file-name-android-api.md
+++ b/.changes/path-file-name-android-api.md
@@ -1,0 +1,6 @@
+---
+"tauri": minor:feat
+"@tauri-apps/api": minor:feat
+---
+
+The `path` basename and extname APIs now accept Android content URIs (such as the paths returned by the dialog plugin).

--- a/.changes/path-file-name-android-api.md
+++ b/.changes/path-file-name-android-api.md
@@ -3,4 +3,4 @@
 "@tauri-apps/api": minor:feat
 ---
 
-The `path` basename and extname APIs now accept Android content URIs (such as the paths returned by the dialog plugin).
+The `path` basename and extname APIs now accept Android content URIs, such as the paths returned by the dialog plugin.

--- a/.changes/path-file-name-android.md
+++ b/.changes/path-file-name-android.md
@@ -1,0 +1,5 @@
+---
+"tauri": minor:feat
+---
+
+Added `PathResolver::file_name` to resolve file names from content URIs on Android (leverating `std::path::Path::file_name` on other platforms).

--- a/crates/tauri/src/path/desktop.rs
+++ b/crates/tauri/src/path/desktop.rs
@@ -4,7 +4,7 @@
 
 use super::{Error, Result};
 use crate::{AppHandle, Manager, Runtime};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The path resolver is a helper class for general and application-specific path APIs.
 pub struct PathResolver<R: Runtime>(pub(crate) AppHandle<R>);
@@ -16,6 +16,22 @@ impl<R: Runtime> Clone for PathResolver<R> {
 }
 
 impl<R: Runtime> PathResolver<R> {
+  /// Returns the final component of the `Path`, if there is one.
+  ///
+  /// If the path is a normal file, this is the file name. If it's the path of a directory, this
+  /// is the directory name.
+  ///
+  /// Returns [`None`] if the path terminates in `..`.
+  ///
+  /// On Android this also supports checking the file name of content URIs, such as the values returned by the dialog plugin.
+  ///
+  /// If you are dealing with plain file system paths or not worried about Android content URIs, prefer [`Path::file_name`].
+  pub fn file_name(&self, path: &str) -> Option<String> {
+    Path::new(path)
+      .file_name()
+      .map(|name| name.to_string_lossy().into_owned())
+  }
+
   /// Returns the path to the user's audio directory.
   ///
   /// ## Platform-specific


### PR DESCRIPTION
This PR adds a new Android path plugin function to resolve file names from content URIs. `PathResolver::file_name` was added to expose this API on Rust, and the existing `@tauri-apps/api/path` basename and extname function now leverages it on Android.

Closes https://github.com/tauri-apps/plugins-workspace/issues/1775

Tauri core port from https://github.com/tauri-apps/plugins-workspace/pull/2421

Co-authored-by: VulnX <62636727+VulnX@users.noreply.github.com>
