### PR TITLE
ci: remove redundant corepack enable

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -34,9 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -44,9 +44,7 @@ jobs:
     if: needs.changes.outputs.api == 'true'
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -23,9 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -75,9 +73,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,9 +66,7 @@ jobs:
         with:
           targets: ${{ matrix.target.name }}
 
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -26,9 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -19,9 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
@@ -33,9 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'

--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -49,7 +49,6 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |
               npm i -g --force corepack
-              corepack enable
               cd packages/cli
               pnpm build --target x86_64-unknown-linux-gnu
               strip *.node
@@ -70,7 +69,6 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             build: |
               npm i -g --force corepack
-              corepack enable
               cd packages/cli
               pnpm build --target aarch64-unknown-linux-gnu
               aarch64-unknown-linux-gnu-strip *.node
@@ -105,9 +103,7 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: Setup node
         uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
@@ -217,9 +213,7 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -250,9 +244,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -289,9 +281,7 @@ jobs:
       image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -382,9 +372,7 @@ jobs:
       id-token: write # npm provenance
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -42,9 +42,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.1
 
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-cli-js.yml
+++ b/.github/workflows/test-cli-js.yml
@@ -38,9 +38,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - run: |
-          npm i -g --force corepack
-          corepack enable
+      - run: npm i -g --force corepack
       - name: setup node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
The command `corepack enable` is not required to be run after globally installing corepack