### PR TITLE
chore: fix clippy lints

### DIFF
--- a/crates/tauri/src/test/mod.rs
+++ b/crates/tauri/src/test/mod.rs
@@ -243,6 +243,7 @@ pub fn assert_ipc_response<
   );
 }
 
+#[allow(clippy::needless_doctest_main)]
 /// Executes the given IPC message and get the return value.
 ///
 /// # Examples


### PR DESCRIPTION
having fn main here very much makes sense. the lint just doesn't see the context
