### PR TITLE
fix(protocol): proxy body in mobile dev

### DIFF
--- a/.changes/proxy-body.md
+++ b/.changes/proxy-body.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Forward request body on the mobile frontend proxy.

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -69,7 +69,7 @@ pub fn get<R: Runtime>(
 }
 
 fn get_response<R: Runtime>(
-  request: Request<Vec<u8>>,
+  #[allow(unused_mut)] mut request: Request<Vec<u8>>,
   #[allow(unused_variables)] manager: &AppManager<R>,
   window_origin: &str,
   web_resource_request_handler: Option<&WebResourceRequestHandler>,
@@ -118,6 +118,7 @@ fn get_response<R: Runtime>(
       .build()
       .unwrap()
       .request(request.method().clone(), &url);
+    proxy_builder = proxy_builder.body(std::mem::take(request.body_mut()));
     for (name, value) in request.headers() {
       proxy_builder = proxy_builder.header(name, value);
     }

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -121,6 +121,7 @@ fn get_response<R: Runtime>(
     for (name, value) in request.headers() {
       proxy_builder = proxy_builder.header(name, value);
     }
+    proxy_builder = proxy_builder.body(request.body().clone());
     match crate::async_runtime::safe_block_on(proxy_builder.send()) {
       Ok(r) => {
         let mut response_cache_ = response_cache.lock().unwrap();


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fixes #13166 for basic non-streaming requests on iOS, Android untested. I originally wanted to use `std::mem::take(request.body_mut())` to avoid a clone, but I don't know if `WebResourceRequestHandler`s depend on the original request body.