### PR TITLE
docs: update example for webview ts api

### DIFF
--- a/packages/api/src/webview.ts
+++ b/packages/api/src/webview.ts
@@ -108,11 +108,23 @@ export type WebviewLabel = string
  *
  * // loading embedded asset:
  * const webview = new Webview(appWindow, 'theUniqueLabel', {
- *   url: 'path/to/page.html'
+ *   url: 'path/to/page.html',
+ *
+ *   // create a webview with specific logical position and size
+ *   x: 0,
+ *   y: 0,
+ *   width: 800,
+ *   height: 600,
  * });
  * // alternatively, load a remote URL:
  * const webview = new Webview(appWindow, 'theUniqueLabel', {
  *   url: 'https://github.com/tauri-apps/tauri'
+ *
+ *   // create a webview with specific logical position and size
+ *   x: 0,
+ *   y: 0,
+ *   width: 800,
+ *   height: 600,
  * });
  *
  * webview.once('tauri://created', function () {
@@ -148,7 +160,13 @@ class Webview {
    * import { Webview } from '@tauri-apps/api/webview'
    * const appWindow = new Window('my-label')
    * const webview = new Webview(appWindow, 'my-label', {
-   *   url: 'https://github.com/tauri-apps/tauri'
+   *   url: 'https://github.com/tauri-apps/tauri',
+   *
+   *   // create a webview with specific logical position and size
+   *   x: 0,
+   *   y: 0,
+   *   width: 800,
+   *   height: 600,
    * });
    * webview.once('tauri://created', function () {
    *  // webview successfully created


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

As title shown, currently, the example in `Webview` is not correct and tsc raises error:

```
Argument of type '{ url: string; }' is not assignable to parameter of type 'WebviewOptions'.
  Type '{ url: string; }' is missing the following properties from type 'WebviewOptions': x, y, width, heightts(2345)
```
