### PR TITLE
fix(cli): use platform name to detect iOS architecture to build

### DIFF
--- a/.changes/xcode-script-simulator-detect-fix.md
+++ b/.changes/xcode-script-simulator-detect-fix.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix simulator build detection on Xcode.

--- a/crates/tauri-cli/src/mobile/ios/xcode_script.rs
+++ b/crates/tauri-cli/src/mobile/ios/xcode_script.rs
@@ -175,7 +175,8 @@ pub fn command(options: Options) -> Result<()> {
 
   let isysroot = format!("-isysroot {}", options.sdk_root.display());
 
-  let simulator = options.arches.contains(&"Simulator".to_string());
+  let simulator =
+    options.platform == "iOS Simulator" || options.arches.contains(&"Simulator".to_string());
   let arches = if simulator {
     // when compiling for the simulator, we don't need to build other targets
     vec![if cfg!(target_arch = "aarch64") {


### PR DESCRIPTION
somehow some user's xcode is sending `--platform iOS Simulator ... arm64` though mine sends `--platform iOS ... Simulator arm64` so the arch detection is broken, i've tweaked it a bit here so it checks the platform argument aswell

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
