### PR TITLE
fix(cli): skip checks ndk when NDK_HOME set

### DIFF
--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -352,6 +352,20 @@ fn ensure_sdk(non_interactive: bool) -> Result<()> {
 }
 
 fn ensure_ndk(non_interactive: bool) -> Result<()> {
+
+  // Return Ok if NDK_HOME is set by user and its path exists
+  if let Some(ndk_home) = std::env::var_os("NDK_HOME").map(PathBuf::from) {
+    if ndk_home.exists() {
+      log::info!("Using NDK from NDK_HOME: {}", ndk_home.display());
+      return Ok(());
+    } else {
+      crate::error::bail!(
+        "NDK_HOME is set to {}, but the path does not exist.",
+        ndk_home.display()
+      );
+    }
+  }
+
   // re-evaluate ANDROID_HOME
   let android_home = std::env::var_os("ANDROID_HOME")
     .map(PathBuf::from)


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

In the original code, the way to ensure NDK installation is to check whether the ndk folder exists under the `$ANDROID_HOME` directory. If it exists, the `NDK_HOME` environment variable is set; otherwise, the NDK will be installed. This approach overrides any user-set `NDK_HOME` variable. However, on some systems (like NixOS), the NDK installed via package managers may not be located in the `$ANDROID_HOME/ndk` directory but elsewhere. Ignoring the `NDK_HOME` variable would render such system-installed NDKs unusable.

This PR bypasses the NDK check when `NDK_HOME` has already been set.
