### PR TITLE
fix(core): parse Android plugin args starting with `is`, closes #14254

### DIFF
--- a/.changes/android-plugin-bool-is-deserialize.md
+++ b/.changes/android-plugin-bool-is-deserialize.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Properly deserialize Android plugin args with key starting with `is` (previously treated as a getter instead of a field name).

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginManager.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginManager.kt
@@ -17,6 +17,8 @@ import app.tauri.annotation.InvokeArg
 import app.tauri.FsUtils
 import app.tauri.JniMethod
 import app.tauri.Logger
+import com.fasterxml.jackson.annotation.JsonAutoDetect
+import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -69,6 +71,7 @@ class PluginManager(val activity: AppCompatActivity) {
     jsonMapper = ObjectMapper()
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+      .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
 
     val channelDeserializer = ChannelDeserializer({ channelId, payload ->
       sendChannelData(channelId, payload)


### PR DESCRIPTION
by default Jackson treats the `isX` as a getter, so it looks for the `x` key in the JSON. To match behavior on other platforms we now configure Jackson to treat it as the field name itself.
