### PR TITLE
feat: add LSItemContentTypes and CFBundleTypeIconFile support for fileAssociations on macOS

### DIFF
--- a/.changes/feat-add-utis-support-for-fileassociation.md
+++ b/.changes/feat-add-utis-support-for-fileassociation.md
@@ -1,0 +1,8 @@
+---
+"tauri-bundler": "minor:feat"
+"tauri-utils": "minor:feat"
+"tauri-cli": "minor:feat"
+"@tauri-apps/cli": "minor:feat"
+---
+
+Feat: add `LSItemContentTypes` and `CFBundleTypeIconFile` support for `fileAssociations` on macOS.

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -272,6 +272,20 @@ fn create_info_plist(
               association.role.to_string().into(),
             );
             dict.insert("LSHandlerRank".into(), association.rank.to_string().into());
+            if let Some(item_content_types) = &association.item_content_types {
+              dict.insert(
+                "LSItemContentTypes".into(),
+                plist::Value::Array(
+                  item_content_types
+                    .iter()
+                    .map(|uti| uti.to_string().into())
+                    .collect(),
+                ),
+              );
+            }
+            if let Some(icns) = &association.icon_file {
+              dict.insert("CFBundleTypeIconFile".into(), icns.to_string().into());
+            }
             plist::Value::Dictionary(dict)
           })
           .collect(),

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -2354,6 +2354,23 @@
               "$ref": "#/definitions/HandlerRank"
             }
           ]
+        },
+        "itemContentTypes": {
+          "description": "The document file types the app supports. Maps to `LSItemContentTypes` on macOS.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/UniformTypeIdentifiers"
+          }
+        },
+        "iconFile": {
+          "description": "This key contains a string with the name of the icon file (.icns) to associate with this macOS document type. Maps to `CFBundleTypeIconFile` on macOS.\n For more information about specifying document icons, see [Document Icons](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW9).",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -2434,6 +2451,10 @@
           ]
         }
       ]
+    },
+    "UniformTypeIdentifiers": {
+      "description": "Provide uniform type identifiers that describe file types for storage or transfer.",
+      "type": "string"
     },
     "WindowsConfig": {
       "description": "Windows bundler configuration.\n\n See more: <https://v2.tauri.app/reference/config/#windowsconfig>",

--- a/crates/tauri-cli/schema.json
+++ b/crates/tauri-cli/schema.json
@@ -1975,6 +1975,23 @@
               "$ref": "#/definitions/HandlerRank"
             }
           ]
+        },
+        "itemContentTypes": {
+          "description": "The document file types the app supports. Maps to `LSItemContentTypes` on macOS.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/UniformTypeIdentifiers"
+          }
+        },
+        "iconFile": {
+          "description": "This key contains a string with the name of the icon file (.icns) to associate with this macOS document type. Maps to `CFBundleTypeIconFile` on macOS.\n For more information about specifying document icons, see [Document Icons](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW9).",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -2055,6 +2072,10 @@
           ]
         }
       ]
+    },
+    "UniformTypeIdentifiers": {
+      "description": "Provide uniform type identifiers that describe file types for storage or transfer.",
+      "type": "string"
     },
     "WindowsConfig": {
       "description": "Windows bundler configuration.\n\n See more: <https://tauri.app/v1/api/config#windowsconfig>",

--- a/crates/tauri-cli/tauri.config.schema.json
+++ b/crates/tauri-cli/tauri.config.schema.json
@@ -1975,6 +1975,23 @@
               "$ref": "#/definitions/HandlerRank"
             }
           ]
+        },
+        "itemContentTypes": {
+          "description": "The document file types the app supports. Maps to `LSItemContentTypes` on macOS.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/UniformTypeIdentifiers"
+          }
+        },
+        "iconFile": {
+          "description": "This key contains a string with the name of the icon file (.icns) to associate with this macOS document type. Maps to `CFBundleTypeIconFile` on macOS.\n For more information about specifying document icons, see [Document Icons](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW9).",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -2055,6 +2072,10 @@
           ]
         }
       ]
