### PR TITLE
Fix `clippy::used_underscore_binding` lint in command macro

### DIFF
--- a/crates/tauri-macros/src/command/wrapper.rs
+++ b/crates/tauri-macros/src/command/wrapper.rs
@@ -197,7 +197,7 @@ pub fn wrapper(attributes: TokenStream, item: TokenStream) -> TokenStream {
             };
 
             async_command_check = quote_spanned! {return_type.span() =>
-              #[allow(unreachable_code, clippy::diverging_sub_expression)]
+              #[allow(unreachable_code, clippy::diverging_sub_expression, clippy::used_underscore_binding)]
               const _: () = if false {
                 #diagnostic
                 trait AsyncCommandMustReturnResult {}


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

With `clippy::pedantic` enabled, I get a warning for every use of the `#[tauri::command]` macro on a function that returns a `Result`:

```
warning: used underscore-prefixed binding
  --> src-tauri/src/commands/demos.rs:28:6
   |
28 | ) -> Result<Vec<Arc<Demo>>> {
   |      ^^^^^^
   |
note: binding is defined here
  --> src-tauri/src/commands/demos.rs:28:6
   |
28 | ) -> Result<Vec<Arc<Demo>>> {
   |      ^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#used_underscore_binding
   = note: `-W clippy::used-underscore-binding` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::used_underscore_binding)]`
```

This PR ignores this lint in the proc-macro output, fixing the problem.