### PR TITLE
fix: call on_window_destroyed for all window kinds

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -696,10 +696,44 @@ wrap_life_span_handler! {
       }
     }
 
-    fn on_before_close(&self, _browser: Option<&mut Browser>) {
-      // if self.window_kind == WindowKind::Browser {
-      on_window_destroyed(self.window_id, &self.context);
-      // }
+    fn on_before_close(&self, browser: Option<&mut Browser>) {
+      match self.window_kind {
+        WindowKind::Browser => {
+          on_window_destroyed(self.window_id, &self.context);
+        }
+        WindowKind::Tauri => {
+          let Some(browser) = browser else {
+            return;
+          };
+          let browser_id = browser.identifier();
+
+          let mut windows = self.context.windows.borrow_mut();
+          let Some(app_window) = windows.get_mut(&self.window_id) else {
+            return;
+          };
+          let webview_index = app_window
+            .webviews
+            .iter()
+            .position(|w| *w.browser_id.borrow() == browser_id);
+          let Some(index) = webview_index else {
+            return;
+          };
+          let webview = app_window.webviews.remove(index);
+          let webview_id = webview.webview_id;
+          app_window
+            .webview_event_listeners
+            .lock()
+            .unwrap()
+            .remove(&webview_id);
+          drop(webview);
+
+          let is_last_in_window = app_window.webviews.is_empty();
+          if is_last_in_window {
+            drop(windows);
+            on_window_destroyed(self.window_id, &self.context);
+          }
+        }
+      }
     }
 
     fn on_before_popup(
@@ -989,6 +1023,7 @@ wrap_window_delegate! {
           window.set_title(Some(&CefString::from(title.as_str())));
         }
 
+        #[allow(unused_mut)]
         if let Some(mut inner_size) = &a.inner_size {
           if let Some(display) = window.display() {
             let scale = display.device_scale_factor() as f64;
@@ -2487,6 +2522,7 @@ fn handle_window_message<T: UserEvent>(
         }
       }
     }
+    #[allow(unused_mut)]
     WindowMessage::SetSize(mut size) => {
       if let Some(app_window) = context.windows.borrow().get(&window_id) {
         if let Some(window) = app_window.window() {
@@ -3044,17 +3080,16 @@ fn on_window_close(window_id: WindowId, windows: &Arc<RefCell<HashMap<WindowId, 
 }
 
 fn on_window_destroyed<T: UserEvent>(window_id: WindowId, context: &Context<T>) {
+  if context.windows.borrow().get(&window_id).is_none() {
+    return;
+  }
+
   let event = WindowEvent::Destroyed;
   send_window_event(window_id, &context.windows, &context.callback, event);
 
-  let window = {
+  {
     let mut guard = context.windows.borrow_mut();
-    guard.remove(&window_id)
-  };
-  let removed = window.is_some();
-  drop(window);
-  if !removed {
-    return;
+    guard.remove(&window_id);
   }
 
   let is_empty = context.windows.borrow().is_empty();

--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -697,9 +697,9 @@ wrap_life_span_handler! {
     }
 
     fn on_before_close(&self, _browser: Option<&mut Browser>) {
-      if self.window_kind == WindowKind::Browser {
-        on_window_destroyed(self.window_id, &self.context);
-      }
+      // if self.window_kind == WindowKind::Browser {
+      on_window_destroyed(self.window_id, &self.context);
+      // }
     }
 
     fn on_before_popup(

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use cef::{rc::Rc, CefString, ImplCommandLine, ImplTaskRunner};
+use cef::{CefString, ImplCommandLine, ImplTaskRunner};
 use tauri_runtime::{
   dpi::{PhysicalPosition, PhysicalSize, Position, Rect, Size},
   monitor::Monitor,
@@ -256,6 +256,7 @@ pub(crate) struct AppWebview {
   // so we need to use the browser_id to identify the browser
   pub browser_id: Arc<RefCell<i32>>,
   pub bounds: Arc<Mutex<Option<WebviewBounds>>>,
+  #[allow(unused)]
   pub devtools_enabled: bool,
   pub uri_scheme_protocols:
     Arc<HashMap<String, Arc<Box<tauri_runtime::webview::UriSchemeProtocolHandler>>>>,
@@ -302,7 +303,6 @@ impl AppWindow {
 
 #[derive(Clone)]
 pub struct RuntimeContext<T: UserEvent> {
-  windows: Arc<RefCell<HashMap<WindowId, AppWindow>>>,
   main_thread_task_runner: cef::TaskRunner,
   main_thread_id: ThreadId,
   cef_context: cef_impl::Context<T>,
@@ -1980,7 +1980,6 @@ impl<T: UserEvent> CefRuntime<T> {
 
     let main_thread_id = thread::current().id();
     let context = RuntimeContext {
-      windows: Default::default(),
       main_thread_task_runner: cef::task_runner_get_for_current_thread().expect("null task runner"),
       main_thread_id,
       cef_context,
@@ -2276,13 +2275,6 @@ impl<T: UserEvent> Runtime<T> for CefRuntime<T> {
 
       // Emit MainEventsCleared event
       (self.context.cef_context.callback.borrow())(RunEvent::MainEventsCleared);
-    }
-
-    let windows = self.context.windows.borrow();
-    for window in windows.values() {
-      if let AppWindowKind::Window(window) = &window.window {
-        assert!(window.has_one_ref());
-      }
     }
 
     cef::shutdown();


### PR DESCRIPTION
This is one possible fix for the "double X required to close app" issue but i feel like it's not the correct approach? @lucasfernog 

also seems to fix the macos exit crash