### PR TITLE
fix(cli): apply CliOptions to the initial target build

### DIFF
--- a/.changes/fix-cli-options-mobile.md
+++ b/.changes/fix-cli-options-mobile.md
@@ -1,0 +1,6 @@
+---
+"@tauri-apps/cli": patch:bug
+"tauri-cli": patch:bug
+---
+
+Fixes Cargo features and args not being applied to the first cargo build calls of `[android|ios] [dev|build]` commands.

--- a/crates/tauri-cli/src/mobile/android/build.rs
+++ b/crates/tauri-cli/src/mobile/android/build.rs
@@ -153,7 +153,15 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<BuiltApplica
       &app,
       tauri_config_,
       build_options.features.as_ref(),
-      &Default::default(),
+      &CliOptions {
+        dev: false,
+        features: build_options.features.clone(),
+        args: build_options.args.clone(),
+        noise_level,
+        vars: Default::default(),
+        config: build_options.config.clone(),
+        target_device: options.target_device.clone(),
+      },
     );
     (interface, config, metadata)
   };

--- a/crates/tauri-cli/src/mobile/android/dev.rs
+++ b/crates/tauri-cli/src/mobile/android/dev.rs
@@ -193,7 +193,18 @@ fn run_command(options: Options, noise_level: NoiseLevel) -> Result<()> {
       &app,
       tauri_config_,
       dev_options.features.as_ref(),
-      &Default::default(),
+      &CliOptions {
+        dev: true,
+        features: dev_options.features.clone(),
+        args: dev_options.args.clone(),
+        noise_level,
+        vars: Default::default(),
+        config: dev_options.config.clone(),
+        target_device: device.as_ref().map(|d| TargetDevice {
+          id: d.serial_no().to_string(),
+          name: d.name().to_string(),
+        }),
+      },
     );
     (interface, config, metadata)
   };

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -202,7 +202,15 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<BuiltApplica
       &app,
       tauri_config_,
       build_options.features.as_ref(),
-      &Default::default(),
+      &CliOptions {
+        dev: false,
+        features: build_options.features.clone(),
+        args: build_options.args.clone(),
+        noise_level,
+        vars: Default::default(),
+        config: build_options.config.clone(),
+        target_device: options.target_device.clone(),
+      },
     )?;
     (interface, config)
   };

--- a/crates/tauri-cli/src/mobile/ios/dev.rs
+++ b/crates/tauri-cli/src/mobile/ios/dev.rs
@@ -198,7 +198,15 @@ fn run_command(options: Options, noise_level: NoiseLevel) -> Result<()> {
       &app,
       tauri_config_,
       dev_options.features.as_ref(),
-      &Default::default(),
+      &CliOptions {
+        dev: true,
+        features: dev_options.features.clone(),
+        args: dev_options.args.clone(),
+        noise_level,
+        vars: Default::default(),
+        config: dev_options.config.clone(),
+        target_device: None,
+      },
     )?;
 
     (interface, config)


### PR DESCRIPTION
I noticed this in a workspace where i needed to disable default-features otherwise the crate wouldn't compile for Android, and the build failed with the crate I needed to disable being compiled anyway. This happens because we run an initial build for caching and we were using CliOptions::default() instead of actually creating a proper instance with the provided values.