### PR TITLE
ci: don't cache pnpm files in version-or-publish workflow

### DIFF
--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -78,7 +78,6 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
 
       - name: cargo login
         run: cargo login ${{ secrets.ORG_CRATES_IO_TOKEN }}


### PR DESCRIPTION
This keeps failing to cache for some reason and we don't gain that much from the pnpm cache anyway.