### PR TITLE
feat(bundler): consider extensions defined in main.wxs.

### DIFF
--- a/.changes/support-template-extensions.md
+++ b/.changes/support-template-extensions.md
@@ -1,5 +1,5 @@
 ---
-tauri-bundler: minor:feat
+tauri-bundler: patch:enhance
 ---
 
 Consider extensions that are defined in the wxs template.

--- a/.changes/support-template-extensions.md
+++ b/.changes/support-template-extensions.md
@@ -1,0 +1,5 @@
+---
+tauri-bundler: minor:feat
+---
+
+Consider extensions that are defined in the wxs template.

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -753,14 +753,14 @@ pub fn build_wix_app_installer(
   }
 
   let main_wxs_path = output_path.join("main.wxs");
-  fs::write(main_wxs_path, handlebars.render("main.wxs", &data)?)?;
+  fs::write(main_wxs_path.clone(), handlebars.render("main.wxs", &data)?)?;
 
   let mut candle_inputs = vec![];
 
   let current_dir = std::env::current_dir()?;
   let extension_regex = Regex::new("\"http://schemas.microsoft.com/wix/(\\w+)\"")?;
-  let input_paths = std::iter::once(output_path.join(PathBuf::from("main.wxs")))
-    .chain(fragment_paths.iter().map(|p| current_dir.join(p)));
+  let input_paths =
+    std::iter::once(main_wxs_path).chain(fragment_paths.iter().map(|p| current_dir.join(p)));
 
   for input_path in input_paths {
     let input_content = fs::read_to_string(&input_path)?;

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -755,24 +755,26 @@ pub fn build_wix_app_installer(
   let main_wxs_path = output_path.join("main.wxs");
   fs::write(main_wxs_path, handlebars.render("main.wxs", &data)?)?;
 
-  let mut candle_inputs = vec![("main.wxs".into(), Vec::new())];
+  let mut candle_inputs = vec![];
 
   let current_dir = std::env::current_dir()?;
   let extension_regex = Regex::new("\"http://schemas.microsoft.com/wix/(\\w+)\"")?;
-  for fragment_path in fragment_paths {
-    let fragment_path = current_dir.join(fragment_path);
-    let fragment_content = fs::read_to_string(&fragment_path)?;
-    let fragment_handlebars = Handlebars::new();
-    let fragment = fragment_handlebars.render_template(&fragment_content, &data)?;
+  let input_paths = std::iter::once(output_path.join(PathBuf::from("main.wxs")))
+    .chain(fragment_paths.iter().map(|p| current_dir.join(p)));
+
+  for input_path in input_paths {
+    let input_content = fs::read_to_string(&input_path)?;
+    let input_handlebars = Handlebars::new();
+    let input = input_handlebars.render_template(&input_content, &data)?;
     let mut extensions = Vec::new();
-    for cap in extension_regex.captures_iter(&fragment) {
+    for cap in extension_regex.captures_iter(&input) {
       let path = wix_toolset_path.join(format!("Wix{}.dll", &cap[1]));
       if settings.windows().can_sign() {
         try_sign(&path, settings)?;
       }
       extensions.push(path);
     }
-    candle_inputs.push((fragment_path, extensions));
+    candle_inputs.push((input_path, extensions));
   }
 
   let mut fragment_extensions = HashSet::new();

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -753,7 +753,7 @@ pub fn build_wix_app_installer(
   }
 
   let main_wxs_path = output_path.join("main.wxs");
-  fs::write(main_wxs_path.clone(), handlebars.render("main.wxs", &data)?)?;
+  fs::write(&main_wxs_path, handlebars.render("main.wxs", &data)?)?;
 
   let mut candle_inputs = vec![];
 


### PR DESCRIPTION
## Description

This PR extends extension support for the Tauri installer by considering not only `fragment_paths` for extension inclusion, but also the main `main.wxs` configuration file itself.  
Previously, the integration of extensions was limited to fragments, making it harder to manage installer customization in a centralized location.

## What’s changed

- **Extensions defined in both `fragment_paths` and the main `main.wxs` file are now recognized and included during the installer build process.**
- **The logic for extension detection and inclusion has been unified, streamlining the handling of installer resources and extensions.**

## Why

This change allows developers to manage all necessary installer extensions directly in fragments as well as in template, enabling more flexible and maintainable Windows installer configurations and reducing the need to split extension logic unnecessarily.