### PR TITLE
fix(nsis): can't include resources with `$`

### DIFF
--- a/.changes/escape-nsis-resource-sidecar.md
+++ b/.changes/escape-nsis-resource-sidecar.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: patch:bug
+---
+
+Fix NSIS bundler can't include resources and sidecars with `$` in the path

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -630,12 +630,12 @@ Section Install
     CreateDirectory "$INSTDIR\\{{this}}"
   {{/each}}
   {{#each resources}}
-    File /a "/oname={{this.[1]}}" "{{@key}}"
+    File /a "/oname={{this.[1]}}" "{{no-escape @key}}"
   {{/each}}
 
   ; Copy external binaries
   {{#each binaries}}
-    File /a "/oname={{this}}" "{{@key}}"
+    File /a "/oname={{this}}" "{{no-escape @key}}"
   {{/each}}
 
   ; Create file associations

--- a/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
@@ -467,6 +467,7 @@ fn build_nsis_app_installer(
   let mut handlebars = Handlebars::new();
   handlebars.register_helper("or", Box::new(handlebars_or));
   handlebars.register_helper("association-description", Box::new(association_description));
+  handlebars.register_helper("no-escape", Box::new(handlebars_no_escape));
   handlebars.register_escape_fn(|s| {
     let mut output = String::new();
     for c in s.chars() {
@@ -592,6 +593,24 @@ fn association_description(
   } else {
     description
   })?;
+  Ok(())
+}
+
+fn handlebars_no_escape(
+  h: &handlebars::Helper<'_>,
+  _: &Handlebars<'_>,
+  _: &handlebars::Context,
+  _: &mut handlebars::RenderContext<'_, '_>,
+  out: &mut dyn handlebars::Output,
+) -> handlebars::HelperResult {
+  // get parameter from helper or throw an error
+  let param = h
+    .param(0)
+    .ok_or(handlebars::RenderErrorReason::ParamNotFoundForIndex(
+      "no-escape",
+      0,
+    ))?;
+  write!(out, "{}", param.render())?;
   Ok(())
 }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix #9657

`File` seems to be a special case where it doesn't allow escaping the file path to be bundled

> https://nsis-dev.github.io/NSIS-Forums/html/t-197115.html