### PR TITLE
chore: fix typos in comments

### DIFF
--- a/crates/tauri-bundler/src/bundle/macos/sign.rs
+++ b/crates/tauri-bundler/src/bundle/macos/sign.rs
@@ -21,7 +21,7 @@ pub fn keychain(identity: Option<&str>) -> crate::Result<Option<tauri_macos_sign
     var_os("APPLE_CERTIFICATE"),
     var_os("APPLE_CERTIFICATE_PASSWORD"),
   ) {
-    // import user certificate - useful for for CI build
+    // import user certificate - useful for CI build
     let keychain =
       tauri_macos_sign::Keychain::with_certificate(&certificate_encoded, &certificate_password)
         .map_err(Box::new)?;

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -231,7 +231,7 @@ pub struct AppImageSettings {
 pub struct RpmSettings {
   /// The list of RPM dependencies your application relies on.
   pub depends: Option<Vec<String>>,
-  /// the list of of RPM dependencies your application recommends.
+  /// the list of RPM dependencies your application recommends.
   pub recommends: Option<Vec<String>>,
   /// The list of RPM dependencies your application provides.
   pub provides: Option<Vec<String>>,

--- a/crates/tauri-runtime-wry/src/window/mod.rs
+++ b/crates/tauri-runtime-wry/src/window/mod.rs
@@ -39,7 +39,7 @@ pub trait WindowExt {
   /// - **Android / iOS**: Unsupported.
   fn center(&self) {}
 
-  /// Clears the window surface. i.e make it it transparent.
+  /// Clears the window surface. i.e make it transparent.
   #[cfg(windows)]
   fn draw_surface(
     &self,

--- a/crates/tauri-runtime/src/webview.rs
+++ b/crates/tauri-runtime/src/webview.rs
@@ -363,7 +363,7 @@ pub struct WebviewAttributes {
   /// see https://docs.rs/objc2-web-kit/latest/objc2_web_kit/struct.WKWebView.html#method.allowsLinkPreview
   pub allow_link_preview: bool,
   pub scroll_bar_style: ScrollBarStyle,
-  /// Allows overriding the the keyboard accessory view on iOS.
+  /// Allows overriding the keyboard accessory view on iOS.
   /// Returning `None` effectively removes the view.
   ///
   /// The closure parameter is the webview instance.

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1202,7 +1202,7 @@ fn main() {
     self
   }
 
-  /// Allows overriding the the keyboard accessory view on iOS.
+  /// Allows overriding the keyboard accessory view on iOS.
   /// Returning `None` effectively removes the view.
   ///
   /// The closure parameter is the webview instance.

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -1230,7 +1230,7 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
     self
   }
 
-  /// Allows overriding the the keyboard accessory view on iOS.
+  /// Allows overriding the keyboard accessory view on iOS.
   /// Returning `None` effectively removes the view.
   ///
   /// The closure parameter is the webview instance.


### PR DESCRIPTION
Fix typos in comments:
- `it it` → `it`
- `the the` → `the` (x3)
- `for for` → `for`
- `of of` → `of`