### PR TITLE
fix(specta): don't use `#[specta(rename = ...)]` with `tauri::ipc::Channel`

### DIFF
--- a/.changes/change-pr-14812.md
+++ b/.changes/change-pr-14812.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch
+---
+
+fix(specta): don't use `#[specta(rename = ...)]` with `tauri::ipc::Channel`

--- a/.changes/change-pr-14812.md
+++ b/.changes/change-pr-14812.md
@@ -1,5 +1,5 @@
 ---
-"tauri": patch
+"tauri": patch:bug
 ---
 
 fix(specta): don't use `#[specta(rename = ...)]` with `tauri::ipc::Channel`

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -54,9 +54,9 @@ pub struct Channel<TSend = InvokeResponseBody> {
 #[cfg(feature = "specta")]
 const _: () = {
   #[derive(specta::Type)]
-  #[specta(remote = super::Channel, rename = "TAURI_CHANNEL")]
+  #[specta(remote = super::Channel)]
   #[allow(dead_code)]
-  struct Channel<TSend>(std::marker::PhantomData<TSend>);
+  struct TAURI_CHANNEL<TSend>(std::marker::PhantomData<TSend>);
 };
 
 impl<TSend> Clone for Channel<TSend> {

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -55,7 +55,7 @@ pub struct Channel<TSend = InvokeResponseBody> {
 const _: () = {
   #[derive(specta::Type)]
   #[specta(remote = super::Channel)]
-  #[allow(dead_code)]
+  #[allow(dead_code, non_camel_case_types)]
   struct TAURI_CHANNEL<TSend>(std::marker::PhantomData<TSend>);
 };
 


### PR DESCRIPTION
With some futures changes coming in the next Specta release this will cause problems.

This change of code is backwards compatible because Specta does something like `attributes.rename.unwrap_or_else(|| ident.to_string())` so removing the `attributes.rename` is fine if we change `ident` to match it's value.