### PR TITLE
fix: Can't register multiple plugin listeners for an event

### DIFF
--- a/.changes/fix-ios-register-listener.md
+++ b/.changes/fix-ios-register-listener.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes multiple event listeners registration for iOS plugins.

--- a/crates/tauri/mobile/ios-api/Sources/Tauri/Plugin/Plugin.swift
+++ b/crates/tauri/mobile/ios-api/Sources/Tauri/Plugin/Plugin.swift
@@ -61,6 +61,7 @@ open class Plugin: NSObject {
 
     if var eventListeners = listeners[args.event] {
       eventListeners.append(args.handler)
+      listeners[args.event] = eventListeners
     } else {
       listeners[args.event] = [args.handler]
     }


### PR DESCRIPTION
Reference: https://github.com/tauri-apps/tauri/issues/13359

Arrays and Dictionaries are value types in Swift, not reference types. So when  if `var eventListeners = listeners[args.event]` executes, then `eventListeners` is a copy and therefore executing `.append` will only affect the copy, not the original array value in the `listeners` dictionary.