### PR TITLE
feat: add method set_title_monospaced_digit for tray title

### DIFF
--- a/.changes/feat-monospaced-digit-tray-title.md
+++ b/.changes/feat-monospaced-digit-tray-title.md
@@ -1,0 +1,5 @@
+---
+"tauri": "minor:feat"
+---
+
+Add the method `set_title_monospaced_digit` and associated command for tauri/tray.

--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -550,6 +550,14 @@ impl<R: Runtime> TrayIcon<R> {
     run_item_main_thread!(self, |self_: Self| self_.inner.set_title(s))
   }
 
+  /// Set the title for this tray icon using the system monospaced digit font. **macOS only**.
+  pub fn set_title_monospaced_digit<S: AsRef<str>>(&self, title: Option<S>) -> crate::Result<()> {
+    let s = title.map(|s| s.as_ref().to_string());
+    run_item_main_thread!(self, |self_: Self| self_
+      .inner
+      .set_title_monospaced_digit(s))
+  }
+
   /// Show or hide this tray icon.
   pub fn set_visible(&self, visible: bool) -> crate::Result<()> {
     run_item_main_thread!(self, |self_: Self| self_.inner.set_visible(visible))?.map_err(Into::into)

--- a/crates/tauri/src/tray/plugin.rs
+++ b/crates/tauri/src/tray/plugin.rs
@@ -171,6 +171,17 @@ fn set_title<R: Runtime>(
 }
 
 #[command(root = "crate")]
+fn set_title_monospaced_digit<R: Runtime>(
+  app: AppHandle<R>,
+  rid: ResourceId,
+  title: Option<String>,
+) -> crate::Result<()> {
+  let resources_table = app.resources_table();
+  let tray = resources_table.get::<TrayIcon<R>>(rid)?;
+  tray.set_title_monospaced_digit(title)
+}
+
+#[command(root = "crate")]
 fn set_visible<R: Runtime>(app: AppHandle<R>, rid: ResourceId, visible: bool) -> crate::Result<()> {
   let resources_table = app.resources_table();
   let tray = resources_table.get::<TrayIcon<R>>(rid)?;
@@ -221,6 +232,7 @@ pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
       set_menu,
       set_tooltip,
       set_title,
+      set_title_monospaced_digit,
       set_visible,
       set_temp_dir_path,
       set_icon_as_template,


### PR DESCRIPTION
It addresses https://github.com/tauri-apps/tauri/issues/6537.

It allows use cases such showing a timer on the status bar on macOS.

(Depends on https://github.com/tauri-apps/tray-icon/pull/258.)