### PR TITLE
fix(macOS): correct value for work_area.position.y

### DIFF
--- a/.changes/work-area.md
+++ b/.changes/work-area.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch:bug
+"tauri-runtime-wry": patch:bug
+---
+
+Fix monitor work area Y position on macOS.

--- a/crates/tauri-runtime-wry/src/monitor/macos.rs
+++ b/crates/tauri-runtime-wry/src/monitor/macos.rs
@@ -19,10 +19,8 @@ impl super::MonitorExt for tao::monitor::MonitorHandle {
 
       position.x += visible_frame.origin.x - screen_frame.origin.x;
 
-      // visible_frame.origin is using a bottom-up coordinate system, so this needs to be converted
-      // to a top-down coordinate system. origin.y will typically represent the top of the dock.
-      position.y += screen_frame.size.height - visible_frame.origin.y - visible_frame.size.height;
-
+position.y += (screen_frame.origin.y + screen_frame.size.height)
+        - (visible_frame.origin.y + visible_frame.size.height);
       PhysicalRect {
         size: LogicalSize::new(visible_frame.size.width, visible_frame.size.height)
           .to_physical(scale_factor),

--- a/crates/tauri-runtime-wry/src/monitor/macos.rs
+++ b/crates/tauri-runtime-wry/src/monitor/macos.rs
@@ -19,6 +19,10 @@ impl super::MonitorExt for tao::monitor::MonitorHandle {
 
       position.x += visible_frame.origin.x - screen_frame.origin.x;
 
+      // visible_frame.origin is using a bottom-up coordinate system, so this needs to be converted
+      // to a top-down coordinate system. origin.y will typically represent the top of the dock.
+      position.y += screen_frame.size.height - visible_frame.origin.y - visible_frame.size.height;
+
       PhysicalRect {
         size: LogicalSize::new(visible_frame.size.width, visible_frame.size.height)
           .to_physical(scale_factor),


### PR DESCRIPTION
Currently, the value of `work_area.position.y` is returning 0. On a screen with a menubar, this should be something like 38. This makes it difficult to position windows at the top of the screen correctly.

This calculation was originally set in https://github.com/tauri-apps/tauri/pull/13309, however the math seems incorrect. 

This calculation was removed in https://github.com/tauri-apps/tauri/pull/13401, which set the value back to 0. 

You can set the window position to 0, and it seems the system will (usually, not always) move the window below the menu bar. However, it would be better if I can just directly move the window to where it should be (y=38).

The PR attempts to correct the calculation for `position.y`. It takes into account the bottom-up coordinate system used by `visible_frame`. It should work correctly regardless of the menu bar size and presence.