### PR TITLE
feat: add bundleName field to schema and MacConfig (#13110)

### DIFF
--- a/.changes/bundler-bundleName.md
+++ b/.changes/bundler-bundleName.md
@@ -1,9 +1,9 @@
 ---
-tauri-bundler: "minor:feat"
-tauri-cli: "minor:feat"
-tauri-codegen: "minor:feat"
-tauri-utils: "minor:feat"
-@tauri-apps/cli: "minor:feat"
+"tauri-bundler": "minor:feat"
+"tauri-cli": "minor:feat"
+"tauri-codegen": "minor:feat"
+"tauri-utils": "minor:feat"
+"@tauri-apps/cli": "minor:feat"
 ---
 
 Added support for the `bundleName` property in the macOS bundler configuration. This allows specifying the `CFBundleName` value for generated macOS bundles.

--- a/.changes/bundler-bundleName.md
+++ b/.changes/bundler-bundleName.md
@@ -1,0 +1,9 @@
+---
+tauri-bundler: "minor:feat"
+tauri-cli: "minor:feat"
+tauri-codegen: "minor:feat"
+tauri-schema-generator: "minor:feat"
+tauri-utils: "minor:feat"
+---
+
+Added support for the `bundleName` property in the macOS bundler configuration. This allows specifying the `CFBundleName` value for generated macOS bundles.

--- a/.changes/bundler-bundleName.md
+++ b/.changes/bundler-bundleName.md
@@ -4,6 +4,7 @@ tauri-cli: "minor:feat"
 tauri-codegen: "minor:feat"
 tauri-schema-generator: "minor:feat"
 tauri-utils: "minor:feat"
+@tauri-apps/cli: "minor:feat"
 ---
 
 Added support for the `bundleName` property in the macOS bundler configuration. This allows specifying the `CFBundleName` value for generated macOS bundles.

--- a/.changes/bundler-bundleName.md
+++ b/.changes/bundler-bundleName.md
@@ -2,7 +2,6 @@
 tauri-bundler: "minor:feat"
 tauri-cli: "minor:feat"
 tauri-codegen: "minor:feat"
-tauri-schema-generator: "minor:feat"
 tauri-utils: "minor:feat"
 @tauri-apps/cli: "minor:feat"
 ---

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -214,7 +214,11 @@ fn create_info_plist(
     settings.bundle_identifier().into(),
   );
   plist.insert("CFBundleInfoDictionaryVersion".into(), "6.0".into());
-  plist.insert("CFBundleName".into(), settings.product_name().into());
+  if let Some(bundle_name) = settings.macos().bundle_name.clone() {
+    plist.insert("CFBundleName".into(), bundle_name.into());
+  } else {
+    plist.insert("CFBundleName".into(), settings.product_name().into());
+  }
   plist.insert("CFBundlePackageType".into(), "APPL".into());
   plist.insert(
     "CFBundleShortVersionString".into(),

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -214,11 +214,15 @@ fn create_info_plist(
     settings.bundle_identifier().into(),
   );
   plist.insert("CFBundleInfoDictionaryVersion".into(), "6.0".into());
-  if let Some(bundle_name) = settings.macos().bundle_name.clone() {
-    plist.insert("CFBundleName".into(), bundle_name.into());
-  } else {
-    plist.insert("CFBundleName".into(), settings.product_name().into());
-  }
+  plist.insert(
+    "CFBundleName".into(),
+    settings
+      .macos()
+      .bundle_name
+      .as_deref()
+      .unwrap_or(settings.product_name())
+      .into(),
+  );
   plist.insert("CFBundlePackageType".into(), "APPL".into());
   plist.insert(
     "CFBundleShortVersionString".into(),

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -217,8 +217,9 @@ fn create_info_plist(
   if let Some(bundle_name) = settings
     .macos()
     .bundle_name
-    .as_ref()
-    .or(settings.product_name())
+    .as_deref()
+    .unwrap_or_else(|| settings.product_name())
+    .into()
   {
     plist.insert("CFBundleName".into(), bundle_name.into());
   }

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -214,15 +214,14 @@ fn create_info_plist(
     settings.bundle_identifier().into(),
   );
   plist.insert("CFBundleInfoDictionaryVersion".into(), "6.0".into());
-  plist.insert(
-    "CFBundleName".into(),
-    settings
-      .macos()
-      .bundle_name
-      .as_deref()
-      .unwrap_or(settings.product_name())
-      .into(),
-  );
+  if let Some(bundle_name) = settings
+    .macos()
+    .bundle_name
+    .as_ref()
+    .or(settings.product_name())
+  {
+    plist.insert("CFBundleName".into(), bundle_name.into());
+  }
   plist.insert("CFBundlePackageType".into(), "APPL".into());
   plist.insert(
     "CFBundleShortVersionString".into(),

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -333,6 +333,8 @@ pub struct MacOsSettings {
   pub files: HashMap<PathBuf, PathBuf>,
   /// The version of the build that identifies an iteration of the bundle.
   pub bundle_version: Option<String>,
+  /// The name of the build that identifies an string of the bundle.
+  pub bundle_name: Option<String>,
   /// A version string indicating the minimum MacOS version that the bundled app supports (e.g. `"10.11"`).
   /// If you are using this config field, you may also want have your `build.rs` script emit `cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.11`.
   pub minimum_system_version: Option<String>,

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -334,7 +334,7 @@ pub struct MacOsSettings {
   /// The version of the build that identifies an iteration of the bundle.
   pub bundle_version: Option<String>,
   /// The name of the build that identifies a string of the bundle.
-  /// 
+  ///
   /// If not set, defaults to the package's product name.
   pub bundle_name: Option<String>,
   /// A version string indicating the minimum MacOS version that the bundled app supports (e.g. `"10.11"`).

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -333,7 +333,9 @@ pub struct MacOsSettings {
   pub files: HashMap<PathBuf, PathBuf>,
   /// The version of the build that identifies an iteration of the bundle.
   pub bundle_version: Option<String>,
-  /// The name of the build that identifies an string of the bundle.
+  /// The name of the build that identifies a string of the bundle.
+  /// 
+  /// If not set, defaults to the package's product name.
   pub bundle_name: Option<String>,
   /// A version string indicating the minimum MacOS version that the bundled app supports (e.g. `"10.11"`).
   /// If you are using this config field, you may also want have your `build.rs` script emit `cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.11`.

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -3413,6 +3413,13 @@
             "null"
           ]
         },
+        "bundleName": {
+          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "minimumSystemVersion": {
           "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.\n\n Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`\n and the `MACOSX_DEPLOYMENT_TARGET` environment variable.\n\n An empty string is considered an invalid value so the default value is used.",
           "default": "10.13",

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -3414,7 +3414,7 @@
           ]
         },
         "bundleName": {
-          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.\n \n If not set, defaults to the package's product name.",
+          "description": "The name of the builder that built the bundle.\n\n Translates to the bundle's CFBundleName property.\n\n If not set, defaults to the package's product name.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -3414,7 +3414,7 @@
           ]
         },
         "bundleName": {
-          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.",
+          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.\n \n If not set, defaults to the package's product name.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1438,6 +1438,7 @@ fn tauri_config_to_bundle_settings(
       frameworks: config.macos.frameworks,
       files: config.macos.files,
       bundle_version: config.macos.bundle_version,
+      bundle_name: config.macos.bundle_name,
       minimum_system_version: config.macos.minimum_system_version,
       exception_domain: config.macos.exception_domain,
       signing_identity,

--- a/crates/tauri-codegen/src/context.rs
+++ b/crates/tauri-codegen/src/context.rs
@@ -309,17 +309,16 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
     };
 
     if let Some(plist) = info_plist.as_dictionary_mut() {
-      plist.insert(
-        "CFBundleName".into(),
-        config
-          .bundle
-          .macos
-          .bundle_name
-          .as_deref()
-          .or_else(|| config.product_name.as_deref())
-          .unwrap()
-          .into(),
-      );
+      if let Some(bundle_name) = config
+        .bundle
+        .macos
+        .bundle_name
+        .as_ref()
+        .or(config.product_name.as_ref())
+      {
+        plist.insert("CFBundleName".into(), bundle_name.as_str().into());
+      }
+
       if let Some(version) = &config.version {
         let bundle_version = &config.bundle.macos.bundle_version;
         plist.insert("CFBundleShortVersionString".into(), version.clone().into());

--- a/crates/tauri-codegen/src/context.rs
+++ b/crates/tauri-codegen/src/context.rs
@@ -309,7 +309,9 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
     };
 
     if let Some(plist) = info_plist.as_dictionary_mut() {
-      if let Some(product_name) = &config.product_name {
+      if let Some(bundle_name) = &config.bundle.macos.bundle_name {
+        plist.insert("CFBundleName".into(), bundle_name.clone().into());
+      }  else if let Some(product_name) = &config.product_name {
         plist.insert("CFBundleName".into(), product_name.clone().into());
       }
       if let Some(version) = &config.version {

--- a/crates/tauri-codegen/src/context.rs
+++ b/crates/tauri-codegen/src/context.rs
@@ -309,11 +309,17 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
     };
 
     if let Some(plist) = info_plist.as_dictionary_mut() {
-      if let Some(bundle_name) = &config.bundle.macos.bundle_name {
-        plist.insert("CFBundleName".into(), bundle_name.clone().into());
-      }  else if let Some(product_name) = &config.product_name {
-        plist.insert("CFBundleName".into(), product_name.clone().into());
-      }
+      plist.insert(
+        "CFBundleName".into(),
+        config
+          .bundle
+          .macos
+          .bundle_name
+          .as_deref()
+          .or_else(|| config.product_name.as_deref())
+          .unwrap()
+          .into(),
+      );
       if let Some(version) = &config.version {
         let bundle_version = &config.bundle.macos.bundle_version;
         plist.insert("CFBundleShortVersionString".into(), version.clone().into());

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -3413,6 +3413,13 @@
             "null"
           ]
         },
+        "bundleName": {
+          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "minimumSystemVersion": {
           "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.\n\n Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`\n and the `MACOSX_DEPLOYMENT_TARGET` environment variable.\n\n An empty string is considered an invalid value so the default value is used.",
           "default": "10.13",

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -3414,7 +3414,7 @@
           ]
         },
         "bundleName": {
-          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.\n \n If not set, defaults to the package's product name.",
+          "description": "The name of the builder that built the bundle.\n\n Translates to the bundle's CFBundleName property.\n\n If not set, defaults to the package's product name.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -3414,7 +3414,7 @@
           ]
         },
         "bundleName": {
-          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.",
+          "description": "The name of the builder that built the bundle.\n \n Translates to the bundle's CFBundleName property.\n \n If not set, defaults to the package's product name.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -617,6 +617,11 @@ pub struct MacConfig {
   /// Translates to the bundle's CFBundleVersion property.
   #[serde(alias = "bundle-version")]
   pub bundle_version: Option<String>,
+  /// The name of the builder that built the bundle.
+  /// 
+  /// Translates to the bundle's CFBundleName property.
+  #[serde(alias = "bundle-name")]
+  pub bundle_name: Option<String>,
   /// A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.
   ///
   /// Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`
@@ -655,6 +660,7 @@ impl Default for MacConfig {
       frameworks: None,
       files: HashMap::new(),
       bundle_version: None,
+      bundle_name: None,
       minimum_system_version: macos_minimum_system_version(),
       exception_domain: None,
       signing_identity: None,

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -618,9 +618,9 @@ pub struct MacConfig {
   #[serde(alias = "bundle-version")]
   pub bundle_version: Option<String>,
   /// The name of the builder that built the bundle.
-  /// 
+  ///
   /// Translates to the bundle's CFBundleName property.
-  /// 
+  ///
   /// If not set, defaults to the package's product name.
   #[serde(alias = "bundle-name")]
   pub bundle_name: Option<String>,

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -620,6 +620,8 @@ pub struct MacConfig {
   /// The name of the builder that built the bundle.
   /// 
   /// Translates to the bundle's CFBundleName property.
+  /// 
+  /// If not set, defaults to the package's product name.
   #[serde(alias = "bundle-name")]
   pub bundle_name: Option<String>,
   /// A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.

--- a/crates/tauri/test/fixture/src-tauri/tauri.conf.json
+++ b/crates/tauri/test/fixture/src-tauri/tauri.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "../../../../../crates/tauri-schema-generator/schemas/config.schema.json",
   "identifier": "studio.tauri.example",
-  "productName": "TestApp",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:4000"

--- a/crates/tauri/test/fixture/src-tauri/tauri.conf.json
+++ b/crates/tauri/test/fixture/src-tauri/tauri.conf.json
@@ -17,6 +17,9 @@
     }
   },
   "bundle": {
-    "active": true
+    "active": true,
+    "macOS": {
+      "bundleName": "TestBundleName"
+    }
   }
 }

--- a/crates/tauri/test/fixture/src-tauri/tauri.conf.json
+++ b/crates/tauri/test/fixture/src-tauri/tauri.conf.json
@@ -1,6 +1,7 @@
 {
   "$schema": "../../../../../crates/tauri-schema-generator/schemas/config.schema.json",
   "identifier": "studio.tauri.example",
+  "productName": "TestApp",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:4000"
@@ -17,9 +18,6 @@
     }
   },
   "bundle": {
-    "active": true,
-    "macOS": {
-      "bundleName": "TestBundleName"
-    }
+    "active": true
   }
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Added plist bundleName option for macOS, enhancing bundle configuration flexibility. Now, `tauri.config.json` support `macOS > bundle > bundleName`

Feature tested on cargo cli `cargo tauri bundle`