### PR TITLE
fix(linux): work area returns logical rect

### DIFF
--- a/.changes/linux-workarea-logical-size.md
+++ b/.changes/linux-workarea-logical-size.md
@@ -1,0 +1,6 @@
+---
+tauri: patch:bug
+tauri-runtime-wry: patch:bug
+---
+
+Fix `Monitor::work_area` returns logical position and size inside the `PhysicalRect` on Linux

--- a/crates/tauri-runtime-wry/src/monitor/linux.rs
+++ b/crates/tauri-runtime-wry/src/monitor/linux.rs
@@ -4,14 +4,15 @@
 
 use gtk::prelude::MonitorExt;
 use tao::platform::unix::MonitorHandleExtUnix;
-use tauri_runtime::dpi::{PhysicalPosition, PhysicalRect, PhysicalSize};
+use tauri_runtime::dpi::{LogicalPosition, LogicalSize, PhysicalRect};
 
 impl super::MonitorExt for tao::monitor::MonitorHandle {
   fn work_area(&self) -> PhysicalRect<i32, u32> {
     let rect = self.gdk_monitor().workarea();
+    let scale_factor = self.scale_factor();
     PhysicalRect {
-      size: PhysicalSize::new(rect.width() as u32, rect.height() as u32),
-      position: PhysicalPosition::new(rect.x(), rect.y()),
+      size: LogicalSize::new(rect.width() as u32, rect.height() as u32).to_physical(scale_factor),
+      position: LogicalPosition::new(rect.x(), rect.y()).to_physical(scale_factor),
     }
   }
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix #14630

(untested, but the doc does mention the returned values are in application pixels: https://gtk-rs.org/gtk3-rs/git/docs/gdk/struct.Monitor.html#method.workarea)