### PR TITLE
fix(cli): improve Android BuildTask.kt Windows executable detection for nvm4w Fixes #13892

### DIFF
--- a/.changes/android-init-windows-unix.md
+++ b/.changes/android-init-windows-unix.md
@@ -1,0 +1,6 @@
+---
+'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': patch:bug
+---
+
+Strip Windows-only extensions from the binary path so an Android project initialized on Windows can be used on UNIX systems.

--- a/.changes/fix-android-build-nvm4w-windows.md
+++ b/.changes/fix-android-build-nvm4w-windows.md
@@ -1,5 +1,6 @@
 ---
 'tauri-cli': 'patch:bug'
+'@tauri-apps/cli': patch:bug
 ---
 
-Fix Android build error on Windows when using nvm4w (issue documented at #13892 [bug] [android] [windows] [cli] [build] Android Build Error: A problem occurred starting process 'command 'C:\nvm4w\nodejs\node.exe.cmd'' and Error: Cannot find module '...tauri' when using nvm4w). The BuildTask.kt template now includes robust fallback logic for Windows executable detection, preventing the "Cannot find module" and "node.exe.cmd" errors that occurred with nvm4w Node.js installations. The fix tries multiple Windows-specific fallbacks including .cmd, .bat extensions and cargo as a last resort.
+Enhance Android build script usage on Windows by attempting to run cmd, bat and exe formats.

--- a/.changes/fix-android-build-nvm4w-windows.md
+++ b/.changes/fix-android-build-nvm4w-windows.md
@@ -1,0 +1,5 @@
+---
+'tauri-cli': 'patch:bug'
+---
+
+Fix Android build error on Windows when using nvm4w (issue documented at #13892 [bug] [android] [windows] [cli] [build] Android Build Error: A problem occurred starting process 'command 'C:\nvm4w\nodejs\node.exe.cmd'' and Error: Cannot find module '...tauri' when using nvm4w). The BuildTask.kt template now includes robust fallback logic for Windows executable detection, preventing the "Cannot find module" and "node.exe.cmd" errors that occurred with nvm4w Node.js installations. The fix tries multiple Windows-specific fallbacks including .cmd, .bat extensions and cargo as a last resort.

--- a/crates/tauri-cli/src/mobile/init.rs
+++ b/crates/tauri-cli/src/mobile/init.rs
@@ -117,7 +117,16 @@ pub fn exec(
   build_args.push(target.command_name());
   build_args.push(target.ide_build_script_name());
 
-  map.insert("tauri-binary", binary.to_string_lossy());
+  let mut binary = binary.to_string_lossy().to_string();
+  if binary.ends_with(".exe") || binary.ends_with(".cmd") || binary.ends_with(".bat") {
+    // remove Windows-only extension
+    binary.pop();
+    binary.pop();
+    binary.pop();
+    binary.pop();
+  }
+
+  map.insert("tauri-binary", binary);
   map.insert("tauri-binary-args", &build_args);
   map.insert("tauri-binary-args-str", build_args.join(" "));
 

--- a/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
+++ b/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
@@ -21,7 +21,24 @@ open class BuildTask : DefaultTask() {
             runTauriCli(executable)
         } catch (e: Exception) {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                runTauriCli("$executable.cmd")
+                // Try different Windows-specific fallbacks
+                val fallbacks = listOf(
+                    "$executable.cmd",
+                    "$executable.bat",
+                    "cargo.exe",
+                    "cargo"
+                )
+                
+                var lastException: Exception = e
+                for (fallback in fallbacks) {
+                    try {
+                        runTauriCli(fallback)
+                        return
+                    } catch (fallbackException: Exception) {
+                        lastException = fallbackException
+                    }
+                }
+                throw lastException
             } else {
                 throw e;
             }
@@ -32,7 +49,15 @@ open class BuildTask : DefaultTask() {
         val rootDirRel = rootDirRel ?: throw GradleException("rootDirRel cannot be null")
         val target = target ?: throw GradleException("target cannot be null")
         val release = release ?: throw GradleException("release cannot be null")
-        val args = listOf({{quote-and-join tauri-binary-args}});
+        
+        val baseArgs = listOf({{quote-and-join tauri-binary-args}});
+        
+        // If we're using cargo as a fallback, we need to prepend "tauri" to the args
+        val args = if (executable.contains("cargo")) {
+            listOf("tauri") + baseArgs
+        } else {
+            baseArgs
+        }.toMutableList()
 
         project.exec {
             workingDir(File(project.projectDir, rootDirRel))

--- a/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
+++ b/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
@@ -21,12 +21,11 @@ open class BuildTask : DefaultTask() {
             runTauriCli(executable)
         } catch (e: Exception) {
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                // Try different Windows-specific fallbacks
+                // Try different Windows-specific extensions
                 val fallbacks = listOf(
+                    "$executable.exe",
                     "$executable.cmd",
                     "$executable.bat",
-                    "cargo.exe",
-                    "cargo"
                 )
                 
                 var lastException: Exception = e

--- a/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
+++ b/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
@@ -48,15 +48,7 @@ open class BuildTask : DefaultTask() {
         val rootDirRel = rootDirRel ?: throw GradleException("rootDirRel cannot be null")
         val target = target ?: throw GradleException("target cannot be null")
         val release = release ?: throw GradleException("release cannot be null")
-        
-        val baseArgs = listOf({{quote-and-join tauri-binary-args}});
-        
-        // If we're using cargo as a fallback, we need to prepend "tauri" to the args
-        val args = if (executable.contains("cargo")) {
-            listOf("tauri") + baseArgs
-        } else {
-            baseArgs
-        }.toMutableList()
+        val args = listOf({{quote-and-join tauri-binary-args}});
 
         project.exec {
             workingDir(File(project.projectDir, rootDirRel))


### PR DESCRIPTION
## Description
Fixes Android build error on Windows when using nvm4w Node.js installations.

## Problem
When using nvm4w on Windows, `cargo tauri android dev` fails with:
- "Cannot find module" errors
- "node.exe.cmd" not found errors

## Solution
- Improved Windows executable detection in BuildTask.kt template
- Added fallback logic: .cmd → .bat → cargo.exe → cargo
- Maintains compatibility with existing setups

## Testing
-  Generated BuildTask.kt contains fallback logic
-  Template properly handles cargo vs node executables
-  Needs contributors with full Android SDK to test build

Fixes #13892

## Notes
- Clippy passes with no warnings
- One ACL snapshot test fails on Windows (unrelated to this change) this appears to be a platform-specific test issue. No ACL code was modified in this PR