### PR TITLE
feat(cli): allow for toml files in --config arg, closes #7859

### DIFF
--- a/.changes/toml-json5-configs-in-cli.md
+++ b/.changes/toml-json5-configs-in-cli.md
@@ -1,0 +1,6 @@
+---
+tauri-cli: minor:enhance
+"@tauri-apps/cli": minor:enhance
+---
+
+Add support for passing TOML and JSON5 config files to `--config` arg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8537,6 +8537,7 @@ dependencies = [
  "insta",
  "itertools 0.13.0",
  "json-patch 3.0.1",
+ "json5",
  "jsonrpsee",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -51,6 +51,7 @@ tauri-bundler = { version = "2.3.0", default-features = false, path = "../tauri-
 colored = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+json5 = "0.4"
 notify = "8"
 notify-debouncer-full = "0.5"
 shared_child = "1"

--- a/crates/tauri-cli/src/build.rs
+++ b/crates/tauri-cli/src/build.rs
@@ -45,7 +45,7 @@ pub struct Options {
   /// Skip the bundling step even if `bundle > active` is `true` in tauri config.
   #[clap(long)]
   pub no_bundle: bool,
-  /// JSON strings or path to JSON files to merge with the default configuration file
+  /// JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
   ///
   /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
   ///

--- a/crates/tauri-cli/src/bundle.rs
+++ b/crates/tauri-cli/src/bundle.rs
@@ -60,7 +60,7 @@ pub struct Options {
   /// Space or comma separated list of bundles to package.
   #[clap(short, long, action = ArgAction::Append, num_args(0..), value_delimiter = ',')]
   pub bundles: Option<Vec<BundleFormat>>,
-  /// JSON strings or path to JSON files to merge with the default configuration file
+  /// JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
   ///
   /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
   ///

--- a/crates/tauri-cli/src/dev.rs
+++ b/crates/tauri-cli/src/dev.rs
@@ -59,7 +59,7 @@ pub struct Options {
   /// Exit on panic
   #[clap(short, long)]
   pub exit_on_panic: bool,
-  /// JSON strings or path to JSON files to merge with the default configuration file
+  /// JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
   ///
   /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
   ///

--- a/crates/tauri-cli/src/mobile/android/build.rs
+++ b/crates/tauri-cli/src/mobile/android/build.rs
@@ -49,7 +49,7 @@ pub struct Options {
   /// List of cargo features to activate
   #[clap(short, long, action = ArgAction::Append, num_args(0..))]
   pub features: Option<Vec<String>>,
-  /// JSON strings or path to JSON files to merge with the default configuration file
+  /// JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
   ///
   /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
   ///

--- a/crates/tauri-cli/src/mobile/android/dev.rs
+++ b/crates/tauri-cli/src/mobile/android/dev.rs
@@ -48,7 +48,7 @@ pub struct Options {
   /// Exit on panic
   #[clap(short, long)]
   exit_on_panic: bool,
-  /// JSON strings or path to JSON files to merge with the default configuration file
+  /// JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
   ///
   /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
   ///

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -60,7 +60,7 @@ pub struct Options {
   /// List of cargo features to activate
   #[clap(short, long, action = ArgAction::Append, num_args(0..))]
   pub features: Option<Vec<String>>,
-  /// JSON strings or path to JSON files to merge with the default configuration file
+  /// JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
   ///
   /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
   ///

--- a/crates/tauri-cli/src/mobile/ios/dev.rs
+++ b/crates/tauri-cli/src/mobile/ios/dev.rs
@@ -54,7 +54,7 @@ pub struct Options {
   /// Exit on panic
   #[clap(short, long)]
   exit_on_panic: bool,
-  /// JSON strings or path to JSON files to merge with the default configuration file
+  /// JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
   ///
   /// Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
   ///


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
closes #7859 
## Why
1. can already use toml for the base config, just bringing parity to the --config feat
2. pretty small change

## Tests
- [x] `cargo test`
- [x] `cargo clippy`