### PR TITLE
fix(cli): set package type for Deno

### DIFF
--- a/.changes/fix-cli-deno.md
+++ b/.changes/fix-cli-deno.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:bug
+"tauri-cli": patch:bug
+---
+
+Fix usage with Deno failing with `ReferenceError: require is not defined`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@tauri-apps/cli",
   "version": "2.8.3",
   "description": "Command line interface for building Tauri apps",
+  "type": "commonjs",
   "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/tauri"


### PR DESCRIPTION
without the type Deno assumes that the package is a ESM so it cannot use `require` we should probably update our minimum Node.js version and use ESM instead, but I want to ship this fix first
