### PR TITLE
fix(bundler): set APPIMAGE_EXTRACT_AND_RUN env var as well for linuxdeploy

### DIFF
--- a/.changes/linuxdeploy-extract.md
+++ b/.changes/linuxdeploy-extract.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: patch
+---
+
+Set `APPIMAGE_EXTRACT_AND_RUN` on top of using the `--appimage-extra-and-run` cli arg for linuxdeploy.

--- a/.changes/linuxdeploy-extract.md
+++ b/.changes/linuxdeploy-extract.md
@@ -1,5 +1,5 @@
 ---
-tauri-bundler: patch
+tauri-bundler: patch:bug
 ---
 
 Set `APPIMAGE_EXTRACT_AND_RUN` on top of using the `--appimage-extra-and-run` cli arg for linuxdeploy.

--- a/crates/tauri-bundler/src/bundle/linux/appimage.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage.rs
@@ -190,6 +190,8 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let mut cmd = Command::new(linuxdeploy_path);
   cmd.env("OUTPUT", &appimage_path);
   cmd.env("ARCH", tools_arch);
+  // Looks like the cli arg isn't enough for the updated AppImage output-plugin.
+  cmd.env("APPIMAGE_EXTRACT_AND_RUN", "1");
   cmd.args([
     "--appimage-extract-and-run",
     "--verbosity",


### PR DESCRIPTION
ever since we updated the appimage output plugin users had linuxdeploy error out with an error not telling them anything. I heard about fuse issues twice though https://github.com/tauri-apps/tauri/issues/8929#issuecomment-3361352855 
Since we already set that env var's cli arg equivalent, this change should be a nobrainer and if it doesn't help, it at least can't realistically make it worse either.