### PR TITLE
refactor: move unsafe send sync impl up to `Context`

### DIFF
--- a/.changes/fix-send-sync.md
+++ b/.changes/fix-send-sync.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": minor:breaking
+---
+
+`WindowsStore` and `DispatcherMainThreadContext` are no longer `Send` and `Sync`, and unsafe impl has been moved to `Context` directly.

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -249,6 +249,7 @@ pub(crate) fn send_user_message<T: UserEvent>(
   }
 }
 
+unsafe impl<T: UserEvent> Send for Context<T> {}
 unsafe impl<T: UserEvent> Sync for Context<T> {}
 
 #[derive(Clone)]
@@ -434,10 +435,6 @@ pub enum ActiveTracingSpan {
 #[derive(Debug)]
 pub struct WindowsStore(pub RefCell<BTreeMap<WindowId, WindowWrapper>>);
 
-// SAFETY: we ensure this type is only used on the main thread.
-#[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl Send for WindowsStore {}
-
 #[derive(Debug, Clone)]
 pub struct DispatcherMainThreadContext<T: UserEvent> {
   pub window_target: EventLoopWindowTarget<Message<T>>,
@@ -447,10 +444,6 @@ pub struct DispatcherMainThreadContext<T: UserEvent> {
   #[cfg(feature = "tracing")]
   pub active_tracing_spans: ActiveTraceSpanStore,
 }
-
-// SAFETY: we ensure this type is only used on the main thread.
-#[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl<T: UserEvent> Send for DispatcherMainThreadContext<T> {}
 
 impl<T: UserEvent> fmt::Debug for Context<T> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -249,9 +249,6 @@ pub(crate) fn send_user_message<T: UserEvent>(
   }
 }
 
-unsafe impl<T: UserEvent> Send for Context<T> {}
-unsafe impl<T: UserEvent> Sync for Context<T> {}
-
 #[derive(Clone)]
 pub struct Context<T: UserEvent> {
   pub window_id_map: WindowIdStore,
@@ -265,6 +262,9 @@ pub struct Context<T: UserEvent> {
   next_webview_event_id: Arc<AtomicU32>,
   webview_runtime_installed: bool,
 }
+
+unsafe impl<T: UserEvent> Send for Context<T> {}
+unsafe impl<T: UserEvent> Sync for Context<T> {}
 
 impl<T: UserEvent> Context<T> {
   pub fn run_threaded<R, F>(&self, f: F) -> R

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -249,6 +249,8 @@ pub(crate) fn send_user_message<T: UserEvent>(
   }
 }
 
+unsafe impl<T: UserEvent> Sync for Context<T> {}
+
 #[derive(Clone)]
 pub struct Context<T: UserEvent> {
   pub window_id_map: WindowIdStore,
@@ -436,10 +438,6 @@ pub struct WindowsStore(pub RefCell<BTreeMap<WindowId, WindowWrapper>>);
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for WindowsStore {}
 
-// SAFETY: we ensure this type is only used on the main thread.
-#[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl Sync for WindowsStore {}
-
 #[derive(Debug, Clone)]
 pub struct DispatcherMainThreadContext<T: UserEvent> {
   pub window_target: EventLoopWindowTarget<Message<T>>,
@@ -453,10 +451,6 @@ pub struct DispatcherMainThreadContext<T: UserEvent> {
 // SAFETY: we ensure this type is only used on the main thread.
 #[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<T: UserEvent> Send for DispatcherMainThreadContext<T> {}
-
-// SAFETY: we ensure this type is only used on the main thread.
-#[allow(clippy::non_send_fields_in_send_ty)]
-unsafe impl<T: UserEvent> Sync for DispatcherMainThreadContext<T> {}
 
 impl<T: UserEvent> fmt::Debug for Context<T> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -2830,6 +2830,7 @@ impl<T: UserEvent> Wry<T> {
     let main_thread_id = current_thread().id();
     let web_context = WebContextStore::default();
 
+    #[allow(clippy::arc_with_non_send_sync)]
     let windows = Arc::new(WindowsStore(RefCell::new(BTreeMap::default())));
     let window_id_map = WindowIdStore::default();
 


### PR DESCRIPTION
Fixes #14801

Depends on [wry PR 1657](https://github.com/tauri-apps/wry/pull/1657).

I'm not intimately familiar with what is going on in this code, so I'm using heuristics to guide my fix:

- most of the arguments passed to `fn on_event` from the `Plugin` trait are not Sync
- `WindowsStore` is sandwiched between two types that are both not Sync, it contains types that are not Sync and it itself is contained in
```rust
unsafe impl<T: UserEvent> Sync for DispatcherMainThreadContext<T> {}

pub struct DispatcherMainThreadContext<T: UserEvent> {
  pub window_target: EventLoopWindowTarget<Message<T>>,
  pub web_context: WebContextStore,
  // changing this to an Rc will cause frequent app crashes.
  pub windows: Arc<WindowsStore>,
  #[cfg(feature = "tracing")]
  pub active_tracing_spans: ActiveTraceSpanStore,
}
```
and
```rust
pub struct EventLoopIterationContext<'a, T: UserEvent> {
  pub callback: &'a mut (dyn FnMut(RunEvent<T>) + 'static),
  pub window_id_map: WindowIdStore,
  pub windows: Arc<WindowsStore>,
  #[cfg(feature = "tracing")]
  pub active_tracing_spans: ActiveTraceSpanStore,
}
```
of which the last is not Sync.

For basic soundness based on the examples in #14801 if a non-Sync field is public in a public struct that struct *must* be not Sync as well.
We have two choices, make both these structs that contain public `WindowsStore`s `Sync` or make them both not Sync. Attempting to make both of these structs `Sync` is a rat's nest, so let's take the alternative, let's assume they must be both not Sync. This implies the Sync impl of both `WindowsStore` and `DispatcherMainThreadContext` are mistaken.

Removing the Sync impl of `DispatcherMainThreadContext` leads to another rat's nest of errors. `Context` used to inherit Sync based on its fields, so removing Sync from `DispatcherMainThreadContext` makes it not Sync as well.

I can't reason whether `Context` should or should not be Sync, but in any case we are overriding Sync "at the edges" of the code, so there is a larger space in which the absence of Sync will be caught by the compiler.

In summary, these changes strictly reduce the ways to be unsound. More cases are caught that were previously not sound.