### PR TITLE
Remove `AsRef<Window>` on `WebviewWindow`

### DIFF
--- a/.changes/WebviewWindow-on_webview_event.md
+++ b/.changes/WebviewWindow-on_webview_event.md
@@ -2,10 +2,4 @@
 tauri: minor:enhance
 ---
 
-- Implemented `Webview::on_webview_event` for `WebviewWindow` as well
-- Implemented `AsRef<Window<R>>` for `WebviewWindow<R>`
-
-    This can be considered a *BREAKING CHANGE* in very specific cases:
-    Typically, this means you are relying on implicit type inference, such as `let webview: _ = WebviewWindow.as_ref()`.
-    To resolve this, you should explicitly specify the type, for example `let webview: &Window<R> = WebviewWindow.as_ref()`
-    or `let webview: _ = AsRef::<Webview<R>>::as_ref(&WebviewWindow)`.
+Implemented `Webview::on_webview_event` for `WebviewWindow` as well

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -1365,12 +1365,6 @@ impl<R: Runtime> AsRef<Webview<R>> for WebviewWindow<R> {
   }
 }
 
-impl<R: Runtime> AsRef<Window<R>> for WebviewWindow<R> {
-  fn as_ref(&self) -> &Window<R> {
-    &self.window
-  }
-}
-
 impl<R: Runtime> Clone for WebviewWindow<R> {
   fn clone(&self) -> Self {
     Self {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This reverts the `AsRef<Window>` impl for `WebviewWindow` made in #14012

cc @WSH032, after some discussion with the team, we think we should avoid this type of breaking changes in minors

And we can instead, add explicit methods like `as_window`, `as_webview`