### PR TITLE
fix(cli): iOS simulator dev/build on Apple Intel, closes #13456

### DIFF
--- a/.changes/fix-ios-sim-intel.md
+++ b/.changes/fix-ios-sim-intel.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:enhance
+"tauri-cli": patch:enhance
+---
+
+Fix iOS dev and build targeting the simulator on Intel machines.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-mobile2"
-version = "0.20.4"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93c1021dbbc971a4801008e7faf1c255b56c8317a2a10970703ee46caa3343e"
+checksum = "567e0eecdee84aa11424c2ad1c5dd30cdd820934e1ef1cc9fc51cfbde5782589"
 dependencies = [
  "colored",
  "core-foundation 0.10.0",

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -36,7 +36,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
-cargo-mobile2 = { version = "0.20.2", default-features = false }
+cargo-mobile2 = { version = "0.20.5", default-features = false }
 
 [dependencies]
 jsonrpsee = { version = "0.24", features = ["server"] }


### PR DESCRIPTION
applies https://github.com/tauri-apps/cargo-mobile2/pull/479
