### PR TITLE
feat(cli): enhance iOS bundle version formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-mobile2"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9faa9fae5ccf60d68e6b766293be17bbce2de0aece38886f2eb1ac8da8718942"
+checksum = "24b5acda005352ad50a3e58c8777781732d6ac1e8a82ab90d5ffd70b69c665f1"
 dependencies = [
  "colored",
  "core-foundation 0.10.0",
@@ -1355,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2347,7 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5792,7 +5792,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -6372,7 +6372,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7057,7 +7057,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8917,7 +8917,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix 0.38.43",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10178,7 +10178,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -36,7 +36,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
-cargo-mobile2 = { version = "0.18", default-features = false }
+cargo-mobile2 = { version = "0.19", default-features = false }
 
 [dependencies]
 jsonrpsee = { version = "0.24", features = ["server"] }

--- a/crates/tauri-cli/src/helpers/mod.rs
+++ b/crates/tauri-cli/src/helpers/mod.rs
@@ -119,3 +119,22 @@ pub fn run_hook(
 
   Ok(())
 }
+
+pub fn strip_semver_prerelease_tag(version: &mut semver::Version) -> crate::Result<()> {
+  if !version.pre.is_empty() {
+    if let Some((_prerelease_tag, number)) = version.pre.as_str().to_string().split_once('.') {
+      version.pre = semver::Prerelease::EMPTY;
+      version.build = semver::BuildMetadata::new(&format!(
+        "{prefix}{number}",
+        prefix = if version.build.is_empty() {
+          "".to_string()
+        } else {
+          format!(".{}", version.build.as_str())
+        }
+      ))
+      .with_context(|| format!("bundle version {number:?} prerelease is invalid"))?;
+    }
+  }
+
+  Ok(())
+}

--- a/crates/tauri-cli/src/helpers/mod.rs
+++ b/crates/tauri-cli/src/helpers/mod.rs
@@ -120,6 +120,7 @@ pub fn run_hook(
   Ok(())
 }
 
+#[cfg(target_os = "macos")]
 pub fn strip_semver_prerelease_tag(version: &mut semver::Version) -> crate::Result<()> {
   if !version.pre.is_empty() {
     if let Some((_prerelease_tag, number)) = version.pre.as_str().to_string().split_once('.') {


### PR DESCRIPTION
follow-up for #13030 and https://github.com/tauri-apps/cargo-mobile2/pull/450

the bundle version validation has been updated, now it can actually handle one or two integers (e.g. `100` or `10.7`) instead of just full triple semver strings (e.g. `10.7.1`).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
