### PR TITLE
fix(cli): add single-instance autostart init code

### DIFF
--- a/.changes/add-code-single-instance-autostart.md
+++ b/.changes/add-code-single-instance-autostart.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix the generated plugin init code of `tauri add` for `tauri-plugin-autostart` and `tauri-plugin-single-instance`

--- a/crates/tauri-cli/src/add.rs
+++ b/crates/tauri-cli/src/add.rs
@@ -130,6 +130,8 @@ pub fn run(options: Options) -> Result<()> {
     "Builder::new(|pass| todo!()).build()"
   } else if plugin == "localhost" {
     "Builder::new(todo!()).build()"
+  } else if plugin == "single-instance" {
+    "init(|app, args, cwd| {})"
   } else if metadata.builder {
     "Builder::new().build()"
   } else {

--- a/crates/tauri-cli/src/helpers/plugins.rs
+++ b/crates/tauri-cli/src/helpers/plugins.rs
@@ -38,6 +38,7 @@ pub fn known_plugins() -> HashMap<&'static str, PluginMetadata> {
 
   // uses builder pattern
   for p in [
+    "autostart",
     "global-shortcut",
     "localhost",
     "log",


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix the generated plugin init code of `tauri add` for `tauri-plugin-autostart` and `tauri-plugin-single-instance`

Closes #13972