### PR TITLE
refactor: simplify `future` in command IPC structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8350,7 +8350,6 @@ dependencies = [
  "dirs 6.0.0",
  "dunce",
  "embed_plist",
- "futures-util",
  "getrandom 0.2.15",
  "glob",
  "gtk",

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -52,7 +52,6 @@ tokio = { version = "1", features = [
   "fs",
   "io-util",
 ] }
-futures-util = "0.3"
 uuid = { version = "1", features = ["v4"], optional = true }
 url = "2"
 anyhow = "1"

--- a/crates/tauri/src/ipc/mod.rs
+++ b/crates/tauri/src/ipc/mod.rs
@@ -6,9 +6,11 @@
 //!
 //! This module includes utilities to send messages to the JS layer of the webview.
 
-use std::sync::{Arc, Mutex};
+use std::{
+  future::Future,
+  sync::{Arc, Mutex},
+};
 
-use futures_util::Future;
 use http::HeaderMap;
 use serde::{
   de::{DeserializeOwned, IntoDeserializer},


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: #13382

This reduced the incremental compilation time from 4.36s to 3.59s on my machine quite consistently (tested by adding and removing a new line inside an async command)

I don't fully understand the differences between an async function vs `impl Future` in rust though, but I think they're the same in this case