### PR TITLE
fix(cli): escape special characters in Android strings.xml productName (fix #14634)

### DIFF
--- a/.changes/android-escape-product-name.md
+++ b/.changes/android-escape-product-name.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Escape special characters in `productName` when generating Android `strings.xml`, fixing build failures when the name contains single quotes or other XML-unsafe characters.

--- a/crates/tauri-cli/src/mobile/init.rs
+++ b/crates/tauri-cli/src/mobile/init.rs
@@ -182,6 +182,7 @@ fn handlebars(app: &App) -> (Handlebars<'static>, JsonMap) {
   h.register_escape_fn(handlebars::no_escape);
 
   h.register_helper("html-escape", Box::new(html_escape));
+  h.register_helper("android-string-escape", Box::new(android_string_escape));
   h.register_helper("join", Box::new(join));
   h.register_helper("quote-and-join", Box::new(quote_and_join));
   h.register_helper(
@@ -225,6 +226,23 @@ fn html_escape(
   out
     .write(&handlebars::html_escape(get_str(helper)))
     .map_err(Into::into)
+}
+
+fn android_string_escape(
+  helper: &Helper,
+  _: &Handlebars,
+  _ctx: &Context,
+  _: &mut RenderContext,
+  out: &mut dyn Output,
+) -> HelperResult {
+  let raw = get_str(helper);
+  let escaped = raw
+    .replace('&', "&amp;")
+    .replace('<', "&lt;")
+    .replace('>', "&gt;")
+    .replace('"', "\\\"")
+    .replace('\'', "\\'");
+  out.write(&escaped).map_err(Into::into)
 }
 
 fn join(

--- a/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
+++ b/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">{{app.stylized-name}}</string>
-    <string name="main_activity_title">{{app.stylized-name}}</string>
+    <string name="app_name">{{android-string-escape app.stylized-name}}</string>
+    <string name="main_activity_title">{{android-string-escape app.stylized-name}}</string>
 </resources>


### PR DESCRIPTION
## Summary

- Adds an `android-string-escape` handlebars helper that escapes `&`, `<`, `>`, `"`, and `'` for Android string resources
- Uses the helper in the `strings.xml` template for `app_name` and `main_activity_title`

## Motivation

When `productName` in `tauri.conf.json` contains a single quote (e.g. `"Aircraft's Hub"`), `cargo tauri android init` generates invalid `strings.xml` that causes `aapt2` to fail during Android builds. The handlebars engine is configured with `no_escape`, so `{{app.stylized-name}}` is rendered raw.

## Approach

A new `android-string-escape` helper follows the existing pattern of `html-escape` and `escape-kotlin-keyword`. This keeps escaping explicit and visible in the template rather than silently modifying data before rendering. The helper handles both XML-level entities (`&amp;`, `&lt;`, `&gt;`) and Android string resource conventions (`\'`, `\"`).

## Test plan

- [x] `cargo check -p tauri-cli` compiles
- [x] `cargo clippy -p tauri-cli --no-deps` — no new warnings (3 pre-existing needless borrow warnings in unrelated code)
- [x] `cargo test -p tauri-cli` — all 47 tests pass
- [x] Verified `"Aircraft's Hub"` would produce `Aircraft\'s Hub` in the generated XML


🤖 Generated with [Claude Code](https://claude.com/claude-code)