### PR TITLE
fix(windows): isolation pattern create iframe loop

### DIFF
--- a/.changes/isolation-iframe-loop.md
+++ b/.changes/isolation-iframe-loop.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix isolation pattern creates iframes within iframes on Windows

--- a/crates/tauri/src/pattern.rs
+++ b/crates/tauri/src/pattern.rs
@@ -84,12 +84,12 @@ pub(crate) struct PatternJavascript {
   pub(crate) pattern: PatternObject,
 }
 
-#[allow(dead_code)]
+#[cfg(feature = "isolation")]
 pub(crate) fn format_real_schema(schema: &str, https: bool) -> String {
   if cfg!(windows) || cfg!(target_os = "android") {
     let scheme = if https { "https" } else { "http" };
-    format!("{scheme}://{schema}.{ISOLATION_IFRAME_SRC_DOMAIN}")
+    format!("{scheme}://{schema}.{ISOLATION_IFRAME_SRC_DOMAIN}/")
   } else {
-    format!("{schema}://{ISOLATION_IFRAME_SRC_DOMAIN}")
+    format!("{schema}://{ISOLATION_IFRAME_SRC_DOMAIN}/")
   }
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

The `location.href !== __TEMPLATE_isolation_src__` never matches because of a missing `/` at the end, this probably doesn't affect other platforms since init script for main frame only works on those platforms