### PR TITLE
feat(bundler): add consistent_name setting

### DIFF
--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -19,8 +19,10 @@ use std::{
 /// Bundles the project.
 /// Returns a vector of PathBuf that shows where the AppImage was created.
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
-  // generate the deb binary name
-  let appimage_arch: &str = match settings.binary_arch() {
+  let product_name = settings.product_name();
+  let version = settings.version_string();
+  // generate the deb??? binary name (remove this comment?)
+  let arch = match settings.binary_arch() {
     Arch::X86_64 => "amd64",
     Arch::X86 => "i386",
     Arch::AArch64 => "aarch64",
@@ -57,7 +59,6 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let package_dir = settings.project_out_directory().join("bundle/appimage_deb");
 
   let main_binary = settings.main_binary()?;
-  let product_name = settings.product_name();
 
   let mut settings = settings.clone();
   if main_binary.name().contains(' ') {
@@ -80,12 +81,15 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   fs::create_dir_all(&output_path)?;
   let app_dir_path = output_path.join(format!("{}.AppDir", settings.product_name()));
-  let appimage_filename = format!(
-    "{}_{}_{}.AppImage",
-    settings.product_name(),
-    settings.version_string(),
-    appimage_arch
+  let package_base_name = format!(
+    "{product_name}_{version}_{}",
+    if settings.consistent_name() {
+      settings.binary_arch().to_string()
+    } else {
+      arch.to_string()
+    }
   );
+  let appimage_filename = format!("{package_base_name}.AppImage");
   let appimage_path = output_path.join(&appimage_filename);
   fs_utils::create_dir(&app_dir_path, true)?;
 

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -40,6 +40,8 @@ use std::{
 /// Bundles the project.
 /// Returns a vector of PathBuf that shows where the DEB was created.
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
+  let product_name = settings.product_name();
+  let version = settings.version_string();
   let arch = match settings.binary_arch() {
     Arch::X86_64 => "amd64",
     Arch::X86 => "i386",
@@ -54,10 +56,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     }
   };
   let package_base_name = format!(
-    "{}_{}_{}",
-    settings.product_name(),
-    settings.version_string(),
-    arch
+    "{product_name}_{version}_{}",
+    if settings.consistent_name() {
+      settings.binary_arch().to_string()
+    } else {
+      arch.to_string()
+    }
   );
   let package_name = format!("{package_base_name}.deb");
 

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -39,7 +39,11 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   let summary = settings.short_description().trim();
 
-  let package_base_name = format!("{product_name}-{version}-{release}.{arch}");
+  let package_base_name = if settings.consistent_name() {
+    format!("{product_name}_{version}_{}", settings.binary_arch())
+  } else {
+    format!("{product_name}-{version}-{release}.{arch}")
+  };
   let package_name = format!("{package_base_name}.rpm");
 
   let base_dir = settings.project_out_directory().join("bundle/rpm");

--- a/crates/tauri-bundler/src/bundle/macos/app.rs
+++ b/crates/tauri-bundler/src/bundle/macos/app.rs
@@ -52,9 +52,26 @@ const NESTED_CODE_FOLDER: [&str; 6] = [
 /// Bundles the project.
 /// Returns a vector of PathBuf that shows where the .app was created.
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
-  // we should use the bundle name (App name) as a MacOS standard.
-  // version or platform shouldn't be included in the App name.
-  let app_product_name = format!("{}.app", settings.product_name());
+  let product_name = settings.product_name();
+  let package_base_name = if settings.consistent_name() {
+    let version = settings.version_string();
+    let arch = match settings.binary_arch() {
+      // Is this match correct?
+      Arch::AArch64 => "aarch64",
+      target => {
+        return Err(crate::Error::ArchError(format!(
+          "Unsupported architecture: {target:?}"
+        )));
+      }
+    };
+    format!("{product_name}_{version}_{}", settings.binary_arch())
+  } else {
+    // we should use the bundle name (App name) as a MacOS standard.
+    // version or platform shouldn't be included in the App name.
+    // (remove this comment?)
+    product_name
+  };
+  let app_product_name = format!("{package_base_name}.app");
 
   let app_bundle_path = settings
     .project_out_directory()

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -27,6 +27,18 @@ pub struct Bundled {
 /// Bundles the project.
 /// Returns a vector of PathBuf that shows where the DMG was created.
 pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<Bundled> {
+  let product_name = settings.product_name();
+  let version = settings.version_string();
+  let arch = match settings.binary_arch() {
+    Arch::X86_64 => "x64",
+    Arch::AArch64 => "aarch64",
+    Arch::Universal => "universal",
+    target => {
+      return Err(crate::Error::ArchError(format!(
+        "Unsupported architecture: {target:?}"
+      )));
+    }
+  };
   // generate the .app bundle if needed
   let app_bundle_paths = if !bundles
     .iter()
@@ -40,21 +52,14 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
   // get the target path
   let output_path = settings.project_out_directory().join("bundle/dmg");
   let package_base_name = format!(
-    "{}_{}_{}",
-    settings.product_name(),
-    settings.version_string(),
-    match settings.binary_arch() {
-      Arch::X86_64 => "x64",
-      Arch::AArch64 => "aarch64",
-      Arch::Universal => "universal",
-      target => {
-        return Err(crate::Error::ArchError(format!(
-          "Unsupported architecture: {target:?}"
-        )));
-      }
+    "{product_name}_{version}_{}",
+    if settings.consistent_name() {
+      settings.binary_arch().to_string()
+    } else {
+      arch.to_string()
     }
   );
-  let dmg_name = format!("{}.dmg", &package_base_name);
+  let dmg_name = format!("{package_base_name}.dmg");
   let dmg_path = output_path.join(&dmg_name);
 
   let product_name = settings.product_name();

--- a/crates/tauri-bundler/src/bundle/macos/ios.rs
+++ b/crates/tauri-bundler/src/bundle/macos/ios.rs
@@ -34,7 +34,23 @@ use std::{
 pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   log::warn!("iOS bundle support is still experimental.");
 
-  let app_product_name = format!("{}.app", settings.product_name());
+  let product_name = settings.product_name();
+  let package_base_name = if settings.consistent_name() {
+    let version = settings.version_string();
+    let arch = match settings.binary_arch() {
+      // Is this match correct?
+      Arch::AArch64 => "aarch64",
+      target => {
+        return Err(crate::Error::ArchError(format!(
+          "Unsupported architecture: {target:?}"
+        )));
+      }
+    };
+    format!("{product_name}_{version}_{}", settings.binary_arch())
+  } else {
+    product_name
+  };
+  let app_product_name = format!("{package_base_name}.app");
 
   let app_bundle_path = settings
     .project_out_directory()

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -629,6 +629,9 @@ pub struct BundleSettings {
   pub short_description: Option<String>,
   /// the app's long description.
   pub long_description: Option<String>,
+  /// Whether to name all package types' files with a consistent naming scheme.
+  /// Default is false, which means each package type will use its own conventional naming scheme.
+  pub consistent_name: bool,
   // Bundles for other binaries:
   /// Configuration map for the apps to bundle.
   pub bin: Option<HashMap<String, BundleSettings>>,
@@ -743,6 +746,21 @@ pub enum Arch {
   Riscv64,
   /// For universal macOS applications.
   Universal,
+}
+
+impl std::fmt::Display for Arch {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let arch = match self {
+      Arch::X86_64 => "x86_64",
+      Arch::X86 => "x68",
+      Arch::AArch64 => "aarch64",
+      Arch::Armhf => "armhf",
+      Arch::Armel => "armel",
+      Arch::Riscv64 => "riscv64",
+      Arch::Universal => "universal", // Is this a collection of supported by Rust platforms?
+    };
+    write!(f, "{arch}")
+  }
 }
 
 /// The Settings exposed by the module.
@@ -934,6 +952,12 @@ impl Settings {
     } else {
       panic!("Unexpected target triple {}", self.target)
     }
+  }
+
+  /// Returns whether to name all package types' files with a consistent naming scheme.
+  // Maybe is_consistent_name()?
+  pub fn consistent_name(&self) -> bool {
+    self.bundle_settings.consistent_name
   }
 
   /// Returns the file name of the binary being bundled.

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -215,6 +215,8 @@ fn app_installer_output_path(
   version: &str,
   updater: bool,
 ) -> crate::Result<PathBuf> {
+  let product_name = settings.product_name();
+  let version = settings.version_string();
   let arch = match settings.binary_arch() {
     Arch::X86_64 => "x64",
     Arch::X86 => "x86",
@@ -227,21 +229,22 @@ fn app_installer_output_path(
   };
 
   let package_base_name = format!(
-    "{}_{}_{}_{}",
-    settings.product_name(),
-    version,
-    arch,
-    language,
+    "{product_name}_{version}_{}_{}",
+    if settings.consistent_name() {
+      settings.binary_arch().to_string()
+    } else {
+      arch.to_string()
+    }
+    language, // Special case for "consistent" name?
   );
 
   Ok(settings.project_out_directory().to_path_buf().join(format!(
-    "bundle/{}/{}.msi",
+    "bundle/{}/{package_base_name}.msi",
     if updater {
       WIX_UPDATER_OUTPUT_FOLDER_NAME
     } else {
       WIX_OUTPUT_FOLDER_NAME
-    },
-    package_base_name
+    }
   )))
 }
 

--- a/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
@@ -171,6 +171,8 @@ fn build_nsis_app_installer(
   tauri_tools_path: &Path,
   updater: bool,
 ) -> crate::Result<Vec<PathBuf>> {
+  let product_name = settings.product_name();
+  let version = settings.version_string();
   let arch = match settings.binary_arch() {
     Arch::X86_64 => "x64",
     Arch::X86 => "x86",
@@ -288,7 +290,6 @@ fn build_nsis_app_installer(
     data.insert("uninstaller_sign_cmd", to_json(sign_cmd));
   }
 
-  let version = settings.version_string();
   data.insert("version", to_json(version));
   data.insert(
     "version_with_build",
@@ -581,22 +582,20 @@ fn build_nsis_app_installer(
     handlebars.render("installer.nsi", &data)?,
   )?;
 
-  let package_base_name = format!(
-    "{}_{}_{}-setup",
-    settings.product_name(),
-    settings.version_string(),
-    arch,
-  );
+  let package_base_name = if settings.consistent_name() {
+    format!("{product_name}_{version}_{}", settings.binary_arch())
+  } else {
+    format!("{product_name}_{version}_{arch}-setup")
+  };
 
   let nsis_output_path = output_path.join(out_file);
   let nsis_installer_path = settings.project_out_directory().to_path_buf().join(format!(
-    "bundle/{}/{}.exe",
+    "bundle/{}/{package_base_name}.exe",
     if updater {
       NSIS_UPDATER_OUTPUT_FOLDER_NAME
     } else {
       NSIS_OUTPUT_FOLDER_NAME
     },
-    package_base_name
   ));
   fs::create_dir_all(nsis_installer_path.parent().unwrap())?;
 


### PR DESCRIPTION
Resolves https://github.com/tauri-apps/tauri/issues/13893.

There are a bunch of small thing that I'm not sure about that I commented through out the changes.

I guess the total number of package types is 8.

I don't know if I should make `arch` as `mut` and just write `if consistent_name { arch = ...; }` instead of inline if-else expression in `format!`. At least because architecture is technically immutable. There are a few different approaches. You can also just shadow the var by writing a new `let arch`. I think this would be a better approach than the current one, just don't know if shadowing is allowed here.

I opted into a bit more changes to make constructing the package file name _also consistent_.

The things that can be debated is what _is_ the default consistent naming scheme? I think underscores are very dominant in file names, so it might be the safest bet. Though there is MSI that also have a language, which kinda breaks the consistency. As well as the "universal" architecture (which is a very bad, non-descriptive name for an architecture). Also don't know about architecture names in general, I just converted the enum variant names to lowercase strings.

Maybe the docs wording could be better.

Waiting for feedback. The general idea is already fully implemented.

I just don't know how to test this. I didn't find tests in a file when I was searching. I guess there are snapshot tests, but [I can't run them](https://github.com/tauri-apps/tauri/pull/13909#issue-3270969839:~:text=Well%2C%20apparently%20the%20dev%20has%20tests%20passing%2C%20but%20for%20me%20dev%20does%20not%20pass%2C%20so%20is%20this%20branch%2E).

rust-analyzer only works for half of the files.