### PR TITLE
fix(core): capability filtering crashing allowed command generation

### DIFF
--- a/.changes/fix-capability-filter.md
+++ b/.changes/fix-capability-filter.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:bug
+---
+
+Fix capability filtering via `tauri.conf.json > app > security > capabilities` not working when generating allowed commands.

--- a/crates/tauri-build/src/acl.rs
+++ b/crates/tauri-build/src/acl.rs
@@ -437,7 +437,7 @@ pub fn build(out_dir: &Path, target: Target, attributes: &Attributes) -> super::
     permissions_map.insert(APP_ACL_KEY.to_string(), app_acl.permission_files);
   }
 
-  tauri_utils::acl::build::generate_allowed_commands(out_dir, permissions_map)?;
+  tauri_utils::acl::build::generate_allowed_commands(out_dir, Some(capabilities), permissions_map)?;
 
   Ok(())
 }

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -367,6 +367,8 @@ impl Attributes {
 
   /// Set the glob pattern to be used to find the capabilities.
   ///
+  /// **WARNING:** The `removeUnusedCommands` option does not work with a custom capabilities path.
+  ///
   /// **Note:** You must emit [rerun-if-changed] instructions for your capabilities directory.
   ///
   /// [rerun-if-changed]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed

--- a/crates/tauri-codegen/src/context.rs
+++ b/crates/tauri-codegen/src/context.rs
@@ -395,7 +395,7 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
   let capabilities_file_path = out_dir.join(CAPABILITIES_FILE_NAME);
   let capabilities = get_capabilities(
     &config,
-    Some(&capabilities_file_path),
+    &capabilities_file_path,
     additional_capabilities.as_deref(),
   )
   .unwrap();

--- a/crates/tauri-codegen/src/context.rs
+++ b/crates/tauri-codegen/src/context.rs
@@ -393,9 +393,16 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
   };
 
   let capabilities_file_path = out_dir.join(CAPABILITIES_FILE_NAME);
+  let capabilities_from_files = if capabilities_file_path.exists() {
+    let capabilities_json =
+      std::fs::read_to_string(&capabilities_file_path).expect("failed to read capabilities");
+    serde_json::from_str(&capabilities_json).expect("failed to parse capabilities")
+  } else {
+    Default::default()
+  };
   let capabilities = get_capabilities(
     &config,
-    &capabilities_file_path,
+    capabilities_from_files,
     additional_capabilities.as_deref(),
   )
   .unwrap();

