### PR TITLE
fix: monitor work_area on macOS

### DIFF
--- a/crates/tauri-runtime-wry/src/monitor/macos.rs
+++ b/crates/tauri-runtime-wry/src/monitor/macos.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use tauri_runtime::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalRect};
+use tauri_runtime::dpi::{LogicalSize, PhysicalRect};
 
 impl super::MonitorExt for tao::monitor::MonitorHandle {
   fn work_area(&self) -> PhysicalRect<i32, u32> {
@@ -10,11 +10,20 @@ impl super::MonitorExt for tao::monitor::MonitorHandle {
     use tao::platform::macos::MonitorHandleExtMacOS;
     if let Some(ns_screen) = self.ns_screen() {
       let ns_screen: &NSScreen = unsafe { &*ns_screen.cast() };
-      let rect = ns_screen.visibleFrame();
+      let screen_frame = ns_screen.frame();
+      let visible_frame = ns_screen.visibleFrame();
+
       let scale_factor = self.scale_factor();
+
+      let mut position = self.position().to_logical::<f64>(scale_factor);
+
+      position.x += visible_frame.origin.x - screen_frame.origin.x;
+      position.y -= visible_frame.origin.y - screen_frame.origin.y;
+
       PhysicalRect {
-        size: LogicalSize::new(rect.size.width, rect.size.height).to_physical(scale_factor),
-        position: LogicalPosition::new(rect.origin.x, rect.origin.y).to_physical(scale_factor),
+        size: LogicalSize::new(visible_frame.size.width, visible_frame.size.height)
+          .to_physical(scale_factor),
+        position: position.to_physical(scale_factor),
       }
     } else {
       PhysicalRect {


### PR DESCRIPTION
macOS uses a different coordinate system for visibleFrame, so to get accurate values we should only get the diff between frame() and visibleFrame() and apply that to the standard monitor position returned by CGDisplayBounds. Size isn't impacted by this, and properly returns the value (accounting for dock position).

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
