### PR TITLE
ci: disable renovate for 1.x branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:recommended"],
-  "baseBranches": ["dev", "1.x"],
+  "baseBranches": ["dev"],
   "labels": ["type: chore"],
   "enabledManagers": ["cargo", "npm"],
   "rangeStrategy": "replace",


### PR DESCRIPTION
the last few months it was almost only the @types/node package we were able to merge. most rust packages are out of the msrv range. i don't see any value in renovate's prs on the v1 branch anymore, it's just wasting CI time at this point.