### PR TITLE
fix(cli): use original identifier to fix mobile options reading

### DIFF
--- a/.changes/fix-mobile-identifier-changes.md
+++ b/.changes/fix-mobile-identifier-changes.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fixes Android and iOS dev/build commands not working when the app identifier is being modified by the `--config` option.

--- a/crates/tauri-cli/src/mobile/android/android_studio_script.rs
+++ b/crates/tauri-cli/src/mobile/android/android_studio_script.rs
@@ -51,7 +51,7 @@ pub fn command(options: Options) -> Result<()> {
   let (config, metadata, cli_options) = {
     let tauri_config_guard = tauri_config.lock().unwrap();
     let tauri_config_ = tauri_config_guard.as_ref().unwrap();
-    let cli_options = read_options(&tauri_config_);
+    let cli_options = read_options(tauri_config_);
     let (config, metadata) = get_config(
       &get_app(
         MobileTarget::Android,

--- a/crates/tauri-cli/src/mobile/android/android_studio_script.rs
+++ b/crates/tauri-cli/src/mobile/android/android_studio_script.rs
@@ -51,7 +51,7 @@ pub fn command(options: Options) -> Result<()> {
   let (config, metadata, cli_options) = {
     let tauri_config_guard = tauri_config.lock().unwrap();
     let tauri_config_ = tauri_config_guard.as_ref().unwrap();
-    let cli_options = read_options(&tauri_config_.identifier);
+    let cli_options = read_options(&tauri_config_);
     let (config, metadata) = get_config(
       &get_app(
         MobileTarget::Android,

--- a/crates/tauri-cli/src/mobile/android/build.rs
+++ b/crates/tauri-cli/src/mobile/android/build.rs
@@ -213,7 +213,7 @@ fn run_build(
     config: build_options.config,
     target_device: None,
   };
-  let handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
+  let handle = write_options(tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
   inject_resources(config, tauri_config.lock().unwrap().as_ref().unwrap())?;
 

--- a/crates/tauri-cli/src/mobile/android/build.rs
+++ b/crates/tauri-cli/src/mobile/android/build.rs
@@ -213,10 +213,7 @@ fn run_build(
     config: build_options.config,
     target_device: None,
   };
-  let handle = write_options(
-    &tauri_config.lock().unwrap().as_ref().unwrap().identifier,
-    cli_options,
-  )?;
+  let handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
   inject_resources(config, tauri_config.lock().unwrap().as_ref().unwrap())?;
 

--- a/crates/tauri-cli/src/mobile/android/dev.rs
+++ b/crates/tauri-cli/src/mobile/android/dev.rs
@@ -275,7 +275,7 @@ fn run_dev(
         }),
       };
 
-      let _handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
+      let _handle = write_options(tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
       inject_resources(config, tauri_config.lock().unwrap().as_ref().unwrap())?;
 

--- a/crates/tauri-cli/src/mobile/android/dev.rs
+++ b/crates/tauri-cli/src/mobile/android/dev.rs
@@ -275,10 +275,7 @@ fn run_dev(
         }),
       };
 
-      let _handle = write_options(
-        &tauri_config.lock().unwrap().as_ref().unwrap().identifier,
-        cli_options,
-      )?;
+      let _handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
       inject_resources(config, tauri_config.lock().unwrap().as_ref().unwrap())?;
 

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -295,7 +295,7 @@ fn run_build(
     config: build_options.config.clone(),
     target_device: None,
   };
-  let handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
+  let handle = write_options(tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
   if options.open {
     return Ok(handle);

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -295,10 +295,7 @@ fn run_build(
     config: build_options.config.clone(),
     target_device: None,
   };
-  let handle = write_options(
-    &tauri_config.lock().unwrap().as_ref().unwrap().identifier,
-    cli_options,
-  )?;
+  let handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
   if options.open {
     return Ok(handle);

--- a/crates/tauri-cli/src/mobile/ios/dev.rs
+++ b/crates/tauri-cli/src/mobile/ios/dev.rs
@@ -279,10 +279,7 @@ fn run_dev(
         config: dev_options.config.clone(),
         target_device: None,
       };
-      let _handle = write_options(
-        &tauri_config.lock().unwrap().as_ref().unwrap().identifier,
-        cli_options,
-      )?;
+      let _handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
       let open_xcode = || {
         if !set_host {

--- a/crates/tauri-cli/src/mobile/ios/dev.rs
+++ b/crates/tauri-cli/src/mobile/ios/dev.rs
@@ -279,7 +279,7 @@ fn run_dev(
         config: dev_options.config.clone(),
         target_device: None,
       };
-      let _handle = write_options(&tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
+      let _handle = write_options(tauri_config.lock().unwrap().as_ref().unwrap(), cli_options)?;
 
       let open_xcode = || {
         if !set_host {

--- a/crates/tauri-cli/src/mobile/ios/xcode_script.rs
+++ b/crates/tauri-cli/src/mobile/ios/xcode_script.rs
@@ -87,7 +87,7 @@ pub fn command(options: Options) -> Result<()> {
   let (config, metadata, cli_options) = {
     let tauri_config_guard = tauri_config.lock().unwrap();
     let tauri_config_ = tauri_config_guard.as_ref().unwrap();
-    let cli_options = read_options(&tauri_config_);
+    let cli_options = read_options(tauri_config_);
     let (config, metadata) = get_config(
       &get_app(
         MobileTarget::Ios,

--- a/crates/tauri-cli/src/mobile/ios/xcode_script.rs
+++ b/crates/tauri-cli/src/mobile/ios/xcode_script.rs
@@ -87,7 +87,7 @@ pub fn command(options: Options) -> Result<()> {
   let (config, metadata, cli_options) = {
     let tauri_config_guard = tauri_config.lock().unwrap();
     let tauri_config_ = tauri_config_guard.as_ref().unwrap();
-    let cli_options = read_options(&tauri_config_.identifier);
+    let cli_options = read_options(&tauri_config_);
     let (config, metadata) = get_config(
       &get_app(
         MobileTarget::Ios,

--- a/crates/tauri-cli/src/mobile/mod.rs
+++ b/crates/tauri-cli/src/mobile/mod.rs
@@ -5,7 +5,7 @@
 use crate::{
   helpers::{
     app_paths::tauri_dir,
-    config::{reload as reload_config, Config as TauriConfig, ConfigHandle},
+    config::{reload as reload_config, Config as TauriConfig, ConfigHandle, ConfigMetadata},
   },
   interface::{AppInterface, AppSettings, DevProcess, Interface, Options as InterfaceOptions},
   ConfigValue,
@@ -365,7 +365,10 @@ fn env() -> Result<Env, EnvError> {
 pub struct OptionsHandle(#[allow(unused)] Runtime, #[allow(unused)] ServerHandle);
 
 /// Writes CLI options to be used later on the Xcode and Android Studio build commands
-pub fn write_options(identifier: &str, mut options: CliOptions) -> crate::Result<OptionsHandle> {
+pub fn write_options(
+  config: &ConfigMetadata,
+  mut options: CliOptions,
+) -> crate::Result<OptionsHandle> {
   options.vars.extend(env_vars());
 
   let runtime = Runtime::new().unwrap();
@@ -383,18 +386,28 @@ pub fn write_options(identifier: &str, mut options: CliOptions) -> crate::Result
   let (handle, addr) = r?;
 
   write(
-    temp_dir().join(format!("{identifier}-server-addr")),
+    temp_dir().join(format!(
+      "{}-server-addr",
+      config
+        .original_identifier()
+        .context("app configuration is missing an identifier")?
+    )),
     addr.to_string(),
   )?;
 
   Ok(OptionsHandle(runtime, handle))
 }
 
-fn read_options(identifier: &str) -> CliOptions {
+fn read_options(config: &ConfigMetadata) -> CliOptions {
   let runtime = tokio::runtime::Runtime::new().unwrap();
   let options = runtime
     .block_on(async move {
-      let addr_path = temp_dir().join(format!("{identifier}-server-addr"));
+      let addr_path = temp_dir().join(format!(
+        "{}-server-addr",
+        config
+          .original_identifier()
+          .context("app configuration is missing an identifier")?
+      ));
       let (tx, rx) = WsTransportClientBuilder::default()
         .build(
           format!(

--- a/crates/tauri-cli/src/mobile/mod.rs
+++ b/crates/tauri-cli/src/mobile/mod.rs
@@ -10,7 +10,6 @@ use crate::{
   interface::{AppInterface, AppSettings, DevProcess, Interface, Options as InterfaceOptions},
   ConfigValue,
 };
-#[cfg(unix)]
 use anyhow::Context;
 use anyhow::{bail, Result};
 use heck::ToSnekCase;


### PR DESCRIPTION
the iOS and Android CLI commands leverage an android_studio_script/xcode_script that is executed by the native IDE or build tool. This script reads the Tauri configuration to find the app identifier used to communicate with the parent Tauri CLI process to read CLI options.

The communication is broken when the `--config` arg is used, since the IDE script does not have access to that value before reaching the parent process, which is impossible without knowing the actual identifier used.

To bypass this we'll agree on using the original identifier. This obviously won't work if the original tauri.conf.json do not have an identifier, so we error out in this case

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
