### PR TITLE
docs(webview): corrected examples to ensure webview is created after window initialization

### DIFF
--- a/packages/api/src/webview.ts
+++ b/packages/api/src/webview.ts
@@ -118,7 +118,7 @@ export type WebviewLabel = string
  * });
  * // alternatively, load a remote URL:
  * const webview = new Webview(appWindow, 'theUniqueLabel', {
- *   url: 'https://github.com/tauri-apps/tauri'
+ *   url: 'https://github.com/tauri-apps/tauri',
  *
  *   // create a webview with specific logical position and size
  *   x: 0,

--- a/packages/api/src/webview.ts
+++ b/packages/api/src/webview.ts
@@ -106,39 +106,45 @@ export type WebviewLabel = string
  *
  * const appWindow = new Window('uniqueLabel');
  *
- * // loading embedded asset:
- * const webview = new Webview(appWindow, 'theUniqueLabel', {
- *   url: 'path/to/page.html',
+ * appWindow.once('tauri://created', async function () {
+ *   // `new Webview` Should be called after the window is successfully created,
+ *   // or webview may not be attached to the window since window is not created yet.
  *
- *   // create a webview with specific logical position and size
- *   x: 0,
- *   y: 0,
- *   width: 800,
- *   height: 600,
- * });
- * // alternatively, load a remote URL:
- * const webview = new Webview(appWindow, 'theUniqueLabel', {
- *   url: 'https://github.com/tauri-apps/tauri',
+ *   // loading embedded asset:
+ *   const webview = new Webview(appWindow, 'theUniqueLabel', {
+ *     url: 'path/to/page.html',
  *
- *   // create a webview with specific logical position and size
- *   x: 0,
- *   y: 0,
- *   width: 800,
- *   height: 600,
- * });
+ *     // create a webview with specific logical position and size
+ *     x: 0,
+ *     y: 0,
+ *     width: 800,
+ *     height: 600,
+ *   });
+ *   // alternatively, load a remote URL:
+ *   const webview = new Webview(appWindow, 'theUniqueLabel', {
+ *     url: 'https://github.com/tauri-apps/tauri',
  *
- * webview.once('tauri://created', function () {
- *  // webview successfully created
- * });
- * webview.once('tauri://error', function (e) {
- *  // an error happened creating the webview
- * });
+ *     // create a webview with specific logical position and size
+ *     x: 0,
+ *     y: 0,
+ *     width: 800,
+ *     height: 600,
+ *   });
  *
- * // emit an event to the backend
- * await webview.emit("some-event", "data");
- * // listen to an event from the backend
- * const unlisten = await webview.listen("event-name", e => {});
- * unlisten();
+ *   webview.once('tauri://created', function () {
+ *     // webview successfully created
+ *   });
+ *   webview.once('tauri://error', function (e) {
+ *     // an error happened creating the webview
+ *   });
+ *
+ *
+ *   // emit an event to the backend
+ *   await webview.emit("some-event", "data");
+ *   // listen to an event from the backend
+ *   const unlisten = await webview.listen("event-name", e => { });
+ *   unlisten();
+ * });
  * ```
  *
  * @since 2.0.0
@@ -159,20 +165,24 @@ class Webview {
    * import { Window } from '@tauri-apps/api/window'
    * import { Webview } from '@tauri-apps/api/webview'
    * const appWindow = new Window('my-label')
-   * const webview = new Webview(appWindow, 'my-label', {
-   *   url: 'https://github.com/tauri-apps/tauri',
    *
-   *   // create a webview with specific logical position and size
-   *   x: 0,
-   *   y: 0,
-   *   width: 800,
-   *   height: 600,
-   * });
-   * webview.once('tauri://created', function () {
-   *  // webview successfully created
-   * });
-   * webview.once('tauri://error', function (e) {
-   *  // an error happened creating the webview
+   * appWindow.once('tauri://created', async function() {
+   *   const webview = new Webview(appWindow, 'my-label', {
+   *     url: 'https://github.com/tauri-apps/tauri',
+   *
+   *     // create a webview with specific logical position and size
+   *     x: 0,
+   *     y: 0,
+   *     width: 800,
+   *     height: 600,
+   *   });
+   *
+   *   webview.once('tauri://created', function () {
+   *     // webview successfully created
+   *   });
+   *   webview.once('tauri://error', function (e) {
+   *     // an error happened creating the webview
+   *   });
    * });
    * ```
    *


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Since what constructor of `Window` does is async. We should ensure `WebView` is created after `Window` is successfully initialized.

https://github.com/tauri-apps/tauri/blob/4e00b279130b46483f7a4d8a377d7d4eb45314f1/packages/api/src/window.ts#L300-L311