### PR TITLE
fix(ios): Tauri iOS build with binary XCFramework dependencies

### DIFF
--- a/.changes/fix-ios-binary-framework-dependencies.md
+++ b/.changes/fix-ios-binary-framework-dependencies.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": patch:bug
+---
+
+Fix Tauri iOS build with binary XCFramework dependencies, allows extracting binaryTargets that are zipped and also not including XCFrameworks when linking.

--- a/crates/tauri-utils/src/build.rs
+++ b/crates/tauri-utils/src/build.rs
@@ -75,6 +75,7 @@ fn link_xcode_library(name: &str, source: impl AsRef<std::path::Path>) {
     .arg("OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface")
     .current_dir(source)
     .env_clear()
+    .env("PATH", std::env::var_os("PATH").unwrap_or_default())
     .status()
     .unwrap();
 
@@ -85,6 +86,8 @@ fn link_xcode_library(name: &str, source: impl AsRef<std::path::Path>) {
     .join("Products")
     .join(format!("{configuration}-{sdk}"));
 
+  println!("cargo::rustc-link-search=framework={}", lib_out_dir.display());
+  println!("cargo:include={}", lib_out_dir.display());
   println!("cargo:rerun-if-changed={}", source.display());
   println!("cargo:rustc-link-search=native={}", lib_out_dir.display());
   println!("cargo:rustc-link-lib=static={name}");

--- a/crates/tauri-utils/src/build.rs
+++ b/crates/tauri-utils/src/build.rs
@@ -90,7 +90,6 @@ fn link_xcode_library(name: &str, source: impl AsRef<std::path::Path>) {
     "cargo::rustc-link-search=framework={}",
     lib_out_dir.display()
   );
-  println!("cargo:include={}", lib_out_dir.display());
   println!("cargo:rerun-if-changed={}", source.display());
   println!("cargo:rustc-link-search=native={}", lib_out_dir.display());
   println!("cargo:rustc-link-lib=static={name}");

--- a/crates/tauri-utils/src/build.rs
+++ b/crates/tauri-utils/src/build.rs
@@ -86,7 +86,10 @@ fn link_xcode_library(name: &str, source: impl AsRef<std::path::Path>) {
     .join("Products")
     .join(format!("{configuration}-{sdk}"));
 
-  println!("cargo::rustc-link-search=framework={}", lib_out_dir.display());
+  println!(
+    "cargo::rustc-link-search=framework={}",
+    lib_out_dir.display()
+  );
   println!("cargo:include={}", lib_out_dir.display());
   println!("cargo:rerun-if-changed={}", source.display());
   println!("cargo:rustc-link-search=native={}", lib_out_dir.display());


### PR DESCRIPTION
Fix Tauri iOS build with binary XCFramework dependencies, allows extracting binaryTargets that are zipped and also not including XCFrameworks when linking.

Closes https://github.com/tauri-apps/tauri/issues/13332
