### PR TITLE
feat: expose api to run initialization scripts on all frames.

### DIFF
--- a/.changes/init-script-on-all-frames.md
+++ b/.changes/init-script-on-all-frames.md
@@ -1,0 +1,9 @@
+---
+tauri: minor
+tauri-runtime: minor
+---
+
+- Breaking API Additions:
+  - `WebviewBuilder::initialization_script` add `run_only_on_main_frame` parameter
+  - `WebviewWindowBuilder::initialization_script` add `run_only_on_main_frame` parameter
+- add API `WebviewAttributes::initialization_script_on_all_frames`

--- a/.changes/init-script-on-all-frames.md
+++ b/.changes/init-script-on-all-frames.md
@@ -3,7 +3,7 @@ tauri: minor:feat
 tauri-runtime: minor:feat
 ---
 
-- add API to run initialisation scripts on all frames
+- add API to run initialization scripts on all frames
   - `WebviewBuilder::initialization_script_on_all_frames`
   - `WebviewWindowBuilder::initialization_script_on_all_frames`
   - `WebviewAttributes::initialization_script_on_all_frames`

--- a/.changes/init-script-on-all-frames.md
+++ b/.changes/init-script-on-all-frames.md
@@ -1,6 +1,6 @@
 ---
-tauri: minor
-tauri-runtime: minor
+tauri: minor:feat
+tauri-runtime: minor:feat
 ---
 
 - add API to run initialisation scripts on all frames

--- a/.changes/init-script-on-all-frames.md
+++ b/.changes/init-script-on-all-frames.md
@@ -3,7 +3,7 @@ tauri: minor
 tauri-runtime: minor
 ---
 
