### PR TITLE
feat: impl `AsRef<Window>` and `on_webview_event` for `WebviewWindow`

### DIFF
--- a/.changes/WebviewWindow-on_webview_event.md
+++ b/.changes/WebviewWindow-on_webview_event.md
@@ -1,0 +1,11 @@
+---
+tauri: minor:enhance
+---
+
+- Implemented `Webview::on_webview_event` for `WebviewWindow` as well
+- Implemented `AsRef<Window<R>>` for `WebviewWindow<R>`
+
+    This can be considered a *BREAKING CHANGE* in very specific cases:
+    Typically, this means you are relying on implicit type inference, such as `let webview: _ = WebviewWindow.as_ref()`.
+    To resolve this, you should explicitly specify the type, for example `let webview: &Window<R> = WebviewWindow.as_ref()`
+    or `let webview: _ = AsRef::<Webview<R>>::as_ref(&WebviewWindow)`.

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1121,7 +1121,7 @@ impl<R: Runtime> Webview<R> {
     self.use_https_scheme
   }
 
-  /// Registers a window event listener.
+  /// Registers a webview event listener.
   pub fn on_webview_event<F: Fn(&WebviewEvent) + Send + 'static>(&self, f: F) {
     self
       .webview

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -34,7 +34,7 @@ use crate::{
   ipc::{CommandArg, CommandItem, InvokeError, OwnedInvokeResponder},
   manager::AppManager,
   sealed::{ManagerBase, RuntimeOrDispatch},
-  webview::{Cookie, PageLoadPayload, WebviewBuilder},
+  webview::{Cookie, PageLoadPayload, WebviewBuilder, WebviewEvent},
   window::WindowBuilder,
   AppHandle, Event, EventId, Manager, Runtime, Webview, WindowEvent,
 };
@@ -1193,6 +1193,12 @@ impl<R: Runtime> AsRef<Webview<R>> for WebviewWindow<R> {
   }
 }
 
+impl<R: Runtime> AsRef<Window<R>> for WebviewWindow<R> {
+  fn as_ref(&self) -> &Window<R> {
+    &self.window
+  }
+}
+
 impl<R: Runtime> Clone for WebviewWindow<R> {
   fn clone(&self) -> Self {
     Self {
@@ -1204,7 +1210,7 @@ impl<R: Runtime> Clone for WebviewWindow<R> {
 
 impl<R: Runtime> Eq for WebviewWindow<R> {}
 impl<R: Runtime> PartialEq for WebviewWindow<R> {
-  /// Only use the [`Window`]'s label to compare equality.
+  /// Only use the [`Webview`]'s label to compare equality.
   fn eq(&self, other: &Self) -> bool {
     self.webview.eq(&other.webview)
   }
@@ -1267,6 +1273,11 @@ impl<R: Runtime> WebviewWindow<R> {
   /// Registers a window event listener.
   pub fn on_window_event<F: Fn(&WindowEvent) + Send + 'static>(&self, f: F) {
     self.window.on_window_event(f);
+  }
+
+  /// Registers a webview event listener.
+  pub fn on_webview_event<F: Fn(&WebviewEvent) + Send + 'static>(&self, f: F) {
+    self.webview.on_webview_event(f);
   }
 
   /// Resolves the given command scope for this webview on the currently loaded URL.


### PR DESCRIPTION
Similar to the purpose of <https://github.com/tauri-apps/tauri/pull/14008#issue-3324704887>, I implemented these methods for symmetry.

Currently, `Webview` still has two separate APIs: `set_bounds` and `set_size`, but I think these APIs are not suitable for `WebviewWindow`, so I didn't add them.

In addition, I also fixed some typos.