### PR TITLE
chore: Set minimumReleaseAge to 3 days in renovate and pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "devDependencies": {
     "prettier": "^3.5.3"
   },
-  "packageManager": "pnpm@10.12.1",
+  "minimumReleaseAge": 4320,
+  "packageManager": "pnpm@10.16.0",
   "pnpm": {
     "overrides": {
       "brace-expansion@<4.0.1": ">=4.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,9 @@
   "rangeStrategy": "replace",
   "packageRules": [
     {
+      "matchPackageNames": ["*"],
       "semanticCommitType": "chore",
-      "matchPackageNames": ["*"]
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Disable node/pnpm version updates",


### PR DESCRIPTION
in lights of recent events (that feel like they're getting more frequent) i thought using these options would be reasonable. 3 days is also the timeframe npm authors have to revoke their packages.