### PR TITLE
fix(tauri-runtime-wry): ignore about:blank initial URL

### DIFF
--- a/.changes/about-blank-ignore.md
+++ b/.changes/about-blank-ignore.md
@@ -1,6 +1,6 @@
 ---
-"tauri-runtime-wry": patch
-"tauri": patch
+"tauri-runtime-wry": patch:bug
+"tauri": patch:bug
 ---
 
 Ignore initial navigation to `about:blank` so `on_new_window` does not give a warning on first navigation on macOS.

--- a/.changes/about-blank-ignore.md
+++ b/.changes/about-blank-ignore.md
@@ -1,0 +1,6 @@
+---
+"tauri-runtime-wry": patch
+"tauri": patch
+---
+
+Ignore initial navigation to `about:blank` so `on_new_window` does not give a warning on first navigation on macOS.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5816,7 +5816,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -10943,9 +10943,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wry"
-version = "0.53.1"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5698e50a589268aec06d2219f48b143222f7b5ad9aa690118b8dce0a8dcac574"
+checksum = "e3b6763512fe4b51c80b3ce9b50939d682acb4de335dfabbdb20d7a2642199b7"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.0",

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -17,7 +17,7 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-wry = { version = "0.53.1", default-features = false, features = [
+wry = { version = "0.53.2", default-features = false, features = [
   "drag-drop",
   "protocol",
   "os-webview",

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4578,12 +4578,15 @@ You may have it installed on another user account, but it is not available for t
   let mut webview_builder = WebViewBuilder::new_with_web_context(&mut web_context.inner)
     .with_id(&label)
     .with_focused(webview_attributes.focus)
-    .with_url(&url)
     .with_transparent(webview_attributes.transparent)
     .with_accept_first_mouse(webview_attributes.accept_first_mouse)
     .with_incognito(webview_attributes.incognito)
     .with_clipboard(webview_attributes.clipboard)
     .with_hotkeys_zoom(webview_attributes.zoom_hotkeys_enabled);
+
+  if url != "about:blank" {
+    webview_builder = webview_builder.with_url(&url);
+  }
 
   #[cfg(target_os = "macos")]
   if let Some(webview_configuration) = webview_attributes.webview_configuration {


### PR DESCRIPTION
fixes a macOS warning when a navigation handler is registered and you choose to create a new window on the on_new_window hook - in this case we shouldn't perform the initial navigation since the URL is provided by the webview configuration from the hook
