### PR TITLE
fix(android): escape special characters in product name for strings.xml

### DIFF
--- a/crates/tauri-cli/src/mobile/init.rs
+++ b/crates/tauri-cli/src/mobile/init.rs
@@ -179,6 +179,7 @@ fn handlebars(app: &App) -> (Handlebars<'static>, JsonMap) {
   h.register_escape_fn(handlebars::no_escape);
 
   h.register_helper("html-escape", Box::new(html_escape));
+  h.register_helper("android-escape", Box::new(android_escape));
   h.register_helper("join", Box::new(join));
   h.register_helper("quote-and-join", Box::new(quote_and_join));
   h.register_helper(
@@ -222,6 +223,24 @@ fn html_escape(
   out
     .write(&handlebars::html_escape(get_str(helper)))
     .map_err(Into::into)
+}
+
+fn android_escape(
+  helper: &Helper,
+  _: &Handlebars,
+  _ctx: &Context,
+  _: &mut RenderContext,
+  out: &mut dyn Output,
+) -> HelperResult {
+  // Escape special characters for Android XML strings
+  // Single quotes must be escaped with a backslash
+  let input = get_str(helper);
+  let escaped = input.replace('\\', "\\\\").replace('\'', "\\'")
+    .replace('"', "\\\"")
+    .replace('\n', "\\n")
+    .replace('\r', "\\r")
+    .replace('\t', "\\t");
+  out.write(&escaped).map_err(Into::into)
 }
 
 fn join(

--- a/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
+++ b/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">{{app.stylized-name}}</string>
-    <string name="main_activity_title">{{app.stylized-name}}</string>
+    <string name="app_name">{{android-escape app.stylized-name}}</string>
+    <string name="main_activity_title">{{android-escape app.stylized-name}}</string>
 </resources>


### PR DESCRIPTION
Bug fix
Fixes #14634

Description

When `productName` in `tauri.conf.json` contains special characters like single quotes (e.g., "Aircraft's Hub"), the generated Android `strings.xml` file causes build failures because these characters aren't properly escaped according to Android XML string resource rules.

### Problem

Android XML string resources require certain characters to be escaped with a backslash:
- Single quotes (`'`) must be escaped as `\'`
- Backslashes (`\`) must be escaped as `\\`
- Double quotes (`"`) must be escaped as `\"`
- Special whitespace characters (newlines, tabs, etc.) must also be escaped

The Handlebars template was directly inserting `{{app.stylized-name}}` without any escaping, causing XML parsing errors during Android builds.

Solution
This PR adds proper escaping for Android XML strings by:

1. **Created `android_escape` helper function** (`crates/tauri-cli/src/mobile/init.rs`):
   - Escapes single quotes: `'` → `\'`
   - Escapes backslashes: `\` → `\\`
   - Escapes double quotes: `"` → `\"`
   - Escapes newlines: `\n` → `\\n`
   - Escapes carriage returns: `\r` → `\\r`
   - Escapes tabs: `\t` → `\\t`

2. **Registered the helper** in the Handlebars instance

3. **Updated the template** (`crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml`):
   - Changed `{{app.stylized-name}}` to `{{android-escape app.stylized-name}}`
   - Applied to both `app_name` and `main_activity_title` strings

Changes Made
Modified Files:
- `crates/tauri-cli/src/mobile/init.rs` (+19 lines)
- `crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml` (2 lines modified)

Testing

### Before Fix:
```json
{
  "productName": "Aircraft's Hub"
}
<resources>
    <string name="app_name">Aircraft's Hub</string>
    <string name="main_activity_title">Aircraft's Hub</string>
</resources>
Result: Build fails with XML parsing error

After Fix:
<resources>
    <string name="app_name">Aircraft\'s Hub</string>
    <string name="main_activity_title">Aircraft\'s Hub</string>
    
</resources>
Result: Builds successfully

This fix follows Android's official XML string resource formatting rules as documented in the [Android Developer Documentation](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%203.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

The escaping logic is minimal and focused, only affecting the display strings in [strings.xml](vscode-file://vscode-app/Applications/Visual%20Studio%20Code%203.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) without impacting any other Android generation code or Kotlin identifiers.






