### PR TITLE
Fix:  Updater signer failed signing file without extension

### DIFF
--- a/.changes/updater-signer-files-without-extension.md
+++ b/.changes/updater-signer-files-without-extension.md
@@ -1,0 +1,5 @@
+---
+tauri-cli: patch:bug
+---
+
+`ext.to_os_string().unwrap()` returns None on files without an extension in `sign_file()`

--- a/.changes/updater-signer-files-without-extension.md
+++ b/.changes/updater-signer-files-without-extension.md
@@ -1,5 +1,6 @@
 ---
 tauri-cli: patch:bug
+"@tauri-apps/cli": patch:bug
 ---
 
-`ext.to_os_string().unwrap()` returns None on files without an extension in `sign_file()`
+`tauri signer sign` doesn't work for files without an extension

--- a/crates/tauri-cli/src/helpers/updater_signature.rs
+++ b/crates/tauri-cli/src/helpers/updater_signature.rs
@@ -120,9 +120,15 @@ where
 {
   let bin_path = bin_path.as_ref();
   // We need to append .sig at the end it's where the signature will be stored
-  let mut extension = bin_path.extension().unwrap().to_os_string();
-  extension.push(".sig");
-  let signature_path = bin_path.with_extension(extension);
+  // Previously if the file didn't have an extension, it broke as
+  // bin_path.extension().unwrap().to_os_string(); returned None and unwrwap failed.
+  let signature_path = if bin_path.extension().is_some() {
+    let mut extension = bin_path.extension().unwrap().to_os_string();
+    extension.push(".sig");
+    bin_path.with_extension(extension)
+  } else {
+    bin_path.with_extension("sig")
+  };
 
   let trusted_comment = format!(
     "timestamp:{}\tfile:{}",

--- a/crates/tauri-cli/src/helpers/updater_signature.rs
+++ b/crates/tauri-cli/src/helpers/updater_signature.rs
@@ -120,8 +120,7 @@ where
 {
   let bin_path = bin_path.as_ref();
   // We need to append .sig at the end it's where the signature will be stored
-  // Previously if the file didn't have an extension, it broke as
-  // bin_path.extension().unwrap().to_os_string(); returned None and unwrwap failed.
+  // TODO: use with_added_extension when we bump MSRV to > 1.91'
   let signature_path = if let Some(ext) = bin_path.extension() {
     let mut extension = ext.to_os_string();
     extension.push(".sig");

--- a/crates/tauri-cli/src/helpers/updater_signature.rs
+++ b/crates/tauri-cli/src/helpers/updater_signature.rs
@@ -122,8 +122,8 @@ where
   // We need to append .sig at the end it's where the signature will be stored
   // Previously if the file didn't have an extension, it broke as
   // bin_path.extension().unwrap().to_os_string(); returned None and unwrwap failed.
-  let signature_path = if bin_path.extension().is_some() {
-    let mut extension = bin_path.extension().unwrap().to_os_string();
+  let signature_path = if let Some(ext) = bin_path.extension() {
+    let mut extension = ext.to_os_string();
     extension.push(".sig");
     bin_path.with_extension(extension)
   } else {


### PR DESCRIPTION

If we tried to sign a file without extension (for example in linux) 
Before:

`bin_path.extension().unwrap().to_os_string(); `

returned None and unwrap of course failed.

Change:

```
  let signature_path = if bin_path.extension().is_some() {
    let mut extension = bin_path.extension().unwrap().to_os_string();
    extension.push(".sig");
    bin_path.with_extension(extension)
  } else {
    bin_path.with_extension("sig")
  };

So if we have an extension we just add ".sig" as another extension. Otherwise with just add it to the filename.
```