-- Breaking API Additions:
-  - `WebviewBuilder::initialization_script` add `run_only_on_main_frame` parameter
-  - `WebviewWindowBuilder::initialization_script` add `run_only_on_main_frame` parameter
-- add API `WebviewAttributes::initialization_script_on_all_frames`
+- add API to run initialisation scripts on all frames
+  - `WebviewBuilder::initialization_script_on_all_frames`
+  - `WebviewWindowBuilder::initialization_script_on_all_frames`
+  - `WebviewAttributes::initialization_script_on_all_frames`

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4557,7 +4557,7 @@ fn create_webview<T: UserEvent>(
   ));
 
   for script in webview_attributes.initialization_scripts {
-    webview_builder = webview_builder.with_initialization_script(&script);
+    webview_builder = webview_builder.with_initialization_script_for_main_only(&script.0, script.1);
   }
 
   for (scheme, protocol) in uri_scheme_protocols {

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4557,7 +4557,8 @@ fn create_webview<T: UserEvent>(
   ));
 
   for script in webview_attributes.initialization_scripts {
-    webview_builder = webview_builder.with_initialization_script_for_main_only(&script.0, script.1);
+    webview_builder = webview_builder
+      .with_initialization_script_for_main_only(&script.script, script.for_main_frame_only);
   }
 
   for (scheme, protocol) in uri_scheme_protocols {

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -201,9 +201,6 @@ pub struct WebviewAttributes {
   /// When webview load a new page, this initialization code will be executed.
   /// It is guaranteed that code is executed before `window.onload`.
   ///
-  /// Second parameter represents if script should be added to main frame only or sub frames also.
-  /// `true` for main frame only, `false` for all frames including sub frames.
-  ///
   /// ## Platform-specific
   ///
   /// - **Android on Wry:** The Android WebView does not provide an API for initialization scripts,

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -208,7 +208,7 @@ pub struct WebviewAttributes {
   ///
   /// - **Android on Wry:** The Android WebView does not provide an API for initialization scripts,
   ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
-  pub initialization_scripts: Vec<(String, bool)>,
+  pub initialization_scripts: Vec<InitializationScript>,
   pub data_directory: Option<PathBuf>,
   pub drag_drop_handler_enabled: bool,
   pub clipboard: bool,
@@ -333,7 +333,10 @@ impl WebviewAttributes {
   ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
   #[must_use]
   pub fn initialization_script(mut self, script: &str) -> Self {
-    self.initialization_scripts.push((script.to_string(), true));
+    self.initialization_scripts.push(InitializationScript {
+      script: script.to_string(),
+      for_main_frame_only: true,
+    });
     self
   }
 
@@ -354,9 +357,10 @@ impl WebviewAttributes {
   ///   You can disable WebRTC this way, for example.
   #[must_use]
   pub fn initialization_script_on_all_frames(mut self, script: &str) -> Self {
-    self
-      .initialization_scripts
-      .push((script.to_string(), false));
+    self.initialization_scripts.push(InitializationScript {
+      script: script.to_string(),
+      for_main_frame_only: false,
+    });
     self
   }
 
@@ -545,3 +549,21 @@ impl WebviewAttributes {
 
 /// IPC handler.
 pub type WebviewIpcHandler<T, R> = Box<dyn Fn(DetachedWebview<T, R>, Request<String>) + Send>;
+
+/// An initialization script
+#[derive(Debug, Clone)]
+pub struct InitializationScript {
+  /// The script to run
+  pub script: String,
+  /// Whether the script should be injected to main frame only
+  pub for_main_frame_only: bool,
+}
+
+impl InitializationScript {
+  pub fn new(script: &str, for_main_frame_only: bool) -> Self {
+    Self {
+      script: script.to_owned(),
+      for_main_frame_only,
+    }
+  }
+}

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -197,7 +197,18 @@ impl<T: UserEvent, R: Runtime<T>> PartialEq for DetachedWebview<T, R> {
 pub struct WebviewAttributes {
   pub url: WebviewUrl,
   pub user_agent: Option<String>,
-  pub initialization_scripts: Vec<String>,
+  /// A list of initialization javascript scripts to run when loading new pages.
+  /// When webview load a new page, this initialization code will be executed.
+  /// It is guaranteed that code is executed before `window.onload`.
+  ///
+  /// Second parameter represents if script should be added to main frame only or sub frames also.
+  /// `true` for main frame only, `false` for all frames including sub frames.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android on Wry:** The Android WebView does not provide an API for initialization scripts,
+  ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
+  pub initialization_scripts: Vec<(String, bool)>,
   pub data_directory: Option<PathBuf>,
   pub drag_drop_handler_enabled: bool,
   pub clipboard: bool,
@@ -307,10 +318,45 @@ impl WebviewAttributes {
     self
   }
 
-  /// Sets the init script.
+  /// Adds an init script for the main frame.
+  ///
+  /// When webview load a new page, this initialization code will be executed.
+  /// It is guaranteed that code is executed before `window.onload`.
+  ///
+  /// This is executed only on the main frame.
+  /// If you only want to run it in all frames, use [Self::initialization_script_on_all_frames] instead.
+  ///
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android on Wry:** The Android WebView does not provide an API for initialization scripts,
+  ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
   #[must_use]
   pub fn initialization_script(mut self, script: &str) -> Self {
-    self.initialization_scripts.push(script.to_string());
+    self.initialization_scripts.push((script.to_string(), true));
+    self
+  }
+
+  /// Adds an init script for all frames.
+  ///
+  /// When webview load a new page, this initialization code will be executed.
+  /// It is guaranteed that code is executed before `window.onload`.
+  ///
+  /// This is executed on all frames, main frame and also sub frames.
+  /// If you only want to run it in the main frame, use [Self::initialization_script] instead.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android on Wry:** The Android WebView does not provide an API for initialization scripts,
+  ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
+  ///
+  /// - On **macOS** and **iOS** you can use this to overwrite browser apis to make them inacessible even in iframes.
+  ///   You can disable WebRTC this way, for example.
+  #[must_use]
+  pub fn initialization_script_on_all_frames(mut self, script: &str) -> Self {
+    self
+      .initialization_scripts
+      .push((script.to_string(), false));
     self
   }
 

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -352,9 +352,6 @@ impl WebviewAttributes {
   ///
   /// - **Android on Wry:** The Android WebView does not provide an API for initialization scripts,
   ///   so we prepend them to each HTML head. They are only implemented on custom protocol URLs.
-  ///
-  /// - On **macOS** and **iOS** you can use this to overwrite browser apis to make them inacessible even in iframes.
-  ///   You can disable WebRTC this way, for example.
   #[must_use]
   pub fn initialization_script_on_all_frames(mut self, script: &str) -> Self {
     self.initialization_scripts.push(InitializationScript {

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -211,9 +211,12 @@ impl<R: Runtime> WebviewManager<R> {
       }
     }
 
-    webview_attributes
-      .initialization_scripts
-      .splice(0..0, all_initialization_scripts);
+    webview_attributes.initialization_scripts.splice(
+      0..0,
+      all_initialization_scripts
+        .into_iter()
+        .map(|script| (script, true /* only run on main frame */)),
+    );
 
     pending.webview_attributes = webview_attributes;
 
@@ -527,13 +530,14 @@ impl<R: Runtime> WebviewManager<R> {
         os_name: &'a str,
       }
 
-      pending.webview_attributes.initialization_scripts.push(
+      pending.webview_attributes.initialization_scripts.push((
         HotkeyZoom {
           os_name: std::env::consts::OS,
         }
         .render_default(&Default::default())?
         .into_string(),
-      )
+        true,
+      ))
     }
 
     #[cfg(feature = "isolation")]

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -13,7 +13,7 @@ use std::{
 use serde::Serialize;
 use serialize_to_javascript::{default_template, DefaultTemplate, Template};
 use tauri_runtime::{
-  webview::{DetachedWebview, PendingWebview},
+  webview::{DetachedWebview, InitializationScript, PendingWebview},
   window::DragDropEvent,
 };
 use tauri_utils::config::WebviewUrl;
@@ -215,7 +215,10 @@ impl<R: Runtime> WebviewManager<R> {
       0..0,
       all_initialization_scripts
         .into_iter()
-        .map(|script| (script, true /* only run on main frame */)),
+        .map(|script| InitializationScript {
+          script,
+          for_main_frame_only: true,
+        }),
     );
 
     pending.webview_attributes = webview_attributes;
@@ -530,14 +533,17 @@ impl<R: Runtime> WebviewManager<R> {
         os_name: &'a str,
       }
 
-      pending.webview_attributes.initialization_scripts.push((
-        HotkeyZoom {
-          os_name: std::env::consts::OS,
-        }
-        .render_default(&Default::default())?
-        .into_string(),
-        true,
-      ))
+      pending
+        .webview_attributes
+        .initialization_scripts
+        .push(InitializationScript {
+          script: HotkeyZoom {
+            os_name: std::env::consts::OS,
+          }
+          .render_default(&Default::default())?
+          .into_string(),
+          for_main_frame_only: true,
+        })
     }
 
     #[cfg(feature = "isolation")]

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -634,8 +634,11 @@ impl<R: Runtime> WebviewBuilder<R> {
   /// Adds the provided JavaScript to a list of scripts that should be run after the global object has been created,
   /// but before the HTML document has been parsed and before any other script included by the HTML document is run.
   ///
-  /// Since it runs on all top-level document navigastions (and also child frame page navigations, if you set `run_only_on_main_frame` to false),
+  /// Since it runs on all top-level document navigations,
   /// it's recommended to check the `window.location` to guard your script from running on unexpected origins.
+  ///
+  /// This is executed only on the main frame.
+  /// If you only want to run it in all frames, use [Self::initialization_script_for_all_frames] instead.
   ///
   /// # Examples
   ///
@@ -658,7 +661,7 @@ fn main() {
     .setup(|app| {
       let window = tauri::window::WindowBuilder::new(app, "label").build()?;
       let webview_builder = tauri::webview::WebviewBuilder::new("label", tauri::WebviewUrl::App("index.html".into()))
-        .initialization_script(INIT_SCRIPT, true);
+        .initialization_script(INIT_SCRIPT);
       let webview = window.add_child(webview_builder, tauri::LogicalPosition::new(0, 0), window.inner_size().unwrap())?;
       Ok(())
     });
@@ -667,11 +670,58 @@ fn main() {
   "####
   )]
   #[must_use]
-  pub fn initialization_script(mut self, script: &str, run_only_on_main_frame: bool) -> Self {
+  pub fn initialization_script(mut self, script: &str) -> Self {
     self
       .webview_attributes
       .initialization_scripts
-      .push((script.to_string(), run_only_on_main_frame));
+      .push((script.to_string(), true));
+    self
+  }
+
+  /// Adds the provided JavaScript to a list of scripts that should be run after the global object has been created,
+  /// but before the HTML document has been parsed and before any other script included by the HTML document is run.
+  ///
+  /// Since it runs on all top-level document navigations and also child frame page navigations,
+  /// it's recommended to check the `window.location` to guard your script from running on unexpected origins.
+  ///
+  /// This is executed on all frames, main frame and also sub frames.
+  /// If you only want to run it in the main frame, use [Self::initialization_script] instead.
+  ///
+  /// # Examples
+  ///
+  #[cfg_attr(
+    feature = "unstable",
+    doc = r####"
+```rust
+use tauri::{WindowBuilder, Runtime};
+
+const INIT_SCRIPT: &str = r#"
+  if (window.location.origin === 'https://tauri.app') {
+    console.log("hello world from js init script");
+
+    window.__MY_CUSTOM_PROPERTY__ = { foo: 'bar' };
+  }
+"#;
+
+fn main() {
+  tauri::Builder::default()
+    .setup(|app| {
+      let window = tauri::window::WindowBuilder::new(app, "label").build()?;
+      let webview_builder = tauri::webview::WebviewBuilder::new("label", tauri::WebviewUrl::App("index.html".into()))
+        .initialization_script_for_all_frames(INIT_SCRIPT);
+      let webview = window.add_child(webview_builder, tauri::LogicalPosition::new(0, 0), window.inner_size().unwrap())?;
+      Ok(())
+    });
+}
+```
+  "####
+  )]
+  #[must_use]
+  pub fn initialization_script_for_all_frames(mut self, script: &str) -> Self {
+    self
+      .webview_attributes
+      .initialization_scripts
+      .push((script.to_string(), false));
     self
   }
 

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -634,7 +634,7 @@ impl<R: Runtime> WebviewBuilder<R> {
   /// Adds the provided JavaScript to a list of scripts that should be run after the global object has been created,
   /// but before the HTML document has been parsed and before any other script included by the HTML document is run.
   ///
-  /// Since it runs on all top-level document and child frame page navigations,
+  /// Since it runs on all top-level document navigastions (and also child frame page navigations, if you set `run_only_on_main_frame` to false),
   /// it's recommended to check the `window.location` to guard your script from running on unexpected origins.
   ///
   /// # Examples
@@ -658,7 +658,7 @@ fn main() {
     .setup(|app| {
       let window = tauri::window::WindowBuilder::new(app, "label").build()?;
       let webview_builder = tauri::webview::WebviewBuilder::new("label", tauri::WebviewUrl::App("index.html".into()))
-        .initialization_script(INIT_SCRIPT);
+        .initialization_script(INIT_SCRIPT, true);
       let webview = window.add_child(webview_builder, tauri::LogicalPosition::new(0, 0), window.inner_size().unwrap())?;
       Ok(())
     });
@@ -667,11 +667,11 @@ fn main() {
   "####
   )]
   #[must_use]
-  pub fn initialization_script(mut self, script: &str) -> Self {
+  pub fn initialization_script(mut self, script: &str, run_only_on_main_frame: bool) -> Self {
     self
       .webview_attributes
       .initialization_scripts
-      .push(script.to_string());
+      .push((script.to_string(), run_only_on_main_frame));
     self
   }
 

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -20,7 +20,7 @@ use tauri_runtime::{
   WindowDispatch,
 };
 use tauri_runtime::{
-  webview::{DetachedWebview, PendingWebview, WebviewAttributes},
+  webview::{DetachedWebview, InitializationScript, PendingWebview, WebviewAttributes},
   WebviewDispatch,
 };
 pub use tauri_utils::config::Color;
@@ -674,7 +674,10 @@ fn main() {
     self
       .webview_attributes
       .initialization_scripts
-      .push((script.to_string(), true));
+      .push(InitializationScript {
+        script: script.to_string(),
+        for_main_frame_only: true,
+      });
     self
   }
 
@@ -721,7 +724,10 @@ fn main() {
     self
       .webview_attributes
       .initialization_scripts
-      .push((script.to_string(), false));
+      .push(InitializationScript {
+        script: script.to_string(),
+        for_main_frame_only: false,
+      });
     self
   }
 

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -765,7 +765,7 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   /// Adds the provided JavaScript to a list of scripts that should be run after the global object has been created,
   /// but before the HTML document has been parsed and before any other script included by the HTML document is run.
   ///
-  /// Since it runs on all top-level document and child frame page navigations,
+  /// Since it runs on all top-level document navigastions (and also child frame page navigations, if you set `run_only_on_main_frame` to false),
   /// it's recommended to check the `window.location` to guard your script from running on unexpected origins.
   ///
   /// # Examples
@@ -785,15 +785,17 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   ///   tauri::Builder::default()
   ///     .setup(|app| {
   ///       let webview = tauri::WebviewWindowBuilder::new(app, "label", tauri::WebviewUrl::App("index.html".into()))
-  ///         .initialization_script(INIT_SCRIPT)
+  ///         .initialization_script(INIT_SCRIPT, true)
   ///         .build()?;
   ///       Ok(())
   ///     });
   /// }
   /// ```
   #[must_use]
-  pub fn initialization_script(mut self, script: &str) -> Self {
-    self.webview_builder = self.webview_builder.initialization_script(script);
+  pub fn initialization_script(mut self, script: &str, run_only_on_main_frame: bool) -> Self {
+    self.webview_builder = self
+      .webview_builder
+      .initialization_script(script, run_only_on_main_frame);
     self
   }
 

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -768,6 +768,9 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   /// Since it runs on all top-level document navigastions (and also child frame page navigations, if you set `run_only_on_main_frame` to false),
   /// it's recommended to check the `window.location` to guard your script from running on unexpected origins.
   ///
+  /// This is executed only on the main frame.
+  /// If you only want to run it in all frames, use [Self::initialization_script_for_all_frames] instead.
+  ///
   /// # Examples
   ///
   /// ```rust
@@ -785,17 +788,54 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   ///   tauri::Builder::default()
   ///     .setup(|app| {
   ///       let webview = tauri::WebviewWindowBuilder::new(app, "label", tauri::WebviewUrl::App("index.html".into()))
-  ///         .initialization_script(INIT_SCRIPT, true)
+  ///         .initialization_script(INIT_SCRIPT)
   ///         .build()?;
   ///       Ok(())
   ///     });
   /// }
   /// ```
   #[must_use]
-  pub fn initialization_script(mut self, script: &str, run_only_on_main_frame: bool) -> Self {
+  pub fn initialization_script(mut self, script: &str) -> Self {
+    self.webview_builder = self.webview_builder.initialization_script(script);
+    self
+  }
+
+  /// Adds the provided JavaScript to a list of scripts that should be run after the global object has been created,
+  /// but before the HTML document has been parsed and before any other script included by the HTML document is run.
+  ///
+  /// Since it runs on all top-level document navigastions (and also child frame page navigations, if you set `run_only_on_main_frame` to false),
+  /// it's recommended to check the `window.location` to guard your script from running on unexpected origins.
+  ///
+  /// This is executed on all frames, main frame and also sub frames.
+  /// If you only want to run it in the main frame, use [Self::initialization_script] instead.
+  /// # Examples
+  ///
+  /// ```rust
+  /// use tauri::{WebviewWindowBuilder, Runtime};
+  ///
+  /// const INIT_SCRIPT: &str = r#"
+  ///   if (window.location.origin === 'https://tauri.app') {
+  ///     console.log("hello world from js init script");
+  ///
+  ///     window.__MY_CUSTOM_PROPERTY__ = { foo: 'bar' };
+  ///   }
+  /// "#;
+  ///
+  /// fn main() {
+  ///   tauri::Builder::default()
+  ///     .setup(|app| {
+  ///       let webview = tauri::WebviewWindowBuilder::new(app, "label", tauri::WebviewUrl::App("index.html".into()))
+  ///         .initialization_script_for_all_frames(INIT_SCRIPT)
+  ///         .build()?;
+  ///       Ok(())
+  ///     });
+  /// }
+  /// ```
+  #[must_use]
+  pub fn initialization_script_for_all_frames(mut self, script: &str) -> Self {
     self.webview_builder = self
       .webview_builder
-      .initialization_script(script, run_only_on_main_frame);
+      .initialization_script_for_all_frames(script);
     self
   }
 

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -765,7 +765,7 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   /// Adds the provided JavaScript to a list of scripts that should be run after the global object has been created,
   /// but before the HTML document has been parsed and before any other script included by the HTML document is run.
   ///
-  /// Since it runs on all top-level document navigastions (and also child frame page navigations, if you set `run_only_on_main_frame` to false),
+  /// Since it runs on all top-level document navigations (and also child frame page navigations, if you set `run_only_on_main_frame` to false),
   /// it's recommended to check the `window.location` to guard your script from running on unexpected origins.
   ///
   /// This is executed only on the main frame.

--- a/examples/file-associations/src-tauri/src/main.rs
+++ b/examples/file-associations/src-tauri/src/main.rs
@@ -42,7 +42,7 @@ fn handle_file_associations(app: AppHandle, files: Vec<PathBuf>) {
     .join(",");
 
   tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
-    .initialization_script(&format!("window.openedFiles = [{files}]"))
+    .initialization_script(&format!("window.openedFiles = [{files}]"), true)
     .build()
     .unwrap();
 }

--- a/examples/file-associations/src-tauri/src/main.rs
+++ b/examples/file-associations/src-tauri/src/main.rs
@@ -42,7 +42,7 @@ fn handle_file_associations(app: AppHandle, files: Vec<PathBuf>) {
     .join(",");
 
   tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
-    .initialization_script(&format!("window.openedFiles = [{files}]"), true)
+    .initialization_script(&format!("window.openedFiles = [{files}]"))
     .build()
     .unwrap();
 }


### PR DESCRIPTION
I need this to disable webrtc in all frames.
```js
try {
window.RTCPeerConnection = ()=>{};
RTCPeerConnection = ()=>{};
} catch (e){console.error("failed to overwrite RTCPeerConnection apis",e)}
try {
    window.webkitRTCPeerConnection = ()=>{};
    webkitRTCPeerConnection = ()=>{};
} catch (e){}
```

Currently the init script only runs on the main script despite the documentation telling otherwise:
```rs
/// Since it runs on all top-level document navigastions (and also child frame page navigations
/// ...
pub fn initialization_script(mut self, script: &str) -> Self {
```
~~This pr exposes the argument (`run_only_on_main_frame`) whether to run in all frames or only on the main frame.~~

- add API to run initialisation scripts on all frames
  - `WebviewBuilder::initialization_script_on_all_frames`
  - `WebviewWindowBuilder::initialization_script_on_all_frames`
  - `WebviewAttributes::initialization_script_on_all_frames`

### Progress

- [x] If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
- [x] Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- [x] Ensure `cargo test` and `cargo clippy` passes.
