### PR TITLE
feat: reduce Debug format size for binary buffers

### DIFF
--- a/.changes/reduce-debug-format-size.md
+++ b/.changes/reduce-debug-format-size.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Reduced `Debug` format size for binary buffers.

--- a/.changes/reduce-debug-format-size.md
+++ b/.changes/reduce-debug-format-size.md
@@ -1,5 +1,6 @@
 ---
 "tauri": patch:enhance
+"tauri-utils": patch:enhance
 ---
 
 Reduced `Debug` format size for binary buffers.

--- a/crates/tauri/src/image/mod.rs
+++ b/crates/tauri/src/image/mod.rs
@@ -27,7 +27,7 @@ impl std::fmt::Debug for Image<'_> {
         // Reduces the debug size compared to the derived default, as the default
         // would format the raw bytes as numbers `[0, 0, 0, 0]` for 1 pixel.
         // The custom format doesn't grow as much with larger images:
-        // `Image { rgba: Cow::Borrowed([u8; 4096]), width: 32, height: 32 }) }`
+        // `Image { rgba: Cow::Borrowed([u8; 4096]), width: 32, height: 32 }`
         &format_args!(
           "Cow::{}([u8; {}])",
           match &self.rgba {

--- a/crates/tauri/src/image/mod.rs
+++ b/crates/tauri/src/image/mod.rs
@@ -12,11 +12,35 @@ use std::sync::Arc;
 use crate::{Resource, ResourceId, ResourceTable};
 
 /// An RGBA Image in row-major order from top to bottom.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Image<'a> {
   rgba: Cow<'a, [u8]>,
   width: u32,
   height: u32,
+}
+
+impl std::fmt::Debug for Image<'_> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("Image")
+      .field(
+        "rgba",
+        // Reduces the debug size compared to the derived default, as the default
+        // would format the raw bytes as numbers `[0, 0, 0, 0]` for 1 pixel.
+        // The custom format doesn't grow as much with larger images:
+        // `Image { rgba: Cow::Borrowed([u8; 4096]), width: 32, height: 32 }) }`
+        &format_args!(
+          "Cow::{}([u8; {}])",
+          match &self.rgba {
+            Cow::Borrowed(_) => "Borrowed",
+            Cow::Owned(_) => "Owned",
+          },
+          self.rgba.len()
+        ),
+      )
+      .field("width", &self.width)
+      .field("height", &self.height)
+      .finish()
+  }
 }
 
 impl Resource for Image<'static> {}

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -397,12 +397,32 @@ pub struct Context<R: Runtime> {
   pub(crate) plugin_global_api_scripts: Option<&'static [&'static str]>,
 }
 
+/// Temporary struct that overrides the Debug formatting for the `app_icon` field.
+///
+/// It reduces the output size compared to the default, as that would format the binary
+/// data as a slice of numbers `[65, 66, 67]`. This instead shows the length of the Vec.
+///
+/// For example: `Some([u8; 493])`
+pub(crate) struct DebugAppIcon<'a>(&'a Option<Vec<u8>>);
+
+impl std::fmt::Debug for DebugAppIcon<'_> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self.0 {
+      Option::None => f.write_str("None"),
+      Option::Some(icon) => f
+        .debug_tuple("Some")
+        .field(&format_args!("[u8; {}]", icon.len()))
+        .finish(),
+    }
+  }
+}
+
 impl<R: Runtime> fmt::Debug for Context<R> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     let mut d = f.debug_struct("Context");
     d.field("config", &self.config)
       .field("default_window_icon", &self.default_window_icon)
-      .field("app_icon", &self.app_icon)
+      .field("app_icon", &DebugAppIcon(&self.app_icon))
       .field("package_info", &self.package_info)
       .field("pattern", &self.pattern)
       .field("plugin_global_api_scripts", &self.plugin_global_api_scripts);

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -18,7 +18,6 @@ use tauri_utils::{
   config::{Csp, CspDirectiveSources},
 };
 
-use crate::resources::ResourceTable;
 use crate::{
   app::{
     AppHandle, ChannelInterceptor, GlobalWebviewEventListener, GlobalWindowEventListener,
@@ -27,8 +26,9 @@ use crate::{
   event::{EmitArgs, Event, EventId, EventTarget, Listeners},
   ipc::{Invoke, InvokeHandler, RuntimeAuthority},
   plugin::PluginStore,
+  resources::ResourceTable,
   utils::{config::Config, PackageInfo},
-  Assets, Context, EventName, Pattern, Runtime, StateManager, Webview, Window,
+  Assets, Context, DebugAppIcon, EventName, Pattern, Runtime, StateManager, Webview, Window,
 };
 
 #[cfg(desktop)]
@@ -233,7 +233,7 @@ impl<R: Runtime> fmt::Debug for AppManager<R> {
       .field("plugins", &self.plugins)
       .field("state", &self.state)
       .field("config", &self.config)
-      .field("app_icon", &self.app_icon)
+      .field("app_icon", &DebugAppIcon(&self.app_icon))
       .field("package_info", &self.package_info)
       .field("pattern", &self.pattern);
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This makes the debug output of large Tauri structs more manageable.
I primarily looked at `AppHandle` and the binary buffer fields that it contains.

Try it out by logging the AppHandle in `examples/api/src-tauri/src/lib.rs`:
```rust
log::info!("Running app {app_handle:?}");
```

The icons, images and (compressed) assets can cause some massive debug outputs because their contents are arbitrarily large and the formatting of bytes as decimals (`[0, 0, 0, 0, ...]`) is not compact either.

Generally I'm formatting them here as `[u8; {len}]` similar to the type definition for a fixed length array.

### Alternatives

I used some temporary structs which are only used during the formatting itself. Instead we could also create permanent structs to override the Debug behavior.

Benefit would be that in some cases we can go back to deriving Debug for the parent struct. Downside is we'd need to implement more than just Debug to retain all the properties we care about, like Clone and accessing the contents.

As alternative format to the `[u8; {len}]` we could also use a more compact notation that preserves the contents like base64. Benefit would be you can still debug the contents of these buffers. Downside is it would still be arbitrarily large, just more dense.