### PR TITLE
Fix: Improved error messages regarding cargo metadata

### DIFF
--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1183,7 +1183,7 @@ pub(crate) fn get_cargo_target_dir(args: &[String]) -> crate::Result<PathBuf> {
     std::env::current_dir()?.join(target)
   } else {
     get_cargo_metadata()
-      .with_context(|| "failed to get cargo metadata")?
+      .with_context(|| "failed to run 'cargo metadata' command to get target directory")?
       .target_directory
   };
 
@@ -1221,7 +1221,7 @@ fn get_cargo_option<'a>(args: &'a [String], option: &'a str) -> Option<&'a str> 
 pub fn get_workspace_dir() -> crate::Result<PathBuf> {
   Ok(
     get_cargo_metadata()
-      .context("failed to get cargo metadata")?
+      .context("failed to run 'cargo metadata' command to get workspace directory")?
       .workspace_root,
   )
 }


### PR DESCRIPTION
Hey there, opened a PR regarding the improvement in error messages as mentioned in this issue above. (#12273)
As, mentioned previously the conflict regarding the ``cargo tauri`` and the wrapper script has been resolved and you insisted to update the error messages regarding ``cargo metadata`` as they were a bit misleading.

I've open this new PR. Sorry that, I had made a silly mess in my previous pr with sign verification.

This closes #12273.