### PR TITLE
fix: set webview2 path before initializing runtime

### DIFF
--- a/.changes/fix-webview2-path-timing.md
+++ b/.changes/fix-webview2-path-timing.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+Fixed an issue that caused the runtime WebView2 detection to fail for FixedRuntime installations.

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -2165,6 +2165,26 @@ tauri::Builder::default()
       },
     };
 
+    // The env var must be set before the Runtime is created so that GetAvailableBrowserVersionString picks it up.
+    #[cfg(windows)]
+    {
+      if let crate::utils::config::WebviewInstallMode::FixedRuntime { path } =
+        &manager.config.bundle.windows.webview_install_mode
+      {
+        if let Some(exe_dir) = std::env::current_exe()
+          .ok()
+          .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        {
+          std::env::set_var("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER", exe_dir.join(path));
+        } else {
+          #[cfg(debug_assertions)]
+          eprintln!(
+            "failed to resolve resource directory; fallback to the installed Webview2 runtime."
+          );
+        }
+      }
+    }
+
     #[cfg(any(windows, target_os = "linux"))]
     let mut runtime = if self.runtime_any_thread {
       R::new_any_thread(runtime_args)?
@@ -2241,25 +2261,6 @@ tauri::Builder::default()
 
     app.manage(ChannelDataIpcQueue::default());
     app.handle.plugin(crate::ipc::channel::plugin())?;
-
-    #[cfg(windows)]
-    {
-      if let crate::utils::config::WebviewInstallMode::FixedRuntime { path } =
-        &app.manager.config().bundle.windows.webview_install_mode
-      {
-        if let Ok(resource_dir) = app.path().resource_dir() {
-          std::env::set_var(
-            "WEBVIEW2_BROWSER_EXECUTABLE_FOLDER",
-            resource_dir.join(path),
-          );
-        } else {
-          #[cfg(debug_assertions)]
-          eprintln!(
-            "failed to resolve resource directory; fallback to the installed Webview2 runtime."
-          );
-        }
-      }
-    }
 
     let handle = app.handle();
 

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -2171,7 +2171,7 @@ tauri::Builder::default()
       if let crate::utils::config::WebviewInstallMode::FixedRuntime { path } =
         &manager.config.bundle.windows.webview_install_mode
       {
-        if let Some(exe_dir) = std::env::current_exe()
+        if let Some(exe_dir) = crate::utils::platform::current_exe()
           .ok()
           .and_then(|p| p.parent().map(|p| p.to_path_buf()))
         {


### PR DESCRIPTION
fixes #13817

i don't really like not re-using resource_dir() but i couldn't think of anything that wasn't even worse (eg initializing dummy PackageInfo / Env was really ugly - adding new methods to tauri-utils that don't take those args felt weird as well).