### PR TITLE
chore: Add missing changefile for tauri-macos-sign

### DIFF
--- a/.changes/macos-codesign-error-enum.md
+++ b/.changes/macos-codesign-error-enum.md
@@ -1,5 +1,5 @@
 ---
-tauri-macos-codesign: "minor:enhance"
+tauri-macos-sign: "minor:enhance"
 ---
 
 **Potentially breaking change:** Export custom Error enum instead of using anyhow. The changes happened in https://github.com/tauri-apps/tauri/pull/14126.

--- a/.changes/macos-codesign-error-enum.md
+++ b/.changes/macos-codesign-error-enum.md
@@ -1,0 +1,5 @@
+---
+tauri-macos-codesign: "minor:enhance"
+---
+
+**Potentially breaking change:** Export custom Error enum instead of using anyhow. The changes happened in https://github.com/tauri-apps/tauri/pull/14126.


### PR DESCRIPTION
fixes #14335

i guess this is a breaking change? i somehow didn't even notice any changes in that crate in the prior PR x)

i hope this won't break older cli versions too much but we're advertising `--locked` anyway so this should hopefullyyyyy be fine ignoring that i asked to revert a breaking change in the bundler itself.