### PR TITLE
docs: Fix description and add example for `WebviewWindowBuilder::from_config`

### DIFF
--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -137,8 +137,8 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   /// #[tauri::command]
   /// async fn open_window_multiple(app: tauri::AppHandle) {
   ///   let mut conf = app.config().app.windows.iter().find(|c| c.label == "template-for-multiwindow").unwrap().clone();
-  ///   // This should be a unique label for all windows. For example, we can use a random UUID:
-  ///   conf.label = format!("my-multiwindow-{}", uuid::Uuid::new_v4());
+  ///   // This should be a unique label for all windows. For example, we can use a random suffix:
+  ///   conf.label = format!("my-multiwindow-{}", getrandom::u32().unwrap());
   ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, &conf)
   ///     .unwrap()
   ///     .build()

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -139,7 +139,7 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   ///   let mut conf = &app.config().app.windows.iter().find(|c| c.label == "template-for-multiwindow").unwrap().clone();
   ///   // This should be a unique label for all windows. For example, we can use a random UUID:
   ///   conf.label = format!("my-multiwindow-{}", uuid::Uuid::new_v4());
-  ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, conf)
+  ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, &conf)
   ///     .unwrap()
   ///     .build()
   ///     .unwrap();

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -136,7 +136,7 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   /// ```
   /// #[tauri::command]
   /// async fn open_window_multiple(app: tauri::AppHandle) {
-  ///   let mut conf = &app.config().app.windows.iter().find(|c| c.label == "template-for-multiwindow").unwrap().clone();
+  ///   let mut conf = app.config().app.windows.iter().find(|c| c.label == "template-for-multiwindow").unwrap().clone();
   ///   // This should be a unique label for all windows. For example, we can use a random UUID:
   ///   conf.label = format!("my-multiwindow-{}", uuid::Uuid::new_v4());
   ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, &conf)

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -110,7 +110,7 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
 
   /// Initializes a webview window builder from a [`WindowConfig`] from tauri.conf.json.
   /// Keep in mind that you can't create 2 windows with the same `label` so make sure
-  /// that the initial window was closed or change the label of the new [`WebviewWindowBuilder`].
+  /// that the initial window was closed or change the label of the cloned [`WindowConfig`].
   ///
   /// # Known issues
   ///
@@ -124,7 +124,22 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   /// ```
   /// #[tauri::command]
   /// async fn reopen_window(app: tauri::AppHandle) {
-  ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, &app.config().app.windows.get(0).unwrap().clone())
+  ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, &app.config().app.windows.get(0).unwrap())
+  ///     .unwrap()
+  ///     .build()
+  ///     .unwrap();
+  /// }
+  /// ```
+  ///
+  /// - Create a window in a command from a config with a specific label, and change its label so multiple instances can exist:
+  ///
+  /// ```
+  /// #[tauri::command]
+  /// async fn open_window_multiple(app: tauri::AppHandle) {
+  ///   let mut conf = &app.config().app.windows.iter().find(|c| c.label == "template-for-multiwindow").unwrap().clone();
+  ///   // This should be a unique label for all windows. For example, we can use a random UUID:
+  ///   conf.label = format!("my-multiwindow-{}", uuid::Uuid::new_v4());
+  ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, conf)
   ///     .unwrap()
   ///     .build()
   ///     .unwrap();

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -138,7 +138,9 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
   /// async fn open_window_multiple(app: tauri::AppHandle) {
   ///   let mut conf = app.config().app.windows.iter().find(|c| c.label == "template-for-multiwindow").unwrap().clone();
   ///   // This should be a unique label for all windows. For example, we can use a random suffix:
-  ///   conf.label = format!("my-multiwindow-{}", getrandom::u32().unwrap());
+  ///   let mut buf = [0u8; 1];
+  ///   assert_eq!(getrandom::getrandom(&mut buf), Ok(()));
+  ///   conf.label = format!("my-multiwindow-{}", buf[0]);
   ///   let webview_window = tauri::WebviewWindowBuilder::from_config(&app, &conf)
   ///     .unwrap()
   ///     .build()


### PR DESCRIPTION
The documentation for `WebviewWindowBuilder::from_config` mentions changing the label of the new `WebviewWindowBuilder`, which is not possible (there is no such API).

Instead, the label must be changed in the `WindowConfig` that is passed into `WebviewWindowBuilder::from_config`.

This change fixes that description and adds an example code snippet for this use-case.

Additionally, it updates the existing example, as the `WindowConfig` that was being retrieved from `app.config()` was being cloned and then used behind a reference. As such, we can remove the unnecessary clone to make the example cleaner.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
