### PR TITLE
feat: add Bring All to Front predefined menu item type

### DIFF
--- a/.changes/add-bring-all-to-front-predefined-menu-item-type.md
+++ b/.changes/add-bring-all-to-front-predefined-menu-item-type.md
@@ -1,0 +1,6 @@
+---
+'tauri': 'minor:feat'
+'@tauri-apps/api': 'minor:feat'
+---
+
+Add Bring All to Front predefined menu item type

--- a/.changes/add-bring-all-to-front-predefined-menu-item-type.md
+++ b/.changes/add-bring-all-to-front-predefined-menu-item-type.md
@@ -1,6 +1,6 @@
 ---
-'tauri': 'minor:feat'
-'@tauri-apps/api': 'minor:feat'
+'tauri': 'patch:enhance'
+'@tauri-apps/api': 'patch:enhance'
 ---
 
 Add Bring All to Front predefined menu item type

--- a/.changes/add-bring-all-to-front-predefined-menu-item-type.md
+++ b/.changes/add-bring-all-to-front-predefined-menu-item-type.md
@@ -1,6 +1,6 @@
 ---
-'tauri': 'patch:enhance'
-'@tauri-apps/api': 'patch:enhance'
+'tauri': 'minor:feat'
+'@tauri-apps/api': 'minor:feat'
 ---
 
 Add Bring All to Front predefined menu item type

--- a/crates/tauri/src/menu/builders/menu.rs
+++ b/crates/tauri/src/menu/builders/menu.rs
@@ -642,6 +642,30 @@ macro_rules! shared_menu_builder {
           .push(PredefinedMenuItem::services(self.manager, Some(text.as_ref())).map(|i| i.kind()));
         self
       }
+
+      /// Add Bring All to Front menu item to the menu.
+      ///
+      /// ## Platform-specific:
+      ///
+      /// - **Windows / Linux:** Unsupported.
+      pub fn bring_all_to_front(mut self) -> Self {
+        self
+          .items
+          .push(PredefinedMenuItem::bring_all_to_front(self.manager, None).map(|i| i.kind()));
+        self
+      }
+
+      /// Add Bring All to Front menu item with specified text to the menu.
+      ///
+      /// ## Platform-specific:
+      ///
+      /// - **Windows / Linux:** Unsupported.
+      pub fn bring_all_to_front_with_text<S: AsRef<str>>(mut self, text: S) -> Self {
+        self.items.push(
+          PredefinedMenuItem::bring_all_to_front(self.manager, Some(text.as_ref())).map(|i| i.kind()),
+        );
+        self
+      }
     }
   };
 }

--- a/crates/tauri/src/menu/builders/menu.rs
+++ b/crates/tauri/src/menu/builders/menu.rs
@@ -662,7 +662,8 @@ macro_rules! shared_menu_builder {
       /// - **Windows / Linux:** Unsupported.
       pub fn bring_all_to_front_with_text<S: AsRef<str>>(mut self, text: S) -> Self {
         self.items.push(
-          PredefinedMenuItem::bring_all_to_front(self.manager, Some(text.as_ref())).map(|i| i.kind()),
+          PredefinedMenuItem::bring_all_to_front(self.manager, Some(text.as_ref()))
+            .map(|i| i.kind()),
         );
         self
       }

--- a/crates/tauri/src/menu/plugin.rs
+++ b/crates/tauri/src/menu/plugin.rs
@@ -91,6 +91,7 @@ enum Predefined {
   Quit,
   About(Option<AboutMetadata>),
   Services,
+  BringAllToFront,
 }
 
 #[derive(Deserialize)]
@@ -303,6 +304,7 @@ impl PredefinedMenuItemPayload {
         PredefinedMenuItem::about(webview, self.text.as_deref(), metadata)
       }
       Predefined::Services => PredefinedMenuItem::services(webview, self.text.as_deref()),
+      Predefined::BringAllToFront => PredefinedMenuItem::bring_all_to_front(webview, self.text.as_deref()),
     }
   }
 }

--- a/crates/tauri/src/menu/plugin.rs
+++ b/crates/tauri/src/menu/plugin.rs
@@ -304,7 +304,9 @@ impl PredefinedMenuItemPayload {
         PredefinedMenuItem::about(webview, self.text.as_deref(), metadata)
       }
       Predefined::Services => PredefinedMenuItem::services(webview, self.text.as_deref()),
-      Predefined::BringAllToFront => PredefinedMenuItem::bring_all_to_front(webview, self.text.as_deref()),
+      Predefined::BringAllToFront => {
+        PredefinedMenuItem::bring_all_to_front(webview, self.text.as_deref())
+      }
     }
   }
 }

--- a/crates/tauri/src/menu/predefined.rs
+++ b/crates/tauri/src/menu/predefined.rs
@@ -384,6 +384,29 @@ impl<R: Runtime> PredefinedMenuItem<R> {
     Ok(Self(Arc::new(item)))
   }
 
+  /// Bring All to Front menu item
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Windows / Linux:** Unsupported.
+  pub fn bring_all_to_front<M: Manager<R>>(manager: &M, text: Option<&str>) -> crate::Result<Self> {
+    let handle = manager.app_handle();
+    let app_handle = handle.clone();
+
+    let text = text.map(|t| t.to_owned());
+
+    let item = run_main_thread!(handle, || {
+      let item = muda::PredefinedMenuItem::bring_all_to_front(text.as_deref());
+      PredefinedMenuItemInner {
+        id: item.id().clone(),
+        inner: Some(item),
+        app_handle,
+      }
+    })?;
+
+    Ok(Self(Arc::new(item)))
+  }
+
   /// Returns a unique identifier associated with this menu item.
   pub fn id(&self) -> &MenuId {
     &self.0.id

--- a/examples/api/src/components/MenuItemBuilder.svelte
+++ b/examples/api/src/components/MenuItemBuilder.svelte
@@ -32,7 +32,8 @@
     'ShowAll',
     'CloseWindow',
     'Quit',
-    'Services'
+    'Services',
+    'BringAllToFront'
   ]
 
   function onKindChange(event) {

--- a/packages/api/src/menu/predefinedMenuItem.ts
+++ b/packages/api/src/menu/predefinedMenuItem.ts
@@ -102,6 +102,7 @@ export interface PredefinedMenuItemOptions {
     | 'CloseWindow'
     | 'Quit'
     | 'Services'
+    | 'BringAllToFront'
     | {
         About: AboutMetadata | null
       }


### PR DESCRIPTION
In [`muda` 0.9.4](https://github.com/tauri-apps/muda/blob/dev/CHANGELOG.md#094:~:text=3672a0c(%23130)%20Add%20PredefinedMenuItem%3A%3Abring_all_to_front%20for%20%27Bring%20All%20to%20Front%27%20menu%20item%20on%20macOS.), support was added for the Bring All to Front predefined menu item type on macOS; however, corresponding support was not added to Tauri.  This PR adds the Bring All to Front predefined menu item type to the Rust and TypeScript APIs.

Requested in https://github.com/tauri-apps/tauri/issues/2802#:~:text=Window%20%3E%20Bring%20All%20to%20Front.