### PR TITLE
fix(deps): disable default-features in objc2 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,36 +5072,8 @@ checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
 dependencies = [
  "bitflags 2.7.0",
  "block2 0.6.0",
- "libc",
  "objc2 0.6.0",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-foundation 0.3.0",
- "objc2-quartz-core 0.3.0",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1948a9be5f469deadbd6bcb86ad7ff9e47b4f632380139722f7d9840c0d42c"
-dependencies = [
- "bitflags 2.7.0",
- "objc2 0.6.0",
- "objc2-foundation 0.3.0",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f860f8e841f6d32f754836f51e6bc7777cd7e7053cf18528233f6811d3eceb4"
-dependencies = [
- "bitflags 2.7.0",
- "objc2 0.6.0",
  "objc2-foundation 0.3.0",
 ]
 
@@ -5122,19 +5094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
 dependencies = [
  "bitflags 2.7.0",
- "objc2 0.6.0",
  "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffa6bea72bf42c78b0b34e89c0bafac877d5f80bf91e159a5d96ea7f693ca56"
-dependencies = [
- "objc2 0.6.0",
- "objc2-foundation 0.3.0",
 ]
 
 [[package]]
@@ -5172,18 +5132,6 @@ checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
  "bitflags 2.7.0",
  "block2 0.6.0",
- "libc",
- "objc2 0.6.0",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
-dependencies = [
- "bitflags 2.7.0",
  "objc2 0.6.0",
  "objc2-core-foundation",
 ]
@@ -5214,28 +5162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-quartz-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb3794501bb1bee12f08dcad8c61f2a5875791ad1c6f47faa71a0f033f20071"
-dependencies = [
- "bitflags 2.7.0",
- "objc2 0.6.0",
- "objc2-foundation 0.3.0",
-]
-
-[[package]]
-name = "objc2-security"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3126341c65c5d5728423ae95d788e1b660756486ad0592307ab87ba02d9a7268"
-dependencies = [
- "bitflags 2.7.0",
- "objc2 0.6.0",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-ui-kit"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5259,7 +5185,6 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
- "objc2-security",
 ]
 
 [[package]]
@@ -8044,7 +7969,7 @@ dependencies = [
  "log",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
+ "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
  "wasm-bindgen",
@@ -8905,7 +8830,6 @@ dependencies = [
  "log",
  "objc2 0.6.0",
  "objc2-app-kit",
- "objc2-foundation 0.3.0",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -46,8 +46,7 @@ percent-encoding = "2"
 objc2 = "0.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-foundation = { version = "0.3", features = [] }
-objc2-app-kit = { version = "0.3", features = [
+objc2-app-kit = { version = "0.3", default-features = false, features = [
   "block2",
   "NSApplication",
   "NSResponder",

--- a/crates/tauri-runtime-wry/src/window/macos.rs
+++ b/crates/tauri-runtime-wry/src/window/macos.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use objc2::MainThreadMarker;
 use objc2_app_kit::{NSBackingStoreType, NSWindow, NSWindowStyleMask};
-use objc2_foundation::MainThreadMarker;
 use tao::platform::macos::WindowExtMacOS;
 
 impl super::WindowExt for tao::window::Window {

--- a/crates/tauri-runtime/Cargo.toml
+++ b/crates/tauri-runtime/Cargo.toml
@@ -59,7 +59,11 @@ objc2-ui-kit = { version = "0.3.0", default-features = false, features = [
 [target."cfg(target_os = \"macos\")".dependencies]
 url = "2"
 objc2 = "0.6"
-objc2-web-kit = { version = "0.3", features = ["objc2-app-kit", "WKWebView"] }
+objc2-web-kit = { version = "0.3", default-features = false, features = [
+  "objc2-app-kit",
+  "WKWebView",
+  "WKWebViewConfiguration",
+] }
 
 [features]
 devtools = []

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -121,9 +121,10 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSWindow",
   "NSImage",
 ] }
-objc2-web-kit = { version = "0.3", features = [
+objc2-web-kit = { version = "0.3", default-features = false, features = [
   "objc2-app-kit",
   "WKWebView",
+  "WKWebViewConfiguration",
   "WKUserContentController",
 ] }
 window-vibrancy = "0.6"

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -2414,9 +2414,9 @@ fn on_event_loop_event<R: Runtime>(
       // set the app icon in development
       #[cfg(all(dev, target_os = "macos"))]
       {
-        use objc2::AllocAnyThread;
+        use objc2::{AllocAnyThread, MainThreadMarker};
         use objc2_app_kit::{NSApplication, NSImage};
-        use objc2_foundation::{MainThreadMarker, NSData};
+        use objc2_foundation::NSData;
 
         if let Some(icon) = app_handle.manager.app_icon.clone() {
           // TODO: Enable this check.

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -1248,7 +1248,7 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   ///       #[cfg(target_os = "ios")]
   ///       {
   ///         window_builder = window_builder.with_input_accessory_view_builder(|_webview| unsafe {
-  ///           let mtm = objc2_foundation::MainThreadMarker::new_unchecked();
+  ///           let mtm = objc2::MainThreadMarker::new_unchecked();
   ///           let button = objc2_ui_kit::UIButton::buttonWithType(objc2_ui_kit::UIButtonType(1), mtm);
   ///           button.setTitle_forState(
   ///             Some(&objc2_foundation::NSString::from_str("Tauri")),


### PR DESCRIPTION
We are mistakenly using default features in the crates: `objc2-foundation`, `objc2-app-kit`, and `objc2-web-kit`.

Also, `tauri-runtime-wry` doesn't need to depend on `objc2-foundation` at all: `objc2_foundation::MainThreadMarker` is deprecated and was moved to `objc2::MainThreadMarker`.


Here's the before/after result of `CARGO_PROFILE_RELEASE_LTO=fat cargo llvm-lines -p tauri --example helloworld --release`:

Before:
```
  Lines                  Copies                Function name
  -----                  ------                -------------
  2427243                107287                (TOTAL)
```

After:

```
  Lines                  Copies               Function name
  -----                  ------               -------------
  2234525                93674                (TOTAL)
```