### PR TITLE
fix: return error on window creation failed

### DIFF
--- a/.changes/return-error-on-window-creation-failed.md
+++ b/.changes/return-error-on-window-creation-failed.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": "patch:bug"
+---
+
+Return `tauri_runtime::Error::CreateWindow` instead of panic on window creation failed

--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -303,7 +303,7 @@ fn detect_target_ok<'a>(env: &Env) -> Option<&'a Target<'a>> {
 fn open_and_wait(config: &AndroidConfig, env: &Env) -> ! {
   log::info!("Opening Android Studio");
   if let Err(e) = os::open_file_with("Android Studio", config.project_dir(), &env.base) {
-    log::error!("{}", e);
+    log::error!("{e}");
   }
   loop {
     sleep(Duration::from_secs(24 * 60 * 60));

--- a/crates/tauri-cli/src/mobile/ios/mod.rs
+++ b/crates/tauri-cli/src/mobile/ios/mod.rs
@@ -389,7 +389,7 @@ fn detect_target_ok<'a>(env: &Env) -> Option<&'a Target<'a>> {
 fn open_and_wait(config: &AppleConfig, env: &Env) -> ! {
   log::info!("Opening Xcode");
   if let Err(e) = os::open_file_with("Xcode", config.project_dir(), env) {
-    log::error!("{}", e);
+    log::error!("{e}");
   }
   loop {
     sleep(Duration::from_secs(24 * 60 * 60));

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -3521,14 +3521,14 @@ fn handle_user_message<T: UserEvent>(
           WebviewMessage::EvaluateScript(script, tx, span) => {
             let _span = span.entered();
             if let Err(e) = webview.evaluate_script(&script) {
-              log::error!("{}", e);
+              log::error!("{e}");
             }
             tx.send(()).unwrap();
           }
           #[cfg(not(all(feature = "tracing", not(target_os = "android"))))]
           WebviewMessage::EvaluateScript(script) => {
             if let Err(e) = webview.evaluate_script(&script) {
-              log::error!("{}", e);
+              log::error!("{e}");
             }
           }
           WebviewMessage::Navigate(url) => {
@@ -3800,7 +3800,7 @@ fn handle_user_message<T: UserEvent>(
             });
           }
           Err(e) => {
-            log::error!("{}", e);
+            log::error!("{e}");
           }
         }
       }
@@ -3810,7 +3810,7 @@ fn handle_user_message<T: UserEvent>(
         windows.0.borrow_mut().insert(window_id, webview);
       }
       Err(e) => {
-        log::error!("{}", e);
+        log::error!("{e}");
       }
     },
     Message::CreateRawWindow(window_id, handler, sender) => {
@@ -4303,7 +4303,10 @@ fn create_window<T: UserEvent, F: Fn(RawWindow) + Send + 'static>(
     }
   };
 
-  let window = window_builder.inner.build(event_loop).unwrap();
+  let window = window_builder
+    .inner
+    .build(event_loop)
+    .map_err(|_| Error::CreateWindow)?;
 
   #[cfg(feature = "tracing")]
   {

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -126,6 +126,7 @@ pub enum Error {
   /// Failed to create webview.
   #[error("failed to create webview: {0}")]
   CreateWebview(Box<dyn std::error::Error + Send + Sync>),
+  // TODO: Make it take an error like `CreateWebview` in v3
   /// Failed to create window.
   #[error("failed to create window")]
   CreateWindow,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference: #13969

Not sure if we could change the `CreateWindow` error varient to something like what we have for `CreateWebview` to include the actual error

```rust
  #[error("failed to create webview: {0}")]
  CreateWebview(Box<dyn std::error::Error + Send + Sync>),
```

I'm not entirely sure if this panic is intentional or not (I would assume not) and the git blame shows that it's from ages ago