### PR TITLE
fix: main binary name can't contain dots

### DIFF
--- a/.changes/fix-main-binary-name-with-dot.md
+++ b/.changes/fix-main-binary-name-with-dot.md
@@ -1,0 +1,6 @@
+---
+"tauri-utils": "patch:bug"
+"tauri-bundler": "patch:bug"
+---
+
+Fix `mainBinaryName` doesn't work when there's `.` in it

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -528,7 +528,7 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
 
   if let Some(paths) = &config.bundle.external_bin {
     copy_binaries(
-      ResourcePaths::new(external_binaries(paths, &target_triple).as_slice(), true),
+      ResourcePaths::new(&external_binaries(paths, &target_triple, &target), true),
       &target_triple,
       target_dir,
       manifest.package.as_ref().map(|p| &p.name),

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -12,6 +12,7 @@ use tauri_utils::{
     BundleType, DeepLinkProtocol, FileAssociation, NSISInstallerMode, NsisCompression,
     RpmCompression,
   },
+  platform::Target as TargetPlatform,
   resources::{external_binaries, ResourcePaths},
 };
 
@@ -760,6 +761,8 @@ pub struct Settings {
   bundle_settings: BundleSettings,
   /// the binaries to bundle.
   binaries: Vec<BundleBinary>,
+  /// The target platform.
+  target_platform: TargetPlatform,
   /// The target triple.
   target: String,
 }
@@ -875,6 +878,7 @@ impl SettingsBuilder {
           .map(|bins| external_binaries(bins, &target)),
         ..self.bundle_settings
       },
+      target_platform: TargetPlatform::from_triple(&target),
       target,
     })
   }
