### PR TITLE
fix(core): raw channel message type regression

### DIFF
--- a/.changes/fix-channel-raw-message-type.md
+++ b/.changes/fix-channel-raw-message-type.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+Fix a regression that made the raw type messages received from `Channel.onmessage` became `number[]` instead of `ArrayBuffer`

--- a/.changes/fix-channel-raw-message-type.md
+++ b/.changes/fix-channel-raw-message-type.md
@@ -2,4 +2,4 @@
 tauri: patch:bug
 ---
 
-Fix a regression that made the raw type messages received from `Channel.onmessage` became `number[]` instead of `ArrayBuffer`
+Fix a regression that made the raw type messages received from `Channel.onmessage` became `number[]` instead of `ArrayBuffer` when that message is small

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -154,9 +154,9 @@ impl JavaScriptChannelId {
             ))?;
           }
           InvokeResponseBody::Raw(bytes) if bytes.len() < MAX_RAW_DIRECT_EXECUTE_THRESHOLD => {
-            let formated_bytes = serde_json::to_string(&bytes)?;
+            let bytes_as_json_array = serde_json::to_string(&bytes)?;
             webview.eval(format!(
-              "window['_{callback_id}']({{ message: new Uint8Array({formated_bytes}).buffer, index: {current_index} }})",
+              "window['_{callback_id}']({{ message: new Uint8Array({bytes_as_json_array}).buffer, index: {current_index} }})",
             ))?;
           }
           // use the fetch API to speed up larger response payloads
@@ -246,9 +246,9 @@ impl<TSend> Channel<TSend> {
             webview.eval(format!("window['_{callback_id}']({string})"))?;
           }
           InvokeResponseBody::Raw(bytes) if bytes.len() < MAX_RAW_DIRECT_EXECUTE_THRESHOLD => {
-            let formated_bytes = serde_json::to_string(&bytes)?;
+            let bytes_as_json_array = serde_json::to_string(&bytes)?;
             webview.eval(format!(
-              "window['_{callback_id}'](new Uint8Array({formated_bytes}).buffer)",
+              "window['_{callback_id}'](new Uint8Array({bytes_as_json_array}).buffer)",
             ))?;
           }
           // use the fetch API to speed up larger response payloads

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -154,9 +154,9 @@ impl JavaScriptChannelId {
             ))?;
           }
           InvokeResponseBody::Raw(bytes) if bytes.len() < MAX_RAW_DIRECT_EXECUTE_THRESHOLD => {
+            let formated_bytes = serde_json::to_string(&bytes)?;
             webview.eval(format!(
-              "window['_{callback_id}']({{ message: {}, index: {current_index} }})",
-              serde_json::to_string(&bytes)?,
+              "window['_{callback_id}']({{ message: new Uint8Array({formated_bytes}).buffer, index: {current_index} }})",
             ))?;
           }
           // use the fetch API to speed up larger response payloads
@@ -246,9 +246,9 @@ impl<TSend> Channel<TSend> {
             webview.eval(format!("window['_{callback_id}']({string})"))?;
           }
           InvokeResponseBody::Raw(bytes) if bytes.len() < MAX_RAW_DIRECT_EXECUTE_THRESHOLD => {
+            let formated_bytes = serde_json::to_string(&bytes)?;
             webview.eval(format!(
-              "window['_{callback_id}']({})",
-              serde_json::to_string(&bytes)?,
+              "window['_{callback_id}'](new Uint8Array({formated_bytes}).buffer)",
             ))?;
           }
           // use the fetch API to speed up larger response payloads


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix https://github.com/tauri-apps/tauri/pull/13136#discussion_r2051756480

Fix a regression introduced in #13138 that made the raw type messages received from `Channel.onmessage` became `number[]` instead of `ArrayBuffer` when that message is small