### PR TITLE
docs: add missing `trafficLightPosition` to `WindowOptions` (fix #13790)

### DIFF
--- a/.changes/traffic-light-position-type.md
+++ b/.changes/traffic-light-position-type.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/api": "patch:bug"
+---
+
+Add missing `trafficLightPosition` TypeScript type definition

--- a/packages/api/src/dpi.ts
+++ b/packages/api/src/dpi.ts
@@ -206,7 +206,7 @@ class Size {
 }
 
 /**
- *  A position represented in logical pixels.
+ * A position represented in logical pixels.
  * For an explanation of what logical pixels are, see description of {@linkcode LogicalSize}.
  *
  * @since 2.0.0
@@ -272,7 +272,7 @@ class LogicalPosition {
 }
 
 /**
- *  A position represented in physical pixels.
+ * A position represented in physical pixels.
  *
  * For an explanation of what physical pixels are, see description of {@linkcode PhysicalSize}.
  *

--- a/packages/api/src/window.ts
+++ b/packages/api/src/window.ts
@@ -2326,6 +2326,18 @@ interface WindowOptions {
    */
   titleBarStyle?: TitleBarStyle
   /**
+   * The position of the window controls on macOS.
+   *
+   * Requires `titleBarStyle: 'overlay'` and `decorations: true`.
+   *
+   * #### Platform-specific:
+   *
+   * - **Windows / Linux**: Unsupported.
+   *
+   * @since 2.4.0
+   */
+  trafficLightPosition?: { x: number; y: number }
+  /**
    * If `true`, sets the window title to be hidden on macOS.
    */
   hiddenTitle?: boolean

--- a/packages/api/src/window.ts
+++ b/packages/api/src/window.ts
@@ -2330,13 +2330,9 @@ interface WindowOptions {
    *
    * Requires `titleBarStyle: 'overlay'` and `decorations: true`.
    *
-   * #### Platform-specific:
-   *
-   * - **Windows / Linux**: Unsupported.
-   *
    * @since 2.4.0
    */
-  trafficLightPosition?: { x: number; y: number }
+  trafficLightPosition?: LogicalPosition
   /**
    * If `true`, sets the window title to be hidden on macOS.
    */


### PR DESCRIPTION
- `trafficLightPosition` was added to Tauri in v2.4.0 (https://tauri.app/release/@tauri-apps/cli/v2.4.0/#new-features)
- It is also supported in the JavaScript API, but it's not documented.
- This PR closes #13790.

