### PR TITLE
feat: expose internal TrayIcon

### DIFF
--- a/.changes/expose-inner-tray-icon.md
+++ b/.changes/expose-inner-tray-icon.md
@@ -1,0 +1,8 @@
+---
+"tauri": 'minor:enhance'
+---
+
+Introduce `with_inner_tray_icon` for Tauri `TrayIcon` to access the inner platform-specific tray icon.
+
+Note that `tray-icon` crate may be updated in minor releases of Tauri.
+Therefore, it’s recommended to pin Tauri to at least a minor version when you’re using `with_inner_tray_icon`.

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -72,7 +72,7 @@ glob = "0.3"
 urlpattern = "0.3"
 mime = "0.3"
 data-url = { version = "0.3", optional = true }
-serialize-to-javascript = "0.1.1"
+serialize-to-javascript = "0.1.2"
 image = { version = "0.25", default-features = false, optional = true }
 http-range = { version = "0.1", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -72,7 +72,7 @@ glob = "0.3"
 urlpattern = "0.3"
 mime = "0.3"
 data-url = { version = "0.3", optional = true }
-serialize-to-javascript = "0.1.2"
+serialize-to-javascript = "0.1.1"
 image = { version = "0.25", default-features = false, optional = true }
 http-range = { version = "0.1", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -603,6 +603,11 @@ impl<R: Runtime> TrayIcon<R> {
       })
     })
   }
+
+  /// Get the inner tray icon.
+  pub fn inner(&self) -> &tray_icon::TrayIcon {
+    &self.inner
+  }
 }
 
 impl<R: Runtime> Resource for TrayIcon<R> {

--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -604,16 +604,16 @@ impl<R: Runtime> TrayIcon<R> {
     })
   }
 
-  /// Get the inner tray icon.
+  /// Do something with the inner [`tray_icon::TrayIcon`] on main thread
   ///
   /// Note that `tray-icon` crate may be updated in minor releases of Tauri.
   /// Therefore, it’s recommended to pin Tauri to at least a minor version when you’re using `with_inner_tray_icon`.
   pub fn with_inner_tray_icon<F, T>(&self, f: F) -> crate::Result<T>
   where
-    F: FnOnce(tray_icon::TrayIcon) -> T + Send + 'static,
+    F: FnOnce(&tray_icon::TrayIcon) -> T + Send + 'static,
     T: Send + 'static,
   {
-    run_item_main_thread!(self, |self_: Self| { f(self_.inner.clone()) })
+    run_item_main_thread!(self, |self_: Self| { f(&self_.inner) })
   }
 }
 
@@ -635,7 +635,6 @@ mod tests {
   fn tray_event_json_serialization() {
     // NOTE: if this test is ever changed, you probably need to change `TrayIconEvent` in JS as well
 
-    use super::*;
     let event = TrayIconEvent::Click {
       button: MouseButton::Left,
       button_state: MouseButtonState::Down,

--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -605,8 +605,15 @@ impl<R: Runtime> TrayIcon<R> {
   }
 
   /// Get the inner tray icon.
-  pub fn inner(&self) -> &tray_icon::TrayIcon {
-    &self.inner
+  ///
+  /// Note that `tray-icon` crate may be updated in minor releases of Tauri.
+  /// Therefore, it’s recommended to pin Tauri to at least a minor version when you’re using `with_inner_tray_icon`.
+  pub fn with_inner_tray_icon<F, T>(&self, f: F) -> crate::Result<T>
+  where
+    F: FnOnce(tray_icon::TrayIcon) -> T + Send + 'static,
+    T: Send + 'static,
+  {
+    run_item_main_thread!(self, |self_: Self| { f(self_.inner.clone()) })
   }
 }
 
@@ -628,7 +635,6 @@ mod tests {
   fn tray_event_json_serialization() {
     // NOTE: if this test is ever changed, you probably need to change `TrayIconEvent` in JS as well
 
-    use super::*;
     let event = TrayIconEvent::Click {
       button: MouseButton::Left,
       button_state: MouseButtonState::Down,

--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -635,6 +635,7 @@ mod tests {
   fn tray_event_json_serialization() {
     // NOTE: if this test is ever changed, you probably need to change `TrayIconEvent` in JS as well
 
+    use super::*;
     let event = TrayIconEvent::Click {
       button: MouseButton::Left,
       button_state: MouseButtonState::Down,


### PR DESCRIPTION
Hello there! Thanks a lot for Tauri.

This PR exposes the internal TrayIcon to be able to access the platform implementations.
This is pretty important and my use case is to access the underlying `ns_status_item()` (and then NSWindow, and then NSScreen). TrayIcon already exposes that, but it's unavailable if using the Tauri plugin.