### PR TITLE
fix: write default permission words if not empty

### DIFF
--- a/.changes/default-permissions-doc.md
+++ b/.changes/default-permissions-doc.md
@@ -1,0 +1,5 @@
+---
+tauri-utils: "minor:bug"
+---
+
+Only write `This default permission set includes the following` to the reference if the default permission set is not empty

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -349,7 +349,7 @@ pub fn generate_docs(
     }
 
     if let Some(default) = &permission.default {
-      default_permission = format!("## Default Permission\n\n");
+      default_permission.push_str("## Default Permission\n\n");
       default_permission.push_str(default.description.as_deref().unwrap_or_default().trim());
       default_permission.push('\n');
       default_permission.push('\n');

--- a/crates/tauri-utils/src/acl/build.rs
+++ b/crates/tauri-utils/src/acl/build.rs
@@ -326,10 +326,8 @@ pub fn generate_docs(
   out_dir: &Path,
   plugin_identifier: &str,
 ) -> Result<(), Error> {
+  let mut default_permission = "".to_owned();
   let mut permission_table = "".to_string();
-
-  let mut default_permission = "## Default Permission\n\n".to_string();
-  let mut contains_default = false;
 
   fn docs_from(id: &str, description: Option<&str>, plugin_identifier: &str) -> String {
     let mut docs = format!("\n<tr>\n<td>\n\n`{plugin_identifier}:{id}`\n\n</td>\n");
@@ -351,15 +349,16 @@ pub fn generate_docs(
     }
 
     if let Some(default) = &permission.default {
-      contains_default = true;
-
-      default_permission.push_str(default.description.as_deref().unwrap_or_default());
+      default_permission = format!("## Default Permission\n\n");
+      default_permission.push_str(default.description.as_deref().unwrap_or_default().trim());
       default_permission.push('\n');
       default_permission.push('\n');
-      default_permission.push_str("#### This default permission set includes the following:\n");
-      default_permission.push('\n');
-      for permission in &default.permissions {
-        default_permission.push_str(&format!("- `{permission}`\n"));
+      if !default.permissions.is_empty() {
+        default_permission.push_str("#### This default permission set includes the following:\n\n");
+        for permission in &default.permissions {
+          default_permission.push_str(&format!("- `{permission}`\n"));
+        }
+        default_permission.push('\n');
       }
     }
 
@@ -373,12 +372,7 @@ pub fn generate_docs(
     }
   }
 
-  if !contains_default {
-    default_permission = "".to_string();
-  }
-
-  let docs =
-    format!("{default_permission}\n{PERMISSION_TABLE_HEADER}\n{permission_table}</table>\n");
+  let docs = format!("{default_permission}{PERMISSION_TABLE_HEADER}\n{permission_table}</table>\n");
 
   let reference_path = out_dir.join(PERMISSION_DOCS_FILE_NAME);
   write_if_changed(&reference_path, docs).map_err(|e| Error::WriteFile(e, reference_path))?;

--- a/examples/api/src-tauri/tauri-plugin-sample/permissions/autogenerated/reference.md
+++ b/examples/api/src-tauri/tauri-plugin-sample/permissions/autogenerated/reference.md
@@ -1,4 +1,3 @@
-
 ## Permission Table
 
 <table>


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix #13645

Only write `This default permission set includes the following` to the reference if the default permission set is not empty