### PR TITLE
chore(deps): unlock webkit2gtk patch version

### DIFF
--- a/.changes/unlock-webkitgtkrs.md
+++ b/.changes/unlock-webkitgtkrs.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:deps
+---
+
+Unlocked version range for webkit2gtk-rs dependency.

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -97,7 +97,7 @@ tray-icon = { version = "0.21", default-features = false, features = [
 # linux
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
-webkit2gtk = { version = "=2.0.2", features = ["v2_40"], optional = true }
+webkit2gtk = { version = "=2.0", features = ["v2_40"], optional = true }
 
 # darwin
 [target.'cfg(target_vendor = "apple")'.dependencies]

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -97,7 +97,7 @@ tray-icon = { version = "0.21", default-features = false, features = [
 # linux
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
-webkit2gtk = { version = "=2.0", features = ["v2_40"], optional = true }
+webkit2gtk = { version = "2", features = ["v2_40"], optional = true }
 
 # darwin
 [target.'cfg(target_vendor = "apple")'.dependencies]


### PR DESCRIPTION
draft until 2.10 is done publishing

ref https://github.com/tauri-apps/tauri/pull/14778#discussion_r2754493651 - turns out it was renovate, i always thought we did that intentionally