### PR TITLE
fix(macros): stack overflow in invoke handler

### DIFF
--- a/.changes/stack-overflow-release-build.md
+++ b/.changes/stack-overflow-release-build.md
@@ -1,0 +1,6 @@
+---
+"tauri": "patch:bug"
+"tauri-macros": "patch:bug"
+---
+
+Fix the stack overflow when having too many commands in a single invoke handler in release build

--- a/crates/tauri-macros/src/command/wrapper.rs
+++ b/crates/tauri-macros/src/command/wrapper.rs
@@ -283,10 +283,9 @@ pub fn wrapper(attributes: TokenStream, item: TokenStream) -> TokenStream {
     macro_rules! #wrapper {
       // double braces because the item is expected to be a block expression
       ($path:path, $invoke:ident) => {
-        // The IIFE here is for preventing stack overflow on Windows debug build,
+        // The IIFE here is for preventing stack overflow on Windows,
         // see https://github.com/tauri-apps/tauri/issues/12488
         {
-          #[cfg_attr(not(debug_assertions), inline(always))]
           move || {
             #[allow(unused_imports)]
             use #root::ipc::private::*;


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix the stack overflow when having too many commands in a single invoke handler in release build

Fix #14167

So it turned out we can't really rely on the compiler to optimize this away, let's remove the `inline(always)` in release build as well

References:

- https://github.com/tauri-apps/tauri/pull/13217#discussion_r2042998427 (😂)
- #12488