### PR TITLE
feat(tauri): impl `App::set_device_event_filter` for `AppHandle` also

### DIFF
--- a/.changes/impl-set_device_event_filter-for-apphandle.md
+++ b/.changes/impl-set_device_event_filter-for-apphandle.md
@@ -1,7 +1,6 @@
 ---
-"tauri-runtime-wry": minor
-"tauri-runtime": minor
-"tauri": minor
----
+"tauri-runtime-wry": minor:feat
+"tauri-runtime": minor:feat
+"tauri": minor:feat
 
 Implement `App::set_device_event_filter` for `AppHandle` also.

--- a/.changes/impl-set_device_event_filter-for-apphandle.md
+++ b/.changes/impl-set_device_event_filter-for-apphandle.md
@@ -2,5 +2,6 @@
 "tauri-runtime-wry": minor:feat
 "tauri-runtime": minor:feat
 "tauri": minor:feat
+---
 
 Implement `App::set_device_event_filter` for `AppHandle` also.

--- a/.changes/impl-set_device_event_filter-for-apphandle.md
+++ b/.changes/impl-set_device_event_filter-for-apphandle.md
@@ -1,0 +1,7 @@
+---
+"tauri-runtime-wry": minor
+"tauri-runtime": minor
+"tauri": minor
+---
+
+Implement `App::set_device_event_filter` for `AppHandle` also.

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -1430,6 +1430,7 @@ pub enum WebviewMessage {
 pub enum EventLoopWindowTargetMessage {
   CursorPosition(Sender<Result<PhysicalPosition<f64>>>),
   SetTheme(Option<Theme>),
+  SetDeviceEventFilter(DeviceEventFilter),
 }
 
 pub type CreateWindowClosure<T> =
@@ -2635,6 +2636,13 @@ impl<T: UserEvent> RuntimeHandle<T> for WryHandle<T> {
       &self.context,
       Message::Application(ApplicationMessage::Hide),
     )
+  }
+
+  fn set_device_event_filter(&self, filter: DeviceEventFilter) {
+    let _ = send_user_message(
+      &self.context,
+      Message::EventLoopWindowTarget(EventLoopWindowTargetMessage::SetDeviceEventFilter(filter)),
+    );
   }
 
   #[cfg(target_os = "android")]
@@ -3891,6 +3899,9 @@ fn handle_user_message<T: UserEvent>(
       }
       EventLoopWindowTargetMessage::SetTheme(theme) => {
         event_loop.set_theme(to_tao_theme(theme));
+      }
+      EventLoopWindowTargetMessage::SetDeviceEventFilter(filter) => {
+        event_loop.set_device_event_filter(DeviceEventFilterWrapper::from(filter).0);
       }
     },
   }

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -329,6 +329,15 @@ pub trait RuntimeHandle<T: UserEvent>: Debug + Clone + Send + Sync + Sized + 'st
   #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
   fn hide(&self) -> Result<()>;
 
+  /// Change the device event filter mode.
+  ///
+  /// See [Runtime::set_device_event_filter] for details.
+  ///
+  /// ## Platform-specific
+  ///
+  /// See [Runtime::set_device_event_filter] for details.
+  fn set_device_event_filter(&self, filter: DeviceEventFilter);
+
   /// Finds an Android class in the project scope.
   #[cfg(target_os = "android")]
   fn find_class<'a>(

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -623,6 +623,17 @@ impl<R: Runtime> AppHandle<R> {
       .set_dock_visibility(visible)
       .map_err(Into::into)
   }
+
+  /// Change the device event filter mode.
+  ///
+  /// See [App::set_device_event_filter] for details.
+  ///
+  /// ## Platform-specific
+  ///
+  /// See [App::set_device_event_filter] for details.
+  pub fn set_device_event_filter(&self, filter: DeviceEventFilter) {
+    self.runtime_handle.set_device_event_filter(filter);
+  }
 }
 
 impl<R: Runtime> Manager<R> for AppHandle<R> {

--- a/crates/tauri/src/test/mock_runtime.rs
+++ b/crates/tauri/src/test/mock_runtime.rs
@@ -270,6 +270,10 @@ impl<T: UserEvent> RuntimeHandle<T> for MockRuntimeHandle {
     Ok(())
   }
 
+  fn set_device_event_filter(&self, _: DeviceEventFilter) {
+    // no-op
+  }
+
   #[cfg(target_os = "android")]
   fn find_class<'a>(
     &self,


### PR DESCRIPTION
Not sure why this API wasn't added before: <https://github.com/tauri-apps/tauri/pull/5562#issuecomment-3190866523>. For the symmetry, I submitted this PR.

I encountered this issue while implementing API bindings for pytauri. Generally, for APIs that exist on both `App` and `AppHandle`, I only implement them on `AppHandle`; I only implement APIs specific to `App` (such as `run` and `run_iter`) on `App` itself.

In other words, I'm fine with whether this PR gets merged or not. I just want to know if there was a deliberate reason for not adding this API to `AppHandle`.