### PR TITLE
fix(cli): xcode-script tauri path resolution

### DIFF
--- a/crates/tauri-cli/src/mobile/ios/mod.rs
+++ b/crates/tauri-cli/src/mobile/ios/mod.rs
@@ -102,18 +102,23 @@ enum Commands {
 
 pub fn command(cli: Cli, verbosity: u8) -> Result<()> {
   let noise_level = NoiseLevel::from_occurrences(verbosity as u64);
-  let dirs = crate::helpers::app_paths::resolve_dirs();
   match cli.command {
-    Commands::Init(options) => init_command(
-      MobileTarget::Ios,
-      options.ci,
-      options.reinstall_deps,
-      options.skip_targets_install,
-      options.config,
-      &dirs,
-    )?,
+    Commands::Init(options) => {
+      let dirs = crate::helpers::app_paths::resolve_dirs();
+      init_command(
+        MobileTarget::Ios,
+        options.ci,
+        options.reinstall_deps,
+        options.skip_targets_install,
+        options.config,
+        &dirs,
+      )?
+    }
     Commands::Dev(options) => dev::command(options, noise_level)?,
-    Commands::Build(options) => build::command(options, noise_level, &dirs).map(|_| ())?,
+    Commands::Build(options) => {
+      let dirs = crate::helpers::app_paths::resolve_dirs();
+      build::command(options, noise_level, &dirs).map(|_| ())?
+    }
     Commands::Run(options) => run::command(options, noise_level)?,
     Commands::XcodeScript(options) => xcode_script::command(options)?,
   }


### PR DESCRIPTION
regression from #14668
when running the tauri CLI via cargo, the CWD is changed by the xcode-script command - moves from src-tauri/gen/apple to src-tauri so the CLI can resolve the app path properly resolving early breaks this, so we must be careful with the #14668 change

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
