### PR TITLE
fix: using center and prevent overflow together crashes

### DIFF
--- a/crates/tauri-runtime-wry/src/window/mod.rs
+++ b/crates/tauri-runtime-wry/src/window/mod.rs
@@ -77,7 +77,7 @@ pub fn calculate_window_center_position(
   }
 
   tao::dpi::PhysicalPosition::new(
-    (monitor_size.width - window_size.width) as i32 / 2 + monitor_position.x,
-    (monitor_size.height - window_size.height) as i32 / 2 + monitor_position.y,
+    (monitor_size.width as i32 - window_size.width as i32) / 2 + monitor_position.x,
+    (monitor_size.height as i32 - window_size.height as i32) / 2 + monitor_position.y,
   )
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix a regression from #9687, appearently I shouldn't have combined the `as i32` to after the subtraction