### PR TITLE
feat: add x11 feature flag to allow disabling x11 dependencies

### DIFF
--- a/.changes/x11-feature.md
+++ b/.changes/x11-feature.md
@@ -1,0 +1,6 @@
+---
+tauri: minor
+tauri-runtime-wry: minor
+---
+
+Added `x11` feature flag (enabled by default).

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -64,6 +64,8 @@ objc2-app-kit = { version = "0.3", features = [
 jni = "0.21"
 
 [features]
+default = ["x11"]
+x11 = ["wry/x11", "tao/x11"]
 devtools = ["wry/devtools", "tauri-runtime/devtools"]
 macos-private-api = [
   "wry/fullscreen",

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -62,7 +62,7 @@ tauri-macros = { version = "2.1.0", path = "../tauri-macros" }
 tauri-utils = { version = "2.3.0", features = [
   "resources",
 ], path = "../tauri-utils" }
-tauri-runtime-wry = { version = "2.5.0", path = "../tauri-runtime-wry", optional = true }
+tauri-runtime-wry = { version = "2.5.0", path = "../tauri-runtime-wry", optional = true, default-features = false}
 getrandom = "0.2"
 serde_repr = "0.1"
 http = "1"
@@ -174,7 +174,7 @@ objc2-web-kit = { version = "0.3", features = [
 ] }
 
 [features]
-default = ["wry", "compression", "common-controls-v6"]
+default = ["wry", "compression", "common-controls-v6", "x11"]
 unstable = ["tauri-runtime-wry/unstable"]
 common-controls-v6 = [
   "tray-icon?/common-controls-v6",
@@ -185,6 +185,7 @@ tracing = ["dep:tracing", "tauri-macros/tracing", "tauri-runtime-wry/tracing"]
 test = []
 compression = ["tauri-macros/compression", "tauri-utils/compression"]
 wry = ["webview2-com", "webkit2gtk", "tauri-runtime-wry"]
+x11 = ["tauri-runtime-wry?/x11"]
 # TODO: Remove in v3 - wry does not have this feature anymore
 objc-exception = []
 linux-libxdo = ["tray-icon/libxdo", "muda/libxdo"]


### PR DESCRIPTION
This allows me to reduce the number of dependencies and final binary size of my tauri app which is running on a wayland only kiosk.

Note that this is a draft for now as it depends on the following tao and wry PR to be released:
- https://github.com/tauri-apps/tao/pull/1103
- https://github.com/tauri-apps/wry/pull/1528