### PR TITLE
fix(linux): Fix app icon not showing on Gnome+Wayland (#5258)

### DIFF
--- a/.changes/fix-dock-icon-gnome-wayland.md
+++ b/.changes/fix-dock-icon-gnome-wayland.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:bug
+---
+
+Fixes app icon not being displayed on Gnome dock and grid view when using Wayland.

--- a/crates/tauri-bundler/src/bundle/linux/freedesktop/main.desktop
+++ b/crates/tauri-bundler/src/bundle/linux/freedesktop/main.desktop
@@ -4,6 +4,7 @@ Categories={{categories}}
 Comment={{comment}}
 {{/if}}
 Exec={{exec}}
+StartupWMClass={{exec}}
 Icon={{icon}}
 Name={{name}}
 Terminal=false


### PR DESCRIPTION
closes #5258

Spinned off a Fedora VM to test Museeks, and realized the icon would never show in dock, nor the installer. Modern Fedora uses Wayland. This also applied to Ubuntu. Forcing x11 shown the correct icon.

For whatever reasons, setting `StartupWMClass` to the name of the app fixes it. See the discussion linked above. I don't know if this is just Gnome, or Freedesktop or whatever, but this fixes it.

#### Before:

![Screenshot 2025-06-06 at 14 58 21](https://github.com/user-attachments/assets/b8594ff8-4370-4847-834f-9706e32254e9)
![Screenshot 2025-06-06 at 14 58 57](https://github.com/user-attachments/assets/8759ca09-7370-4ee4-a300-1568ef32f3b6)

#### After:

Icon is still not showing on installer:
![Screenshot 2025-06-06 at 14 59 57](https://github.com/user-attachments/assets/4963088e-133e-4695-bf57-1696f0d1f81b)

but is showing correctly in dock + grid view:

![Screenshot 2025-06-06 at 15 00 22](https://github.com/user-attachments/assets/b6790b45-9966-4f9e-bbb4-f498f76b9c83)

I tested that locally with a local template, I know, not perfect. If I can test it using the real tauri repo.