### PR TITLE
feat(core): add capability `devOnly` field

### DIFF
--- a/.changes/capability-dev-only.md
+++ b/.changes/capability-dev-only.md
@@ -1,0 +1,7 @@
+---
+"tauri-utils": minor:feat
+"tauri-codegen": minor:feat
+"tauri": minor:feat
+---
+
+Added `devOnly` option to the capability that lets you define a capability only for development - for instance to allow local APIs in scopes.

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -1409,6 +1409,10 @@
           "items": {
             "$ref": "#/definitions/Target"
           }
+        },
+        "devOnly": {
+          "description": "Whether this capability is only applied on dev or not.",
+          "type": "boolean"
         }
       }
     },

--- a/crates/tauri-cli/src/acl/capability/new.rs
+++ b/crates/tauri-cli/src/acl/capability/new.rs
@@ -103,6 +103,7 @@ pub fn command(options: Options) -> Result<()> {
       })
       .collect(),
     platforms: None,
+    dev_only: false,
   };
 
   let path = match options.out {

--- a/crates/tauri-cli/src/migrate/migrations/v1/config.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v1/config.rs
@@ -46,6 +46,7 @@ pub fn migrate(tauri_dir: &Path) -> Result<MigratedConfig> {
         webviews: vec![],
         permissions,
         platforms: None,
+        dev_only: false,
       })?,
     )?;
 

--- a/crates/tauri-codegen/src/context.rs
+++ b/crates/tauri-codegen/src/context.rs
@@ -398,7 +398,10 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
     Some(&capabilities_file_path),
     additional_capabilities.as_deref(),
   )
-  .unwrap();
+  .unwrap()
+  .into_iter()
+  .filter(|(_key, capability)| !capability.dev_only || dev)
+  .collect();
 
   let resolved = Resolved::resolve(&acl, capabilities, target).expect("failed to resolve ACL");
 

--- a/crates/tauri-schema-generator/schemas/capability.schema.json
+++ b/crates/tauri-schema-generator/schemas/capability.schema.json
@@ -64,6 +64,10 @@
       "items": {
         "$ref": "#/definitions/Target"
       }
+    },
+    "devOnly": {
+      "description": "Whether this capability is only applied on dev or not.",
+      "type": "boolean"
     }
   },
   "definitions": {

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -1409,6 +1409,10 @@
           "items": {
             "$ref": "#/definitions/Target"
           }
+        },
+        "devOnly": {
+          "description": "Whether this capability is only applied on dev or not.",
+          "type": "boolean"
         }
       }
     },

--- a/crates/tauri-utils/src/acl/capability.rs
+++ b/crates/tauri-utils/src/acl/capability.rs
@@ -202,6 +202,18 @@ pub struct Capability {
   /// `["macOS","windows"]`
   #[serde(skip_serializing_if = "Option::is_none")]
   pub platforms: Option<Vec<Target>>,
+  /// Whether this capability is only applied on dev or not.
+  #[serde(
+    default,
+    skip_serializing_if = "is_false",
+    rename = "devOnly",
+    alias = "dev-only"
+  )]
+  pub dev_only: bool,
+}
+
+fn is_false(f: &bool) -> bool {
+  !f
 }
 
 impl Capability {
@@ -431,6 +443,7 @@ mod tests {
       webviews: vec![],
       permissions: vec![],
       platforms: None,
+      dev_only: false,
     };
     let capability_json = serde_json::to_string(&capability).unwrap();
 

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -95,6 +95,7 @@ impl CapabilityBuilder {
       webviews: Vec::new(),
       permissions: Vec::new(),
       platforms: None,
+      dev_only: false,
     })
   }
 


### PR DESCRIPTION
a dev environment might need particular scope configurations (such as allowing a localhost API). This change allows marking a whole capability file as "dev only"

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
