### PR TITLE
feat(cli): ensure mobile Rust targets are installed

### DIFF
--- a/.changes/ensure-targets-mobile.md
+++ b/.changes/ensure-targets-mobile.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:enhance
+"tauri-cli": patch:enhance
+---
+
+Ensure Rust targets for mobile are installed when running the dev and build commands (previously only checked on init).

--- a/crates/tauri-cli/src/mobile/android/android_studio_script.rs
+++ b/crates/tauri-cli/src/mobile/android/android_studio_script.rs
@@ -132,11 +132,21 @@ pub fn command(options: Options) -> Result<()> {
 
   let mut validated_lib = false;
 
+  let installed_targets =
+    crate::interface::rust::installation::installed_targets().unwrap_or_default();
+
   call_for_targets_with_fallback(
     options.targets.unwrap_or_default().iter(),
     &detect_target_ok,
     &env,
     |target: &Target| {
+      if !installed_targets.contains(&target.triple().into()) {
+        log::info!("Installing target {}", target.triple());
+        target
+          .install()
+          .context("failed to install target with rustup")?;
+      }
+
       target.build(
         &config,
         &metadata,

--- a/crates/tauri-cli/src/mobile/android/build.rs
+++ b/crates/tauri-cli/src/mobile/android/build.rs
@@ -167,6 +167,15 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   crate::build::setup(&interface, &mut build_options, tauri_config.clone(), true)?;
 
+  let installed_targets =
+    crate::interface::rust::installation::installed_targets().unwrap_or_default();
+
+  if !installed_targets.contains(&first_target.triple().into()) {
+    log::info!("Installing target {}", first_target.triple());
+    first_target
+      .install()
+      .context("failed to install target with rustup")?;
+  }
   // run an initial build to initialize plugins
   first_target.build(&config, &metadata, &env, noise_level, true, profile)?;
 

--- a/crates/tauri-cli/src/mobile/android/dev.rs
+++ b/crates/tauri-cli/src/mobile/android/dev.rs
@@ -252,12 +252,22 @@ fn run_dev(
 
   configure_cargo(&mut env, config)?;
 
+  let installed_targets =
+    crate::interface::rust::installation::installed_targets().unwrap_or_default();
+
   // run an initial build to initialize plugins
   let target_triple = dev_options.target.as_ref().unwrap();
   let target = Target::all()
     .values()
     .find(|t| t.triple == target_triple)
     .unwrap_or_else(|| Target::all().values().next().unwrap());
+  if !installed_targets.contains(&target.triple().into()) {
+    log::info!("Installing target {}", target.triple());
+    target
+      .install()
+      .context("failed to install target with rustup")?;
+  }
+
   target.build(
     config,
     metadata,

--- a/crates/tauri-cli/src/mobile/android/project.rs
+++ b/crates/tauri-cli/src/mobile/android/project.rs
@@ -45,8 +45,9 @@ pub fn gen(
       .collect::<Vec<&Target>>();
 
     if !missing_targets.is_empty() {
-      println!("Installing Android Rust toolchains...");
+      log::info!("Installing Android Rust targets...");
       for target in missing_targets {
+        log::info!("Installing target {}", target.triple());
         target
           .install()
           .context("failed to install target with rustup")?;

--- a/crates/tauri-cli/src/mobile/ios/project.rs
+++ b/crates/tauri-cli/src/mobile/ios/project.rs
@@ -50,8 +50,9 @@ pub fn gen(
       .collect::<Vec<&Target>>();
 
     if !missing_targets.is_empty() {
-      println!("Installing iOS Rust toolchains...");
+      log::info!("Installing iOS Rust targets...");
       for target in missing_targets {
+        log::info!("Installing target {}", target.triple());
         target
           .install()
           .context("failed to install target with rustup")?;


### PR DESCRIPTION
currently we only install Rust targets for mobile when initializing the projects.

Users can commit the Android/iOS projects, so running the init command is not a requirement to develop mobile apps. This change ensures the Rust targets are installed before trying to compile them.

