### PR TITLE
failed binary patch warning

### DIFF
--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -127,7 +127,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<Bundle>> {
     }
 
     if let Err(e) = patch_binary(&settings.binary_path(main_binary), package_type) {
-      log::warn!("Failed to add package type information to the binary. Updater plugin may not be able to update this package: {}", e);
+      log::warn!("Failed to add bundler type to the binary: {e}. Updater plugin may not be able to update this package. This shouldn't normally happen, please report it to https://github.com/tauri-apps/tauri/issues");
     }
 
     let bundle_paths = match package_type {

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -126,7 +126,9 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<Bundle>> {
       continue;
     }
 
-    patch_binary(&settings.binary_path(main_binary), package_type)?;
+    if let Err(e) = patch_binary(&settings.binary_path(main_binary), package_type) {
+      log::warn!("Failed to add package type information to the binary. Updater plugin may not be able to update this package: {}", e);
+    }
 
     let bundle_paths = match package_type {
       #[cfg(target_os = "macos")]


### PR DESCRIPTION
As agree in https://github.com/tauri-apps/tauri/pull/13812#issuecomment-3065893529 changing error to warning here.

Keep in mind that tests I added to updater-plugin will fail if the binary can't be patched correctly so there's still some verification for this feature in the pipeline. 