--- a/crates/tauri-plugin/src/build/mod.rs
+++ b/crates/tauri-plugin/src/build/mod.rs
@@ -137,7 +137,7 @@ impl<'a> Builder<'a> {
 
     let mut permissions_map = BTreeMap::new();
     permissions_map.insert(name.clone(), permissions);
-    tauri_utils::acl::build::generate_allowed_commands(&out_dir, permissions_map)?;
+    tauri_utils::acl::build::generate_allowed_commands(&out_dir, None, permissions_map)?;
 
     if let Some(global_scope_schema) = self.global_scope_schema {
       acl::build::define_global_scope_schema(global_scope_schema, &name, &out_dir)?;

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use crate::{
-  acl::{has_app_manifest, AllowedCommands, Error},
+  acl::{has_app_manifest, AllowedCommands, Error, CAPABILITIES_FILE_NAME},
   config::Config,
   write_if_changed,
 };
@@ -419,11 +419,6 @@ pub fn generate_allowed_commands(
     println!("cargo:rerun-if-changed={}", capabilities_path.display());
   }
 
-  let mut capabilities = crate::acl::build::parse_capabilities(&format!(
-    "{}/**/*",
-    glob::Pattern::escape(&capabilities_path.to_string_lossy())
-  ))?;
-
   let target_triple = env::var("TARGET")?;
   let target = crate::platform::Target::from_triple(&target_triple);
   let (mut config, config_paths) = crate::config::parse::read_from(target, &config_directory)?;
@@ -460,9 +455,23 @@ pub fn generate_allowed_commands(
     })
     .collect();
 
-  capabilities.extend(crate::acl::get_capabilities(&config, None, None)?);
+  let capabilities_file_path = out_dir.join(CAPABILITIES_FILE_NAME);
+  // the capabilities file only exist in the tauri-build context
+  if !capabilities_file_path.exists() {
+    let capabilities = crate::acl::build::parse_capabilities(&format!(
+      "{}/**/*",
+      glob::Pattern::escape(&capabilities_path.to_string_lossy())
+    ))?;
+    // write to capabilities path because we still want to go through acl::get_capabilities because it filters based on the config
+    std::fs::write(
+      &capabilities_file_path,
+      serde_json::to_string(&capabilities)?,
+    )?;
+  }
+  let capabilities = crate::acl::get_capabilities(&config, &capabilities_file_path, None)?;
 
   let permission_entries = capabilities
+    .clone()
     .into_iter()
     .flat_map(|(_, capabilities)| capabilities.permissions);
   let mut allowed_commands = AllowedCommands {

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use crate::{
-  acl::{has_app_manifest, AllowedCommands, Error, CAPABILITIES_FILE_NAME},
+  acl::{has_app_manifest, AllowedCommands, Error},
   config::Config,
   write_if_changed,
 };

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -467,7 +467,6 @@ pub fn generate_allowed_commands(
   let capabilities = crate::acl::get_capabilities(&config, capabilities_from_files, None)?;
 
   let permission_entries = capabilities
-    .clone()
     .into_iter()
     .flat_map(|(_, capabilities)| capabilities.permissions);
   let mut allowed_commands = AllowedCommands {

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -393,6 +393,7 @@ pub fn generate_docs(
 /// Generate allowed commands file for the `generate_handler` macro to remove never allowed commands
 pub fn generate_allowed_commands(
   out_dir: &Path,
+  capabilities_from_files: Option<BTreeMap<String, Capability>>,
   permissions_map: BTreeMap<String, Vec<PermissionFile>>,
 ) -> Result<(), anyhow::Error> {
   println!("cargo:rerun-if-env-changed={REMOVE_UNUSED_COMMANDS_ENV_VAR}");
@@ -455,20 +456,15 @@ pub fn generate_allowed_commands(
     })
     .collect();
 
-  let capabilities_file_path = out_dir.join(CAPABILITIES_FILE_NAME);
-  // the capabilities file only exist in the tauri-build context
-  if !capabilities_file_path.exists() {
-    let capabilities = crate::acl::build::parse_capabilities(&format!(
+  let capabilities_from_files = if let Some(capabilities) = capabilities_from_files {
+    capabilities
+  } else {
+    crate::acl::build::parse_capabilities(&format!(
       "{}/**/*",
       glob::Pattern::escape(&capabilities_path.to_string_lossy())
-    ))?;
-    // write to capabilities path because we still want to go through acl::get_capabilities because it filters based on the config
-    std::fs::write(
-      &capabilities_file_path,
-      serde_json::to_string(&capabilities)?,
-    )?;
-  }
-  let capabilities = crate::acl::get_capabilities(&config, &capabilities_file_path, None)?;
+    ))?
+  };
+  let capabilities = crate::acl::get_capabilities(&config, capabilities_from_files, None)?;
 
   let permission_entries = capabilities
     .clone()

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -355,8 +355,6 @@ pub fn get_capabilities(
   capabilities_from_files: BTreeMap<String, Capability>,
   additional_capability_files: Option<&[PathBuf]>,
 ) -> anyhow::Result<BTreeMap<String, Capability>> {
-  let mut capabilities_from_files: BTreeMap<String, Capability> = BTreeMap::new();
-
   let mut capabilities = if config.app.security.capabilities.is_empty() {
     capabilities_from_files
   } else {

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -352,7 +352,7 @@ pub fn has_app_manifest(acl: &BTreeMap<String, crate::acl::manifest::Manifest>) 
 /// Get the capabilities from the config file
 pub fn get_capabilities(
   config: &Config,
-  capabilities_from_files: BTreeMap<String, Capability>,
+  mut capabilities_from_files: BTreeMap<String, Capability>,
   additional_capability_files: Option<&[PathBuf]>,
 ) -> anyhow::Result<BTreeMap<String, Capability>> {
   let mut capabilities = if config.app.security.capabilities.is_empty() {

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -352,16 +352,10 @@ pub fn has_app_manifest(acl: &BTreeMap<String, crate::acl::manifest::Manifest>) 
 /// Get the capabilities from the config file
 pub fn get_capabilities(
   config: &Config,
-  pre_built_capabilities_file_path: &Path,
+  capabilities_from_files: BTreeMap<String, Capability>,
   additional_capability_files: Option<&[PathBuf]>,
 ) -> anyhow::Result<BTreeMap<String, Capability>> {
   let mut capabilities_from_files: BTreeMap<String, Capability> = BTreeMap::new();
-  if pre_built_capabilities_file_path.exists() {
-    let capabilities_file = std::fs::read_to_string(pre_built_capabilities_file_path)
-      .context("failed to read capabilities")?;
-    capabilities_from_files =
-      serde_json::from_str(&capabilities_file).context("failed to parse capabilities")?;
-  }
 
   let mut capabilities = if config.app.security.capabilities.is_empty() {
     capabilities_from_files

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -28,7 +28,7 @@ use std::{
   collections::{BTreeMap, HashSet},
   fs,
   num::NonZeroU64,
-  path::{Path, PathBuf},
+  path::PathBuf,
   str::FromStr,
   sync::Arc,
 };

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -352,17 +352,15 @@ pub fn has_app_manifest(acl: &BTreeMap<String, crate::acl::manifest::Manifest>) 
 /// Get the capabilities from the config file
 pub fn get_capabilities(
   config: &Config,
-  pre_built_capabilities_file_path: Option<&Path>,
+  pre_built_capabilities_file_path: &Path,
   additional_capability_files: Option<&[PathBuf]>,
 ) -> anyhow::Result<BTreeMap<String, Capability>> {
   let mut capabilities_from_files: BTreeMap<String, Capability> = BTreeMap::new();
-  if let Some(capabilities_file_path) = pre_built_capabilities_file_path {
-    if capabilities_file_path.exists() {
-      let capabilities_file =
-        std::fs::read_to_string(capabilities_file_path).context("failed to read capabilities")?;
-      capabilities_from_files =
-        serde_json::from_str(&capabilities_file).context("failed to parse capabilities")?;
-    }
+  if pre_built_capabilities_file_path.exists() {
+    let capabilities_file = std::fs::read_to_string(pre_built_capabilities_file_path)
+      .context("failed to read capabilities")?;
+    capabilities_from_files =
+      serde_json::from_str(&capabilities_file).context("failed to parse capabilities")?;
   }
 
   let mut capabilities = if config.app.security.capabilities.is_empty() {

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -350,7 +350,7 @@ fn main() {
   }
 
   let permissions = define_permissions(&out_dir);
-  tauri_utils::acl::build::generate_allowed_commands(&out_dir, permissions).unwrap();
+  tauri_utils::acl::build::generate_allowed_commands(&out_dir, None, permissions).unwrap();
 }
 
 const LICENSE_HEADER: &str = r"# Copyright 2019-2024 Tauri Programme within The Commons Conservancy


### PR DESCRIPTION
tauri-plugin and tauri build scripts cannot have access to the capabilities file (generated by tauri-build) and can only infer capabilities from the config path (from the env var)
