### PR TITLE
fix(cli): empty Android emulator name

### DIFF
--- a/.changes/fix-emulator-name.md
+++ b/.changes/fix-emulator-name.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fixes empty device name when using an Android emulator causing the emulator to never be detected as running.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-mobile2"
-version = "0.20.5"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567e0eecdee84aa11424c2ad1c5dd30cdd820934e1ef1cc9fc51cfbde5782589"
+checksum = "35613119e2e16b293e56557a27da0d5bc42031f5edc0bf4f73a2b4d310d39c65"
 dependencies = [
  "colored",
  "core-foundation 0.10.0",

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -36,7 +36,7 @@ name = "cargo-tauri"
 path = "src/main.rs"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"openbsd\", target_os = \"netbsd\", target_os = \"windows\", target_os = \"macos\"))".dependencies]
-cargo-mobile2 = { version = "0.20.5", default-features = false }
+cargo-mobile2 = { version = "0.20.6", default-features = false }
 
 [dependencies]
 jsonrpsee = { version = "0.24", features = ["server"] }


### PR DESCRIPTION
applies https://github.com/tauri-apps/cargo-mobile2/pull/481
