### PR TITLE
Fix unsound Send+Sync impl

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -804,10 +804,6 @@ impl std::fmt::Debug for WindowBuilderWrapper {
   }
 }
 
-// SAFETY: this type is `Send` since `menu_items` are read only here
-#[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl Send for WindowBuilderWrapper {}
-
 impl WindowBuilderBase for WindowBuilderWrapper {}
 impl WindowBuilder for WindowBuilderWrapper {
   fn new() -> Self {
@@ -5224,5 +5220,14 @@ fn to_tao_theme(theme: Option<Theme>) -> Option<TaoTheme> {
     Some(Theme::Light) => Some(TaoTheme::Light),
     Some(Theme::Dark) => Some(TaoTheme::Dark),
     _ => None,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  fn is_send<T: Send>() {}
+  #[test]
+  fn are_send() {
+    is_send::<super::WindowBuilderWrapper>();
   }
 }

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -64,7 +64,7 @@ pub(crate) type GlobalWebviewEventListener<R> =
   Box<dyn Fn(&Webview<R>, &WebviewEvent) + Send + Sync>;
 /// A closure that is run when the Tauri application is setting up.
 pub type SetupHook<R> =
-  Box<dyn FnOnce(&mut App<R>) -> std::result::Result<(), Box<dyn std::error::Error>> + Send>;
+  Box<dyn FnOnce(&mut App<R>) -> Result<(), Box<dyn std::error::Error>> + Send>;
 /// A closure that is run every time a page starts or finishes loading.
 pub type OnPageLoad<R> = dyn Fn(&Webview<R>, &PageLoadPayload<'_>) + Send + Sync + 'static;
 pub type ChannelInterceptor<R> =
@@ -443,7 +443,7 @@ impl<R: Runtime> Clone for AppHandle<R> {
 
 impl<'de, R: Runtime> CommandArg<'de, R> for AppHandle<R> {
   /// Grabs the [`Window`] from the [`CommandItem`] and returns the associated [`AppHandle`]. This will never fail.
-  fn from_command(command: CommandItem<'de, R>) -> std::result::Result<Self, InvokeError> {
+  fn from_command(command: CommandItem<'de, R>) -> Result<Self, InvokeError> {
     Ok(command.message.webview().app_handle)
   }
 }
@@ -1640,7 +1640,7 @@ tauri::Builder::default()
   #[must_use]
   pub fn setup<F>(mut self, setup: F) -> Self
   where
-    F: FnOnce(&mut App<R>) -> std::result::Result<(), Box<dyn std::error::Error>> + Send + 'static,
+    F: FnOnce(&mut App<R>) -> Result<(), Box<dyn std::error::Error>> + Send + 'static,
   {
     self.setup = Box::new(setup);
     self
@@ -2353,7 +2353,7 @@ fn init_app_menu<R: Runtime>(menu: &Menu<R>) -> crate::Result<()> {
 impl<R: Runtime> HasDisplayHandle for AppHandle<R> {
   fn display_handle(
     &self,
-  ) -> std::result::Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+  ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
     self.runtime_handle.display_handle()
   }
 }
@@ -2361,7 +2361,7 @@ impl<R: Runtime> HasDisplayHandle for AppHandle<R> {
 impl<R: Runtime> HasDisplayHandle for App<R> {
   fn display_handle(
     &self,
-  ) -> std::result::Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
+  ) -> Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError> {
     self.handle.display_handle()
   }
 }

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -64,7 +64,7 @@ pub(crate) type GlobalWebviewEventListener<R> =
   Box<dyn Fn(&Webview<R>, &WebviewEvent) + Send + Sync>;
 /// A closure that is run when the Tauri application is setting up.
 pub type SetupHook<R> =
-  Box<dyn FnOnce(&mut App<R>) -> Result<(), Box<dyn std::error::Error>> + Send>;
+  Box<dyn FnOnce(&mut App<R>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send>;
 /// A closure that is run every time a page starts or finishes loading.
 pub type OnPageLoad<R> = dyn Fn(&Webview<R>, &PageLoadPayload<'_>) + Send + Sync + 'static;
 pub type ChannelInterceptor<R> =
@@ -1640,7 +1640,7 @@ tauri::Builder::default()
   #[must_use]
   pub fn setup<F>(mut self, setup: F) -> Self
   where
-    F: FnOnce(&mut App<R>) -> Result<(), Box<dyn std::error::Error>> + Send + 'static,
+    F: FnOnce(&mut App<R>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + 'static,
   {
     self.setup = Box::new(setup);
     self

--- a/crates/tauri/src/error.rs
+++ b/crates/tauri/src/error.rs
@@ -6,18 +6,13 @@ use std::fmt;
 
 /// A generic boxed error.
 #[derive(Debug)]
-pub struct SetupError(Box<dyn std::error::Error>);
+pub struct SetupError(Box<dyn std::error::Error + Send + Sync>);
 
-impl From<Box<dyn std::error::Error>> for SetupError {
-  fn from(error: Box<dyn std::error::Error>) -> Self {
+impl From<Box<dyn std::error::Error + Send + Sync>> for SetupError {
+  fn from(error: Box<dyn std::error::Error + Send + Sync>) -> Self {
     Self(error)
   }
 }
-
-// safety: the setup error is only used on the main thread
-// and we exit the process immediately.
-unsafe impl Send for SetupError {}
-unsafe impl Sync for SetupError {}
 
 impl fmt::Display for SetupError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This is a tiny breaking change to fix an unsoundness in the public API of tauri.
There is no non-breaking change that could fix this, and anybody without a Sync+Send error type is doing something shady anyway.

The issue is we can have an error type with an `Rc` that is then laundered by the Tauri `unsafe impl` into a `SetupError` which can be freely sent to a different thread. See this modification of helloworld.rs

```rust
fn main() {
  use std::cell::RefCell;
  use std::rc::Rc;

  thread_local! {
      static LOCAL: RefCell<Option<Rc<()>>> = RefCell::new(None);
  };
  LOCAL.with(|m| *m.borrow_mut() = Some(Rc::new(())));
  // Rc -> SetupError(Box<dyn std::error::Error + Send + Sync>) Laundromat
  // free to send one end to another thread
  if let tauri::Error::Setup(e) = tauri::Builder::default()
    .setup(move |_| Err(Error(LOCAL.with(|m| m.borrow_mut().take().unwrap())).into()))
    .invoke_handler(tauri::generate_handler![])
    .run(tauri::generate_context!(
      "../../examples/helloworld/tauri.conf.json"
    ))
    .unwrap_err()
  {
    std::thread::spawn(move || e);
  };
}

#[derive(Clone)]
struct Error(std::rc::Rc<()>);

impl std::fmt::Debug for Error {
  fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
    todo!()
  }
}

impl std::fmt::Display for Error {
  fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
    todo!()
  }
}

impl std::error::Error for Error {}
```

---------------------------------------------------------------------

There is another soundness issue in `tauri-runtime-wry`'s [`WindowsStore`](https://github.com/tauri-apps/tauri/blob/e919a760edfc115f9e4b5d841e29cc38d5535ed1/crates/tauri-runtime-wry/src/lib.rs#L428-L437) where there's an unsafe `Sync` impl even though the inner type is public. I haven't been able to verify whether the code was ever sound, but since the inner field was made public it definitely became unsound, `RefCell` is not `Sync`, but the wrapper type is, so we can trivially send references to `WindowsStore` to multiple threads and then open them up to references to `RefCell`.
The safety comments "// SAFETY: we ensure this type is only used on the main thread." are incorrect.

