### PR TITLE
fix(cli): `tauri info` can't find the latest version for rust crates

### DIFF
--- a/.changes/fix-tauri-info-crate-latest-version.md
+++ b/.changes/fix-tauri-info-crate-latest-version.md
@@ -1,0 +1,5 @@
+---
+"tauri-cli": patch:bug
+---
+
+Fix `tauri info` can't find the latest version for rust crates

--- a/.changes/fix-tauri-info-request-log-level.md
+++ b/.changes/fix-tauri-info-request-log-level.md
@@ -1,0 +1,5 @@
+---
+"tauri-cli": patch:bug
+---
+
+Fix `tauri info` logging network operations in `info` level instead of `debug`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4305,7 +4305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5792,7 +5792,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -9654,9 +9654,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6a209bb4b8d5903579fc4f8cd12ce5594f1ed6b735bf290ab5e2bdb3e70013"
+checksum = "217751151c53226090391713e533d9a5e904ba2570dabaaace29032687589c3e"
 dependencies = [
  "base64 0.22.1",
  "cc",
@@ -10177,7 +10177,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/tauri-cli/src/info/packages_rust.rs
+++ b/crates/tauri-cli/src/info/packages_rust.rs
@@ -45,20 +45,22 @@ pub fn items(frontend_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<Se
       .ok()
       .map(|o| {
         if o.status.success() {
-          let out = String::from_utf8_lossy(o.stdout.as_slice());
+          let out = dbg!(String::from_utf8_lossy(o.stdout.as_slice()));
           let (package, version) = out.split_once(' ').unwrap_or_default();
-          let latest_ver = crate_latest_version(package).unwrap_or_default();
+          let version = version.split_once('\n').unwrap_or_default().0;
+          let latest_version = crate_latest_version(package).unwrap_or_default();
           format!(
-            "{} {}: {}{}",
-            package,
-            "🦀",
-            version.split_once('\n').unwrap_or_default().0,
-            if !(version.is_empty() || latest_ver.is_empty()) {
-              let version = semver::Version::parse(version).unwrap();
-              let target_version = semver::Version::parse(latest_ver.as_str()).unwrap();
+            "{package} 🦀: {version}{}",
+            if !(version.is_empty() || latest_version.is_empty()) {
+              let current_version = semver::Version::parse(version).unwrap();
+              let target_version = semver::Version::parse(latest_version.as_str()).unwrap();
 
-              if version < target_version {
-                format!(" ({}, latest: {})", "outdated".yellow(), latest_ver.green())
+              if current_version < target_version {
+                format!(
+                  " ({}, latest: {})",
+                  "outdated".yellow(),
+                  latest_version.green()
+                )
               } else {
                 "".into()
               }

--- a/crates/tauri-cli/src/info/packages_rust.rs
+++ b/crates/tauri-cli/src/info/packages_rust.rs
@@ -45,7 +45,7 @@ pub fn items(frontend_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<Se
       .ok()
       .map(|o| {
         if o.status.success() {
-          let out = dbg!(String::from_utf8_lossy(o.stdout.as_slice()));
+          let out = String::from_utf8_lossy(o.stdout.as_slice());
           let (package, version) = out.split_once(' ').unwrap_or_default();
           let version = version.split_once('\n').unwrap_or_default().0;
           let latest_version = crate_latest_version(package).unwrap_or_default();

--- a/crates/tauri-cli/src/info/packages_rust.rs
+++ b/crates/tauri-cli/src/info/packages_rust.rs
@@ -47,7 +47,7 @@ pub fn items(frontend_dir: Option<&PathBuf>, tauri_dir: Option<&Path>) -> Vec<Se
         if o.status.success() {
           let out = String::from_utf8_lossy(o.stdout.as_slice());
           let (package, version) = out.split_once(' ').unwrap_or_default();
-          let version = version.split_once('\n').unwrap_or_default().0;
+          let version = version.strip_suffix('\n').unwrap_or(version);
           let latest_version = crate_latest_version(package).unwrap_or_default();
           format!(
             "{package} 🦀: {version}{}",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Also fixes the wrong log level from ureq by updating it