### PR TITLE
fix(windows): allow web fullscreen APIs to work

### DIFF
--- a/.changes/windows-fullscreen.md
+++ b/.changes/windows-fullscreen.md
@@ -1,5 +1,5 @@
 ---
-tauri-wry: "patch:bug"
+tauri-runtime-wry: "patch:bug"
 ---
 
 Allow web fullscreen APIs to work (e.g. `video.requestFullscreen` and `document.exitFullscreen`)

--- a/.changes/windows-fullscreen.md
+++ b/.changes/windows-fullscreen.md
@@ -1,0 +1,5 @@
+---
+tauri-wry: "patch:bug"
+---
+
+Allow web fullscreen APIs to work (e.g. `video.requestFullscreen` and `document.exitFullscreen`)

--- a/.changes/windows-fullscreen.md
+++ b/.changes/windows-fullscreen.md
@@ -2,4 +2,4 @@
 tauri-runtime-wry: "patch:bug"
 ---
 
-Allow web fullscreen APIs to work (e.g. `video.requestFullscreen` and `document.exitFullscreen`)
+Allow web fullscreen APIs to work on Windows (e.g. `video.requestFullscreen` and `document.exitFullscreen`)

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4881,7 +4881,6 @@ You may have it installed on another user account, but it is not available for t
     .unwrap();
 
     if let Ok(webview) = unsafe { controller.CoreWebView2() } {
-      let window_id_ = window_id.clone();
       let proxy_clone = context.proxy.clone();
       unsafe {
         let _ = webview.add_ContainsFullScreenElementChanged(
@@ -4891,7 +4890,7 @@ You may have it installed on another user account, but it is not available for t
               .ok_or_else(windows::core::Error::empty)?
               .ContainsFullScreenElement(&mut contains_fullscreen_element)?;
             let _ = proxy_clone.send_event(Message::Window(
-              *window_id_.lock().unwrap(),
+              *window_id.lock().unwrap(),
               WindowMessage::SetFullscreen(contains_fullscreen_element.as_bool()),
             ));
             Ok(())

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -38,7 +38,7 @@ use tao::platform::unix::{WindowBuilderExtUnix, WindowExtUnix};
 #[cfg(windows)]
 use tao::platform::windows::{WindowBuilderExtWindows, WindowExtWindows};
 #[cfg(windows)]
-use webview2_com::FocusChangedEventHandler;
+use webview2_com::{ContainsFullScreenElementChangedEventHandler, FocusChangedEventHandler};
 #[cfg(windows)]
 use windows::Win32::Foundation::HWND;
 #[cfg(target_os = "ios")]
@@ -4821,8 +4821,7 @@ You may have it installed on another user account, but it is not available for t
   #[cfg(windows)]
   {
     let controller = webview.controller();
-    let proxy = context.proxy.clone();
-    let proxy_ = proxy.clone();
+    let proxy_clone = context.proxy.clone();
     let window_id_ = window_id.clone();
     let mut token = 0;
     unsafe {
@@ -4837,7 +4836,7 @@ You may have it installed on another user account, but it is not available for t
           focused_webview.replace(label_.clone());
 
           if !already_focused {
-            let _ = proxy.send_event(Message::Webview(
+            let _ = proxy_clone.send_event(Message::Webview(
               *window_id_.lock().unwrap(),
               id,
               WebviewMessage::SynthesizedWindowEvent(SynthesizedWindowEvent::Focused(true)),
@@ -4851,6 +4850,8 @@ You may have it installed on another user account, but it is not available for t
     .unwrap();
     unsafe {
       let label_ = label.clone();
+      let window_id_ = window_id.clone();
+      let proxy_clone = context.proxy.clone();
       controller.add_LostFocus(
         &FocusChangedEventHandler::create(Box::new(move |_, _| {
           let mut focused_webview = focused_webview.lock().unwrap();
@@ -4866,8 +4867,8 @@ You may have it installed on another user account, but it is not available for t
           if lost_window_focus {
             // only reset when we lost window focus - otherwise some other webview is focused
             *focused_webview = None;
-            let _ = proxy_.send_event(Message::Webview(
-              *window_id.lock().unwrap(),
+            let _ = proxy_clone.send_event(Message::Webview(
+              *window_id_.lock().unwrap(),
               id,
               WebviewMessage::SynthesizedWindowEvent(SynthesizedWindowEvent::Focused(false)),
             ));
@@ -4878,6 +4879,27 @@ You may have it installed on another user account, but it is not available for t
       )
     }
     .unwrap();
+
+    if let Ok(webview) = unsafe { controller.CoreWebView2() } {
+      let window_id_ = window_id.clone();
+      let proxy_clone = context.proxy.clone();
+      unsafe {
+        let _ = webview.add_ContainsFullScreenElementChanged(
+          &ContainsFullScreenElementChangedEventHandler::create(Box::new(move |sender, _| {
+            let mut contains_fullscreen_element = windows::core::BOOL::default();
+            sender
+              .ok_or_else(windows::core::Error::empty)?
+              .ContainsFullScreenElement(&mut contains_fullscreen_element)?;
+            let _ = proxy_clone.send_event(Message::Window(
+              *window_id_.lock().unwrap(),
+              WindowMessage::SetFullscreen(contains_fullscreen_element.as_bool()),
+            ));
+            Ok(())
+          })),
+          &mut token,
+        );
+      }
+    }
   }
 
   Ok(WebviewWrapper {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: https://github.com/MicrosoftEdge/WebView2Feedback/issues/1834

Fix #13557

I believe it works in this way on both Mac and Linux, so let's align this behavior on Windows as well