### PR TITLE
fix(macos): Always try to create webview, even if webkit runtime doesn't get detected correctly

### DIFF
--- a/.changes/macos-always-create-webview.md
+++ b/.changes/macos-always-create-webview.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Always try to create macOS WebKit webview, even if webkit runtime doesn't get detected correctly

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4535,7 +4535,11 @@ You may have it installed on another user account, but it is not available for t
 "#,
     );
 
-    return Err(Error::WebviewRuntimeNotInstalled);
+    if cfg!(target_os = "macos") {
+      log::warn!("WebKit webview runtime not found, attempting to create webview anyway.");
+    } else {
+      return Err(Error::WebviewRuntimeNotInstalled);
+    }
   }
 
   #[allow(unused_mut)]


### PR DESCRIPTION
I'm running a Tauri application inside a Pixi/Conda environment under macOS, and for some unknown reasons Tauri fails to detect the `com.apple.WebKit` bundle, which causes that no window / webview gets created, as `webview_runtime_installed` is `false`. 

From what I know, it shouldn't be possible to use macOS without WebKit, as WebKit is integrated in the system image, so the `webview_runtime_installed` check is unnecessary - in theory. So, when the `webview_runtime_installed` check fails for whatever reason, try to create the webview under macOS anyway. 

For testing purposes, I patched out that particular check, and was able to confirm that the webview was created perfectly fine, despite `webview_runtime_installed` being `false` (which wasn't true). 

For more details, see: 
- https://github.com/tauri-apps/tauri/issues/13996#issuecomment-3227848171
- https://github.com/tauri-apps/tauri/issues/13996#issuecomment-3233197495

Closes https://github.com/tauri-apps/tauri/issues/13996