### PR TITLE
fix(windows): Set drag and drop to false in window builder in `disable_drag_and_drop_handler()`

### DIFF
--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -943,6 +943,12 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   #[must_use]
   pub fn disable_drag_drop_handler(mut self) -> Self {
     self.webview_builder = self.webview_builder.disable_drag_drop_handler();
+
+    #[cfg(target_os = "windows")]
+    {
+      self.window_builder = self.window_builder.drag_and_drop(false);
+    }
+
     self
   }
 


### PR DESCRIPTION
Without this, `disable_drag_and_drop_handler()` does not change the bevahior of the tao windows.

For me, this ended up triggering [this panic](https://github.com/tauri-apps/tao/blob/67f00588b4927271cb8b89f1d0c10db3c9727093/src/platform_impl/windows/window.rs#L109). This PR fixes this and I don't have the panic anymore. 