### PR TITLE
docs(api): fix incorrect example and clarify description for dirname in path API docs

### DIFF
--- a/packages/api/src/path.ts
+++ b/packages/api/src/path.ts
@@ -674,12 +674,12 @@ async function join(...paths: string[]): Promise<string> {
 }
 
 /**
- * Returns the directory name of a `path`. Trailing directory separators are ignored.
+ * Returns the parent directory of a given `path`. Trailing directory separators are ignored.
  * @example
  * ```typescript
  * import { dirname } from '@tauri-apps/api/path';
  * const dir = await dirname('/path/to/somedir/');
- * assert(dir === 'somedir');
+ * assert(dir === '/path/to');
  * ```
  *
  * @since 1.0.0


### PR DESCRIPTION
The original comment says "the directory name", but it's actually returning the **parent** directory.
 Also the example is wrong — it says `dirname('/path/to/somedir/') === 'somedir'`, but it should be `'/path/to'`.

Discussion: https://discord.com/channels/616186924390023171/1371133583854665789