### PR TITLE
fix(bundler): custom sign command failing to sign uninstaller executable

### DIFF
--- a/.changes/fix-custom-signer-uninstaller.md
+++ b/.changes/fix-custom-signer-uninstaller.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:bug
+---
+
+Fix custom Windows sign command failing to sign app uninstaller if it references relative paths.

--- a/crates/tauri-bundler/src/bundle/windows/sign.rs
+++ b/crates/tauri-bundler/src/bundle/windows/sign.rs
@@ -142,12 +142,21 @@ pub fn sign_command_custom<P: AsRef<Path>>(
 ) -> crate::Result<Command> {
   let path = path.as_ref();
 
+  let cwd = std::env::current_dir()?;
+
   let mut cmd = Command::new(&command.cmd);
   for arg in &command.args {
     if arg == "%1" {
       cmd.arg(path);
     } else {
-      cmd.arg(arg);
+      let path = Path::new(arg);
+      // turn relative paths into absolute paths - so the uninstall command can use them
+      // since the !uninstfinalize NSIS hook runs in a different directory
+      if path.exists() && path.is_relative() {
+        cmd.arg(cwd.join(path));
+      } else {
+        cmd.arg(arg);
+      }
     }
   }
   Ok(cmd)


### PR DESCRIPTION
our docs has instructions for how to sign Windows apps using Azure Key Vault: https://tauri.app/distribute/sign/windows/#azure-key-vault

the documented approach relies on a relic.conf file, relative to CWD (src-tauri folder). When the NSIS script tries to sign the uninstaller, the working directory is different, so it cannot find that file.

This changes the custom sign command to convert file paths to absolute paths to fix this problem.
