### PR TITLE
FIX: Fixed GDI object leak when a resizable window is created and then closed on Windows platform

### DIFF
--- a/crates/tauri-runtime-wry/src/undecorated_resizing.rs
+++ b/crates/tauri-runtime-wry/src/undecorated_resizing.rs
@@ -430,6 +430,7 @@ mod windows {
 
     CombineRgn(Some(hrgn1), Some(hrgn1), Some(hrgn2), RGN_DIFF);
 
+    DeleteObject(hrgn2.into());
     SetWindowRgn(hwnd, Some(hrgn1), true);
   }
 

--- a/crates/tauri-runtime-wry/src/undecorated_resizing.rs
+++ b/crates/tauri-runtime-wry/src/undecorated_resizing.rs
@@ -420,18 +420,24 @@ mod windows {
     let border_x = util::get_system_metrics_for_dpi(SM_CXFRAME, dpi);
     let border_y = util::get_system_metrics_for_dpi(SM_CYFRAME, dpi);
 
-    let hrgn1 = CreateRectRgn(0, 0, width, height);
+    // hrgn1 must be mutable to call .free() later
+    let mut hrgn1 = CreateRectRgn(0, 0, width, height);
 
     let x1 = if only_top { 0 } else { border_x };
     let y1 = border_y;
     let x2 = if only_top { width } else { width - border_x };
     let y2 = if only_top { height } else { height - border_y };
-    let hrgn2 = CreateRectRgn(x1, y1, x2, y2);
+    
+    // Wrap hrgn2 in Owned so it is automatically freed when going out of scope
+    let hrgn2 = Owned::new(CreateRectRgn(x1, y1, x2, y2));
 
-    CombineRgn(Some(hrgn1), Some(hrgn1), Some(hrgn2), RGN_DIFF);
+    CombineRgn(Some(hrgn1), Some(hrgn1), Some(*hrgn2), RGN_DIFF);
 
-    DeleteObject(hrgn2.into());
-    SetWindowRgn(hwnd, Some(hrgn1), true);
+    // Try to set the window region
+    if SetWindowRgn(hwnd, Some(hrgn1), true) == 0 {
+        // If it fails, we must free hrgn1 manually
+        hrgn1.free();
+    }
   }
 
   pub fn update_drag_hwnd_rgn_for_undecorated(hwnd: isize, has_undecorated_shadows: bool) {

--- a/crates/tauri-runtime-wry/src/undecorated_resizing.rs
+++ b/crates/tauri-runtime-wry/src/undecorated_resizing.rs
@@ -427,7 +427,7 @@ mod windows {
     let y1 = border_y;
     let x2 = if only_top { width } else { width - border_x };
     let y2 = if only_top { height } else { height - border_y };
-    
+
     // Wrap hrgn2 in Owned so it is automatically freed when going out of scope
     let hrgn2 = Owned::new(CreateRectRgn(x1, y1, x2, y2));
 
@@ -435,8 +435,8 @@ mod windows {
 
     // Try to set the window region
     if SetWindowRgn(hwnd, Some(hrgn1), true) == 0 {
-        // If it fails, we must free hrgn1 manually
-        hrgn1.free();
+      // If it fails, we must free hrgn1 manually
+      hrgn1.free();
     }
   }
 


### PR DESCRIPTION
When a window is created in a Tuari application with, for example, call to new WebviewWindow from the Javascript code and later is closed -- exactly 1 GDI object leaks. This happens because of the function set_drag_hwnd_rgn where 2 regions are created, one of them becomes managed by Windows  after call to SetWindowRgn but another one remains dangling. Added correct release of the region handle after it is not used anymore.
