### PR TITLE
fix(macOS): caculation for work area

### DIFF
--- a/.changes/change-pr-13401.md
+++ b/.changes/change-pr-13401.md
@@ -1,0 +1,5 @@
+---
+"tauri": 'patch:bug'
+---
+
+fix(macOS): caculation for work area

--- a/crates/tauri-runtime-wry/src/monitor/macos.rs
+++ b/crates/tauri-runtime-wry/src/monitor/macos.rs
@@ -18,7 +18,6 @@ impl super::MonitorExt for tao::monitor::MonitorHandle {
       let mut position = self.position().to_logical::<f64>(scale_factor);
 
       position.x += visible_frame.origin.x - screen_frame.origin.x;
-      position.y += visible_frame.origin.y - screen_frame.origin.y;
 
       PhysicalRect {
         size: LogicalSize::new(visible_frame.size.width, visible_frame.size.height)


### PR DESCRIPTION
This PR rolls back one of the changes introduced in #13309 that offsets the work area by the visible frame reported by macOS.

I have noticed that on my primary monitor (whether that be internal or external to my laptop) that the [visible frame](https://developer.apple.com/documentation/appkit/nsscreen/visibleframe) reported by macOS is `(0, 83)`. This causes the Tauri calculation to report the start position of the work area as being y `83` when it should be `0`. If I use the changes in this PR I instead get `0` which points to the position directly under the macOS top bar as I would have expected.

I have left the x offset as it accounts for the size of the dock when it's on the left or the right.

# Demo

We use the work area to caculate where to put the window when docking.

### Before

On my primary monitor the work_area would report incorrect so the window would get position lower than expected. This would *only* happen on my primary monitor. It would work correctly on any secondary monitors.

https://github.com/user-attachments/assets/c0e09c17-4d1e-4b04-b61f-90dbd7de069e

### After

https://github.com/user-attachments/assets/5c2ca34d-3389-4ea7-8e0a-5bd9f9adea5a

https://github.com/user-attachments/assets/41cdc932-b77a-4e3a-bbf0-a0122509bf51
