### PR TITLE
fix: sign main binary after patching with bundle info (fix #13868)

### DIFF
--- a/.changes/fix-code-signing-after-patch.md
+++ b/.changes/fix-code-signing-after-patch.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: "patch:bug"
+---
+
+The bundler now signs the main binary after patching it for every package type.

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -84,6 +84,10 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<Bundle>> {
   if matches!(target_os, TargetPlatform::Windows) {
     if settings.can_sign() {
       for bin in settings.binaries() {
+        if bin.main() {
+          // we will sign the main binary after patching per "package type"
+          continue;
+        }
         let bin_path = settings.binary_path(bin);
         windows::sign::try_sign(&bin_path, settings)?;
       }
@@ -128,6 +132,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<Bundle>> {
 
     if let Err(e) = patch_binary(&settings.binary_path(main_binary), package_type) {
       log::warn!("Failed to add bundler type to the binary: {e}. Updater plugin may not be able to update this package. This shouldn't normally happen, please report it to https://github.com/tauri-apps/tauri/issues");
+    }
+
+    // sign main binary for every package type after patch
+    if settings.can_sign() {
+      let bin_path = settings.binary_path(main_binary);
+      windows::sign::try_sign(&bin_path, settings)?;
     }
 
     let bundle_paths = match package_type {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
Closes #13868 
