### PR TITLE
fix(cli): ios command failing when running with deno, closes #13547

### DIFF
--- a/.changes/fix-deno-cli-ios.md
+++ b/.changes/fix-deno-cli-ios.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fixes running `ios` commands with `deno` crashing due to incorrect current working directory resolution.

--- a/crates/tauri-cli/src/mobile/ios/xcode_script.rs
+++ b/crates/tauri-cli/src/mobile/ios/xcode_script.rs
@@ -65,12 +65,16 @@ pub fn command(options: Options) -> Result<()> {
     }
   }
 
-  // `xcode-script` is ran from the `gen/apple` folder when not using NPM/yarn/pnpm.
+  let process_path = std::env::current_exe().unwrap_or_default();
+
+  // `xcode-script` is ran from the `gen/apple` folder when not using NPM/yarn/pnpm/deno.
   // so we must change working directory to the src-tauri folder to resolve the tauri dir
   // additionally, bun@<1.2 does not modify the current working directory, so it is also runs this script from `gen/apple`
   // bun@>1.2 now actually moves the CWD to the package root so we shouldn't modify CWD in that case
   // see https://bun.sh/blog/bun-v1.2#bun-run-uses-the-correct-directory
-  if (var_os("npm_lifecycle_event").is_none() && var_os("PNPM_PACKAGE_NAME").is_none())
+  if (var_os("npm_lifecycle_event").is_none()
+    && var_os("PNPM_PACKAGE_NAME").is_none()
+    && process_path.file_stem().unwrap_or_default() != "deno")
     || var("npm_config_user_agent")
       .is_ok_and(|agent| agent.starts_with("bun/1.0") || agent.starts_with("bun/1.1"))
   {


### PR DESCRIPTION
Deno doesn't set an environment variable to help us, so I had to use the exe path to determine whether we're running under deno or not
