### PR TITLE
refactor: use u64 instead of usize for nonce gen

### DIFF
--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -129,14 +129,7 @@ fn replace_csp_nonce(
 ) {
   let mut nonces = Vec::new();
   *asset = replace_with_callback(asset, token, || {
-    #[cfg(target_pointer_width = "64")]
-    let mut raw = [0u8; 8];
-    #[cfg(target_pointer_width = "32")]
-    let mut raw = [0u8; 4];
-    #[cfg(target_pointer_width = "16")]
-    let mut raw = [0u8; 2];
-    getrandom::fill(&mut raw).expect("failed to get random bytes");
-    let nonce = usize::from_ne_bytes(raw);
+    let nonce = getrandom::u64().expect("failed to get random bytes");
     nonces.push(nonce);
     nonce.to_string()
   });


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

`nonce` string length shouldn't be related to platform pointer size really