### PR TITLE
fix(nsis): per-machine installer not requesting elevation when run by non-admin users

### DIFF
--- a/.changes/fix-nsis-per-machine-installer-elevation.md
+++ b/.changes/fix-nsis-per-machine-installer-elevation.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: patch:bug
+---
+
+Fix NSIS per-machine installer not requesting elevation when run by non-admin users.

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -95,7 +95,7 @@ VIAddVersionKey "ProductVersion" "${VERSION}"
 
 ; Handle install mode, `perUser`, `perMachine` or `both`
 !if "${INSTALLMODE}" == "perMachine"
-  RequestExecutionLevel highest
+  RequestExecutionLevel admin
 !endif
 
 !if "${INSTALLMODE}" == "currentUser"


### PR DESCRIPTION
According to the [NSIS docs](https://nsis.sourceforge.io/Reference/RequestExecutionLevel) `RequestExecutionLevel highest` will request the highest execution level available for the current user.

This makes it so that, if the user launching the installer is not an Administrator, the installer will not ask to be elevated and the installation will fail when reaching a step that requires admin priviledges.

Switching to `RequestExecutionLevel admin` ensures the installer always asks for elevation.