### PR TITLE
chore: remove `--cfg docsrs` to fix docs.rs builds

### DIFF
--- a/.changes/docsrs.md
+++ b/.changes/docsrs.md
@@ -1,0 +1,9 @@
+---
+tauri: patch:bug
+tauri-build: patch:bug
+tauri-plugin: patch:bug
+tauri-runtime: patch:bug
+tauri-runtime-wry: patch:bug
+---
+
+Fixed an issue that caused docs.rs builds to fail. No user facing changes.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,7 +98,7 @@ You can use `cargo install --path . --debug` to speed up test builds.
 You can build the Rust documentation locally running the following script:
 
 ```bash
-$ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open
+$ cargo +nightly doc --all-features --open
 ```
 
 ### Developing the JS API

--- a/crates/tauri-build/Cargo.toml
+++ b/crates/tauri-build/Cargo.toml
@@ -22,8 +22,6 @@ targets = [
   "x86_64-linux-android",
   "x86_64-apple-ios",
 ]
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 anyhow = "1"

--- a/crates/tauri-plugin/Cargo.toml
+++ b/crates/tauri-plugin/Cargo.toml
@@ -12,8 +12,6 @@ rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["build", "runtime"]
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 build = [

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -12,10 +12,6 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
-[package.metadata.docs.rs]
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
-
 [dependencies]
 wry = { version = "0.53.4", default-features = false, features = [
   "drag-drop",

--- a/crates/tauri-runtime/Cargo.toml
+++ b/crates/tauri-runtime/Cargo.toml
@@ -14,8 +14,6 @@ rust-version.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
   "x86_64-pc-windows-msvc",

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -26,8 +26,6 @@ features = [
   "test",
   "specta",
 ]
-rustc-args = ["--cfg", "docsrs"]
-rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-unknown-linux-gnu"
 targets = [
   "x86_64-pc-windows-msvc",


### PR DESCRIPTION
this worked in tao but i forgot to include it in tauri for 2.9