@@ -899,6 +903,11 @@ impl Settings {
   /// Returns the target triple.
   pub fn target(&self) -> &str {
     &self.target
+  }
+
+  /// Returns the [`TargetPlatform`].
+  pub fn target_platform(&self) -> &TargetPlatform {
+    &self.target_platform
   }
 
   /// Returns the architecture for the binary being bundled (e.g. "arm", "x86" or "x86_64").
@@ -955,19 +964,23 @@ impl Settings {
 
   /// Returns the path to the specified binary.
   pub fn binary_path(&self, binary: &BundleBinary) -> PathBuf {
-    let target_os = self
-      .target()
-      .split('-')
-      .nth(2)
-      .unwrap_or(std::env::consts::OS);
+    let target_os = self.target_platform();
 
-    let path = self.project_out_directory.join(binary.name());
+    let mut path = self.project_out_directory.join(binary.name());
 
-    if target_os == "windows" {
-      path.with_extension("exe")
-    } else {
-      path
-    }
+    if matches!(target_os, TargetPlatform::Windows) {
+      // Append the `.exe` extension without overriding the existing extensions
+      let extension = if let Some(extension) = path.extension() {
+        let mut extension = extension.to_os_string();
+        extension.push(".exe");
+        extension
+      } else {
+        "exe".into()
+      };
+      path.set_extension(extension);
+    };
+
+    path
   }
 
   /// Returns the list of binaries to bundle.
@@ -985,18 +998,13 @@ impl Settings {
   ///
   /// Fails if the host/target's native package type is not supported.
   pub fn package_types(&self) -> crate::Result<Vec<PackageType>> {
-    let target_os = self
-      .target
-      .split('-')
-      .nth(2)
-      .unwrap_or(std::env::consts::OS)
-      .replace("darwin", "macos");
+    let target_os = self.target_platform();
 
-    let platform_types = match target_os.as_str() {
-      "macos" => vec![PackageType::MacOsBundle, PackageType::Dmg],
-      "ios" => vec![PackageType::IosBundle],
-      "linux" => vec![PackageType::Deb, PackageType::Rpm, PackageType::AppImage],
-      "windows" => vec![PackageType::WindowsMsi, PackageType::Nsis],
+    let platform_types = match target_os {
+      TargetPlatform::MacOS => vec![PackageType::MacOsBundle, PackageType::Dmg],
+      TargetPlatform::Ios => vec![PackageType::IosBundle],
+      TargetPlatform::Linux => vec![PackageType::Deb, PackageType::Rpm, PackageType::AppImage],
+      TargetPlatform::Windows => vec![PackageType::WindowsMsi, PackageType::Nsis],
       os => {
         return Err(crate::Error::GenericError(format!(
           "Native {os} bundles not yet supported."

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -858,6 +858,7 @@ impl SettingsBuilder {
     } else {
       target_triple()?
     };
+    let target_platform = TargetPlatform::from_triple(&target);
 
     Ok(Settings {
       log_level: self.log_level.unwrap_or(log::Level::Error),
@@ -875,10 +876,10 @@ impl SettingsBuilder {
           .bundle_settings
           .external_bin
           .as_ref()
-          .map(|bins| external_binaries(bins, &target)),
+          .map(|bins| external_binaries(bins, &target, &target_platform)),
         ..self.bundle_settings
       },
-      target_platform: TargetPlatform::from_triple(&target),
+      target_platform,
       target,
     })
   }

--- a/crates/tauri-bundler/src/bundle/updater_bundle.rs
+++ b/crates/tauri-bundler/src/bundle/updater_bundle.rs
@@ -14,7 +14,7 @@ use crate::{
   utils::fs_utils,
   Settings,
 };
-use tauri_utils::display_path;
+use tauri_utils::{display_path, platform::Target as TargetPlatform};
 
 use std::{
   fs::{self, File},
@@ -27,14 +27,9 @@ use zip::write::SimpleFileOptions;
 
 // Build update
 pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<Vec<PathBuf>> {
-  let target_os = settings
-    .target()
-    .split('-')
-    .nth(2)
-    .unwrap_or(std::env::consts::OS)
-    .replace("darwin", "macos");
+  let target_os = settings.target_platform();
 
-  if target_os == "windows" {
+  if matches!(target_os, TargetPlatform::Windows) {
     return bundle_update_windows(settings, bundles);
   }
 

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -24,7 +24,7 @@
       "pattern": "^[^/\\:*?\"<>|]+$"
     },
     "mainBinaryName": {
-      "description": "App main binary filename. Defaults to the name of your cargo crate.",
+      "description": "Overrides app's main binary filename.\n\n By default, Tauri uses the output binary from `cargo`, by setting this, we will rename that binary in `tauri-cli`'s\n `tauri build` command, and target `tauri bundle` to it\n\n If possible, change the [`package name`] or set the [`name field`] instead,\n and if that's not enough and you're using nightly, consider using the [`different-binary-name`] feature instead\n\n Note: this config should not include the binary extension (e.g. `.exe`), we'll add that for you\n\n [`package name`]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field\n [`name field`]: https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-name-field\n [`different-binary-name`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#different-binary-name",
       "type": [
         "string",
         "null"

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -35,7 +35,7 @@ use crate::{
   },
   ConfigValue,
 };
-use tauri_utils::{display_path, platform::Target};
+use tauri_utils::{display_path, platform::Target as TargetPlatform};
 
 mod cargo_config;
 mod desktop;
@@ -537,7 +537,7 @@ impl Rust {
 
           if let Some(event_path) = event.paths.first() {
             if !ignore_matcher.is_ignore(event_path, event_path.is_dir()) {
-              if is_configuration_file(self.app_settings.target, event_path) {
+              if is_configuration_file(self.app_settings.target_platform, event_path) {
                 if let Ok(config) = reload_config(merge_configs) {
                   let (manifest, modified) =
                     rewrite_manifest(config.lock().unwrap().as_ref().unwrap())?;
@@ -652,7 +652,16 @@ struct WorkspacePackageSettings {
 #[derive(Clone, Debug, Deserialize)]
 struct BinarySettings {
   name: String,
+  /// This is from nightly: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#different-binary-name
+  filename: Option<String>,
   path: Option<String>,
+}
+
+impl BinarySettings {
+  /// The file name without the binary extension (e.g. `.exe`)
+  pub fn file_name(&self) -> &str {
+    self.filename.as_ref().unwrap_or(&self.name)
+  }
 }
 
 /// The package settings.
@@ -711,7 +720,7 @@ pub struct RustAppSettings {
   package_settings: PackageSettings,
   cargo_config: CargoConfig,
   target_triple: String,
-  target: Target,
+  target_platform: TargetPlatform,
 }
 
 #[derive(Deserialize)]
@@ -878,13 +887,19 @@ impl AppSettings for RustAppSettings {
       .out_dir(options)
       .context("failed to get project out directory")?;
 
-    let ext = if self.target_triple.contains("windows") {
-      "exe"
-    } else {
-      ""
+    let mut path = out_dir.join(bin_name);
+    if matches!(self.target_platform, TargetPlatform::Windows) {
+      // Append the `.exe` extension without overriding the existing extensions
+      let extension = if let Some(extension) = path.extension() {
+        let mut extension = extension.to_os_string();
+        extension.push(".exe");
+        extension
+      } else {
+        "exe".into()
+      };
+      path.set_extension(extension);
     };
-
-    Ok(out_dir.join(bin_name).with_extension(ext))
+    Ok(path)
   }
 
   fn get_binaries(&self) -> crate::Result<Vec<BundleBinary>> {
@@ -897,9 +912,10 @@ impl AppSettings for RustAppSettings {
         .clone()
         .unwrap_or_default();
       for bin in bins {
-        let is_main = bin.name == self.cargo_package_settings.name || bin.name == default_run;
+        let file_name = bin.file_name();
+        let is_main = file_name == self.cargo_package_settings.name || file_name == default_run;
         binaries.push(BundleBinary::with_path(
-          bin.name.clone(),
+          file_name.to_owned(),
           is_main,
           bin.path.clone(),
         ))
@@ -1100,7 +1116,7 @@ impl RustAppSettings {
             .to_string()
         })
     });
-    let target = Target::from_triple(&target_triple);
+    let target = TargetPlatform::from_triple(&target_triple);
 
     Ok(Self {
       manifest: Mutex::new(manifest),
@@ -1110,7 +1126,7 @@ impl RustAppSettings {
       package_settings,
       cargo_config,
       target_triple,
-      target,
+      target_platform: target,
     })
   }
 

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -24,7 +24,7 @@
       "pattern": "^[^/\\:*?\"<>|]+$"
     },
     "mainBinaryName": {
-      "description": "App main binary filename. Defaults to the name of your cargo crate.",
+      "description": "Overrides app's main binary filename.\n\n By default, Tauri uses the output binary from `cargo`, by setting this, we will rename that binary in `tauri-cli`'s\n `tauri build` command, and target `tauri bundle` to it\n\n If possible, change the [`package name`] or set the [`name field`] instead,\n and if that's not enough and you're using nightly, consider using the [`different-binary-name`] feature instead\n\n Note: this config should not include the binary extension (e.g. `.exe`), we'll add that for you\n\n [`package name`]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field\n [`name field`]: https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-name-field\n [`different-binary-name`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#different-binary-name",
       "type": [
         "string",
         "null"

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -2946,7 +2946,19 @@ pub struct Config {
   #[serde(alias = "product-name")]
   #[cfg_attr(feature = "schema", validate(regex(pattern = "^[^/\\:*?\"<>|]+$")))]
   pub product_name: Option<String>,
-  /// App main binary filename. Defaults to the name of your cargo crate.
+  /// Overrides app's main binary filename.
+  ///
+  /// By default, Tauri uses the output binary from `cargo`, by setting this, we will rename that binary in `tauri-cli`'s
+  /// `tauri build` command, and target `tauri bundle` to it
+  ///
+  /// If possible, change the [`package name`] or set the [`name field`] instead,
+  /// and if that's not enough and you're using nightly, consider using the [`different-binary-name`] feature instead
+  ///
+  /// Note: this config should not include the binary extension (e.g. `.exe`), we'll add that for you
+  ///
+  /// [`package name`]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field
+  /// [`name field`]: https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-name-field
+  /// [`different-binary-name`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#different-binary-name
   #[serde(alias = "main-binary-name")]
   pub main_binary_name: Option<String>,
   /// App version. It is a semver version number or a path to a `package.json` file containing the `version` field.

--- a/crates/tauri-utils/src/resources.rs
+++ b/crates/tauri-utils/src/resources.rs
@@ -44,16 +44,12 @@ fn normalize(path: &Path) -> PathBuf {
 pub fn external_binaries(external_binaries: &[String], target_triple: &str) -> Vec<String> {
   let mut paths = Vec::new();
   for curr_path in external_binaries {
-    paths.push(format!(
-      "{}-{}{}",
-      curr_path,
-      target_triple,
-      if target_triple.contains("windows") {
-        ".exe"
-      } else {
-        ""
-      }
-    ));
+    let extension = if target_triple.contains("windows") {
+      ".exe"
+    } else {
+      ""
+    };
+    paths.push(format!("{curr_path}-{target_triple}{extension}"));
   }
   paths
 }

--- a/crates/tauri-utils/src/resources.rs
+++ b/crates/tauri-utils/src/resources.rs
@@ -9,6 +9,8 @@ use std::{
 
 use walkdir::WalkDir;
 
+use crate::platform::Target as TargetPlatform;
+
 /// Given a path (absolute or relative) to a resource file, returns the
 /// relative path from the bundle resources directory where that resource
 /// should be stored.
@@ -41,10 +43,14 @@ fn normalize(path: &Path) -> PathBuf {
 }
 
 /// Parses the external binaries to bundle, adding the target triple suffix to each of them.
-pub fn external_binaries(external_binaries: &[String], target_triple: &str) -> Vec<String> {
+pub fn external_binaries(
+  external_binaries: &[String],
+  target_triple: &str,
+  target_platform: &TargetPlatform,
+) -> Vec<String> {
   let mut paths = Vec::new();
   for curr_path in external_binaries {
-    let extension = if target_triple.contains("windows") {
+    let extension = if matches!(target_platform, TargetPlatform::Windows) {
       ".exe"
     } else {
       ""

--- a/examples/api/src-tauri/tauri.conf.json
+++ b/examples/api/src-tauri/tauri.conf.json
@@ -6,6 +6,7 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
+    "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
     "removeUnusedCommands": true
   },

--- a/examples/api/src-tauri/tauri.conf.json
+++ b/examples/api/src-tauri/tauri.conf.json
@@ -6,7 +6,6 @@
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
-    "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
     "removeUnusedCommands": true
   },


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix #13420

So we used to use `with_extension` to append the `.exe` on Windows, weirdly enough, this will replace the extension instead of appending one, so before [`with_added_extension`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.with_added_extension) gets stabilized, we do this manually

This also adds the support for the bundler to pickup the binary name from nightly feature [`different-binary-name`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#different-binary-name)

And documented how `mainBinaryName` works