### PR TITLE
fix: don't ship global api bundle if withGlobalTauri is false

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -4,7 +4,7 @@
     "feat": "New Features",
     "enhance": "Enhancements",
     "bug": "Bug Fixes",
-    "pref": "Performance Improvements",
+    "perf": "Performance Improvements",
     "changes": "What's Changed",
     "sec": "Security fixes",
     "deps": "Dependencies",

--- a/.changes/dont-ship-global-bundle-if-no-global-tauri.md
+++ b/.changes/dont-ship-global-bundle-if-no-global-tauri.md
@@ -1,0 +1,8 @@
+---
+tauri: 'patch:perf'
+tauri-build: 'patch:perf'
+tauri-plugin: 'patch:perf'
+tauri-utils: 'patch:perf'
+---
+
+Don't ship global `bundle.global.js` if `app > withGlobalTauri` is set to false

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ The list of Tauri's features includes, but is not limited to:
 
 Tauri currently supports development and distribution on the following platforms:
 
-| Platform          | Versions                                                                                                        |
-| :---------------- | :-------------------------------------------------------------------------------------------------------------- |
-| Windows           | 7 and above                                                                                                     |
-| macOS             | 10.15 and above                                                                                                 |
-| Linux             | webkit2gtk 4.0 for Tauri v1 (for example Ubuntu 18.04). webkit2gtk 4.1 for Tauri v2 (for example Ubuntu 22.04). |
-| iOS/iPadOS        | 9 and above                                                                                                     |
-| Android           | 7 and above (currently 8 and above)                                                                             |
+| Platform   | Versions                                                                                                        |
+| :--------- | :-------------------------------------------------------------------------------------------------------------- |
+| Windows    | 7 and above                                                                                                     |
+| macOS      | 10.15 and above                                                                                                 |
+| Linux      | webkit2gtk 4.0 for Tauri v1 (for example Ubuntu 18.04). webkit2gtk 4.1 for Tauri v2 (for example Ubuntu 22.04). |
+| iOS/iPadOS | 9 and above                                                                                                     |
+| Android    | 7 and above (currently 8 and above)                                                                             |
 
 ## Contributing
 

--- a/crates/tauri-build/src/acl.rs
+++ b/crates/tauri-build/src/acl.rs
@@ -432,8 +432,6 @@ pub fn build(out_dir: &Path, target: Target, attributes: &Attributes) -> super::
   let capabilities_path = save_capabilities(&capabilities)?;
   fs::copy(capabilities_path, out_dir.join(CAPABILITIES_FILE_NAME))?;
 
-  tauri_utils::plugin::save_global_api_scripts_paths(out_dir);
-
   let mut permissions_map = inline_plugins_acl.permission_files;
   if has_app_manifest {
     permissions_map.insert(APP_ACL_KEY.to_string(), app_acl.permission_files);

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -511,6 +511,8 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
 
   acl::build(&out_dir, target, &attributes)?;
 
+  tauri_utils::plugin::save_global_api_scripts_paths(&out_dir, None);
+
   println!("cargo:rustc-env=TAURI_ENV_TARGET_TRIPLE={target_triple}");
   // when running codegen in this build script, we need to access the env var directly
   env::set_var("TAURI_ENV_TARGET_TRIPLE", &target_triple);

--- a/crates/tauri-plugin/src/build/mod.rs
+++ b/crates/tauri-plugin/src/build/mod.rs
@@ -144,7 +144,7 @@ impl<'a> Builder<'a> {
     }
 
     if let Some(path) = self.global_api_script_path {
-      tauri_utils::plugin::define_global_api_script_path(path);
+      tauri_utils::plugin::define_global_api_script_path(&path);
     }
 
     mobile::setup(self.android_path, self.ios_path)?;

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -340,6 +340,8 @@ fn main() {
     .canonicalize()
     .expect("failed to canonicalize tauri global API script path");
   tauri_utils::plugin::define_global_api_script_path(&tauri_global_scripts);
+  // This should usually be done in `tauri-build`,
+  // but we need to do this here for the examples in this workspace to work as they don't have build scripts
   if is_tauri_workspace {
     tauri_utils::plugin::save_global_api_scripts_paths(&out_dir, Some(tauri_global_scripts));
   }

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -336,6 +336,14 @@ fn main() {
     }
   }
 
+  let tauri_global_scripts = PathBuf::from("./scripts/bundle.global.js")
+    .canonicalize()
+    .expect("failed to canonicalize tauri global API script path");
+  tauri_utils::plugin::define_global_api_script_path(&tauri_global_scripts);
+  if is_tauri_workspace {
+    tauri_utils::plugin::save_global_api_scripts_paths(&out_dir, Some(tauri_global_scripts));
+  }
+
   let permissions = define_permissions(&out_dir);
   tauri_utils::acl::build::generate_allowed_commands(&out_dir, permissions).unwrap();
 }

--- a/crates/tauri/scripts/init.js
+++ b/crates/tauri/scripts/init.js
@@ -12,6 +12,4 @@
   __RAW_core_script__
 
   __RAW_event_initialization_script__
-
-  __RAW_bundle_script__
 })()

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -122,7 +122,6 @@ impl<R: Runtime> WebviewManager<R> {
   ) -> crate::Result<PendingWebview<EventLoopMessage, R>> {
     let app_manager = manager.manager();
 
-    let is_init_global = app_manager.config.app.with_global_tauri;
     let plugin_init_scripts = app_manager
       .plugins
       .lock()
@@ -185,7 +184,6 @@ impl<R: Runtime> WebviewManager<R> {
           app_manager,
           &ipc_init.into_string(),
           &pattern_init.into_string(),
-          is_init_global,
           use_https_scheme,
         )?
         .to_string(),
@@ -346,7 +344,6 @@ impl<R: Runtime> WebviewManager<R> {
     app_manager: &AppManager<R>,
     ipc_script: &str,
     pattern_script: &str,
-    with_global_tauri: bool,
     use_https_scheme: bool,
   ) -> crate::Result<String> {
     #[derive(Template)]
@@ -356,8 +353,6 @@ impl<R: Runtime> WebviewManager<R> {
       pattern_script: &'a str,
       #[raw]
       ipc_script: &'a str,
-      #[raw]
-      bundle_script: &'a str,
       #[raw]
       core_script: &'a str,
       #[raw]
@@ -374,12 +369,6 @@ impl<R: Runtime> WebviewManager<R> {
       invoke_key: &'a str,
     }
 
-    let bundle_script = if with_global_tauri {
-      include_str!("../../scripts/bundle.global.js")
-    } else {
-      ""
-    };
-
     let freeze_prototype = if app_manager.config.app.security.freeze_prototype {
       include_str!("../../scripts/freeze_prototype.js")
     } else {
@@ -389,7 +378,6 @@ impl<R: Runtime> WebviewManager<R> {
     InitJavascript {
       pattern_script,
       ipc_script,
-      bundle_script,
       core_script: &CoreJavascript {
         os_name: std::env::consts::OS,
         protocol_scheme: if use_https_scheme { "https" } else { "http" },


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Another effort to reduce bloat, we're currently shipping `bundle.global.js` (~40KB currently) no matter if it's used or not, this PR changes it to use our existing code `plugin_global_api_scripts` for the core plugins as well

Reference: #12820