### PR TITLE
feat: add focusable property to tauri.conf.json (platform:windows) #11130

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8269,8 +8269,6 @@ dependencies = [
 [[package]]
 name = "tao"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e59c1f38e657351a2e822eadf40d6a2ad4627b9c25557bc1180ec1b3295ef82"
 dependencies = [
  "bitflags 2.7.0",
  "core-foundation 0.10.0",
@@ -8280,7 +8278,6 @@ dependencies = [
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
- "gdkx11-sys",
  "gtk",
  "jni",
  "lazy_static",
@@ -8296,13 +8293,21 @@ dependencies = [
  "parking_lot",
  "raw-window-handle",
  "scopeguard",
- "tao-macros",
+ "tao-macros 0.1.3",
  "unicode-segmentation",
  "url",
  "windows 0.61.1",
  "windows-core 0.61.0",
  "windows-version",
- "x11-dl",
+]
+
+[[package]]
+name = "tao-macros"
+version = "0.1.3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -10828,7 +10833,7 @@ dependencies = [
  "raw-window-handle",
  "sha2",
  "soup3",
- "tao-macros",
+ "tao-macros 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 2.0.10",
  "tracing",
  "url",

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -365,6 +365,11 @@
           "default": true,
           "type": "boolean"
         },
+        "focusable": {
+          "description": "Whether the window will be focusable or not.",
+          "default": true,
+          "type": "boolean"
+        },
         "transparent": {
           "description": "Whether the window is transparent or not.\n\n Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.\n WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.",
           "default": false,

--- a/crates/tauri-cli/tauri.config.schema.json
+++ b/crates/tauri-cli/tauri.config.schema.json
@@ -347,6 +347,11 @@
           "default": true,
           "type": "boolean"
         },
+        "focusable": {
+          "description": "Whether the window will be focusable or not.",
+          "default": true,
+          "type": "boolean"
+        },
         "transparent": {
           "description": "Whether the window is transparent or not.\n\n Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.\n WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.",
           "default": false,

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -866,6 +866,7 @@ impl WindowBuilder for WindowBuilderWrapper {
         .title(config.title.to_string())
         .inner_size(config.width, config.height)
         .focused(config.focus)
+        .focusable(config.focusable)
         .visible(config.visible)
         .resizable(config.resizable)
         .fullscreen(config.fullscreen)
@@ -1028,6 +1029,11 @@ impl WindowBuilder for WindowBuilderWrapper {
 
   fn focused(mut self, focused: bool) -> Self {
     self.inner = self.inner.with_focused(focused);
+    self
+  }
+
+ fn focusable(mut self, focusable: bool) -> Self {
+    self.inner = self.inner.with_focusable(focusable);
     self
   }
 

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -226,6 +226,7 @@ pub struct WebviewAttributes {
   pub incognito: bool,
   pub transparent: bool,
   pub focus: bool,
+  pub focusable: bool,
   pub bounds: Option<Rect>,
   pub auto_resize: bool,
   pub proxy_url: Option<Url>,
@@ -280,6 +281,7 @@ impl From<&WindowConfig> for WebviewAttributes {
     let mut builder = Self::new(config.url.clone())
       .incognito(config.incognito)
       .focused(config.focus)
+      .focusable(config.focus)
       .zoom_hotkeys_enabled(config.zoom_hotkeys_enabled)
       .use_https_scheme(config.use_https_scheme)
       .browser_extensions_enabled(config.browser_extensions_enabled)
@@ -344,6 +346,7 @@ impl WebviewAttributes {
       incognito: false,
       transparent: false,
       focus: true,
+      focusable: true,
       bounds: None,
       auto_resize: false,
       proxy_url: None,
@@ -484,6 +487,13 @@ impl WebviewAttributes {
   #[must_use]
   pub fn focused(mut self, focus: bool) -> Self {
     self.focus = focus;
+    self
+  }
+
+  /// Whether the webview should be focusable or not.
+  #[must_use]
+  pub fn focusable(mut self, focusable: bool) -> Self {
+    self.focusable = focusable;
     self
   }
 

--- a/crates/tauri-runtime/src/window.rs
+++ b/crates/tauri-runtime/src/window.rs
@@ -329,6 +329,10 @@ pub trait WindowBuilder: WindowBuilderBase {
   #[must_use]
   fn focused(self, focused: bool) -> Self;
 
+   /// Whether the window will be focusable or not.
+  #[must_use]
+  fn focusable(self, focusable: bool) -> Self;
+
   /// Whether the window should be maximized upon creation.
   #[must_use]
   fn maximized(self, maximized: bool) -> Self;

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -365,6 +365,11 @@
           "default": true,
           "type": "boolean"
         },
+        "focusable": {
+          "description": "Whether the window will be focusable or not.",
+          "default": true,
+          "type": "boolean"
+        },
         "transparent": {
           "description": "Whether the window is transparent or not.\n\n Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.\n WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.",
           "default": false,

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -1618,6 +1618,9 @@ pub struct WindowConfig {
   /// Whether the window will be initially focused or not.
   #[serde(default = "default_true")]
   pub focus: bool,
+   /// Whether the window will be focusable or not.
+  #[serde(default = "default_true")]
+  pub focusable: bool,
   /// Whether the window is transparent or not.
   ///
   /// Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.
@@ -1843,6 +1846,7 @@ impl Default for WindowConfig {
       title: default_title(),
       fullscreen: false,
       focus: false,
+      focusable: true,
       transparent: false,
       maximized: false,
       visible: true,
@@ -3203,6 +3207,7 @@ mod build {
       let proxy_url = opt_lit(self.proxy_url.as_ref().map(url_lit).as_ref());
       let fullscreen = self.fullscreen;
       let focus = self.focus;
+      let focusable = self.focusable;
       let transparent = self.transparent;
       let maximized = self.maximized;
       let visible = self.visible;
@@ -3260,6 +3265,7 @@ mod build {
         proxy_url,
         fullscreen,
         focus,
+        focusable,
         transparent,
         maximized,
         visible,

--- a/crates/tauri/src/test/mock_runtime.rs
+++ b/crates/tauri/src/test/mock_runtime.rs
@@ -407,6 +407,10 @@ impl WindowBuilder for MockWindowBuilder {
     self
   }
 
+   fn focusable(self, focusable: bool) -> Self {
+    self
+  }
+
   fn maximized(self, maximized: bool) -> Self {
     self
   }

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -846,6 +846,13 @@ fn main() {
     self
   }
 
+  /// Whether the webview should be focusable or not.
+  #[must_use]
+  pub fn focusable(mut self, focusable: bool) -> Self {
+    self.webview_attributes.focusable = focusable;
+    self
+  }
+
   /// Sets the webview to automatically grow and shrink its size and position when the parent window resizes.
   #[must_use]
   pub fn auto_resize(mut self) -> Self {

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -524,6 +524,14 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
     self
   }
 
+  /// Whether the window will be focusable or not.
+  #[must_use]
+  pub fn focusable(mut self, focusable: bool) -> Self {
+    self.window_builder = self.window_builder.focusable(focusable);
+    self.webview_builder = self.webview_builder.focusable(focusable);
+    self
+  }
+
   /// Whether the window will be initially focused or not.
   #[must_use]
   pub fn focused(mut self, focused: bool) -> Self {

--- a/crates/tauri/src/window/mod.rs
+++ b/crates/tauri/src/window/mod.rs
@@ -588,6 +588,13 @@ impl<'a, R: Runtime, M: Manager<R>> WindowBuilder<'a, R, M> {
     self
   }
 
+  /// Whether the window will be focusable or not.
+  #[must_use]
+  pub fn focusable(mut self, focusable: bool) -> Self {
+    self.window_builder = self.window_builder.focusable(focusable);
+    self
+  }
+
   /// Whether the window should be maximized upon creation.
   #[must_use]
   pub fn maximized(mut self, maximized: bool) -> Self {


### PR DESCRIPTION
Add focusable property, only for windows platform.

To be use at tauri.conf.json:

By default is true, when is passed as false creates the window not focusable.

"app": {
    "windows": [
      {
        "title": "demoapp",
        "width": 800,
        "height": 600,
        "decorations": false,
        "focusable": false
      }
    ],
  },