### PR TITLE
fix: fix leftover inconsistent env var in `tauri signer sign` command

### DIFF
--- a/.changes/signing-env-vars.md
+++ b/.changes/signing-env-vars.md
@@ -1,0 +1,14 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Added new environment variables for `tauri signer sign` command, to align with existing environment variables used in `tauri build`, `tauri bundle` and `tauri signer generate`
+- `TAURI_SIGNING_PRIVATE_KEY`
+- `TAURI_SIGNING_PRIVATE_KEY_PATH`
+- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+
+The old environment variables are deprecated and will be removed in a future release.
+- `TAURI_PRIVATE_KEY`
+- `TAURI_PRIVATE_KEY_PATH`
+- `TAURI_PRIVATE_KEY_PASSWORD`

--- a/crates/tauri-cli/src/signer/generate.rs
+++ b/crates/tauri-cli/src/signer/generate.rs
@@ -39,26 +39,29 @@ pub fn command(mut options: Options) -> Result<()> {
       save_keypair(options.force, output_path, &keypair.sk, &keypair.pk)
         .expect("Unable to write keypair");
 
-    println!(
-        "\nYour keypair was generated successfully\nPrivate: {} (Keep it secret!)\nPublic: {}\n---------------------------",
-        display_path(secret_path),
-        display_path(public_path)
-        )
+    println!();
+    println!("Your keypair was generated successfully:");
+    println!("Private: {} (Keep it secret!)", display_path(secret_path));
+    println!("Public: {}", display_path(public_path));
+    println!("---------------------------")
   } else {
-    println!(
-      "\nYour secret key was generated successfully - Keep it secret!\n{}\n\n",
-      keypair.sk
-    );
-    println!(
-          "Your public key was generated successfully:\n{}\n\nAdd the public key in your tauri.conf.json\n---------------------------\n",
-          keypair.pk
-        );
+    println!();
+    println!("Your keys were generated successfully!",);
+    println!();
+    println!("Private: (Keep it secret!)");
+    println!("{}", keypair.sk);
+    println!();
+    println!("Public:");
+    println!("{}", keypair.pk);
   }
 
-  println!("\nEnvironment variables used to sign:");
-  println!("`TAURI_SIGNING_PRIVATE_KEY`  Path or String of your private key");
-  println!("`TAURI_SIGNING_PRIVATE_KEY_PASSWORD`  Your private key password (optional)");
-  println!("\nATTENTION: If you lose your private key OR password, you'll not be able to sign your update package and updates will not work.\n---------------------------\n");
+  println!();
+  println!("Environment variables used to sign:");
+  println!("- `TAURI_SIGNING_PRIVATE_KEY`: String of your private key");
+  println!("- `TAURI_SIGNING_PRIVATE_KEY_PATH`: Path to your private key file");
+  println!("- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`:  Your private key password (optional if key has no password)");
+  println!();
+  println!("ATTENTION: If you lose your private key OR password, you'll not be able to sign your update package and updates will not work");
 
   Ok(())
 }


### PR DESCRIPTION
closes #14758

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
