### PR TITLE
fix(windows): bundler should not sign non-binaries

### DIFF
--- a/.changes/dont-sign-non-binary-resources.md
+++ b/.changes/dont-sign-non-binary-resources.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: "patch:bug"
+---
+
+The bundler will no longer try to sign non-binary and already signed binary files on Windows

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -7,7 +7,7 @@ use crate::{
   bundle::{
     settings::{Arch, Settings},
     windows::{
-      sign::try_sign,
+      sign::{should_sign, try_sign},
       util::{
         download_webview2_bootstrapper, download_webview2_offline_installer,
         WIX_OUTPUT_FOLDER_NAME, WIX_UPDATER_OUTPUT_FOLDER_NAME,
@@ -988,7 +988,7 @@ fn generate_resource_data(settings: &Settings) -> crate::Result<ResourceMap> {
     }
     added_resources.push(resource_path.clone());
 
-    if settings.can_sign() {
+    if settings.can_sign() && should_sign(&resource_path)? {
       try_sign(&resource_path, settings)?;
     }
 

--- a/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
@@ -6,7 +6,7 @@ use crate::{
   bundle::{
     settings::Arch,
     windows::{
-      sign::{sign_command, try_sign},
+      sign::{should_sign, sign_command, try_sign},
       util::{
         download_webview2_bootstrapper, download_webview2_offline_installer,
         NSIS_OUTPUT_FOLDER_NAME, NSIS_UPDATER_OUTPUT_FOLDER_NAME,
@@ -743,7 +743,7 @@ fn generate_resource_data(settings: &Settings) -> crate::Result<ResourcesMap> {
     }
     added_resources.push(resource_path.clone());
 
-    if settings.can_sign() {
+    if settings.can_sign() && should_sign(&resource_path)? {
       try_sign(&resource_path, settings)?;
     }
 

--- a/crates/tauri-bundler/src/bundle/windows/sign.rs
+++ b/crates/tauri-bundler/src/bundle/windows/sign.rs
@@ -259,12 +259,24 @@ pub fn try_sign<P: AsRef<Path>>(file_path: P, settings: &Settings) -> crate::Res
 }
 
 /// If the file is signable (is a binary file) and not signed already
+/// (will skip the verification if not on Windows since we can't verify it)
 pub fn should_sign(file_path: &Path) -> crate::Result<bool> {
-  Ok(
-    file_path
-      .extension()
-      .and_then(|extension| extension.to_str())
-      .is_some_and(|extension| matches!(extension, "exe" | "dll"))
-      && !verify(file_path)?,
-  )
+  let is_binary = file_path
+    .extension()
+    .and_then(|extension| extension.to_str())
+    .is_some_and(|extension| matches!(extension, "exe" | "dll"));
+  if !is_binary {
+    return Ok(false);
+  }
+
+  #[cfg(windows)]
+  {
+    let already_signed = verify(file_path)?;
+    Ok(!already_signed)
+  }
+  // Skip verification if not on Windows since we can't verify it
+  #[cfg(not(windows))]
+  {
+    Ok(true)
+  }
 }

--- a/crates/tauri-bundler/src/bundle/windows/sign.rs
+++ b/crates/tauri-bundler/src/bundle/windows/sign.rs
@@ -257,3 +257,14 @@ pub fn try_sign<P: AsRef<Path>>(file_path: P, settings: &Settings) -> crate::Res
   }
   Ok(())
 }
+
+/// If the file is signable (is a binary file) and not signed already
+pub fn should_sign(file_path: &Path) -> crate::Result<bool> {
+  Ok(
+    file_path
+      .extension()
+      .and_then(|extension| extension.to_str())
+      .is_some_and(|extension| matches!(extension, "exe" | "dll"))
+      && !verify(file_path)?,
+  )
+}


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

The bundler will no longer try to sign non-binary and already signed binary files on Windows

Fix #13341

Note: didn't test yet