### PR TITLE
feat(tauri): re-export `PixelUnit`, `PhysicalUnit`, `LogicalUnit`

### DIFF
--- a/.changes/export-PixelUnit.md
+++ b/.changes/export-PixelUnit.md
@@ -1,0 +1,5 @@
+---
+"tauri": minor
+---
+
+re-export `PixelUnit`, `PhysicalUnit`, `LogicalUnit`

--- a/.changes/export-PixelUnit.md
+++ b/.changes/export-PixelUnit.md
@@ -1,5 +1,5 @@
 ---
-"tauri": minor
+"tauri": minor:enhance
 ---
 
 re-export `PixelUnit`, `PhysicalUnit`, `LogicalUnit`

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -223,8 +223,8 @@ pub use {
   self::manager::Asset,
   self::runtime::{
     dpi::{
-      LogicalPosition, LogicalRect, LogicalSize, PhysicalPosition, PhysicalRect, PhysicalSize,
-      Pixel, Position, Rect, Size,
+      LogicalPosition, LogicalRect, LogicalSize, LogicalUnit, PhysicalPosition, PhysicalRect,
+      PhysicalSize, PhysicalUnit, Pixel, PixelUnit, Position, Rect, Size,
     },
     window::{CursorIcon, DragDropEvent, WindowSizeConstraints},
     DeviceEventFilter, UserAttentionType,


### PR DESCRIPTION
If we don't export these APIs, we won't be able to use [WindowSizeConstraints](https://docs.rs/tauri/latest/tauri/struct.WindowSizeConstraints.html) directly.

*I noticed that tauri already exports a lot of items from the `dpi` crate at the top-level namespace, which feels a bit like namespace pollution to me 😂*