### PR TITLE
Add a new cert prefix for iPhone Distribution certs

### DIFF
--- a/crates/tauri-macos-sign/src/keychain/identity.rs
+++ b/crates/tauri-macos-sign/src/keychain/identity.rs
@@ -89,6 +89,7 @@ pub fn list(keychain_path: &Path) -> Result<Vec<Team>> {
     let mut certs = Vec::new();
     for cert_prefix in [
       "iOS Distribution:",
+      "iPhone Distribution:",
       "Apple Distribution:",
       "Developer ID Application:",
       "Mac App Distribution:",


### PR DESCRIPTION
We were just routinely updating our apple certificates. After selecting "iOS Distribution (App Store Connect and Ad Hoc)" we anded up with a certificate which was not recognized by Tauri, I guess because it had an unusual prefix: `iPhone Distribution: `.