### PR TITLE
fix(window): ensure set_window_effects runs on main thread in WindowBuilder (#13422)

### DIFF
--- a/.changes/fix-set-window-effects-main-thread.md
+++ b/.changes/fix-set-window-effects-main-thread.md
@@ -1,18 +1,5 @@
 ---
-"@tauri-apps/api": "patch:bug"
-"tauri-utils": "patch:bug"
-"tauri-macos-sign": "patch:bug"
-"tauri-bundler": "patch:bug"
-"tauri-runtime": "patch:bug"
-"tauri-runtime-wry": "patch:bug"
-"tauri-codegen": "patch:bug"
-"tauri-macros": "patch:bug"
-"tauri-plugin": "patch:bug"
-"tauri-build": "patch:bug"
 "tauri": "patch:bug"
-"@tauri-apps/cli": "patch:bug"
-"tauri-cli": "patch:bug"
-"tauri-driver": "patch:bug"
 ---
 
 Fixed set_window_effects not runs on main thread in WindowBuilder.

--- a/.changes/fix-set-window-effects-main-thread.md
+++ b/.changes/fix-set-window-effects-main-thread.md
@@ -1,0 +1,18 @@
+---
+"@tauri-apps/api": "patch:bug"
+"tauri-utils": "patch:bug"
+"tauri-macos-sign": "patch:bug"
+"tauri-bundler": "patch:bug"
+"tauri-runtime": "patch:bug"
+"tauri-runtime-wry": "patch:bug"
+"tauri-codegen": "patch:bug"
+"tauri-macros": "patch:bug"
+"tauri-plugin": "patch:bug"
+"tauri-build": "patch:bug"
+"tauri": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+"tauri-cli": "patch:bug"
+"tauri-driver": "patch:bug"
+---
+
+Fixed set_window_effects not runs on main thread in WindowBuilder.

--- a/crates/tauri/src/window/mod.rs
+++ b/crates/tauri/src/window/mod.rs
@@ -406,14 +406,12 @@ tauri::Builder::default()
       window.on_menu_event(handler);
     }
 
-    if let Some(effects) = self.window_effects {
-      crate::vibrancy::set_window_effects(&window, Some(effects))?;
-    }
-
     let app_manager = self.manager.manager_owned();
     let window_label = window.label().to_string();
+    let window_ = window.clone();
     // run on the main thread to fix a deadlock on webview.eval if the tracing feature is enabled
     let _ = window.run_on_main_thread(move || {
+      let _ = crate::vibrancy::set_window_effects(&window_, self.window_effects);
       let event = crate::EventName::from_str("tauri://window-created");
       let payload = Some(crate::webview::CreatedEvent {
         label: window_label,

--- a/crates/tauri/src/window/mod.rs
+++ b/crates/tauri/src/window/mod.rs
@@ -411,7 +411,9 @@ tauri::Builder::default()
     let window_ = window.clone();
     // run on the main thread to fix a deadlock on webview.eval if the tracing feature is enabled
     let _ = window.run_on_main_thread(move || {
-      let _ = crate::vibrancy::set_window_effects(&window_, self.window_effects);
+      if let Some(effects) = self.window_effects {
+        _ = crate::vibrancy::set_window_effects(&window_, Some(effects));
+      }
       let event = crate::EventName::from_str("tauri://window-created");
       let payload = Some(crate::webview::CreatedEvent {
         label: window_label,


### PR DESCRIPTION
Ensure set_window_effects runs on main thread in WindowBuilder.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
