### PR TITLE
add #[used] to __TAURI_BUNDLE_TYPE so that it's not stripped 

### DIFF
--- a/crates/tauri-utils/src/platform.rs
+++ b/crates/tauri-utils/src/platform.rs
@@ -347,6 +347,7 @@ fn resource_dir_from<P: AsRef<std::path::Path>>(
 
 // Variable holding the type of bundle the executable is stored in. This is modified by binary
 // patching during build
+#[used]
 #[no_mangle]
 #[cfg_attr(not(target_vendor = "apple"), link_section = ".taubndl")]
 #[cfg_attr(target_vendor = "apple", link_section = "__DATA,taubndl")]


### PR DESCRIPTION
Fixing build issue caused by https://github.com/tauri-apps/tauri/pull/13209