### PR TITLE
fix(ios/macos): Add handler for web content process termination

### DIFF
--- a/.changes/web-content-process-termination.md
+++ b/.changes/web-content-process-termination.md
@@ -1,0 +1,7 @@
+---
+"tauri": minor:feat
+"tauri-runtime": minor:feat
+"tauri-runtime-wry": minor:feat
+---
+
+Add handler for web content process termination on macOS and iOS.

--- a/.changes/web-content-process-termination.md
+++ b/.changes/web-content-process-termination.md
@@ -1,7 +1,7 @@
 ---
-"tauri": minor:feat
-"tauri-runtime": minor:feat
-"tauri-runtime-wry": minor:feat
+"tauri": minor:fix
+"tauri-runtime": minor:fix
+"tauri-runtime-wry": minor:fix
 ---
 
 Add handler for web content process termination on macOS and iOS.

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4891,6 +4891,13 @@ You may have it installed on another user account, but it is not available for t
 
     webview_builder =
       webview_builder.with_allow_link_preview(webview_attributes.allow_link_preview);
+
+    if let Some(on_web_content_process_terminate_handler) =
+      pending.on_web_content_process_terminate_handler
+    {
+      webview_builder = webview_builder
+        .with_on_web_content_process_terminate_handler(on_web_content_process_terminate_handler);
+    }
   }
 
   #[cfg(target_os = "ios")]

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -41,6 +41,9 @@ type DocumentTitleChangedHandler = dyn Fn(String) + Send + 'static;
 
 type DownloadHandler = dyn Fn(DownloadEvent) -> bool + Send + Sync;
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+type OnWebContentProcessTerminateHandler = dyn Fn() + Send;
+
 #[cfg(target_os = "ios")]
 type InputAccessoryViewBuilderFn = dyn Fn(&objc2_ui_kit::UIView) -> Option<objc2::rc::Retained<objc2_ui_kit::UIView>>
   + Send
@@ -224,6 +227,9 @@ pub struct PendingWebview<T: UserEvent, R: Runtime<T>> {
   pub on_page_load_handler: Option<Box<OnPageLoadHandler>>,
 
   pub download_handler: Option<Arc<DownloadHandler>>,
+
+  #[cfg(any(target_os = "macos", target_os = "ios"))]
+  pub on_web_content_process_terminate_handler: Option<Box<OnWebContentProcessTerminateHandler>>,
 }
 
 impl<T: UserEvent, R: Runtime<T>> PendingWebview<T, R> {
@@ -250,6 +256,8 @@ impl<T: UserEvent, R: Runtime<T>> PendingWebview<T, R> {
         web_resource_request_handler: None,
         on_page_load_handler: None,
         download_handler: None,
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        on_web_content_process_terminate_handler: None,
       })
     }
   }

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -65,6 +65,8 @@ pub(crate) type UriSchemeProtocolHandler =
 pub(crate) type OnPageLoad<R> = dyn Fn(Webview<R>, PageLoadPayload<'_>) + Send + Sync + 'static;
 pub(crate) type OnDocumentTitleChanged<R> = dyn Fn(Webview<R>, String) + Send + 'static;
 pub(crate) type DownloadHandler<R> = dyn Fn(Webview<R>, DownloadEvent<'_>) -> bool + Send + Sync;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub(crate) type OnWebContentProcessTerminateHandler<R> = dyn Fn(Webview<R>) + Send;
 
 #[derive(Clone, Serialize)]
 pub(crate) struct CreatedEvent {
@@ -278,6 +280,9 @@ unstable_struct!(
     pub(crate) on_page_load_handler: Option<Box<OnPageLoad<R>>>,
     pub(crate) document_title_changed_handler: Option<Box<OnDocumentTitleChanged<R>>>,
     pub(crate) download_handler: Option<Arc<DownloadHandler<R>>>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    pub(crate) on_web_content_process_terminate_handler:
+      Option<Box<OnWebContentProcessTerminateHandler<R>>>,
   }
 );
 
@@ -356,6 +361,8 @@ async fn create_window(app: tauri::AppHandle) {
       on_page_load_handler: None,
       document_title_changed_handler: None,
       download_handler: None,
+      #[cfg(any(target_os = "macos", target_os = "ios"))]
+      on_web_content_process_terminate_handler: None,
     }
   }
 
@@ -435,6 +442,8 @@ async fn create_window(app: tauri::AppHandle) {
       on_page_load_handler: None,
       document_title_changed_handler: None,
       download_handler: None,
+      #[cfg(any(target_os = "macos", target_os = "ios"))]
+      on_web_content_process_terminate_handler: None,
     }
   }
 
@@ -697,6 +706,17 @@ tauri::Builder::default()
     self
   }
 
+  #[cfg(any(target_os = "macos", target_os = "ios"))]
+  pub fn on_web_content_process_terminate<F: Fn(Webview<R>) + Send + 'static>(
+    mut self,
+    f: F,
+  ) -> Self {
+    self
+      .on_web_content_process_terminate_handler
+      .replace(Box::new(f));
+    self
+  }
+
   pub(crate) fn into_pending_webview<M: Manager<R>>(
     mut self,
     manager: &M,
@@ -775,6 +795,21 @@ tauri::Builder::default()
           }
         }
       }));
+
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    if let Some(on_web_content_process_terminate_handler) =
+      self.on_web_content_process_terminate_handler.take()
+    {
+      let label = pending.label.clone();
+      let manager = manager.manager_owned();
+      pending
+        .on_web_content_process_terminate_handler
+        .replace(Box::new(move || {
+          if let Some(w) = manager.get_webview(&label) {
+            on_web_content_process_terminate_handler(w);
+          }
+        }));
+    }
 
     manager
       .manager()

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -706,6 +706,11 @@ tauri::Builder::default()
     self
   }
 
+  /// Defines a closure to be executed when the web content process terminates.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux / Windows / Android:** Unsupported.
   #[cfg(any(target_os = "macos", target_os = "ios"))]
   pub fn on_web_content_process_terminate<F: Fn(Webview<R>) + Send + 'static>(
     mut self,

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -451,9 +451,7 @@ tauri::Builder::default()
     mut self,
     f: F,
   ) -> Self {
-    self.webview_builder = self
-      .webview_builder
-      .on_web_content_process_terminate(move |webview| f(webview));
+    self.webview_builder = self.webview_builder.on_web_content_process_terminate(f);
     self
   }
 

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -441,6 +441,22 @@ tauri::Builder::default()
     self
   }
 
+  /// Defines a closure to be executed when the web content process terminates.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Linux / Windows / Android:** Unsupported.
+  #[cfg(any(target_os = "macos", target_os = "ios"))]
+  pub fn on_web_content_process_terminate<F: Fn(Webview<R>) + Send + 'static>(
+    mut self,
+    f: F,
+  ) -> Self {
+    self.webview_builder = self
+      .webview_builder
+      .on_web_content_process_terminate(move |webview| f(webview));
+    self
+  }
+
   /// Creates a new window.
   pub fn build(self) -> crate::Result<WebviewWindow<R>> {
     let (window, webview) = self.window_builder.with_webview(self.webview_builder)?;


### PR DESCRIPTION
This PR fixes #14371 and depends on https://github.com/tauri-apps/wry/pull/1624