### PR TITLE
feat(cli): retain all RUST_* env vars on mobile commands

### DIFF
--- a/.changes/retain-rust-vars.md
+++ b/.changes/retain-rust-vars.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:enhance
+"tauri-cli": patch:enhance
+---
+
+Retain `RUST_*` environment variables when running the mobile commands.

--- a/crates/tauri-cli/src/mobile/mod.rs
+++ b/crates/tauri-cli/src/mobile/mod.rs
@@ -347,6 +347,7 @@ fn env_vars() -> HashMap<String, OsString> {
       && k != "TAURI_SIGNING_PRIVATE_KEY_PASSWORD")
       || k.starts_with("WRY")
       || k.starts_with("CARGO_")
+      || k.starts_with("RUST_")
       || k == "TMPDIR"
       || k == "PATH"
     {


### PR DESCRIPTION
useful to propagate RUST_BACKTRACE to the IDE commands
