### PR TITLE
Less statics fixup

### DIFF
--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -104,17 +104,19 @@ enum Commands {
 }
 
 pub fn command(cli: Cli, verbosity: u8) -> Result<()> {
-  let dirs = crate::helpers::app_paths::resolve_dirs();
   let noise_level = NoiseLevel::from_occurrences(verbosity as u64);
   match cli.command {
-    Commands::Init(options) => init_command(
-      MobileTarget::Android,
-      options.ci,
-      false,
-      options.skip_targets_install,
-      options.config,
-      &dirs,
-    )?,
+    Commands::Init(options) => {
+      let dirs = crate::helpers::app_paths::resolve_dirs();
+      init_command(
+        MobileTarget::Android,
+        options.ci,
+        false,
+        options.skip_targets_install,
+        options.config,
+        &dirs,
+      )?
+    }
     Commands::Dev(options) => dev::command(options, noise_level)?,
     Commands::Build(options) => build::command(options, noise_level).map(|_| ())?,
     Commands::Run(options) => run::command(options, noise_level)?,

--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -106,17 +106,13 @@ enum Commands {
 pub fn command(cli: Cli, verbosity: u8) -> Result<()> {
   let noise_level = NoiseLevel::from_occurrences(verbosity as u64);
   match cli.command {
-    Commands::Init(options) => {
-      let dirs = crate::helpers::app_paths::resolve_dirs();
-      init_command(
-        MobileTarget::Android,
-        options.ci,
-        false,
-        options.skip_targets_install,
-        options.config,
-        &dirs,
-      )?
-    }
+    Commands::Init(options) => init_command(
+      MobileTarget::Android,
+      options.ci,
+      false,
+      options.skip_targets_install,
+      options.config,
+    )?,
     Commands::Dev(options) => dev::command(options, noise_level)?,
     Commands::Build(options) => build::command(options, noise_level).map(|_| ())?,
     Commands::Run(options) => run::command(options, noise_level)?,

--- a/crates/tauri-cli/src/mobile/init.rs
+++ b/crates/tauri-cli/src/mobile/init.rs
@@ -29,8 +29,8 @@ pub fn command(
   reinstall_deps: bool,
   skip_targets_install: bool,
   config: Vec<ConfigValue>,
-  dirs: &Dirs,
 ) -> Result<()> {
+  let dirs = crate::helpers::app_paths::resolve_dirs();
   let wrapper = TextWrapper::default();
 
   exec(
@@ -52,7 +52,7 @@ fn exec(
   #[allow(unused_variables)] reinstall_deps: bool,
   skip_targets_install: bool,
   config: Vec<ConfigValue>,
-  dirs: &Dirs,
+  dirs: Dirs,
 ) -> Result<App> {
   let tauri_config = get_tauri_config(
     target.platform_target(),

--- a/crates/tauri-cli/src/mobile/init.rs
+++ b/crates/tauri-cli/src/mobile/init.rs
@@ -45,7 +45,7 @@ pub fn command(
   Ok(())
 }
 
-pub fn exec(
+fn exec(
   target: Target,
   wrapper: &TextWrapper,
   #[allow(unused_variables)] non_interactive: bool,

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -169,6 +169,10 @@ pub struct BuiltApplication {
 
 pub fn command(options: Options, noise_level: NoiseLevel) -> Result<BuiltApplication> {
   let dirs = crate::helpers::app_paths::resolve_dirs();
+  run(options, noise_level, &dirs)
+}
+
+pub fn run(options: Options, noise_level: NoiseLevel, dirs: &Dirs) -> Result<BuiltApplication> {
   let mut build_options: BuildOptions = options.clone().into();
   build_options.target = Some(
     Target::all()

--- a/crates/tauri-cli/src/mobile/ios/build.rs
+++ b/crates/tauri-cli/src/mobile/ios/build.rs
@@ -167,7 +167,8 @@ pub struct BuiltApplication {
   options_handle: OptionsHandle,
 }
 
-pub fn command(options: Options, noise_level: NoiseLevel, dirs: &Dirs) -> Result<BuiltApplication> {
+pub fn command(options: Options, noise_level: NoiseLevel) -> Result<BuiltApplication> {
+  let dirs = crate::helpers::app_paths::resolve_dirs();
   let mut build_options: BuildOptions = options.clone().into();
   build_options.target = Some(
     Target::all()

--- a/crates/tauri-cli/src/mobile/ios/mod.rs
+++ b/crates/tauri-cli/src/mobile/ios/mod.rs
@@ -102,18 +102,20 @@ enum Commands {
 
 pub fn command(cli: Cli, verbosity: u8) -> Result<()> {
   let noise_level = NoiseLevel::from_occurrences(verbosity as u64);
-  let dirs = crate::helpers::app_paths::resolve_dirs();
   match cli.command {
-    Commands::Init(options) => init_command(
-      MobileTarget::Ios,
-      options.ci,
-      options.reinstall_deps,
-      options.skip_targets_install,
-      options.config,
-      &dirs,
-    )?,
+    Commands::Init(options) => {
+      let dirs = crate::helpers::app_paths::resolve_dirs();
+      init_command(
+        MobileTarget::Ios,
+        options.ci,
+        options.reinstall_deps,
+        options.skip_targets_install,
+        options.config,
+        &dirs,
+      )?
+    }
     Commands::Dev(options) => dev::command(options, noise_level)?,
-    Commands::Build(options) => build::command(options, noise_level, &dirs).map(|_| ())?,
+    Commands::Build(options) => build::command(options, noise_level).map(|_| ())?,
     Commands::Run(options) => run::command(options, noise_level)?,
     Commands::XcodeScript(options) => xcode_script::command(options)?,
   }

--- a/crates/tauri-cli/src/mobile/ios/mod.rs
+++ b/crates/tauri-cli/src/mobile/ios/mod.rs
@@ -103,17 +103,13 @@ enum Commands {
 pub fn command(cli: Cli, verbosity: u8) -> Result<()> {
   let noise_level = NoiseLevel::from_occurrences(verbosity as u64);
   match cli.command {
-    Commands::Init(options) => {
-      let dirs = crate::helpers::app_paths::resolve_dirs();
-      init_command(
-        MobileTarget::Ios,
-        options.ci,
-        options.reinstall_deps,
-        options.skip_targets_install,
-        options.config,
-        &dirs,
-      )?
-    }
+    Commands::Init(options) => init_command(
+      MobileTarget::Ios,
+      options.ci,
+      options.reinstall_deps,
+      options.skip_targets_install,
+      options.config,
+    )?,
     Commands::Dev(options) => dev::command(options, noise_level)?,
     Commands::Build(options) => build::command(options, noise_level).map(|_| ())?,
     Commands::Run(options) => run::command(options, noise_level)?,

--- a/crates/tauri-cli/src/mobile/ios/run.rs
+++ b/crates/tauri-cli/src/mobile/ios/run.rs
@@ -76,7 +76,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
 
   let dirs = crate::helpers::app_paths::resolve_dirs();
 
-  let mut built_application = super::build::command(
+  let mut built_application = super::build::run(
     super::build::Options {
       debug: !options.release,
       targets: Some(vec![]), /* skips IPA build since there's no target */


### PR DESCRIPTION
You break, you fix.

Supersedes #14804 

I rechecked #14668 for unintended changes.

If we cherry-pick f7d6378e952b678c8464c7d976c6473445d47352 onto the changes #14668 and run `git checkout pr-14668-plus-cherry && git diff HEAD~2` we can manually grep for `resolve\(` and check that all the original calls that were removed are replaced with an identical call to the new `fn resolve_dirs`. The one or two changes that are not of the form
```text
- crate::helpers::app_paths::resolve();
+ let dirs = crate::helpers::app_paths::resolve_dirs();
```
are within the same hunk and there are no function calls between the call sites that could affect the resolution.