### PR TITLE
fix(cli): allow `build --bundles nsis` arg in linux+macOS

### DIFF
--- a/.changes/fix-build-bundles-arg.md
+++ b/.changes/fix-build-bundles-arg.md
@@ -1,4 +1,5 @@
 ---
+"tauri-bundler": patch:bug
 "tauri-cli": patch:bug
 "@tauri-apps/cli": patch:bug
 ---

--- a/.changes/fix-build-bundles-arg.md
+++ b/.changes/fix-build-bundles-arg.md
@@ -3,4 +3,4 @@
 "@tauri-apps/cli": patch:bug
 ---
 
-Fix `build --bundles` to allow `nsis` arg in linux.
+Fix `build --bundles` to allow `nsis` arg in linux+macOS

--- a/.changes/fix-build-bundles-arg.md
+++ b/.changes/fix-build-bundles-arg.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix `build --bundles` to allow `nsis` arg in linux.

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 
 mod category;
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 mod kmp;
 #[cfg(target_os = "linux")]
 mod linux;
@@ -17,10 +16,8 @@ mod windows;
 
 use tauri_utils::{display_path, platform::Target as TargetPlatform};
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 const BUNDLE_VAR_TOKEN: &[u8] = b"__TAURI_BUNDLE_TYPE_VAR_UNK";
 /// Patch a binary with bundle type information
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn patch_binary(binary: &PathBuf, package_type: &PackageType) -> crate::Result<()> {
   log::info!(
     "Patching {} with bundle type information: {}",
@@ -54,6 +51,17 @@ fn patch_binary(binary: &PathBuf, package_type: &PackageType) -> crate::Result<(
       return Err(crate::Error::InvalidPackageType(
         package_type.short_name().to_owned(),
         "Windows".to_owned(),
+      ))
+    }
+  };
+  #[cfg(target_os = "macos")]
+  let bundle_type = match package_type {
+    // NSIS installers can be built in macOS using cargo-xwin
+    crate::PackageType::Nsis => b"__TAURI_BUNDLE_TYPE_VAR_NSS",
+    _ => {
+      return Err(crate::Error::InvalidPackageType(
+        package_type.short_name().to_owned(),
+        "macOS".to_owned(),
       ))
     }
   };
@@ -135,7 +143,6 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<Bundle>> {
       continue;
     }
 
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
     if let Err(e) = patch_binary(&main_binary_path, package_type) {
       log::warn!("Failed to add bundler type to the binary: {e}. Updater plugin may not be able to update this package. This shouldn't normally happen, please report it to https://github.com/tauri-apps/tauri/issues");
     }

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -19,16 +19,6 @@ use tauri_utils::{display_path, platform::Target as TargetPlatform};
 const BUNDLE_VAR_TOKEN: &[u8] = b"__TAURI_BUNDLE_TYPE_VAR_UNK";
 /// Patch a binary with bundle type information
 fn patch_binary(binary: &PathBuf, package_type: &PackageType) -> crate::Result<()> {
-  log::info!(
-    "Patching {} with bundle type information: {}",
-    display_path(binary),
-    package_type.short_name()
-  );
-
-  let mut file_data = std::fs::read(binary).expect("Could not read binary file.");
-
-  let bundle_var_index =
-    kmp::index_of(BUNDLE_VAR_TOKEN, &file_data).ok_or(crate::Error::MissingBundleTypeVar)?;
   #[cfg(target_os = "linux")]
   let bundle_type = match package_type {
     crate::PackageType::Deb => b"__TAURI_BUNDLE_TYPE_VAR_DEB",
@@ -59,13 +49,20 @@ fn patch_binary(binary: &PathBuf, package_type: &PackageType) -> crate::Result<(
     // NSIS installers can be built in macOS using cargo-xwin
     crate::PackageType::Nsis => b"__TAURI_BUNDLE_TYPE_VAR_NSS",
     _ => {
-      return Err(crate::Error::InvalidPackageType(
-        package_type.short_name().to_owned(),
-        "macOS".to_owned(),
-      ))
+      // skip patching for macOS-native bundles
+      return Ok(())
     }
   };
 
+  log::info!(
+    "Patching {} with bundle type information: {}",
+    display_path(binary),
+    package_type.short_name()
+  );
+
+  let mut file_data = std::fs::read(binary).expect("Could not read binary file.");
+  let bundle_var_index =
+    kmp::index_of(BUNDLE_VAR_TOKEN, &file_data).ok_or(crate::Error::MissingBundleTypeVar)?;
   file_data[bundle_var_index..bundle_var_index + BUNDLE_VAR_TOKEN.len()]
     .copy_from_slice(bundle_type);
 

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -37,6 +37,8 @@ fn patch_binary(binary: &PathBuf, package_type: &PackageType) -> crate::Result<(
     crate::PackageType::Deb => b"__TAURI_BUNDLE_TYPE_VAR_DEB",
     crate::PackageType::Rpm => b"__TAURI_BUNDLE_TYPE_VAR_RPM",
     crate::PackageType::AppImage => b"__TAURI_BUNDLE_TYPE_VAR_APP",
+    // NSIS installers can be built in linux using cargo-xwin
+    crate::PackageType::Nsis => b"__TAURI_BUNDLE_TYPE_VAR_NSS",
     _ => {
       return Err(crate::Error::InvalidPackageType(
         package_type.short_name().to_owned(),

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -48,9 +48,15 @@ fn patch_binary(binary: &PathBuf, package_type: &PackageType) -> crate::Result<(
   let bundle_type = match package_type {
     // NSIS installers can be built in macOS using cargo-xwin
     crate::PackageType::Nsis => b"__TAURI_BUNDLE_TYPE_VAR_NSS",
-    _ => {
+    crate::PackageType::MacOsBundle | crate::PackageType::Dmg => {
       // skip patching for macOS-native bundles
       return Ok(())
+    }
+    _ => {
+      return Err(crate::Error::InvalidPackageType(
+        package_type.short_name().to_owned(),
+        "macOS".to_owned(),
+      ))
     }
   };
 

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -165,7 +165,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<Bundle>> {
 
       #[cfg(target_os = "windows")]
       PackageType::WindowsMsi => windows::msi::bundle_project(settings, false)?,
-      // note: don't restrict to windows as NSIS installers can be built in linux using cargo-xwin
+      // don't restrict to windows as NSIS installers can be built in linux+macOS using cargo-xwin
       PackageType::Nsis => windows::nsis::bundle_project(settings, false)?,
 
       #[cfg(target_os = "linux")]

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -50,7 +50,7 @@ fn patch_binary(binary: &PathBuf, package_type: &PackageType) -> crate::Result<(
     crate::PackageType::Nsis => b"__TAURI_BUNDLE_TYPE_VAR_NSS",
     crate::PackageType::MacOsBundle | crate::PackageType::Dmg => {
       // skip patching for macOS-native bundles
-      return Ok(())
+      return Ok(());
     }
     _ => {
       return Err(crate::Error::InvalidPackageType(

--- a/crates/tauri-bundler/src/bundle/kmp/mod.rs
+++ b/crates/tauri-bundler/src/bundle/kmp/mod.rs
@@ -5,7 +5,6 @@
 
 // Knuth–Morris–Pratt algorithm
 // based on https://github.com/howeih/rust_kmp
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub fn index_of(pattern: &[u8], target: &[u8]) -> Option<usize> {
   let failure_function = find_failure_function(pattern);
 
@@ -38,7 +37,6 @@ pub fn index_of(pattern: &[u8], target: &[u8]) -> Option<usize> {
   None
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn find_failure_function(pattern: &[u8]) -> Vec<usize> {
   let mut i = 1;
   let mut j = 0;

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -126,7 +126,7 @@ const ALL_PACKAGE_TYPES: &[PackageType] = &[
   PackageType::IosBundle,
   #[cfg(target_os = "windows")]
   PackageType::WindowsMsi,
-  #[cfg(any(target_os = "windows", target_os = "linux"))]
+  #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
   PackageType::Nsis,
   #[cfg(target_os = "macos")]
   PackageType::MacOsBundle,

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -126,7 +126,7 @@ const ALL_PACKAGE_TYPES: &[PackageType] = &[
   PackageType::IosBundle,
   #[cfg(target_os = "windows")]
   PackageType::WindowsMsi,
-  #[cfg(target_os = "windows")]
+  #[cfg(any(target_os = "windows", target_os = "linux"))]
   PackageType::Nsis,
   #[cfg(target_os = "macos")]
   PackageType::MacOsBundle,

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -126,7 +126,7 @@ const ALL_PACKAGE_TYPES: &[PackageType] = &[
   PackageType::IosBundle,
   #[cfg(target_os = "windows")]
   PackageType::WindowsMsi,
-  #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+  // NSIS installers can be built on all platforms but it's hidden in the --help output on macOS/Linux.
   PackageType::Nsis,
   #[cfg(target_os = "macos")]
   PackageType::MacOsBundle,

--- a/crates/tauri-cli/src/bundle.rs
+++ b/crates/tauri-cli/src/bundle.rs
@@ -43,7 +43,7 @@ impl ValueEnum for BundleFormat {
   }
 
   fn to_possible_value(&self) -> Option<PossibleValue> {
-    let hide = self.0 == PackageType::Updater;
+    let hide = (!cfg!(windows) && self.0 == PackageType::Nsis) || self.0 == PackageType::Updater;
     Some(PossibleValue::new(self.0.short_name()).hide(hide))
   }
 }


### PR DESCRIPTION
Allow `nsis` value to be passed as arg to `build` subcommand when cross-compiling windows binaries on linux hosts.

This was discussed way back in https://github.com/tauri-apps/tauri/pull/13943 but I hadn't gotten around to implementing it since omitting the `--bundles` flag when invoking `pnpm tauri build --target x86_64-pc-windows-msvc --runner cargo-xwin` would just result in both MSI and NSIS bundles being produced (with MSI bundling being a no-op on linux hosts).

This needs to be explicitly allowed now since https://github.com/tauri-apps/tauri/pull/14521 gated the windows bundling logic behind `#[cfg(target_os = "windows")]`.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
