### PR TITLE
perf: replace Arc<Mutex> with DashMap in ChannelDataIpcQueue for improved performance

### DIFF
--- a/.changes/improve-performance-when-payload-oversize-MAX_RAW_DIRECT_EXECUTE_THRESHOLD.md
+++ b/.changes/improve-performance-when-payload-oversize-MAX_RAW_DIRECT_EXECUTE_THRESHOLD.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:minor
+---
+
+Introducing Dashmap instead of Arc<Mutex> in ChannelDataIpcQueue, improve performance when payload larger than MAX_RAW_DIRECT_EXECUTE_THRESHOLD. No user facing changes.

--- a/.changes/improve-performance-when-payload-oversize-MAX_RAW_DIRECT_EXECUTE_THRESHOLD.md
+++ b/.changes/improve-performance-when-payload-oversize-MAX_RAW_DIRECT_EXECUTE_THRESHOLD.md
@@ -1,5 +1,5 @@
 ---
-"tauri": patch:minor
+"tauri": patch:perf
 ---
 
 Introducing Dashmap instead of Arc<Mutex> in ChannelDataIpcQueue, improve performance when payload larger than MAX_RAW_DIRECT_EXECUTE_THRESHOLD. No user facing changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8499,6 +8499,7 @@ dependencies = [
  "bytes",
  "cargo_toml",
  "cookie",
+ "dashmap",
  "data-url",
  "dirs 6.0.0",
  "dunce",

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -83,6 +83,7 @@ specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, 
 ] }
 # WARNING: cookie::Cookie is re-exported so bumping this is a breaking change, documented to be done as a minor bump
 cookie = "0.18"
+dashmap = "6.1.0"
 
 # desktop
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows", target_os = "macos"))'.dependencies]

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: MIT
 
 use std::{
-  collections::HashMap,
   str::FromStr,
   sync::{
     atomic::{AtomicU32, AtomicUsize, Ordering},
-    Arc, Mutex,
+    Arc,
   },
 };
 
+use dashmap::DashMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
@@ -43,7 +43,7 @@ static CHANNEL_DATA_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// Maps a channel id to a pending data that must be send to the JavaScript side via the IPC.
 #[derive(Default, Clone)]
-pub struct ChannelDataIpcQueue(Arc<Mutex<HashMap<u32, InvokeResponseBody>>>);
+pub struct ChannelDataIpcQueue(DashMap<u32, InvokeResponseBody>);
 
 /// An IPC channel.
 pub struct Channel<TSend = InvokeResponseBody> {
@@ -171,8 +171,6 @@ impl JavaScriptChannelId {
             webview
               .state::<ChannelDataIpcQueue>()
               .0
-              .lock()
-              .unwrap()
               .insert(data_id, body);
 
             webview.eval(format!(
@@ -267,8 +265,6 @@ impl<TSend> Channel<TSend> {
             webview
               .state::<ChannelDataIpcQueue>()
               .0
-              .lock()
-              .unwrap()
               .insert(data_id, body);
 
             webview.eval(format!(
@@ -326,7 +322,7 @@ fn fetch(
     .and_then(|v| v.to_str().ok())
     .and_then(|id| id.parse().ok())
   {
-    if let Some(data) = cache.0.lock().unwrap().remove(&id) {
+    if let Some((_, data)) = cache.0.remove(&id) {
       Ok(Response::new(data))
     } else {
       Err("data not found")


### PR DESCRIPTION
Introducing Dashmap dependency. Test with example, trigge the spawn button on UI.

Some testing usage:

```rust
let start_insert_time = std::time::Instant::now();
            webview
              .state::<ChannelDataIpcQueue>()
              .0
              .lock()
              .unwrap()
              .insert(data_id, body);
            let elapsed_insert = start_insert_time.elapsed();
              println!(
                "[tauri::ipc::channel] inserted channel data id {data_id} in {:?}",
                elapsed_insert
              );
```

```rust
// The repo's example cmd.rs
#[command]
pub fn spam(channel: Channel<Vec<u8>>) -> tauri::Result<()> {
  // make greater than MAX_RAW_DIRECT_EXECUTE_THRESHOLD(1024)
  let size = 50_000usize;
  let data = vec![0u8; size];
  channel.send(data)?;
  Ok(())
}
```

Previous Arc<Mutex<HashMap>>
```
[tauri::ipc::channel] inserted channel data id 0 in 34.334µs
```

Current Dashmap
```
[tauri::ipc::channel] inserted channel data id 0 in 15.958µs
```

Roughly improved 53% cost time.
