### PR TITLE
fix path joining behavior where path.join('', 'a') incorrectly returns "/a" instead of "a" (#13313)

### DIFF
--- a/.changes/fix-path-join-error.md
+++ b/.changes/fix-path-join-error.md
@@ -1,0 +1,6 @@
+---
+"tauri": "minor:bug"
+"@tauri-apps/api": "minor:bug"
+---
+
+Fixed path joining behavior where `path.join('', 'a')` incorrectly returns "/a" instead of "a".

--- a/crates/tauri/src/path/plugin.rs
+++ b/crates/tauri/src/path/plugin.rs
@@ -132,21 +132,19 @@ pub fn normalize(path: String) -> String {
 }
 
 #[command(root = "crate")]
-pub fn join(mut paths: Vec<String>) -> String {
+pub fn join(paths: Vec<String>) -> String {
   let path = PathBuf::from(
     paths
-      .iter_mut()
-      .map(|p| {
-        // Add a `MAIN_SEPARATOR` if it doesn't already have one.
+      .into_iter()
+      .map(|mut p| {
+        // Add a `MAIN_SEPARATOR` if it doesn't already have one and is not an empty string.
         // Doing this to ensure that the vector elements are separated in
         // the resulting string so path.components() can work correctly when called
         // in `normalize_path_no_absolute()` later on.
-        // Issue #13313 - path.join('', 'a') returns "/a" instead of "a"
-        // https://github.com/tauri-apps/tauri/issues/13313
         if !p.is_empty() && !p.ends_with('/') && !p.ends_with('\\') {
           p.push(MAIN_SEPARATOR);
         }
-        p.to_string()
+        p
       })
       .collect::<String>(),
   );
@@ -292,64 +290,24 @@ mod tests {
 
   #[test]
   fn join() {
-    #[cfg(not(target_os = "windows"))]
-    {
-      let paths = vec!["".to_string()];
-      assert_eq!(super::join(paths), ".");
-
-      let paths = vec!["".to_string(), "".to_string()];
-      assert_eq!(super::join(paths), ".");
-
-      let paths = vec!["a".to_string()];
-      assert_eq!(super::join(paths), "a");
-
-      let paths = vec!["".to_string(), "a".to_string()];
-      assert_eq!(super::join(paths), "a");
-
-      let paths = vec!["a".to_string(), "b".to_string()];
-      assert_eq!(super::join(paths), "a/b");
-
-      let paths = vec!["a".to_string(), "".to_string(), "b".to_string()];
-      assert_eq!(super::join(paths), "a/b");
-
-      let paths = vec!["a".to_string(), "/b".to_string(), "c".to_string()];
-      assert_eq!(super::join(paths), "a/b/c");
-
-      let paths = vec!["a".to_string(), "b/c".to_string(), "d".to_string()];
-      assert_eq!(super::join(paths), "a/b/c/d");
-
-      let paths = vec!["a/".to_string(), "b".to_string()];
-      assert_eq!(super::join(paths), "a/b");
+    fn check(paths: Vec<&str>, expected_unix: &str, expected_windows: &str) {
+      let expected = if cfg!(windows) {
+        expected_windows
+      } else {
+        expected_unix
+      };
+      let paths = paths.into_iter().map(String::from).collect();
+      assert_eq!(super::join(paths), expected);
     }
 
-    #[cfg(target_os = "windows")]
-    {
-      let paths = vec!["".to_string()];
-      assert_eq!(super::join(paths), ".");
-
-      let paths = vec!["".to_string(), "".to_string()];
-      assert_eq!(super::join(paths), ".");
-
-      let paths = vec!["a".to_string()];
-      assert_eq!(super::join(paths), "a");
-
-      let paths = vec!["".to_string(), "a".to_string()];
-      assert_eq!(super::join(paths), "a");
-
-      let paths = vec!["a".to_string(), "b".to_string()];
-      assert_eq!(super::join(paths), "a\\b");
-
-      let paths = vec!["a".to_string(), "".to_string(), "b".to_string()];
-      assert_eq!(super::join(paths), "a\\b");
-
-      let paths = vec!["a".to_string(), "\\b".to_string(), "c".to_string()];
-      assert_eq!(super::join(paths), "a\\b\\c");
-
-      let paths = vec!["a".to_string(), "b\\c".to_string(), "d".to_string()];
-      assert_eq!(super::join(paths), "a\\b\\c\\d");
-
-      let paths = vec!["a\\".to_string(), "b".to_string()];
-      assert_eq!(super::join(paths), "a\\b");
-    }
+    check(vec![""], ".", ".");
+    check(vec!["", ""], ".", ".");
+    check(vec!["a"], "a", "a");
+    check(vec!["", "a"], "a", "a");
+    check(vec!["a", "b"], "a/b", r"a\b");
+    check(vec!["a", "", "b"], "a/b", r"a\b");
+    check(vec!["a", "/b", "c"], "a/b/c", r"a\b\c");
+    check(vec!["a", "b/c", "d"], "a/b/c/d", r"a\b\c\d");
+    check(vec!["a/", "b"], "a/b", r"a\b");
   }
 }

--- a/crates/tauri/src/path/plugin.rs
+++ b/crates/tauri/src/path/plugin.rs
@@ -141,7 +141,9 @@ pub fn join(mut paths: Vec<String>) -> String {
         // Doing this to ensure that the vector elements are separated in
         // the resulting string so path.components() can work correctly when called
         // in `normalize_path_no_absolute()` later on.
-        if !p.ends_with('/') && !p.ends_with('\\') {
+        // Issue #13313 - path.join('', 'a') returns "/a" instead of "a"
+        // https://github.com/tauri-apps/tauri/issues/13313
+        if !p.is_empty() && !p.ends_with('/') && !p.ends_with('\\') {
           p.push(MAIN_SEPARATOR);
         }
         p.to_string()
@@ -286,5 +288,68 @@ mod tests {
       super::basename(app.handle().clone(), path, Some(".json")).unwrap(),
       "some-json-file.json.html"
     );
+  }
+
+  #[test]
+  fn join() {
+    #[cfg(not(target_os = "windows"))]
+    {
+      let paths = vec!["".to_string()];
+      assert_eq!(super::join(paths), ".");
+
+      let paths = vec!["".to_string(), "".to_string()];
+      assert_eq!(super::join(paths), ".");
+
+      let paths = vec!["a".to_string()];
+      assert_eq!(super::join(paths), "a");
+
+      let paths = vec!["".to_string(), "a".to_string()];
+      assert_eq!(super::join(paths), "a");
+
+      let paths = vec!["a".to_string(), "b".to_string()];
+      assert_eq!(super::join(paths), "a/b");
+
+      let paths = vec!["a".to_string(), "".to_string(), "b".to_string()];
+      assert_eq!(super::join(paths), "a/b");
+
+      let paths = vec!["a".to_string(), "/b".to_string(), "c".to_string()];
+      assert_eq!(super::join(paths), "a/b/c");
+
+      let paths = vec!["a".to_string(), "b/c".to_string(), "d".to_string()];
+      assert_eq!(super::join(paths), "a/b/c/d");
+
+      let paths = vec!["a/".to_string(), "b".to_string()];
+      assert_eq!(super::join(paths), "a/b");
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+      let paths = vec!["".to_string()];
+      assert_eq!(super::join(paths), ".");
+
+      let paths = vec!["".to_string(), "".to_string()];
+      assert_eq!(super::join(paths), ".");
+
+      let paths = vec!["a".to_string()];
+      assert_eq!(super::join(paths), "a");
+
+      let paths = vec!["".to_string(), "a".to_string()];
+      assert_eq!(super::join(paths), "a");
+
+      let paths = vec!["a".to_string(), "b".to_string()];
+      assert_eq!(super::join(paths), "a\\b");
+
+      let paths = vec!["a".to_string(), "".to_string(), "b".to_string()];
+      assert_eq!(super::join(paths), "a\\b");
+
+      let paths = vec!["a".to_string(), "\\b".to_string(), "c".to_string()];
+      assert_eq!(super::join(paths), "a\\b\\c");
+
+      let paths = vec!["a".to_string(), "b\\c".to_string(), "d".to_string()];
+      assert_eq!(super::join(paths), "a\\b\\c\\d");
+
+      let paths = vec!["a\\".to_string(), "b".to_string()];
+      assert_eq!(super::join(paths), "a\\b");
+    }
   }
 }


### PR DESCRIPTION
Fixed path joining behavior where `path.join('', 'a')` incorrectly returns "/a" instead of "a".

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
