### PR TITLE
feat(windows): keep dwm shadow on frameless windows

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -141,6 +141,8 @@ type IpcHandler = dyn Fn(Request<String>) + 'static;
 #[cfg(not(debug_assertions))]
 mod dialog;
 mod monitor;
+#[cfg(windows)]
+mod shadow;
 #[cfg(any(
   windows,
   target_os = "linux",
@@ -2443,6 +2445,8 @@ pub struct WindowWrapper {
   #[cfg(windows)]
   is_window_transparent: bool,
   #[cfg(windows)]
+  shadow_requested: AtomicBool,
+  #[cfg(windows)]
   surface: Option<softbuffer::Surface<Arc<Window>, Arc<Window>>>,
   focused_webview: Arc<Mutex<Option<String>>>,
 }
@@ -3309,10 +3313,7 @@ fn handle_user_message<T: UserEvent>(
             if !resizable {
               undecorated_resizing::detach_resize_handler(window.hwnd());
             } else if !window.is_decorated() {
-              undecorated_resizing::attach_resize_handler(
-                window.hwnd(),
-                window.has_undecorated_shadow(),
-              );
+              undecorated_resizing::attach_resize_handler(window.hwnd(), false);
             }
           }
           WindowMessage::SetMaximizable(maximizable) => window.set_maximizable(maximizable),
