### PR TITLE
fix: throw on custom protocol IPC fails

### DIFF
--- a/.changes/run-callback-after-catch.md
+++ b/.changes/run-callback-after-catch.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+Fix `undefined is not an object (evaluating '[callbackId, data]')` error on custom protocol IPC fails

--- a/crates/tauri/scripts/ipc-protocol.js
+++ b/crates/tauri/scripts/ipc-protocol.js
@@ -52,19 +52,21 @@
               return response.arrayBuffer().then((r) => [callbackId, r])
           }
         })
-        .catch((e) => {
-          console.warn(
-            'IPC custom protocol failed, Tauri will now use the postMessage interface instead',
-            e
-          )
-          // failed to use the custom protocol IPC (either the webview blocked a custom protocol or it was a CSP error)
-          // so we need to fallback to the postMessage interface
-          customProtocolIpcFailed = true
-          sendIpcMessage(message)
-        })
-        .then(([callbackId, data]) => {
-          window.__TAURI_INTERNALS__.runCallback(callbackId, data)
-        })
+        .then(
+          ([callbackId, data]) => {
+            window.__TAURI_INTERNALS__.runCallback(callbackId, data)
+          },
+          (e) => {
+            console.warn(
+              'IPC custom protocol failed, Tauri will now use the postMessage interface instead',
+              e
+            )
+            // failed to use the custom protocol IPC (either the webview blocked a custom protocol or it was a CSP error)
+            // so we need to fallback to the postMessage interface
+            customProtocolIpcFailed = true
+            sendIpcMessage(message)
+          }
+        )
     } else {
       // otherwise use the postMessage interface
       const { data } = processIpcMessage({
@@ -78,6 +80,7 @@
         payload,
         __TAURI_INVOKE_KEY__
       })
+      // `window.ipc.postMessage` came from `tauri-runtime-wry` > `wry` [`with_ipc_handler`](https://github.com/tauri-apps/wry/blob/a0403b9e2f1ff9d73be7dce1184f058afcaa1d82/src/lib.rs#L1130)
       window.ipc.postMessage(data)
     }
   }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix #14358

A regression from #13325, `then` actually runs if the `catch` itself didn't throw