### PR TITLE
fix: add proxy URL support to Webview at Rust-side.

### DIFF
--- a/.changes/fix-webview-proxy-url.md
+++ b/.changes/fix-webview-proxy-url.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Fix JavaScript API `Webview.proxyUrl` had no effect when used in the `Webview` constructor

--- a/.changes/situ2001-make-changes.md
+++ b/.changes/situ2001-make-changes.md
@@ -1,5 +1,0 @@
----
-'tauri': 'patch:bug'
----
-
-fix: add proxy URL support to Webview at Rust-side.

--- a/.changes/situ2001-make-changes.md
+++ b/.changes/situ2001-make-changes.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+fix: add proxy URL support to Webview at Rust-side.

--- a/crates/tauri/src/webview/plugin.rs
+++ b/crates/tauri/src/webview/plugin.rs
@@ -15,6 +15,7 @@ mod desktop_commands {
   use serde::{Deserialize, Serialize};
   use tauri_runtime::dpi::{Position, Size};
   use tauri_utils::config::{BackgroundThrottlingPolicy, WebviewUrl, WindowConfig};
+  use url::Url;
 
   use super::*;
   use crate::{
@@ -46,6 +47,8 @@ mod desktop_commands {
     window_effects: Option<WindowEffectsConfig>,
     #[serde(default)]
     incognito: bool,
+    #[serde(alias = "proxy-url")]
+    pub proxy_url: Option<Url>,
     #[serde(default)]
     zoom_hotkeys_enabled: bool,
     #[serde(default)]
@@ -70,6 +73,7 @@ mod desktop_commands {
       builder.webview_attributes.accept_first_mouse = config.accept_first_mouse;
       builder.webview_attributes.window_effects = config.window_effects;
       builder.webview_attributes.incognito = config.incognito;
+      builder.webview_attributes.proxy_url = config.proxy_url;
       builder.webview_attributes.zoom_hotkeys_enabled = config.zoom_hotkeys_enabled;
       builder.webview_attributes.background_throttling = config.background_throttling;
       builder.webview_attributes.javascript_disabled = config.javascript_disabled;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

#8441 added support for setting proxy for webview, but it forgot to add `proxy_url` assignment at Rust-side, which made me  figure out why `proxyUrl` is not working on `WebView` (it worked on `WebViewWindow`) for some hours. That is why I opened this PR.

References: https://github.com/tauri-apps/tauri/blob/4e00b279130b46483f7a4d8a377d7d4eb45314f1/crates/tauri-utils/src/config.rs#L1734-L1735