@@ -3335,23 +3336,72 @@ fn handle_user_message<T: UserEvent>(
           WindowMessage::SetDecorations(decorations) => {
             window.set_decorations(decorations);
             #[cfg(windows)]
-            if decorations {
-              undecorated_resizing::detach_resize_handler(window.hwnd());
-            } else if window.is_resizable() {
-              undecorated_resizing::attach_resize_handler(
-                window.hwnd(),
-                window.has_undecorated_shadow(),
-              );
+            {
+              window.set_undecorated_shadow(false);
+              if decorations {
+                crate::shadow::reset(window.hwnd());
+                undecorated_resizing::detach_resize_handler(window.hwnd());
+              } else {
+                let (requested, is_window_transparent) = {
+                  let windows_ref = windows.0.borrow();
+                  windows_ref
+                    .get(&id)
+                    .map(|w| {
+                      (
+                        w.shadow_requested.load(Ordering::Relaxed),
+                        w.is_window_transparent,
+                      )
+                    })
+                    .unwrap_or((false, false))
+                };
+                let enable_shadow = requested && !is_window_transparent;
+                crate::shadow::update(window.hwnd(), enable_shadow);
+                if window.is_resizable() {
+                  undecorated_resizing::attach_resize_handler(window.hwnd(), false);
+                }
+                undecorated_resizing::update_drag_hwnd_rgn_for_undecorated(
+                  window.hwnd(),
+                  false,
+                );
+              }
             }
           }
-          WindowMessage::SetShadow(_enable) => {
+          WindowMessage::SetShadow(enable) => {
             #[cfg(windows)]
             {
-              window.set_undecorated_shadow(_enable);
-              undecorated_resizing::update_drag_hwnd_rgn_for_undecorated(window.hwnd(), _enable);
+              {
+                if let Some(wrapper) = windows.0.borrow_mut().get_mut(&id) {
+                  wrapper
+                    .shadow_requested
+                    .store(enable, Ordering::Relaxed);
+                }
+              }
+              window.set_undecorated_shadow(false);
+              let is_window_transparent = {
+                let windows_ref = windows.0.borrow();
+                windows_ref
+                  .get(&id)
+                  .map(|w| w.is_window_transparent)
+                  .unwrap_or(false)
+              };
+              let decorated = window.is_decorated();
+              let enable_shadow = enable && !decorated && !is_window_transparent;
+              if decorated {
+                crate::shadow::reset(window.hwnd());
+                undecorated_resizing::detach_resize_handler(window.hwnd());
+              } else {
+                crate::shadow::update(window.hwnd(), enable_shadow);
+                if window.is_resizable() {
+                  undecorated_resizing::attach_resize_handler(window.hwnd(), false);
+                }
+                undecorated_resizing::update_drag_hwnd_rgn_for_undecorated(
+                  window.hwnd(),
+                  false,
+                );
+              }
             }
             #[cfg(target_os = "macos")]
-            window.set_has_shadow(_enable);
+            window.set_has_shadow(enable);
           }
           WindowMessage::SetAlwaysOnBottom(always_on_bottom) => {
             window.set_always_on_bottom(always_on_bottom)
@@ -3916,7 +3966,25 @@ fn handle_user_message<T: UserEvent>(
       if let Ok(window) = builder.build(event_loop) {
         window_id_map.insert(window.id(), window_id);
 
+        #[cfg(windows)]
+        let shadow_requested = window.has_undecorated_shadow();
+
         let window = Arc::new(window);
+
+        #[cfg(windows)]
+        if shadow_requested {
+          window.set_undecorated_shadow(false);
+        }
+
+        #[cfg(windows)]
+        {
+          let decorated = window.is_decorated();
+          if decorated || is_window_transparent {
+            crate::shadow::reset(window.hwnd());
+          } else {
+            crate::shadow::update(window.hwnd(), shadow_requested);
+          }
+        }
 
         #[cfg(windows)]
         let surface = if is_window_transparent {
@@ -3946,6 +4014,8 @@ fn handle_user_message<T: UserEvent>(
             background_color,
             #[cfg(windows)]
             is_window_transparent,
+            #[cfg(windows)]
+            shadow_requested: AtomicBool::new(shadow_requested),
             #[cfg(windows)]
             surface,
             focused_webview: Default::default(),
@@ -4403,6 +4473,9 @@ fn create_window<T: UserEvent, F: Fn(RawWindow) + Send + 'static>(
     .build(event_loop)
     .map_err(|_| Error::CreateWindow)?;
 
+  #[cfg(windows)]
+  let shadow_requested = window.has_undecorated_shadow();
+
   #[cfg(feature = "tracing")]
   {
     drop(window_create_span);
@@ -4467,6 +4540,21 @@ fn create_window<T: UserEvent, F: Fn(RawWindow) + Send + 'static>(
   let window = Arc::new(window);
 
   #[cfg(windows)]
+  if shadow_requested {
+    window.set_undecorated_shadow(false);
+  }
+
+  #[cfg(windows)]
+  {
+    let decorated = window.is_decorated();
+    if decorated || is_window_transparent {
+      crate::shadow::reset(window.hwnd());
+    } else {
+      crate::shadow::update(window.hwnd(), shadow_requested);
+    }
+  }
+
+  #[cfg(windows)]
   let surface = if is_window_transparent {
     if let Ok(context) = softbuffer::Context::new(window.clone()) {
       if let Ok(mut surface) = softbuffer::Surface::new(&context, window.clone()) {
@@ -4492,6 +4580,8 @@ fn create_window<T: UserEvent, F: Fn(RawWindow) + Send + 'static>(
     background_color,
     #[cfg(windows)]
     is_window_transparent,
+    #[cfg(windows)]
+    shadow_requested: AtomicBool::new(shadow_requested),
     #[cfg(windows)]
     surface,
     focused_webview,
@@ -5021,7 +5111,7 @@ You may have it installed on another user account, but it is not available for t
     undecorated_resizing::attach_resize_handler(&webview);
     #[cfg(windows)]
     if window.is_resizable() && !window.is_decorated() {
-      undecorated_resizing::attach_resize_handler(window.hwnd(), window.has_undecorated_shadow());
+      undecorated_resizing::attach_resize_handler(window.hwnd(), false);
     }
   }
 

--- a/crates/tauri-runtime-wry/src/shadow.rs
+++ b/crates/tauri-runtime-wry/src/shadow.rs
@@ -1,0 +1,122 @@
+#![cfg(windows)]
+
+use std::mem::size_of;
+use windows::Win32::{
+  Foundation::HWND,
+  Graphics::Dwm::{
+    DwmExtendFrameIntoClientArea, DwmSetWindowAttribute, DWMNCRP_DISABLED, DWMNCRP_ENABLED,
+    DWMWA_BORDER_COLOR, DWMWA_NCRENDERING_POLICY, DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
+    DWMWA_WINDOW_CORNER_PREFERENCE, DWMWCP_DONOTROUND,
+  },
+  UI::Controls::MARGINS,
+};
+
+const RESET_COLOR: u32 = u32::MAX;
+const VISIBLE_BORDER_RESET: u32 = u32::MAX;
+const DWMNCRP_USEWINDOWSTYLE: i32 = 0;
+
+pub fn update(hwnd: isize, enabled: bool) {
+  unsafe {
+    let hwnd = HWND(hwnd as _);
+    if enabled {
+      enable(hwnd);
+    } else {
+      disable(hwnd);
+    }
+  }
+}
+
+pub fn reset(hwnd: isize) {
+  unsafe {
+    let hwnd = HWND(hwnd as _);
+    let policy = DWMNCRP_USEWINDOWSTYLE;
+    let _ = DwmSetWindowAttribute(
+      hwnd,
+      DWMWA_NCRENDERING_POLICY,
+      &policy as *const _ as _,
+      size_of::<i32>() as u32,
+    );
+    let _ = DwmSetWindowAttribute(
+      hwnd,
+      DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
+      &VISIBLE_BORDER_RESET as *const _ as _,
+      size_of::<u32>() as u32,
+    );
+    let margins = MARGINS {
+      cxLeftWidth: 0,
+      cxRightWidth: 0,
+      cyTopHeight: 0,
+      cyBottomHeight: 0,
+    };
+    let _ = DwmExtendFrameIntoClientArea(hwnd, &margins);
+  }
+}
+
+unsafe fn enable(hwnd: HWND) {
+  let policy = DWMNCRP_ENABLED.0;
+  let _ = DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_NCRENDERING_POLICY,
+    &policy as *const _ as _,
+    size_of::<i32>() as u32,
+  );
+  let corner = DWMWCP_DONOTROUND.0 as u32;
+  let _ = DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_WINDOW_CORNER_PREFERENCE,
+    &corner as *const _ as _,
+    size_of::<u32>() as u32,
+  );
+  let border_thickness: u32 = 0;
+  let _ = DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
+    &border_thickness as *const _ as _,
+    size_of::<u32>() as u32,
+  );
+  let border_color: u32 = RESET_COLOR;
+  let _ = DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_BORDER_COLOR,
+    &border_color as *const _ as _,
+    size_of::<u32>() as u32,
+  );
+  let margins = MARGINS {
+    cxLeftWidth: 1,
+    cxRightWidth: 1,
+    cyTopHeight: 0,
+    cyBottomHeight: 1,
+  };
+  let _ = DwmExtendFrameIntoClientArea(hwnd, &margins);
+}
+
+unsafe fn disable(hwnd: HWND) {
+  let policy = DWMNCRP_DISABLED.0;
+  let _ = DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_NCRENDERING_POLICY,
+    &policy as *const _ as _,
+    size_of::<i32>() as u32,
+  );
+  let border_color = RESET_COLOR;
+  let _ = DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_BORDER_COLOR,
+    &border_color as *const _ as _,
+    size_of::<u32>() as u32,
+  );
+  let reset_thickness: u32 = VISIBLE_BORDER_RESET;
+  let _ = DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_VISIBLE_FRAME_BORDER_THICKNESS,
+    &reset_thickness as *const _ as _,
+    size_of::<u32>() as u32,
+  );
+  let margins = MARGINS {
+    cxLeftWidth: 0,
+    cxRightWidth: 0,
+    cyTopHeight: 0,
+    cyBottomHeight: 0,
+  };
+  let _ = DwmExtendFrameIntoClientArea(hwnd, &margins);
+}

--- a/examples/helloworld/tauri.conf.json
+++ b/examples/helloworld/tauri.conf.json
@@ -14,6 +14,8 @@
         "width": 800,
         "height": 600,
         "resizable": true,
+        "decorations": false,
+        "shadow": true,
         "fullscreen": false
       }
     ],

--- a/examples/helloworld/tauri.conf.json
+++ b/examples/helloworld/tauri.conf.json
@@ -14,8 +14,6 @@
         "width": 800,
         "height": 600,
         "resizable": true,
-        "decorations": false,
-        "shadow": true,
         "fullscreen": false
       }
     ],


### PR DESCRIPTION
Fixes #13134.

## Summary
- keep the native DWM shadow when Windows decorations are disabled so frameless windows stay resizable
- store the shadow preference on WindowWrapper and drive it from SetShadow/SetDecorations handlers
- add a dedicated shadow helper to toggle and reset DWM attributes

## Testing
- set `decorations: false` and `shadow: true` in examples/helloworld/tauri.conf.json
- cargo run --example helloworld (Windows 10) and verify the window stays frameless, keeps its shadow, and remains resizable from every edge

