### PR TITLE
fix(tauri-cli, tauri-build): copy external binaries only during bundling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8627,6 +8627,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "cargo-mobile2",
+ "cargo_toml",
  "clap",
  "clap_complete",
  "colored",

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -16,7 +16,7 @@ use cargo_toml::Manifest;
 
 use tauri_utils::{
   config::{BundleResources, Config, WebviewInstallMode},
-  resources::{external_binaries, ResourcePaths},
+  resources::ResourcePaths,
 };
 
 use std::{
@@ -50,37 +50,6 @@ fn copy_file(from: impl AsRef<Path>, to: impl AsRef<Path>) -> Result<()> {
   let dest_dir = to.parent().expect("No data in parent");
   fs::create_dir_all(dest_dir)?;
   fs::copy(from, to)?;
-  Ok(())
-}
-
-fn copy_binaries(
-  binaries: ResourcePaths,
-  target_triple: &str,
-  path: &Path,
-  package_name: Option<&String>,
-) -> Result<()> {
-  for src in binaries {
-    let src = src?;
-    println!("cargo:rerun-if-changed={}", src.display());
-    let file_name = src
-      .file_name()
-      .expect("failed to extract external binary filename")
-      .to_string_lossy()
-      .replace(&format!("-{target_triple}"), "");
-
-    if package_name == Some(&file_name) {
-      return Err(anyhow::anyhow!(
-        "Cannot define a sidecar with the same name as the Cargo package name `{}`. Please change the sidecar name in the filesystem and the Tauri configuration.",
-        file_name
-      ));
-    }
-
-    let dest = path.join(file_name);
-    if dest.exists() {
-      fs::remove_file(&dest).unwrap();
-    }
-    copy_file(&src, &dest)?;
-  }
   Ok(())
 }
 
@@ -527,15 +496,6 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
     .unwrap()
     .parent()
     .unwrap();
-
-  if let Some(paths) = &config.bundle.external_bin {
-    copy_binaries(
-      ResourcePaths::new(&external_binaries(paths, &target_triple, &target), true),
-      &target_triple,
-      target_dir,
-      manifest.package.as_ref().map(|p| &p.name),
-    )?;
-  }
 
   #[allow(unused_mut, clippy::redundant_clone)]
   let mut resources = config

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -114,6 +114,7 @@ rand = "0.9"
 zip = { version = "4", default-features = false, features = ["deflate"] }
 which = "8"
 rayon = "1.10"
+cargo_toml = "0.22.3"
 
 [dev-dependencies]
 insta = "1"

--- a/crates/tauri-cli/src/bundle.rs
+++ b/crates/tauri-cli/src/bundle.rs
@@ -10,10 +10,12 @@ use std::{
 
 use clap::{builder::PossibleValue, ArgAction, Parser, ValueEnum};
 use tauri_bundler::PackageType;
+use tauri_utils::platform::target_triple;
 use tauri_utils::platform::Target;
+use tauri_utils::resources::{external_binaries, ResourcePaths};
 
 use crate::{
-  error::{Context, ErrorExt},
+  error::{bail, Context, ErrorExt},
   helpers::{
     self,
     app_paths::tauri_dir,
@@ -117,6 +119,14 @@ impl From<crate::build::Options> for Options {
   }
 }
 
+fn target(options: &Options) -> (Target, String) {
+  let target_triple = options
+    .target
+    .clone()
+    .unwrap_or_else(|| target_triple().unwrap());
+  (Target::from_triple(&target_triple), target_triple)
+}
+
 pub fn command(options: Options, verbosity: u8) -> crate::Result<()> {
   crate::helpers::app_paths::resolve();
 
@@ -164,6 +174,48 @@ pub fn command(options: Options, verbosity: u8) -> crate::Result<()> {
   )
 }
 
+fn copy_file(from: &Path, to: &Path) -> crate::Result<()> {
+  if !from.exists() {
+    bail!("{:?} does not exist", from);
+  }
+  if !from.is_file() {
+    bail!("{:?} is not a file", from);
+  }
+  let dest_dir = to.parent().expect("No data in parent");
+  std::fs::create_dir_all(dest_dir).with_context(|| format!("failed to create {dest_dir:?}"))?;
+  std::fs::copy(from, to).with_context(|| format!("failed to copy {from:?} to {to:?}"))?;
+  Ok(())
+}
+
+fn copy_binaries(
+  binaries: ResourcePaths,
+  target_triple: &str,
+  path: &Path,
+  package_name: Option<&String>,
+) -> crate::Result<()> {
+  for src in binaries {
+    let src = src.context("error iterating through resources")?;
+    let file_name = src
+      .file_name()
+      .expect("failed to extract external binary filename")
+      .to_string_lossy()
+      .replace(&format!("-{target_triple}"), "");
+
+    if package_name == Some(&file_name) {
+      bail!(
+        "Cannot define a sidecar with the same name as the Cargo package name `{file_name}`. Please change the sidecar name in the filesystem and the Tauri configuration.",
+      );
+    }
+
+    let dest = path.join(file_name);
+    if dest.exists() {
+      std::fs::remove_file(&dest).unwrap();
+    }
+    copy_file(&src, &dest)?;
+  }
+  Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn bundle<A: AppSettings>(
   options: &Options,
@@ -174,6 +226,22 @@ pub fn bundle<A: AppSettings>(
   config: &ConfigMetadata,
   out_dir: &Path,
 ) -> crate::Result<()> {
+  use cargo_toml::Manifest;
+  use cargo_toml::Value;
+
+  let (target, target_triple) = target(options);
+  let cargo_toml_path = tauri_dir().join("Cargo.toml");
+  let manifest = Manifest::<Value>::from_path_with_metadata(cargo_toml_path)
+    .context("failed to open Cargo.toml")?;
+
+  if let Some(paths) = &config.bundle.external_bin {
+    copy_binaries(
+      ResourcePaths::new(&external_binaries(paths, &target_triple, &target), true),
+      &target_triple,
+      out_dir,
+      manifest.package.as_ref().map(|p| &p.name),
+    )?;
+  }
   let package_types: Vec<PackageType> = if let Some(bundles) = &options.bundles {
     bundles.iter().map(|bundle| bundle.0).collect::<Vec<_>>()
   } else {


### PR DESCRIPTION
Should fix #14602 

I'm a bit unsure about moving things from the build script to the `tauri-cli`, since parts of the bundler were placed deliberately in the build script.

If possible, moving as much as possible from the build script into the `tauri-cli` could improve code comprehension.