+    },
+    "UniformTypeIdentifiers": {
+      "description": "Provide uniform type identifiers that describe file types for storage or transfer.",
+      "type": "string"
     },
     "WindowsConfig": {
       "description": "Windows bundler configuration.\n\n See more: <https://tauri.app/v1/api/config#windowsconfig>",

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -2354,6 +2354,23 @@
               "$ref": "#/definitions/HandlerRank"
             }
           ]
+        },
+        "itemContentTypes": {
+          "description": "The document file types the app supports. Maps to `LSItemContentTypes` on macOS.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/UniformTypeIdentifiers"
+          }
+        },
+        "iconFile": {
+          "description": "This key contains a string with the name of the icon file (.icns) to associate with this macOS document type. Maps to `CFBundleTypeIconFile` on macOS.\n For more information about specifying document icons, see [Document Icons](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW9).",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -2434,6 +2451,10 @@
           ]
         }
       ]
+    },
+    "UniformTypeIdentifiers": {
+      "description": "Provide uniform type identifiers that describe file types for storage or transfer.",
+      "type": "string"
     },
     "WindowsConfig": {
       "description": "Windows bundler configuration.\n\n See more: <https://v2.tauri.app/reference/config/#windowsconfig>",

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -1118,6 +1118,24 @@ impl Display for HandlerRank {
   }
 }
 
+/// Provide uniform type identifiers that describe file types for storage or transfer.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct UniformTypeIdentifiers(pub String);
+
+impl fmt::Display for UniformTypeIdentifiers {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}", self.0)
+  }
+}
+
+impl<'d> serde::Deserialize<'d> for UniformTypeIdentifiers {
+  fn deserialize<D: Deserializer<'d>>(deserializer: D) -> Result<Self, D::Error> {
+    let uti = String::deserialize(deserializer)?;
+    Ok(UniformTypeIdentifiers(uti))
+  }
+}
+
 /// An extension for a [`FileAssociation`].
 ///
 /// A leading `.` is automatically stripped.
@@ -1162,6 +1180,11 @@ pub struct FileAssociation {
   /// The ranking of this app among apps that declare themselves as editors or viewers of the given file type.  Maps to `LSHandlerRank` on macOS.
   #[serde(default)]
   pub rank: HandlerRank,
+  /// The document file types the app supports. Maps to `LSItemContentTypes` on macOS.
+  pub item_content_types: Option<Vec<UniformTypeIdentifiers>>,
+  /// This key contains a string with the name of the icon file (.icns) to associate with this macOS document type. Maps to `CFBundleTypeIconFile` on macOS.
+  /// For more information about specifying document icons, see [Document Icons](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW9).
+  pub icon_file: Option<String>,
 }
 
 /// Deep link protocol configuration.

--- a/examples/file-associations/src-tauri/tauri.conf.json
+++ b/examples/file-associations/src-tauri/tauri.conf.json
@@ -23,7 +23,9 @@
       {
         "ext": ["png"],
         "mimeType": "image/png",
-        "rank": "Default"
+        "rank": "Default",
+        "itemContentTypes": ["public.png"],
+        "iconFile": ""
       },
       {
         "ext": ["jpg", "jpeg"],


### PR DESCRIPTION
According to [apple docs](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-101685):
1. `LSItemContentTypes`: `CFBundleTypeExtensions` has been deprecated since `OS X v10.5`, so `LSItemContentTypes` has been added. In macOS 10.5 and later, this key (when present) takes precedence over these type-identifier keys: `CFBundleTypeExtensions`, `CFBundleTypeMIMETypes`, `CFBundleTypeOSTypes`.
2. `CFBundleTypeIconFile`: this key contains a string with the name of the icon file (.icns) to associate with this macOS document type. #13302
3. To avoid breaking changes, the attribute is set as optional.


<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
4. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
5. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
6. Ensure `cargo test` and `cargo clippy` passes.
7. Propose your changes as a draft PR if your work is still in progress.
-->
