### PR TITLE
fix(codegen): Context generation with custom assets

### DIFF
--- a/.changes/codegen-custom-context-assets-fix.md
+++ b/.changes/codegen-custom-context-assets-fix.md
@@ -1,0 +1,5 @@
+---
+"tauri-codegen": patch:bug
+---
+
+Fix `tauri::Context` code generation failing with `can't capture dynamic environment in a fn item` when custom assets are provided.


### PR DESCRIPTION
when custom assets are provided (`tauri::generate_context!(assets = my_assets)`) we can't use the fn inner logic directly and capture variables - we must pass them as arguments

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
