### PR TITLE
ci: declare explicit permissions for lint, test, and check workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,6 +16,9 @@ on:
       - '**/package.json'
       - '**/pnpm-lock.yaml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check-change-tags.yml
+++ b/.github/workflows/check-change-tags.yml
@@ -9,6 +9,10 @@ on:
     paths:
       - '.changes/*.md'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -15,6 +15,10 @@ on:
       - 'crates/tauri-cli/config.schema.json'
       - 'crates/tauri-schema-generator/schemas/*.json'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check-license-header.yml
+++ b/.github/workflows/check-license-header.yml
@@ -7,6 +7,10 @@ name: check license headers
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -7,6 +7,9 @@ name: check formatting
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -10,6 +10,9 @@ on:
       - '.github/workflows/lint-js.yml'
       - 'packages/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -13,6 +13,9 @@ on:
       - '.github/workflows/lint-rust.yml'
       - 'crates/**'
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0 # This would add unnecessary bloat to the target folder, decreasing cache efficiency.

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -17,6 +17,9 @@ on:
       - 'crates/tauri/mobile/android-codegen/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-cli-js.yml
+++ b/.github/workflows/test-cli-js.yml
@@ -15,6 +15,9 @@ on:
       # currently` @tauri-apps/cli` only tests the template
       - 'crates/tauri-cli/templates/app/**'
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0 # This would add unnecessary bloat to the target folder, decreasing cache efficiency.

--- a/.github/workflows/test-cli-rs.yml
+++ b/.github/workflows/test-cli-rs.yml
@@ -15,6 +15,9 @@ on:
       - 'crates/tauri-bundler/**'
       - 'crates/tauri-cli/**'
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0 # This would add unnecessary bloat to the target folder, decreasing cache efficiency.

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -18,6 +18,9 @@ on:
       - '!crates/tauri-macos-sign/**'
       - '!crates/tauri-schema-generator/**'
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0 # This would add unnecessary bloat to the target folder, decreasing cache efficiency.

--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_PROFILE_DEV_DEBUG: 0 # This would add unnecessary bloat to the target folder, decreasing cache efficiency.


### PR DESCRIPTION
## Summary\nAdd explicit least-privilege workflow token permissions to core CI workflows that currently rely on implicit defaults.\n\n## Updated workflows\n- `.github/workflows/audit.yml`\n- `.github/workflows/check-change-tags.yml`\n- `.github/workflows/check-generated-files.yml`\n- `.github/workflows/check-license-header.yml`\n- `.github/workflows/fmt.yml`\n- `.github/workflows/lint-js.yml`\n- `.github/workflows/lint-rust.yml`\n- `.github/workflows/test-android.yml`\n- `.github/workflows/test-cli-js.yml`\n- `.github/workflows/test-cli-rs.yml`\n- `.github/workflows/test-core.yml`\n- `.github/workflows/udeps.yml`\n\n## Permission choices\n- Most workflows: `contents: read`\n- PR metadata checks using paths-filter: `contents: read` + `pull-requests: read`\n\n## Why\nExplicit permissions reduce default token scope and make workflow intent clear and auditable.\n\n## Notes\n- configuration-only changes\n- no build/test logic modified\n