### PR TITLE
fix(bundler): swap WIX registry search order to prioritize InstallDir

### DIFF
--- a/.changes/fix-wix-registry-search-order.md
+++ b/.changes/fix-wix-registry-search-order.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:bug
+---
+
+Fix WIX installer registry search order so that the named `InstallDir` key takes priority over the NSIS default key, preventing install location from changing on updates.

--- a/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
@@ -70,6 +70,10 @@
         <Property Id="ARPURLUPDATEINFO" Value="{{homepage}}"/>
         {{/if}}
 
+        <!-- NOTE: The order of RegistrySearch elements below matters. In WIX, when multiple
+             RegistrySearch elements are listed under a single Property, the LAST successful
+             match wins. We list the NSIS default-key search first and the MSI InstallDir
+             search second so that the MSI-specific path takes priority when both keys exist. -->
         <Property Id="INSTALLDIR">
           <!-- First attempt: Search for the default key value (this is how the nsis installer stores the path) -->
           <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />

--- a/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/main.wxs
@@ -71,11 +71,11 @@
         {{/if}}
 
         <Property Id="INSTALLDIR">
-          <!-- First attempt: Search for "InstallDir" -->
-          <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
-
-          <!-- Second attempt: If the first fails, search for the default key value (this is how the nsis installer currently stores the path) -->
+          <!-- First attempt: Search for the default key value (this is how the nsis installer stores the path) -->
           <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />
+
+          <!-- Second attempt: Search for "InstallDir" which takes priority if found (this is how the msi installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
         </Property>
 
         <!-- launch app checkbox -->


### PR DESCRIPTION
Fixes #14213

When both the NSIS default registry key and the named `InstallDir` key exist (e.g. after migrating from NSIS to WIX), the WIX installer was using the wrong install path on update. This happened because WIX evaluates multiple `RegistrySearch` entries within a `Property` and uses the last value found.

The previous order searched for `InstallDir` first and the NSIS default key second, so the default key would win when both existed. This caused apps installed to `C:\Program Files` to silently move to the AppData folder on update via the updater plugin.

This swaps the order so the NSIS default key is searched first (as a fallback), and the named `InstallDir` key is searched second, giving it priority when present.

As @FabianLars noted in the issue thread, swapping the two searches is the correct approach.