### PR TITLE
fix(windows): fix double free (STATUS_HEAP_CORRUPTION) of resizing handler's userdata

### DIFF
--- a/.changes/fix-resizing-double-free.md
+++ b/.changes/fix-resizing-double-free.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": "patch:bug"
+---
+
+Use WM_NCDESTROY instead of WM_DESTROY to free window userdata, fixing a double-free occurring in the Windows resizing handler for undecorated windows which caused STATUS_HEAP_CORRUPTION

--- a/crates/tauri-runtime-wry/src/undecorated_resizing.rs
+++ b/crates/tauri-runtime-wry/src/undecorated_resizing.rs
@@ -249,7 +249,7 @@ mod windows {
         data.has_undecorated_shadows = wparam.0 != 0;
       }
 
-      WM_DESTROY => {
+      WM_NCDESTROY => {
         let data = data as *mut UndecoratedResizingData;
         drop(Box::from_raw(data));
       }
@@ -388,7 +388,7 @@ mod windows {
         data.has_undecorated_shadows = wparam.0 != 0;
       }
 
-      WM_DESTROY => {
+      WM_NCDESTROY => {
         let data = GetWindowLongPtrW(child, GWLP_USERDATA);
         let data = data as *mut UndecoratedResizingData;
         drop(Box::from_raw(data));


### PR DESCRIPTION
Using WM_NCDESTROY instead of WM_DESTROY is more correct for freeing userdata, as windows can receive multiple WM_DESTROY events if they're parented. WM_NCDESTROY is the last message a window can _ever_ receive, whereas we were experiencing behavior where our application would crash due to a Tauri window receiving multiple WM_DESTROY events.

We tracked this down with ASAN (which reports a double-free almost immediately in our application) and this change fixes the issue.