### PR TITLE
feat(android): edge to edge in init template

### DIFF
--- a/.changes/enable-android-edge-to-edge.md
+++ b/.changes/enable-android-edge-to-edge.md
@@ -1,0 +1,5 @@
+---
+'tauri-cli': 'patch:changes'
+---
+
+Enable edge to edge in `tauri android init` template

--- a/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
     implementation(platform("{{this}}")){{/each}}
     {{~#each android-app-dependencies}}
     implementation("{{this}}"){{/each}}
-    implementation("androidx.webkit:webkit:1.14.1")
+    implementation("androidx.webkit:webkit:1.14.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.activity:activity-ktx:1.10.1")
     implementation("com.google.android.material:material:1.12.0")

--- a/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
@@ -64,9 +64,10 @@ dependencies {
     implementation(platform("{{this}}")){{/each}}
     {{~#each android-app-dependencies}}
     implementation("{{this}}"){{/each}}
-    implementation("androidx.webkit:webkit:1.6.1")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.8.0")
+    implementation("androidx.webkit:webkit:1.14.1")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("androidx.activity:activity-ktx:1.10.1")
+    implementation("com.google.android.material:material:1.12.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.4")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")

--- a/crates/tauri-cli/templates/mobile/android/app/src/main/MainActivity.kt
+++ b/crates/tauri-cli/templates/mobile/android/app/src/main/MainActivity.kt
@@ -1,3 +1,11 @@
 package {{escape-kotlin-keyword app.identifier}}
 
-class MainActivity : TauriActivity()
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+
+class MainActivity : TauriActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    enableEdgeToEdge()
+    super.onCreate(savedInstanceState)
+  }
+}


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: https://github.com/tauri-apps/tauri/issues/12182#issuecomment-2584603995

Follow up of #13759, since we use `targetSdk 36` now, let's enable edge to edge to align the behavior on older android versions