### PR TITLE
fix(cli): fix rollup-plugin-typescript v12 compatiblity

### DIFF
--- a/.changes/plugin-template-build-error.md
+++ b/.changes/plugin-template-build-error.md
@@ -1,5 +1,5 @@
 ---
-tauri-cli: 'patch:fix'
+tauri-cli: 'patch:bug'
 ---
 
 Fixed an issue in the plugin template (`tauri plugin init`) that prevented the js build command to fail.

--- a/.changes/plugin-template-build-error.md
+++ b/.changes/plugin-template-build-error.md
@@ -1,0 +1,5 @@
+---
+tauri-cli: 'patch:fix'
+---
+
+Fixed an issue in the plugin template (`tauri plugin init`) that prevented the js build command to fail.

--- a/crates/tauri-cli/templates/plugin/rollup.config.js
+++ b/crates/tauri-cli/templates/plugin/rollup.config.js
@@ -1,6 +1,6 @@
-import { readFileSync } from 'fs'
-import { join } from 'path'
-import { cwd } from 'process'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { cwd } from 'node:process'
 import typescript from '@rollup/plugin-typescript'
 
 const pkg = JSON.parse(readFileSync(join(cwd(), 'package.json'), 'utf8'))
@@ -20,7 +20,7 @@ export default {
   plugins: [
     typescript({
       declaration: true,
-      declarationDir: `./${pkg.exports.import.split('/')[0]}`
+      declarationDir: dirname(pkg.exports.import)
     })
   ],
   external: [


### PR DESCRIPTION
copied from https://github.com/tauri-apps/plugins-workspace/pull/2467/files#diff-7364276655cd1d00b3ca7946b145773df9d3b249382ba463204108f1050a1071