### PR TITLE
refactor: replace logical OR (`||`) with nullish coalescing (`??`)  

### DIFF
--- a/examples/api/vite.config.js
+++ b/examples/api/vite.config.js
@@ -27,7 +27,7 @@ export default defineConfig({
   clearScreen: false,
   // tauri expects a fixed port, fail if that port is not available
   server: {
-    host: host || false,
+    host: host ?? false,
     port: 1420,
     strictPort: true,
     hmr: host


### PR DESCRIPTION
### Problem  
Using `||` for default values can incorrectly override valid falsy values like `0`, `""`, or `false`.

### Solution  
Replace `||` with the `??` operator where appropriate, since it only falls back on `null`/`undefined`.

### Benefits  
- Safer: Preserves `0`, `""`, and `false` values  
- Modern: Follows JavaScript best practices  