### PR TITLE
(temp) update linuxdeploy to latest for testing

### DIFF
--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -233,7 +233,7 @@ fn prepare_tools(tools_path: &Path, arch: &str, verbose: bool) -> crate::Result<
   let linuxdeploy_arch = if arch == "i686" { "i383" } else { arch };
   let linuxdeploy = tools_path.join(format!("linuxdeploy-{linuxdeploy_arch}.AppImage"));
   if !linuxdeploy.exists() {
-    let data = download(&format!("https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-{linuxdeploy_arch}.AppImage"))?;
+    let data = download(&format!("https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-{linuxdeploy_arch}.AppImage"))?;
     write_and_make_executable(&linuxdeploy, data)?;
   }
 
@@ -249,20 +249,20 @@ fn prepare_tools(tools_path: &Path, arch: &str, verbose: bool) -> crate::Result<
     write_and_make_executable(&gstreamer, data)?;
   }
 
-  let appimage = tools_path.join("linuxdeploy-plugin-appimage.AppImage");
-  if !appimage.exists() {
-    // This is optional, linuxdeploy will fall back to its built-in version if the download failed.
-    let data = download(&format!("https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-{arch}.AppImage"));
-    match data {
-      Ok(data) => write_and_make_executable(&appimage, data)?,
-      Err(err) => {
-        log::error!("Download of AppImage plugin failed. Using older built-in version instead.");
-        if verbose {
-          log::debug!("{err:?}");
-        }
-      }
-    }
-  }
+  // let appimage = tools_path.join("linuxdeploy-plugin-appimage.AppImage");
+  // if !appimage.exists() {
+  //   // This is optional, linuxdeploy will fall back to its built-in version if the download failed.
+  //   let data = download(&format!("https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-{arch}.AppImage"));
+  //   match data {
+  //     Ok(data) => write_and_make_executable(&appimage, data)?,
+  //     Err(err) => {
+  //       log::error!("Download of AppImage plugin failed. Using older built-in version instead.");
+  //       if verbose {
+  //         log::debug!("{err:?}");
+  //       }
+  //     }
+  //   }
+  // }
 
   // This should prevent linuxdeploy to be detected by appimage integration tools
   let _ = Command::new("dd")


### PR DESCRIPTION
I've got multiple reports about the change now, for example in this thread https://discord.com/channels/616186924390023171/1383929416798965932/1411758124586631282.
Unfortunately we cannot get a proper error message without a newer version of linuxdeploy or in our case yet another recompilation of the old version we use. i'll see if i can do it quickly on Tuesday, will open this as a draft to not forget until then.