### PR TITLE
fix: don't try to parse inexistent icons

### DIFF
--- a/crates/tauri-build/src/codegen/context.rs
+++ b/crates/tauri-build/src/codegen/context.rs
@@ -101,11 +101,13 @@ impl CodegenContext {
       }
       _ => (),
     }
-    for icon in &config.bundle.icon {
-      println!(
-        "cargo:rerun-if-changed={}",
-        config_parent.join(icon).display()
-      );
+    if let Some(icons) = &config.bundle.icon {
+      for icon in icons {
+        println!(
+          "cargo:rerun-if-changed={}",
+          config_parent.join(icon).display()
+        );
+      }
     }
     if let Some(tray_icon) = config.app.tray_icon.as_ref().map(|t| &t.icon_path) {
       println!(

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -592,13 +592,14 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
     use tauri_winres::{VersionInfo, WindowsResource};
 
     fn find_icon<F: Fn(&&String) -> bool>(config: &Config, predicate: F, default: &str) -> PathBuf {
-      let icon_path = config
-        .bundle
-        .icon
-        .iter()
-        .find(|i| predicate(i))
-        .cloned()
-        .unwrap_or_else(|| default.to_string());
+      let icon_path = match &config.bundle.icon {
+        None => default.to_string(),
+        Some(icons) => icons
+          .iter()
+          .find(|i| predicate(i))
+          .cloned()
+          .unwrap_or_else(|| default.to_string()),
+      };
       icon_path.into()
     }
 

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -91,7 +91,6 @@
         "iOS": {
           "minimumSystemVersion": "14.0"
         },
-        "icon": [],
         "linux": {
           "appimage": {
             "bundleMediaFramework": false,
@@ -2114,8 +2113,10 @@
         },
         "icon": {
           "description": "The app's icons",
-          "default": [],
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "string"
           }

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1461,7 +1461,7 @@ fn tauri_config_to_bundle_settings(
     identifier: Some(tauri_config.identifier.clone()),
     publisher: config.publisher,
     homepage: config.homepage,
-    icon: Some(config.icon),
+    icon: config.icon,
     resources,
     resources_map,
     copyright: config.copyright,

--- a/crates/tauri-codegen/src/context.rs
+++ b/crates/tauri-codegen/src/context.rs
@@ -213,56 +213,74 @@ pub fn context_codegen(data: ContextData) -> EmbeddedAssetsResult<TokenStream> {
   let default_window_icon = {
     if target == Target::Windows {
       // handle default window icons for Windows targets
-      let icon_path = find_icon(
+      let icon_path_opt = find_icon(
         &config,
         &config_parent,
         |i| i.ends_with(".ico"),
         "icons/icon.ico",
       );
-      if icon_path.exists() {
-        let icon = CachedIcon::new(&root, &icon_path)?;
-        quote!(::std::option::Option::Some(#icon))
+      if let Some(icon_path) = icon_path_opt {
+        if icon_path.exists() {
+          let icon = CachedIcon::new(&root, &icon_path)?;
+          quote!(::std::option::Option::Some(#icon))
+        } else {
+          let icon_path_opt = find_icon(
+            &config,
+            &config_parent,
+            |i| i.ends_with(".png"),
+            "icons/icon.png",
+          );
+          if let Some(icon_path) = icon_path_opt {
+            let icon = CachedIcon::new(&root, &icon_path)?;
+            quote!(::std::option::Option::Some(#icon))
+          } else {
+            quote!(::std::option::Option::None)
+          }
+        }
       } else {
-        let icon_path = find_icon(
-          &config,
-          &config_parent,
-          |i| i.ends_with(".png"),
-          "icons/icon.png",
-        );
-        let icon = CachedIcon::new(&root, &icon_path)?;
-        quote!(::std::option::Option::Some(#icon))
+        quote!(::std::option::Option::None)
       }
     } else {
       // handle default window icons for Unix targets
-      let icon_path = find_icon(
+      let icon_path_opt = find_icon(
         &config,
         &config_parent,
         |i| i.ends_with(".png"),
         "icons/icon.png",
       );
-      let icon = CachedIcon::new(&root, &icon_path)?;
-      quote!(::std::option::Option::Some(#icon))
+      if let Some(icon_path) = icon_path_opt {
+        let icon = CachedIcon::new(&root, &icon_path)?;
+        quote!(::std::option::Option::Some(#icon))
+      } else {
+        quote!(::std::option::Option::None)
+      }
     }
   };
 
   let app_icon = if target == Target::MacOS && dev {
-    let mut icon_path = find_icon(
+    let mut icon_path_opt = find_icon(
       &config,
       &config_parent,
       |i| i.ends_with(".icns"),
       "icons/icon.png",
     );
-    if !icon_path.exists() {
-      icon_path = find_icon(
-        &config,
-        &config_parent,
-        |i| i.ends_with(".png"),
-        "icons/icon.png",
-      );
+    if let Some(ref icon_path) = icon_path_opt {
+      if !icon_path.exists() {
+        icon_path_opt = find_icon(
+          &config,
+          &config_parent,
+          |i| i.ends_with(".png"),
+          "icons/icon.png",
+        );
+      }
     }
 
-    let icon = CachedIcon::new_raw(&root, &icon_path)?;
-    quote!(::std::option::Option::Some(#icon.to_vec()))
+    if let Some(icon_path) = icon_path_opt {
+      let icon = CachedIcon::new_raw(&root, &icon_path)?;
+      quote!(::std::option::Option::Some(#icon.to_vec()))
+    } else {
+      quote!(::std::option::Option::None)
+    }
   } else {
     quote!(::std::option::Option::None)
   };
@@ -490,13 +508,14 @@ fn find_icon(
   config_parent: &Path,
   predicate: impl Fn(&&String) -> bool,
   default: &str,
-) -> PathBuf {
-  let icon_path = config
-    .bundle
-    .icon
-    .iter()
-    .find(predicate)
-    .map(AsRef::as_ref)
-    .unwrap_or(default);
-  config_parent.join(icon_path)
+) -> Option<PathBuf> {
+  match &config.bundle.icon {
+    // None => No specified, fall back to default.
+    None => Some(config_parent.join(default)),
+    // Some(_) => Use explicitly specified icon set.
+    Some(icons) => icons
+      .iter()
+      .find(predicate)
+      .map(|s| config_parent.join(s)),
+  }
 }

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -91,7 +91,6 @@
         "iOS": {
           "minimumSystemVersion": "14.0"
         },
-        "icon": [],
         "linux": {
           "appimage": {
             "bundleMediaFramework": false,
@@ -2114,8 +2113,10 @@
         },
         "icon": {
           "description": "The app's icons",
-          "default": [],
-          "type": "array",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "string"
           }

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -1321,7 +1321,7 @@ pub struct BundleConfig {
   pub homepage: Option<String>,
   /// The app's icons
   #[serde(default)]
-  pub icon: Vec<String>,
+  pub icon: Option<Vec<String>>,
   /// App resources to bundle.
   /// Each resource is a path to a file or directory.
   /// Glob patterns are supported.
@@ -3713,7 +3713,12 @@ mod build {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let publisher = quote!(None);
       let homepage = quote!(None);
-      let icon = vec_lit(&self.icon, str_lit);
+      let icon = if let Some(ref icons) = self.icon {
+        let vec = vec_lit(icons, str_lit);
+        quote!(Some(#vec))
+      } else {
+        quote!(None)
+      };
       let active = self.active;
       let targets = quote!(Default::default());
       let create_updater_artifacts = quote!(Default::default());
@@ -4161,7 +4166,7 @@ mod test {
       create_updater_artifacts: Default::default(),
       publisher: None,
       homepage: None,
-      icon: Vec::new(),
+      icon: Some(Vec::new()),
       resources: None,
       copyright: None,
       category: None,


### PR DESCRIPTION
When Tauri is explicitly configured to use no icons via:

    "bundle": {
      "icon": []
    }  

It still tries to compile icons in a fallback path of `icons/icon.png`. This blocks compiling any project unless artwork is in place, even though this might be entirely beyond scope for a project.

This issue stems from the fact that `Vec<String>` is used to deserialise icons, so there is no way to distinguish "no explicit value" from "explicitly instructed to use no value".

Use an `Option<Vec<String>>` to deserialise configured icons, where no value (None) means "nothing explicitly specified; use the default), and Some(EmptyVec) means "explicitly requested no icons".

This allows compiling small proof of concept projects without having to worry about artwork.

Fixes: https://github.com/tauri-apps/tauri/discussions/14355



