### PR TITLE
fix(cli): error out when migrating from v2 alpha

### DIFF
--- a/.changes/migrate-alpha-error.md
+++ b/.changes/migrate-alpha-error.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:bug
+"tauri-cli": patch:bug
+---
+
+Fail with an error when trying to migrate from v2 alpha

--- a/.changes/v2-beta-to-stable.md
+++ b/.changes/v2-beta-to-stable.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:bug
+"tauri-cli": patch:bug
+---
+
+Use v2 stable instead of v2-rc when migrating from v2-beta

--- a/crates/tauri-cli/src/migrate/migrations/mod.rs
+++ b/crates/tauri-cli/src/migrate/migrations/mod.rs
@@ -3,4 +3,4 @@
 // SPDX-License-Identifier: MIT
 
 pub mod v1;
-pub mod v2_rc;
+pub mod v2_beta;

--- a/crates/tauri-cli/src/migrate/migrations/v2_beta.rs
+++ b/crates/tauri-cli/src/migrate/migrations/v2_beta.rs
@@ -72,7 +72,7 @@ fn migrate_npm_dependencies(frontend_dir: &Path) -> Result<()> {
       .unwrap_or_default()
       .unwrap_or_default();
     if version.starts_with('1') {
-      install_deps.push(format!("{pkg}@^2.0.0-rc.0"));
+      install_deps.push(format!("{pkg}@^2.0.0"));
     }
   }
 
@@ -111,7 +111,7 @@ fn migrate_permissions(tauri_dir: &Path) -> Result<()> {
 }
 
 fn migrate_manifest(manifest: &mut DocumentMut) -> Result<()> {
-  let version = "2.0.0-rc.0";
+  let version = "2.0.0";
 
   let dependencies = manifest
     .as_table_mut()


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: #13819

- Fail with an error when trying to migrate from v2 alpha
- Use v2 stable instead of v2-rc when migrating from v2-beta