### PR TITLE
fix(bundler): replace empty RPM release value with 1

### DIFF
--- a/.changes/fix-bundler-rpm-release-default.md
+++ b/.changes/fix-bundler-rpm-release-default.md
@@ -1,5 +1,5 @@
 ---
-tauri-bundler: "fix:bug"
+tauri-bundler: "patch:bug"
 ---
 
 The bundler now falls back to `1` for the release in case an empty string was provided instead of using `-.` in the file name.

--- a/.changes/fix-bundler-rpm-release-default.md
+++ b/.changes/fix-bundler-rpm-release-default.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: "fix:bug"
+---
+
+The bundler now falls back to `1` for the release in case an empty string was provided instead of using `-.` in the file name.

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -21,7 +21,10 @@ use super::freedesktop;
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let product_name = settings.product_name();
   let version = settings.version_string();
-  let release = settings.rpm().release.as_str();
+  let release = match settings.rpm().release.as_str() {
+    "" => "1", // Considered the default. If left empty, you get file with "-.".
+    v => v,
+  };
   let epoch = settings.rpm().epoch;
   let arch = match settings.binary_arch() {
     Arch::X86_64 => "x86_64",
@@ -234,6 +237,5 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   let mut f = fs::File::create(&package_path)?;
   pkg.write(&mut f)?;
-
   Ok(vec![package_path])
 }


### PR DESCRIPTION
Fixes small issue from https://github.com/tauri-apps/tauri/issues/13893.

1 is considered the default value for this field. Empty string will result in "-." sequence in a file name, which is not desired.

Cc @FabianLars

---

> Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits

It's great that I already have this, otherwise it's strange to demand.

> Ensure `cargo test` and `cargo clippy` passes.

Well, apparently the `dev` has tests passing, but for me `dev` does not pass, so is this branch.

<details><summary>logs</summary>

```text
test tests::resolve_acl ... FAILED

failures:

---- tests::resolve_acl stdout ----
cargo:PERMISSION_FILES_PATH=/tmp/ping-permission-files
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot file: crates/tests/acl/src/../fixtures/snapshots/acl_tests__tests__basic-ping.snap
Snapshot: basic-ping
Source: crates/tests/acl/src/lib.rs:71
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Expression: resolved
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    0     0 │ Resolved {
          1 │+    has_app_acl: false,
    1     2 │     allowed_commands: {
    2     3 │         "plugin:ping|ping": [
    3     4 │             ResolvedCommand {
    4     5 │                 context: Local,
────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
To update snapshots run `cargo insta review`
Stopped on the first failure. Run `cargo insta test` to run all snapshots.
```

</details>

Also couldn't compile test binary without using flake that I used [here](https://codeberg.org/Andrew15-5/bulk-client-renamer) that is mostly from [the Dioxus repo](https://github.com/DioxusLabs/dioxus/blob/main/flake.nix). I'd consider adding flake with envrc directly or providing them in a contributing file or in a non-root directory ("nix" or something). (I use NixOS btw.)
