### PR TITLE
fix: failing scope test on Windows

### DIFF
--- a/crates/tauri/src/scope/fs.rs
+++ b/crates/tauri/src/scope/fs.rs
@@ -611,40 +611,6 @@ mod tests {
       assert!(scope.is_allowed("\\\\?\\anyfile"));
       assert!(!scope.is_allowed("\\\\?\\otherfile"));
     }
-
-    let cwd = std::env::current_dir().unwrap();
-    let disk = {
-      let std::path::Component::Prefix(prefix) = cwd.components().next().unwrap() else {
-        panic!("Expected current dir to start with a prefix");
-      };
-      assert!(
-        matches!(prefix.kind(), std::path::Prefix::Disk(_)),
-        "Expected current dir to be on a disk drive"
-      );
-      prefix.as_os_str().to_string_lossy()
-    };
-
-    let scope = new_scope();
-    {
-      // Disk
-      scope.allow_directory(&*disk, true).unwrap();
-      assert!(scope.is_allowed(format!("{}Cargo.toml", disk)));
-      assert!(scope.is_allowed(cwd.join("Cargo.toml")));
-      assert!(!scope.is_allowed("C:\\Windows"));
-      assert!(!scope.is_allowed("Q:Cargo.toml"));
-    }
-
-    let scope = new_scope();
-    {
-      // Verbatim disk
-      scope
-        .allow_directory(format!("\\\\?\\{}", disk), true)
-        .unwrap();
-      assert!(scope.is_allowed(format!("{}Cargo.toml", disk)));
-      assert!(scope.is_allowed(cwd.join("Cargo.toml")));
-      assert!(!scope.is_allowed("C:\\Windows"));
-      assert!(!scope.is_allowed("Q:Cargo.toml"));
-    }
   }
 
   #[test]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Remove the scope test that depends on the current cwd and that drive letter

I think what they're testing are basically the same as the above tests that we don't really need them anymore, but I don't mind the suggestion from @FabianLars to guard this behined a check (if not run from `C:`)