### PR TITLE
feat(tauri): export `TitleBarStyle` for all platforms

### DIFF
--- a/.changes/export-TitleBarStyle-for-all-platform.md
+++ b/.changes/export-TitleBarStyle-for-all-platform.md
@@ -1,0 +1,5 @@
+---
+tauri: minor:enhance
+---
+
+export `TitleBarStyle` for all platforms.

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -209,7 +209,6 @@ pub use tauri_runtime_wry::webview_version;
 #[cfg_attr(docsrs, doc(cfg(target_os = "macos")))]
 pub use runtime::ActivationPolicy;
 
-#[cfg(target_os = "macos")]
 pub use self::utils::TitleBarStyle;
 
 use self::event::EventName;


### PR DESCRIPTION
Similar to <https://github.com/tauri-apps/tauri/pull/14008#issue-3324704887>, this PR is mainly for the sake of API symmetry.

I can see [`set_title_bar_style`](https://docs.rs/tauri/latest/x86_64-pc-windows-msvc/tauri/?search=set_title_bar_style) on all platforms, but [`TitleBarStyle`](https://docs.rs/tauri/latest/x86_64-apple-darwin/tauri/index.html?search=TitleBarStyle) is *only* visible on macOS.

This feels odd when reading on `docs.rs`, because unlike [`AppHandle::set_activation_policy`](https://docs.rs/tauri/latest/x86_64-apple-darwin/tauri/struct.AppHandle.html#method.set_activation_policy) and `ActivationPolicy`, which appear together only on macOS, `TitleBarStyle` is not paired in the same way.

Also, I feel that `TitleBarStyle` should be exported under `mod window` (instead of the top-level module), similar to how `window::ProgressBarState` is handled, since it's only used for `Window::set_title_bar_style`.