### PR TITLE
fix(bundler): Move AppRun binaries to mirror

### DIFF
--- a/.changes/linux-apprun-url.md
+++ b/.changes/linux-apprun-url.md
@@ -1,0 +1,7 @@
+---
+tauri-bundler: "patch:bug"
+tauri-cli: "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+The AppImage bundler now pulls the AppRun binaries from our GitHub mirror, fixing 404 errors.

--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -221,7 +221,7 @@ fn prepare_tools(tools_path: &Path, arch: &str) -> crate::Result<PathBuf> {
   let apprun = tools_path.join(format!("AppRun-{arch}"));
   if !apprun.exists() {
     let data = download(&format!(
-      "https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-{arch}"
+      "https://github.com/tauri-apps/binary-releases/releases/download/apprun-old/AppRun-{arch}"
     ))?;
     write_and_make_executable(&apprun, data)?;
   }


### PR DESCRIPTION
fixes #13862 

the appimage ecosystem keeps to suck, what a surprise to absolutely nobody. To be fair, this is my bad. I wanted to do this for ages...