### PR TITLE
make static bundle type var mutable

### DIFF
--- a/.github/workflows/test-cli-js.yml
+++ b/.github/workflows/test-cli-js.yml
@@ -14,6 +14,7 @@ on:
       - 'packages/cli/**'
       # currently` @tauri-apps/cli` only tests the template
       - 'crates/tauri-cli/templates/app/**'
+  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/test-cli-js.yml
+++ b/.github/workflows/test-cli-js.yml
@@ -14,7 +14,6 @@ on:
       - 'packages/cli/**'
       # currently` @tauri-apps/cli` only tests the template
       - 'crates/tauri-cli/templates/app/**'
-  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: 1

--- a/crates/tauri-utils/src/platform.rs
+++ b/crates/tauri-utils/src/platform.rs
@@ -348,25 +348,27 @@ fn resource_dir_from<P: AsRef<std::path::Path>>(
 // Variable holding the type of bundle the executable is stored in. This is modified by binary
 // patching during build
 #[used]
-#[no_mangle]
-#[cfg_attr(not(target_vendor = "apple"), link_section = ".taubndl")]
-#[cfg_attr(target_vendor = "apple", link_section = "__DATA,taubndl")]
-static __TAURI_BUNDLE_TYPE: &str = "UNK";
+#[unsafe(no_mangle)]
+#[cfg_attr(not(target_vendor = "apple"), unsafe(link_section = ".taubndl"))]
+#[cfg_attr(target_vendor = "apple", unsafe(link_section = "__DATA,taubndl"))]
+static mut __TAURI_BUNDLE_TYPE: &str = "UNK";
 
 /// Get the type of the bundle current binary is packaged in.
 /// If the bundle type is unknown, it returns [`Option::None`].
 pub fn bundle_type() -> Option<BundleType> {
-  match __TAURI_BUNDLE_TYPE {
-    "DEB" => Some(BundleType::Deb),
-    "RPM" => Some(BundleType::Rpm),
-    "APP" => Some(BundleType::AppImage),
-    "MSI" => Some(BundleType::Msi),
-    "NSS" => Some(BundleType::Nsis),
-    _ => {
-      if cfg!(target_os = "macos") {
-        Some(BundleType::App)
-      } else {
-        None
+  unsafe {
+    match __TAURI_BUNDLE_TYPE {
+      "DEB" => Some(BundleType::Deb),
+      "RPM" => Some(BundleType::Rpm),
+      "APP" => Some(BundleType::AppImage),
+      "MSI" => Some(BundleType::Msi),
+      "NSS" => Some(BundleType::Nsis),
+      _ => {
+        if cfg!(target_os = "macos") {
+          Some(BundleType::App)
+        } else {
+          None
+        }
       }
     }
   }

--- a/crates/tauri-utils/src/platform.rs
+++ b/crates/tauri-utils/src/platform.rs
@@ -348,9 +348,9 @@ fn resource_dir_from<P: AsRef<std::path::Path>>(
 // Variable holding the type of bundle the executable is stored in. This is modified by binary
 // patching during build
 #[used]
-#[unsafe(no_mangle)]
-#[cfg_attr(not(target_vendor = "apple"), unsafe(link_section = ".taubndl"))]
-#[cfg_attr(target_vendor = "apple", unsafe(link_section = "__DATA,taubndl"))]
+#[no_mangle]
+#[cfg_attr(not(target_vendor = "apple"), link_section = ".taubndl")]
+#[cfg_attr(target_vendor = "apple", link_section = "__DATA,taubndl")]
 static mut __TAURI_BUNDLE_TYPE: &str = "UNK";
 
 /// Get the type of the bundle current binary is packaged in.

--- a/crates/tauri-utils/src/platform.rs
+++ b/crates/tauri-utils/src/platform.rs
@@ -351,6 +351,8 @@ fn resource_dir_from<P: AsRef<std::path::Path>>(
 #[no_mangle]
 #[cfg_attr(not(target_vendor = "apple"), link_section = ".taubndl")]
 #[cfg_attr(target_vendor = "apple", link_section = "__DATA,taubndl")]
+// Marked as `mut` becuase it could get optimized away without it,
+// see https://github.com/tauri-apps/tauri/pull/13812
 static mut __TAURI_BUNDLE_TYPE: &str = "UNK";
 
 /// Get the type of the bundle current binary is packaged in.


### PR DESCRIPTION
Related to https://github.com/tauri-apps/tauri/pull/13808#issuecomment-3061308622

Making the static variable mutable so that it's not stripped on stable rust. 

The no_mangle and link_section are made unsafe to comply with 2024 edition changes: https://doc.rust-lang.org/reference/abi.html 