### PR TITLE
perf(cli): optimize npm package version fetching

### DIFF
--- a/crates/tauri-cli/src/info/packages_nodejs.rs
+++ b/crates/tauri-cli/src/info/packages_nodejs.rs
@@ -137,12 +137,27 @@ pub fn items(
 ) -> Vec<SectionItem> {
   let mut items = Vec::new();
   if let Some(frontend_dir) = frontend_dir {
-    for (package, version) in [
-      ("@tauri-apps/api", None),
-      ("@tauri-apps/cli", Some(metadata.js_cli.version.clone())),
-    ] {
+    let mut packages = vec![("@tauri-apps/api", None)];
+    if let Some(cli) = &metadata.js_cli.version {
+      packages.push(("@tauri-apps/cli", Some(cli.clone())));
+    }
+
+    let versions = package_manager
+      .current_package_versions(
+        &packages.iter().map(|(p, _)| p.to_string()).collect::<Vec<_>>(),
+        frontend_dir,
+      )
+      .unwrap_or_default();
+
+    for (package, version) in packages {
       let frontend_dir = frontend_dir.clone();
-      let item = nodejs_section_item(package.into(), version, frontend_dir, package_manager);
+      let item = nodejs_section_item(
+        package.into(),
+        version,
+        frontend_dir,
+        package_manager,
+        versions.get(package).cloned(),
+      );
       items.push(item);
     }
   }
@@ -155,12 +170,17 @@ pub fn nodejs_section_item(
   version: Option<String>,
   frontend_dir: PathBuf,
   package_manager: PackageManager,
+  current_version: Option<semver::Version>,
 ) -> SectionItem {
   SectionItem::new().action(move || {
     let version = version.clone().unwrap_or_else(|| {
-      package_manager
-        .current_package_version(&package, &frontend_dir)
-        .unwrap_or_default()
+      current_version
+        .map(|v| v.to_string())
+        .or_else(|| {
+          package_manager
+            .current_package_version(&package, &frontend_dir)
+            .unwrap_or_default()
+        })
         .unwrap_or_default()
     });
 

--- a/crates/tauri-cli/src/info/plugins.rs
+++ b/crates/tauri-cli/src/info/plugins.rs
@@ -115,7 +115,20 @@ pub fn items(
     if let Some(tauri_dir) = tauri_dir {
       let (manifest, lock) = cargo_manifest_and_lock(tauri_dir);
 
-      for p in helpers::plugins::known_plugins().keys() {
+      let known_plugins = helpers::plugins::known_plugins();
+      let npm_plugins = if let Some(frontend_dir) = frontend_dir {
+        let npm_names: Vec<String> = known_plugins
+          .keys()
+          .map(|plugin_name| format!("@tauri-apps/plugin-{plugin_name}"))
+          .collect();
+        package_manager
+          .current_package_versions(&npm_names, frontend_dir)
+          .unwrap_or_default()
+      } else {
+        HashMap::new()
+      };
+
+      for p in known_plugins.keys() {
         let dep = format!("tauri-plugin-{p}");
         let crate_version = crate_version(tauri_dir, manifest.as_ref(), lock.as_ref(), &dep);
         if !crate_version.has_version() {
@@ -131,10 +144,11 @@ pub fn items(
         let package = format!("@tauri-apps/plugin-{p}");
 
         let item = packages_nodejs::nodejs_section_item(
-          package,
+          package.clone(),
           None,
           frontend_dir.clone(),
           package_manager,
+          npm_plugins.get(&package).cloned(),
         );
         items.push(item);
       }


### PR DESCRIPTION
## Description
This PR optimizes the `tauri info` command by batching npm package version checks. Previously, the CLI spawned a new process for each package to check its version, which could be slow.
## What’s changed
- Modified `crates/tauri-cli/src/info/packages_nodejs.rs` and `crates/tauri-cli/src/info/plugins.rs` to use `current_package_versions`.
- The CLI now fetches all required package versions in a single command execution instead of sequentially.
- Added a release log file for the performance improvement.
## Why
This change significantly reduces the overhead of running `tauri info`, especially in projects with many plugins, by minimizing the number of shell commands executed. This results in a faster and more responsive CLI experience.
