### PR TITLE
docs(webviewWindow): fix incorrect import in JSDoc example

### DIFF
--- a/packages/api/src/webviewWindow.ts
+++ b/packages/api/src/webviewWindow.ts
@@ -102,8 +102,8 @@ class WebviewWindow {
    * Gets the Webview for the webview associated with the given label.
    * @example
    * ```typescript
-   * import { Webview } from '@tauri-apps/api/webviewWindow';
-   * const mainWebview = Webview.getByLabel('main');
+   * import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+   * const mainWebview = WebviewWindow.getByLabel('main');
    * ```
    *
    * @param label The webview label.


### PR DESCRIPTION
The `getByLabel` method is a static method on `WebviewWindow`, not `Webview`. The JSDoc example was importing the wrong class and calling the method on the wrong type.

This change updates the example code to import and use the correct `WebviewWindow` class.