### PR TITLE
feat(bundler): add detachRetries option to DMG configuration (fix #14686)

### DIFF
--- a/.changes/dmg-detach-retries.md
+++ b/.changes/dmg-detach-retries.md
@@ -1,0 +1,7 @@
+---
+'tauri-bundler': 'minor:feat'
+'tauri-utils': 'minor:feat'
+'tauri-cli': 'minor:feat'
+---
+
+Add `detachRetries` option to DMG configuration to customize the maximum number of attempts to detach the DMG volume (fix #14686).

--- a/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
@@ -130,6 +130,8 @@ Options:
       execute hdiutil with sandbox compatibility and do not bless (not supported for APFS disk images)
   --skip-jenkins
       skip Finder-prettifying AppleScript, useful in Sandbox and non-GUI environments
+  --detach-retries <attempts>
+      set maximum number of attempts to detach the DMG volume (default: 3)
   --version
 	    show create-dmg version number
   -h, --help
@@ -264,6 +266,9 @@ while [[ "${1:0:1}" = "-" ]]; do
 		--skip-jenkins)
 			SKIP_JENKINS=1
 			shift;;
+		--detach-retries)
+			MAXIMUM_UNMOUNTING_ATTEMPTS="$2"
+			shift; shift;;
 		-*)
 			echo "Unknown option: $1. Run 'create-dmg --help' for help."
 			exit 1;;

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -179,6 +179,11 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
     }
   }
 
+  // Issue #14686 - Allow customizing detach retries for large DMGs
+  if let Some(detach_retries) = dmg_settings.detach_retries {
+    bundle_dmg_cmd.args(["--detach-retries", &detach_retries.to_string()]);
+  }
+
   log::info!(action = "Running"; "bundle_dmg.sh");
 
   // execute the bundle script

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -304,6 +304,9 @@ pub struct DmgSettings {
   pub app_position: Position,
   /// Position of application folder on window.
   pub application_folder_position: Position,
+  /// Maximum number of attempts to detach the DMG volume before giving up.
+  /// Defaults to 3. Increase this value if you encounter "hdiutil: detach: timeout" errors.
+  pub detach_retries: Option<u32>,
 }
 
 /// The iOS bundle settings.

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1548,6 +1548,7 @@ fn tauri_config_to_bundle_settings(
         x: config.macos.dmg.application_folder_position.x,
         y: config.macos.dmg.application_folder_position.y,
       },
+      detach_retries: config.macos.dmg.detach_retries,
     },
     ios: IosSettings {
       bundle_version: config.ios.bundle_version,

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -563,6 +563,11 @@ pub struct DmgConfig {
     alias = "application-folder-position"
   )]
   pub application_folder_position: Position,
+  /// Maximum number of attempts to detach the DMG volume before giving up.
+  /// Defaults to 3. Increase this value if you encounter "hdiutil: detach: timeout" errors,
+  /// which can occur with large DMG files on CI environments with throttled CPUs.
+  #[serde(alias = "detach-retries")]
+  pub detach_retries: Option<u32>,
 }
 
 impl Default for DmgConfig {
@@ -573,6 +578,7 @@ impl Default for DmgConfig {
       window_size: dmg_window_size(),
       app_position: dmg_app_position(),
       application_folder_position: dmg_application_folder_position(),
+      detach_retries: None,
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `detachRetries` option to `DmgConfig` to customize the maximum number of attempts to detach the DMG volume
- Default remains 3, but users can increase this for large DMG files on CI environments with throttled CPUs

## Usage

In `tauri.conf.json`:
```json
{
  "bundle": {
    "macOS": {
      "dmg": {
        "detachRetries": 10
      }
    }
  }
}
```

Fixes #14686