### PR TITLE
fix(tauri-utils): Use write_if_changed more

### DIFF
--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -91,7 +91,8 @@ pub fn define_permissions<F: Fn(&Path) -> bool>(
   let pkg_name_valid_path = pkg_name.replace(':', "-");
   let permission_files_path = out_dir.join(format!("{}-permission-files", pkg_name_valid_path));
   let permission_files_json = serde_json::to_string(&permission_files)?;
-  fs::write(&permission_files_path, permission_files_json)
+
+  write_if_changed(&permission_files_path, permission_files_json)
     .map_err(|e| Error::WriteFile(e, permission_files_path.clone()))?;
 
   if let Some(plugin_name) = pkg_name.strip_prefix("tauri:") {
@@ -151,7 +152,8 @@ pub fn define_global_scope_schema(
   out_dir: &Path,
 ) -> Result<(), Error> {
   let path = out_dir.join("global-scope.json");
-  fs::write(&path, serde_json::to_vec(&schema)?).map_err(|e| Error::WriteFile(e, path.clone()))?;
+  write_if_changed(&path, serde_json::to_vec(&schema)?)
+    .map_err(|e| Error::WriteFile(e, path.clone()))?;
 
   if let Some(plugin_name) = pkg_name.strip_prefix("tauri:") {
     println!(


### PR DESCRIPTION
Replace `fs::write` with `write_if_changed` in two places. This can prevent unnecessary rebuilds. (I didn’t encounter any, but this should be ok nonetheless.)

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
