### PR TITLE
fix(nsis): wrong required files path for nsis_tauri_utils.dll

### DIFF
--- a/.changes/fix-nsis-tauri-utils-dll-required-files-path.md
+++ b/.changes/fix-nsis-tauri-utils-dll-required-files-path.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: patch:bug
+---
+
+Fix wrong required files path for nsis_tauri_utils.dll

--- a/.changes/fix-nsis-tauri-utils-dll-required-files-path.md
+++ b/.changes/fix-nsis-tauri-utils-dll-required-files-path.md
@@ -2,4 +2,4 @@
 tauri-bundler: patch:bug
 ---
 
-Fix wrong required files path for nsis_tauri_utils.dll
+Fix incorrect expected file path for `nsis_tauri_utils.dll` resulting in tauri-cli re-downloading the file on every build.

--- a/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
@@ -48,7 +48,7 @@ const NSIS_REQUIRED_FILES: &[&str] = &[
   "Bin/makensis.exe",
   "Stubs/lzma-x86-unicode",
   "Stubs/lzma_solid-x86-unicode",
-  "Plugins/x86-unicode/nsis_tauri_utils.dll",
+  "Plugins/x86-unicode/additional/nsis_tauri_utils.dll",
   "Include/MUI2.nsh",
   "Include/FileFunc.nsh",
   "Include/x64.nsh",


### PR DESCRIPTION
The NSIS_REQUIRED_FILES path of the nsis_tauri_utils.dll file was wrong.

This made the verification of the NSIS installation always fail, so the bundler would reinstall NSIS on each build.