### PR TITLE
feat(window): add physical coordinate methods to WindowBuilder (fix #5228)

### DIFF
--- a/.changes/window-builder-physical-size.md
+++ b/.changes/window-builder-physical-size.md
@@ -1,0 +1,7 @@
+---
+'tauri': 'minor:feat'
+'tauri-runtime': 'minor:feat'
+'tauri-runtime-wry': 'minor:feat'
+---
+
+Add physical coordinate methods to WindowBuilder: `position_physical`, `inner_size_physical`, `min_inner_size_physical`, and `max_inner_size_physical` (fix #5228).

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -945,10 +945,22 @@ impl WindowBuilder for WindowBuilderWrapper {
     self
   }
 
+  fn position_physical(mut self, x: i32, y: i32) -> Self {
+    self.inner = self.inner.with_position(TaoPhysicalPosition::new(x, y));
+    self
+  }
+
   fn inner_size(mut self, width: f64, height: f64) -> Self {
     self.inner = self
       .inner
       .with_inner_size(TaoLogicalSize::new(width, height));
+    self
+  }
+
+  fn inner_size_physical(mut self, width: u32, height: u32) -> Self {
+    self.inner = self
+      .inner
+      .with_inner_size(TaoPhysicalSize::new(width, height));
     self
   }
 
@@ -959,10 +971,24 @@ impl WindowBuilder for WindowBuilderWrapper {
     self
   }
 
+  fn min_inner_size_physical(mut self, min_width: u32, min_height: u32) -> Self {
+    self.inner = self
+      .inner
+      .with_min_inner_size(TaoPhysicalSize::new(min_width, min_height));
+    self
+  }
+
   fn max_inner_size(mut self, max_width: f64, max_height: f64) -> Self {
     self.inner = self
       .inner
       .with_max_inner_size(TaoLogicalSize::new(max_width, max_height));
+    self
+  }
+
+  fn max_inner_size_physical(mut self, max_width: u32, max_height: u32) -> Self {
+    self.inner = self
+      .inner
+      .with_max_inner_size(TaoPhysicalSize::new(max_width, max_height));
     self
   }
 

--- a/crates/tauri-runtime/src/window.rs
+++ b/crates/tauri-runtime/src/window.rs
@@ -251,17 +251,33 @@ pub trait WindowBuilder: WindowBuilderBase {
   #[must_use]
   fn position(self, x: f64, y: f64) -> Self;
 
+  /// The initial position of the window in physical pixels.
+  #[must_use]
+  fn position_physical(self, x: i32, y: i32) -> Self;
+
   /// Window size in logical pixels.
   #[must_use]
   fn inner_size(self, width: f64, height: f64) -> Self;
+
+  /// Window size in physical pixels.
+  #[must_use]
+  fn inner_size_physical(self, width: u32, height: u32) -> Self;
 
   /// Window min inner size in logical pixels.
   #[must_use]
   fn min_inner_size(self, min_width: f64, min_height: f64) -> Self;
 
+  /// Window min inner size in physical pixels.
+  #[must_use]
+  fn min_inner_size_physical(self, min_width: u32, min_height: u32) -> Self;
+
   /// Window max inner size in logical pixels.
   #[must_use]
   fn max_inner_size(self, max_width: f64, max_height: f64) -> Self;
+
+  /// Window max inner size in physical pixels.
+  #[must_use]
+  fn max_inner_size_physical(self, max_width: u32, max_height: u32) -> Self;
 
   /// Window inner size constraints.
   #[must_use]

--- a/crates/tauri/src/window/mod.rs
+++ b/crates/tauri/src/window/mod.rs
@@ -450,10 +450,24 @@ impl<'a, R: Runtime, M: Manager<R>> WindowBuilder<'a, R, M> {
     self
   }
 
+  /// The initial position of the window in physical pixels.
+  #[must_use]
+  pub fn position_physical(mut self, x: i32, y: i32) -> Self {
+    self.window_builder = self.window_builder.position_physical(x, y);
+    self
+  }
+
   /// Window size in logical pixels.
   #[must_use]
   pub fn inner_size(mut self, width: f64, height: f64) -> Self {
     self.window_builder = self.window_builder.inner_size(width, height);
+    self
+  }
+
+  /// Window size in physical pixels.
+  #[must_use]
+  pub fn inner_size_physical(mut self, width: u32, height: u32) -> Self {
+    self.window_builder = self.window_builder.inner_size_physical(width, height);
     self
   }
 
@@ -464,10 +478,24 @@ impl<'a, R: Runtime, M: Manager<R>> WindowBuilder<'a, R, M> {
     self
   }
 
+  /// Window min inner size in physical pixels.
+  #[must_use]
+  pub fn min_inner_size_physical(mut self, min_width: u32, min_height: u32) -> Self {
+    self.window_builder = self.window_builder.min_inner_size_physical(min_width, min_height);
+    self
+  }
+
   /// Window max inner size in logical pixels.
   #[must_use]
   pub fn max_inner_size(mut self, max_width: f64, max_height: f64) -> Self {
     self.window_builder = self.window_builder.max_inner_size(max_width, max_height);
+    self
+  }
+
+  /// Window max inner size in physical pixels.
+  #[must_use]
+  pub fn max_inner_size_physical(mut self, max_width: u32, max_height: u32) -> Self {
+    self.window_builder = self.window_builder.max_inner_size_physical(max_width, max_height);
     self
   }
 


### PR DESCRIPTION
## Summary

Add methods to set window position and size in physical coordinates:
- `position_physical(x: i32, y: i32)`
- `inner_size_physical(width: u32, height: u32)`
- `min_inner_size_physical(min_width: u32, min_height: u32)`
- `max_inner_size_physical(max_width: u32, max_height: u32)`

## Usage

```rust
// Position window on a specific monitor using physical pixels
let window = WindowBuilder::new(app, "main")
    .position_physical(1920, 0)  // Start of second monitor
    .inner_size_physical(1920, 1080)
    .build()?;
```

Fixes #5228