### PR TITLE
feat(cli): add RISC-V 64-bit pre-built binary support

### DIFF
--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -48,16 +48,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: 'Setup Rust'
+        if: ${{ !matrix.config.cross }}
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.config.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
+        if: ${{ !matrix.config.cross }}
         with:
           key: ${{ matrix.config.rust_target }}
 
       - name: install Linux dependencies
-        if: matrix.config.os == 'ubuntu-latest'
+        if: ${{ !matrix.config.cross && startsWith(matrix.config.os, 'ubuntu') }}
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev
@@ -66,7 +68,7 @@ jobs:
         if: ${{ matrix.config.cross }}
         uses: taiki-e/install-action@v2
         with:
-          tool: cross
+          tool: cross@0.2.5
 
       - name: Build CLI
         if: ${{ !matrix.config.cross }}

--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.config.runs_on || matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
 
     strategy:
       fail-fast: false
@@ -39,23 +39,20 @@ jobs:
             ext: '.exe'
             args: ''
           - os: ubuntu-22.04
-            runs_on: [self-hosted, riscv64]
             rust_target: riscv64gc-unknown-linux-gnu
             ext: ''
             args: ''
-            self_hosted: true
+            cross: true
 
     steps:
       - uses: actions/checkout@v4
 
       - name: 'Setup Rust'
-        if: ${{ !matrix.config.self_hosted }}
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.config.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
-        if: ${{ !matrix.config.self_hosted }}
         with:
           key: ${{ matrix.config.rust_target }}
 
@@ -65,14 +62,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev
 
+      - name: Install cross
+        if: ${{ matrix.config.cross }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
       - name: Build CLI
+        if: ${{ !matrix.config.cross }}
         run: cargo build --manifest-path ./crates/tauri-cli/Cargo.toml --profile release-size-optimized ${{ matrix.config.args }}
 
+      - name: Build CLI (cross)
+        if: ${{ matrix.config.cross }}
+        run: cross build --manifest-path ./crates/tauri-cli/Cargo.toml --target ${{ matrix.config.rust_target }} --profile release-size-optimized ${{ matrix.config.args }}
+
       - name: Upload CLI
+        if: ${{ !matrix.config.cross }}
         uses: actions/upload-artifact@v4
         with:
           name: cargo-tauri-${{ matrix.config.rust_target }}${{ matrix.config.ext }}
           path: target/release-size-optimized/cargo-tauri${{ matrix.config.ext }}
+          if-no-files-found: error
+
+      - name: Upload CLI (cross)
+        if: ${{ matrix.config.cross }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-tauri-${{ matrix.config.rust_target }}${{ matrix.config.ext }}
+          path: target/${{ matrix.config.rust_target }}/release-size-optimized/cargo-tauri${{ matrix.config.ext }}
           if-no-files-found: error
 
   upload:

--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.runs_on || matrix.config.os }}
 
     strategy:
       fail-fast: false
@@ -38,16 +38,24 @@ jobs:
             rust_target: aarch64-pc-windows-msvc
             ext: '.exe'
             args: ''
+          - os: ubuntu-22.04
+            runs_on: [self-hosted, riscv64]
+            rust_target: riscv64gc-unknown-linux-gnu
+            ext: ''
+            args: ''
+            self_hosted: true
 
     steps:
       - uses: actions/checkout@v4
 
       - name: 'Setup Rust'
+        if: ${{ !matrix.config.self_hosted }}
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.config.rust_target }}
 
       - uses: Swatinem/rust-cache@v2
+        if: ${{ !matrix.config.self_hosted }}
         with:
           key: ${{ matrix.config.rust_target }}
 


### PR DESCRIPTION
## Summary

Add `riscv64gc-unknown-linux-gnu` target to the `tauri-cli` release workflow, enabling pre-built binaries for RISC-V 64-bit Linux systems.

## Motivation

When building a Tauri app for RISC-V:
- `cargo install tauri-cli` compiles 600+ crates
- Under QEMU user-mode emulation: **6+ hours** (often killed before completion)
- On native RISC-V hardware: **~63 minutes**
- With pre-built binary: **seconds**

Every Tauri project wanting RISC-V support currently faces this multi-hour compilation wall. This PR fixes it upstream, benefiting the entire ecosystem.

## Implementation

This PR:
1. Adds RISC-V entry to build matrix with `runs_on: [self-hosted, riscv64]`
2. Supports custom `runs_on` field for matrix entries (falls back to `os`)
3. Skips `dtolnay/rust-toolchain` and `rust-cache` for self-hosted runners
4. Sources `~/.cargo/env` for self-hosted runners where Rust is pre-installed

## Build Verification

Successfully tested on self-hosted RISC-V runner:

| Metric | Value |
|--------|-------|
| Hardware | Banana Pi F3 (RISC-V64, 16GB RAM) |
| OS | Debian Trixie |
| Build time | 1h 2m 28s |
| Binary | ELF 64-bit RISC-V, 16MB stripped |

Full workflow run: https://github.com/gounthar/tauri/actions/runs/20438992682

## Self-Hosted Runner Requirement

This PR requires a self-hosted RISC-V runner. Options:

1. **Community-provided**: I can provide access to my self-hosted RISC-V runners for Tauri releases
2. **Cloud-V**: https://cloud-v.co/github-riscv-runner offers hosted RISC-V GitHub runners
3. **QEMU fallback**: Could add QEMU-based builds as fallback (slower but self-contained)

I'm happy to discuss the best approach for the Tauri project.

## Runner Setup Documentation

For reference, self-hosted RISC-V runner setup: https://github.com/gounthar/bananapi-f3-github-runner

## Test Plan

- [x] Build tauri-cli manually on RISC-V hardware
- [x] Run full workflow with self-hosted runner
- [x] Verify artifact is produced and uploaded
- [ ] Test binary on RISC-V system (download and run `cargo-tauri --version`)