### PR TITLE
fix: don't set macos deployment target in dev

### DIFF
--- a/.changes/skip-deployment-target-in-dev.md
+++ b/.changes/skip-deployment-target-in-dev.md
@@ -1,7 +1,7 @@
 ---
 tauri-build: patch:enhance
 tauri-cli: patch:enhance
-@tauri-apps/cli: patch:enhance
+'@tauri-apps/cli': patch:enhance
 ---
 
 Tauri now ignores `macOS.minimumSystemVersion` in `tauri dev` to prevent forced rebuilds of macOS specific dependencies when using something like `rust-analyzer` at the same time as `tauri dev`.

--- a/.changes/skip-deployment-target-in-dev.md
+++ b/.changes/skip-deployment-target-in-dev.md
@@ -1,7 +1,7 @@
 ---
 tauri-build: patch:enhance
 tauri-cli: patch:enhance
-@tauri-apps/clo: patch:enhance
+@tauri-apps/cli: patch:enhance
 ---
 
 Tauri now ignores `macOS.minimumSystemVersion` in `tauri dev` to prevent forced rebuilds of macOS specific dependencies when using something like `rust-analyzer` at the same time as `tauri dev`.

--- a/.changes/skip-deployment-target-in-dev.md
+++ b/.changes/skip-deployment-target-in-dev.md
@@ -1,0 +1,7 @@
+---
+tauri-build: patch:enhance
+tauri-cli: patch:enhance
+@tauri-apps/clo: patch:enhance
+---
+
+Tauri now ignores `macOS.minimumSystemVersion` in `tauri dev` to prevent forced rebuilds of macOS specific dependencies when using something like `rust-analyzer` at the same time as `tauri dev`.

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -573,8 +573,10 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
       }
     }
 
-    if let Some(version) = &config.bundle.macos.minimum_system_version {
-      println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET={version}");
+    if !is_dev() {
+      if let Some(version) = &config.bundle.macos.minimum_system_version {
+        println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET={version}");
+      }
     }
   }
 

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -3483,7 +3483,7 @@
           ]
         },
         "minimumSystemVersion": {
-          "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.\n\n Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`\n and the `MACOSX_DEPLOYMENT_TARGET` environment variable.\n\n An empty string is considered an invalid value so the default value is used.",
+          "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.\n\n Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`\n and the `MACOSX_DEPLOYMENT_TARGET` environment variable.\n\n Ignored in `tauri dev`.\n\n An empty string is considered an invalid value so the default value is used.",
           "default": "10.13",
           "type": [
             "string",

--- a/crates/tauri-cli/src/build.rs
+++ b/crates/tauri-cli/src/build.rs
@@ -104,6 +104,10 @@ pub fn command(mut options: Options, verbosity: u8) -> Result<()> {
   let config_guard = config.lock().unwrap();
   let config_ = config_guard.as_ref().unwrap();
 
+  if let Some(minimum_system_version) = &config_.bundle.macos.minimum_system_version {
+    std::env::set_var("MACOSX_DEPLOYMENT_TARGET", minimum_system_version);
+  }
+
   let app_settings = interface.app_settings();
   let interface_options = options.clone().into();
 

--- a/crates/tauri-cli/src/bundle.rs
+++ b/crates/tauri-cli/src/bundle.rs
@@ -136,6 +136,10 @@ pub fn command(options: Options, verbosity: u8) -> crate::Result<()> {
   let config_guard = config.lock().unwrap();
   let config_ = config_guard.as_ref().unwrap();
 
+  if let Some(minimum_system_version) = &config_.bundle.macos.minimum_system_version {
+    std::env::set_var("MACOSX_DEPLOYMENT_TARGET", minimum_system_version);
+  }
+
   let app_settings = interface.app_settings();
   let interface_options = options.clone().into();
 

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -157,8 +157,6 @@ impl Interface for Rust {
         "IPHONEOS_DEPLOYMENT_TARGET",
         &config.bundle.ios.minimum_system_version,
       );
-    } else if let Some(minimum_system_version) = &config.bundle.macos.minimum_system_version {
-      std::env::set_var("MACOSX_DEPLOYMENT_TARGET", minimum_system_version);
     }
 
     let app_settings = RustAppSettings::new(config, manifest, target)?;

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -3483,7 +3483,7 @@
           ]
         },
         "minimumSystemVersion": {
-          "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.\n\n Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`\n and the `MACOSX_DEPLOYMENT_TARGET` environment variable.\n\n An empty string is considered an invalid value so the default value is used.",
+          "description": "A version string indicating the minimum macOS X version that the bundled application supports. Defaults to `10.13`.\n\n Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`\n and the `MACOSX_DEPLOYMENT_TARGET` environment variable.\n\n Ignored in `tauri dev`.\n\n An empty string is considered an invalid value so the default value is used.",
           "default": "10.13",
           "type": [
             "string",

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -640,6 +640,8 @@ pub struct MacConfig {
   /// Setting it to `null` completely removes the `LSMinimumSystemVersion` field on the bundle's `Info.plist`
   /// and the `MACOSX_DEPLOYMENT_TARGET` environment variable.
   ///
+  /// Ignored in `tauri dev`.
+  ///
   /// An empty string is considered an invalid value so the default value is used.
   #[serde(
     deserialize_with = "de_macos_minimum_system_version",


### PR DESCRIPTION
fixes #11577 Also interesting: https://github.com/rust-lang/cargo/issues/13115

@lucasfernog i'm really indecisive about this. Do we want to try to "fix" it for all current users (this PR)? Or would you prefer if we'd add a .cargo/config.toml file to all our templates that sets the env var?
Or do you perhaps have another idea?