### PR TITLE
fix(ios): default ARCHS in generated iOS run script to stabilize Intel simulator builds

### DIFF
--- a/crates/tauri-cli/templates/mobile/ios/project.yml
+++ b/crates/tauri-cli/templates/mobile/ios/project.yml
@@ -119,7 +119,8 @@ targets:
         discoveredDependencyFile: {{this.discovered-dependency-file}}{{/if}}
       {{~/each}}
 
-      - script: {{ tauri-binary }} {{ tauri-binary-args-str }} -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:?}
+      - script: {{ tauri-binary }} {{ tauri-binary-args-str }} -v --platform ${PLATFORM_DISPLAY_NAME:?} --sdk-root ${SDKROOT:?} --framework-search-paths "${FRAMEWORK_SEARCH_PATHS:?}" --header-search-paths "${HEADER_SEARCH_PATHS:?}" --gcc-preprocessor-definitions "${GCC_PREPROCESSOR_DEFINITIONS:-}" --configuration ${CONFIGURATION:?} ${FORCE_COLOR} ${ARCHS:-x86_64}
+
         name: Build Rust Code
         basedOnDependencyAnalysis: false
         outputFiles:


### PR DESCRIPTION
**Summary**
On Intel Macs running Xcode 16.x, the generated Tauri iOS Xcode project can fail to build for the iOS
Simulator because the environment variable ARCHS is sometimes empty. The generated “Build Rust
Code” run script uses strict Bash expansion:

${ARCHS:?}

This causes the script to fail with:

ARCHS: parameter null or not set

**Root Cause**
Xcode 16 sometimes omits ARCHS when running script phases for Simulator builds on Intel hosts.
Because the generated project uses the strict ${ARCHS:?} expansion, the Run Script aborts
immediately, breaking tauri ios dev flows.

**The Fix**
This PR updates the iOS project generator template so that all newly generated Xcode projects use a
safe fallback architecture when ARCHS is missing.
Changed from:

${ARCHS:?}

To:

${ARCHS:-x86_64}

**Exactly What Changed**

- Modified a single line in crates/tauri-cli/templates/mobile/ios/project.yml
- Replaced strict expansion ${ARCHS:?} with ${ARCHS:-x86_64}
- No other files or formatting changes


**How to Verify**

1. Generate a new iOS project:
tauri ios init

or:

```sh
tauri ios init
tauri ios dev --open
```


2. **In Xcode, open target app_iOS** → Build Phases → “Build Rust Code”.

Confirm the script ends with:

${ARCHS:-x86_64}

4. Run on an Intel Mac Simulator:
tauri ios dev --device "iPhone 17 Pro"

6. Expected results:
- Build succeeds without “ARCHS: parameter null or not set”
- App launches on Simulator normally
- Hot reload works for both Vite (frontend) and Tauri (Rust)


**Before vs After**
Before:
- Simulator builds fail with ARCHS: parameter null or not set.
- Generator emits strict ${ARCHS:?}.
- Requires manual local patching.
- 
After:
- Simulator builds succeed reliably.
- Uses safe default ${ARCHS:-x86_64}.
- Fix applied automatically for all new projects.


**Notes for Maintainers**
- Affects only Intel macOS hosts on Xcode 16.x
- Apple Silicon builds remain unaffected (ARCHS=arm64 is always set)
- Device builds are unaffected (ARCHS=arm64)
- Patch is small, safe, and localized to the generator template
- Improves stability of tauri ios dev without behavior changes elsewhere