### PR TITLE
fix: remove \\r from schema files on windows

### DIFF
--- a/.changes/schema-carriage-return.md
+++ b/.changes/schema-carriage-return.md
@@ -1,0 +1,5 @@
+---
+tauri-utils: patch:bug
+---
+
+Fixed an issue that caused schema files to have `\r` characters on Windows.

--- a/crates/tauri-utils/src/acl/schema.rs
+++ b/crates/tauri-utils/src/acl/schema.rs
@@ -389,6 +389,9 @@ pub fn generate_permissions_schema<P: AsRef<Path>>(
 
   let schema_str = serde_json::to_string_pretty(&schema)?;
 
+  // FIXME: in schemars@v1 this doesn't seem to be necessary anymore. If it is, find a better solution.
+  let schema_str = schema_str.replace("\\r\\n", "\\n");
+
   let out_dir = out_dir.as_ref().join(PERMISSION_SCHEMAS_FOLDER_NAME);
   fs::create_dir_all(&out_dir).map_err(|e| Error::CreateDir(e, out_dir.clone()))?;
 

--- a/crates/tauri-utils/src/acl/schema.rs
+++ b/crates/tauri-utils/src/acl/schema.rs
@@ -317,6 +317,9 @@ pub fn generate_capability_schema(
   extend_permission_entry_schema(&mut schema, acl);
 
   let schema_str = serde_json::to_string_pretty(&schema).unwrap();
+  // FIXME: in schemars@v1 this doesn't seem to be necessary anymore. If it is, find a better solution.
+  let schema_str = schema_str.replace("\\r\\n", "\\n");
+
   let out_dir = PathBuf::from(CAPABILITIES_SCHEMA_FOLDER_PATH);
   fs::create_dir_all(&out_dir)?;
 


### PR DESCRIPTION
i know this is insane but i've been losing my mind over the last months over this