### PR TITLE
fix(cli): Skip signing updaters if `--no-sign` is requested

### DIFF
--- a/.changes/fix-no-sign-option.md
+++ b/.changes/fix-no-sign-option.md
@@ -1,0 +1,6 @@
+---
+tauri-cli: patch:bug
+---
+
+Fixed an issue that caused the cli to error out with missing private key, in case the option `--no-sign` was requested and the `tauri.config` has signing key set and the plugin `tauri-plugin-updater` is used.
+

--- a/crates/tauri-cli/src/bundle.rs
+++ b/crates/tauri-cli/src/bundle.rs
@@ -249,6 +249,11 @@ fn sign_updaters(
     return Ok(());
   }
 
+  if settings.no_sign() {
+    log::warn!("Updater signing is skipped due to --no-sign flag.");
+    return Ok(());
+  }
+
   // get the public key
   let pubkey = &update_settings.pubkey;
   // check if pubkey points to a file...


### PR DESCRIPTION
Closes #14581

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
