### PR TITLE
ci: enable create-pull-request sign commits

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -33,11 +33,6 @@ Releasing can be as easy as merging the version pull request but here is a check
 
 - [ ] Double check that every package is bumped correctly and there are no accidental major or minor being released unless that is indeed the intention.
 - [ ] Make sure that there are no pending or unfinished [covector-version-or-publish.yml](./workflows/covector-version-or-publish.yml) workflow runs.
-- [ ] Sign the Version PR before merging as we require signed commits
-  - [ ] `git fetch --all`
-  - [ ] `git checkout release/version-updates`
-  - [ ] `git commit --amend -S`
-  - [ ] `git push --force`
 - [ ] Approve and merge the version pull request
 
 ## Publishing failed, what to do?

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -119,6 +119,7 @@ jobs:
           commit-message: 'apply version updates'
           labels: 'version updates'
           body: ${{ steps.covector.outputs.change }}
+          sign-commits: true
 
       - name: Trigger doc update
         if: |


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

As we're using the update to date version of [Create Pull Request](https://github.com/peter-evans/create-pull-request/) now, we could enable [commit-signing](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signing) so we don't need to do the amend force push thing anymore

Not sure how am I gonna test this to be honest, guess we just trust it would work 😂