### PR TITLE
feat(tauri): add `plugin_boxed` methods

### DIFF
--- a/.changes/plugin-boxed.md
+++ b/.changes/plugin-boxed.md
@@ -1,0 +1,5 @@
+---
+tauri: "minor:enhance"
+---
+
+Add `AppHandle::plugin_boxed` and `Builder::plugin_boxed` methods to allow adding plugins in the form of boxed trait objects.

--- a/.changes/plugin-dyn.md
+++ b/.changes/plugin-dyn.md
@@ -1,5 +1,0 @@
----
-tauri: "minor:enhance"
----
-
-Add `AppHandle::plugin_dyn` and `Builder::plugin_dyn` methods to allow adding plugins in the form of boxed trait objects.

--- a/.changes/plugin-dyn.md
+++ b/.changes/plugin-dyn.md
@@ -1,0 +1,5 @@
+---
+tauri: "minor:enhance"
+---
+
+Add `AppHandle::plugin_dyn` and `Builder::plugin_dyn` methods to allow adding plugins in the form of boxed trait objects.

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -484,10 +484,16 @@ impl<R: Runtime> AppHandle<R> {
   ///     Ok(())
   ///   });
   /// ```
-  #[cfg_attr(feature = "tracing", tracing::instrument(name = "app::plugin::register", skip(plugin), fields(name = plugin.name())))]
   pub fn plugin<P: Plugin<R> + 'static>(&self, plugin: P) -> crate::Result<()> {
-    let mut plugin = Box::new(plugin) as Box<dyn Plugin<R>>;
+    self.plugin_dyn(Box::new(plugin))
+  }
 
+  /// Adds a Tauri application plugin.
+  ///
+  /// This method is similar to [`Self::plugin`],
+  /// but accepts a boxed trait object instead of a generic type.
+  #[cfg_attr(feature = "tracing", tracing::instrument(name = "app::plugin::register", skip(plugin), fields(name = plugin.name())))]
+  pub fn plugin_dyn(&self, mut plugin: Box<dyn Plugin<R>>) -> crate::Result<()> {
     let mut store = self.manager().plugins.lock().unwrap();
     store.initialize(&mut plugin, self, &self.config().plugins)?;
     store.register(plugin);
@@ -1683,8 +1689,17 @@ tauri::Builder::default()
   ///   .plugin(plugin::init());
   /// ```
   #[must_use]
-  pub fn plugin<P: Plugin<R> + 'static>(mut self, plugin: P) -> Self {
-    self.plugins.register(Box::new(plugin));
+  pub fn plugin<P: Plugin<R> + 'static>(self, plugin: P) -> Self {
+    self.plugin_dyn(Box::new(plugin))
+  }
+
+  /// Adds a Tauri application plugin.
+  ///
+  /// This method is similar to [`Self::plugin`],
+  /// but accepts a boxed trait object instead of a generic type.
+  #[must_use]
+  pub fn plugin_dyn(mut self, plugin: Box<dyn Plugin<R>>) -> Self {
+    self.plugins.register(plugin);
     self
   }
 

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -485,7 +485,7 @@ impl<R: Runtime> AppHandle<R> {
   ///   });
   /// ```
   pub fn plugin<P: Plugin<R> + 'static>(&self, plugin: P) -> crate::Result<()> {
-    self.plugin_dyn(Box::new(plugin))
+    self.plugin_boxed(Box::new(plugin))
   }
 
   /// Adds a Tauri application plugin.
@@ -493,7 +493,7 @@ impl<R: Runtime> AppHandle<R> {
   /// This method is similar to [`Self::plugin`],
   /// but accepts a boxed trait object instead of a generic type.
   #[cfg_attr(feature = "tracing", tracing::instrument(name = "app::plugin::register", skip(plugin), fields(name = plugin.name())))]
-  pub fn plugin_dyn(&self, mut plugin: Box<dyn Plugin<R>>) -> crate::Result<()> {
+  pub fn plugin_boxed(&self, mut plugin: Box<dyn Plugin<R>>) -> crate::Result<()> {
     let mut store = self.manager().plugins.lock().unwrap();
     store.initialize(&mut plugin, self, &self.config().plugins)?;
     store.register(plugin);
@@ -1690,7 +1690,7 @@ tauri::Builder::default()
   /// ```
   #[must_use]
   pub fn plugin<P: Plugin<R> + 'static>(self, plugin: P) -> Self {
-    self.plugin_dyn(Box::new(plugin))
+    self.plugin_boxed(Box::new(plugin))
   }
 
   /// Adds a Tauri application plugin.
@@ -1698,7 +1698,7 @@ tauri::Builder::default()
   /// This method is similar to [`Self::plugin`],
   /// but accepts a boxed trait object instead of a generic type.
   #[must_use]
-  pub fn plugin_dyn(mut self, plugin: Box<dyn Plugin<R>>) -> Self {
+  pub fn plugin_boxed(mut self, plugin: Box<dyn Plugin<R>>) -> Self {
     self.plugins.register(plugin);
     self
   }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

## Describe the problem

*Because this PR is small enough, I didn’t open a feature request issue in advance.*

I am implementing the feature to add tauri plugins from Python for pytauri: pytauri/pytauri#220.
In pyo3/pytauri, we cannot use generics, so I [store these `TauriPlugin` as `Box<dyn Plugin>`](https://github.com/pytauri/pytauri/blob/aa995097a883d8a6bd67c2b2c50c180a5dafca8f/crates/pytauri-core/src/ext_mod_impl/plugin.rs#L7-L13).

However, `Box<dyn Plugin>` itself does not implement the `Plugin` trait, so I cannot use them in `Builder::plugin` and `AppHandle::plugin`.

## Describe the solution you'd like

Therefore, I would like to add `plugin_dyn` methods to accept `Box<dyn Plugin>` instead of `impl Plugin<R>`.

## Alternatives considered

Alternatively, we could `impl Plugin<R> for Box<dyn Plugin<R>>`. But I don't really like this approach, because it would result in [`Box<Box<dyn Plugin<R>>>`](https://github.com/tauri-apps/tauri/blob/bda8304107da7ca60caaba5674faa793491898c6/crates/tauri/src/app.rs#L489).

But if tauri doesn't want to add a new API, I can also accept this implementation.

