### PR TITLE
fix(cli): properly migrate svelte to v5 in the plugin example template

### DIFF
--- a/.changes/fix-plugin-template-svelte.md
+++ b/.changes/fix-plugin-template-svelte.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+Properly migrate svelte to v5 in the plugin example template

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/jsconfig.json
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "target": "ESNext",
     "module": "ESNext",
     /**
@@ -8,7 +8,7 @@
      * a value or a type, so tell TypeScript to enforce using
      * `import type` instead of `import` for Types.
      */
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     /**

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/App.svelte
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/App.svelte
@@ -2,7 +2,7 @@
   import Greet from './lib/Greet.svelte'
   import { ping } from 'tauri-plugin-{{ plugin_name }}-api'
 
-	let response = ''
+	let response = $state('')
 
 	function updateResponse(returnValue) {
 		response += `[${new Date().toLocaleTimeString()}] ` + (typeof returnValue === 'string' ? returnValue : JSON.stringify(returnValue)) + '<br>'
@@ -37,7 +37,7 @@
   </div>
 
   <div>
-    <button on:click="{_ping}">Ping</button>
+    <button onclick="{_ping}">Ping</button>
     <div>{@html response}</div>
   </div>
 

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/lib/Greet.svelte
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/lib/Greet.svelte
@@ -1,8 +1,8 @@
 <script>
   import { invoke } from "@tauri-apps/api/core"
 
-  let name = "";
-  let greetMsg = ""
+  let name = $state("");
+  let greetMsg = $state("")
 
   async function greet(){
     // Learn more about Tauri commands at https://v2.tauri.app/develop/calling-rust/#commands
@@ -13,7 +13,7 @@
 <div>
   <div class="row">
     <input id="greet-input" placeholder="Enter a name..." bind:value={name} />
-    <button on:click={greet}>
+    <button onclick={greet}>
       Greet
     </button>
   </div>

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/main.js
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/src/main.js
@@ -1,7 +1,8 @@
 import "./style.css";
 import App from "./App.svelte";
+import { mount } from 'svelte';
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById("app"),
 });
 

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/vite.config.js
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/vite.config.js
@@ -5,7 +5,13 @@ const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte({
+    compilerOptions:{
+      compatibility:{
+        componentApi: 4
+      }
+    }
+  })],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   // prevent Vite from obscuring rust errors

--- a/crates/tauri-cli/templates/plugin/__example-api/tauri-app/vite.config.js
+++ b/crates/tauri-cli/templates/plugin/__example-api/tauri-app/vite.config.js
@@ -5,13 +5,7 @@ const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [svelte({
-    compilerOptions:{
-      compatibility:{
-        componentApi: 4
-      }
-    }
-  })],
+  plugins: [svelte()],
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
   // prevent Vite from obscuring rust errors


### PR DESCRIPTION
## Problem
Using the official CLI, I created a plugin following the steps below. However, when I ran the example app, the screen remained completely black with nothing displayed.

## Steps to Reproduce
```sh
# Create the plugin
npx @tauri-apps/cli plugin new my-plugin  

# Build the plugin
cd tauri-plugin-my-plugin  
npm install  
npm run build 

# Run the example app
cd examples/tauri-app  
npm install  
npm run dev
```

After accessing http://localhost:1420/, the page fails to render correctly and shows a completely black screen.

## Solution
I modified vite.config.js as follows to support Svelte 4:

## Significance of This Change
With this fix, the plugin template generated by the official Tauri CLI will now work out of the box in Svelte 4 environments, preventing developers from running into issues at the initial setup stage.

