### PR TITLE
feat: re-export `url::form_urlencoded`

### DIFF
--- a/.changes/feat-re-export-from-url.md
+++ b/.changes/feat-re-export-from-url.md
@@ -1,0 +1,5 @@
+---
+"tauri": feat:minor
+---
+
+Re-export `url::form_urlencoded`

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -79,7 +79,7 @@ pub use tauri_macros::mobile_entry_point;
 pub use tauri_macros::{command, generate_handler};
 
 use tauri_utils::assets::AssetsIter;
-pub use url::Url;
+pub use url::{form_urlencoded, Url};
 
 pub(crate) mod app;
 pub mod async_runtime;


### PR DESCRIPTION
Useful when something likes

```rust
let mut url = match Url::parse(input)?;
url.query_pairs_mut()
                .extend_pairs(form_urlencoded::parse(dirty_params.as_bytes()));
```