### PR TITLE
feat(ios): support async Swift plugin methods (`completionHandler:`) in PluginManager

### DIFF
--- a/.changes/ios-async-support.md
+++ b/.changes/ios-async-support.md
@@ -1,5 +1,5 @@
 ---
-"tauri-ios-api": minor
+"tauri": minor:feat
 ---
 
 Support async Swift plugin methods (`completionHandler:`) in PluginManager

--- a/.changes/ios-async-support.md
+++ b/.changes/ios-async-support.md
@@ -1,0 +1,5 @@
+---
+"tauri-ios-api": minor
+---
+
+Support async Swift plugin methods (`completionHandler:`) in PluginManager


### PR DESCRIPTION
This adds support for invoking plugin methods that Swift exposes as async / async throws.
In the Objective-C runtime, such methods are automatically bridged into selectors with a completionHandler: parameter (e.g. commandName:completionHandler:).
	•	Detects and invokes completionHandler: selectors with a block that rejects if an error is passed.
	•	Falls back to the existing error: selector for throwing methods.
	•	No breaking changes — plugins can now use either throws or async/await Swift APIs.

Code example:

```objc
    @objc public func getProducts(_ invoke: Invoke) async throws {
        let args = try invoke.parseArgs(GetProductsArgs.self)
        
        do {
            let products = try await Product.products(for: args.productIds)
            var productsArray: [[String: Any]] = []
            
            // Other code

            invoke.resolve(["products": productsArray])
        } catch {
            invoke.reject("Failed to fetch products: \(error.localizedDescription)")
        }
    }	
```

Without this change, async Swift plugin methods cannot be called and result is "No command getProducts found for plugin"
	
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
