### PR TITLE
feat: bump Android Gradle Plugin to 9.0.1 and dependencies 

### DIFF
--- a/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
@@ -2,7 +2,6 @@ import java.util.Properties
 
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     id("rust")
     {{~#each android-app-plugins}}
     id("{{this}}"){{/each}}
@@ -47,12 +46,13 @@ android {
             )
         }
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
     buildFeatures {
         buildConfig = true
     }
+}
+
+kotlin {
+    jvmToolchain(8)
 }
 
 rust {
@@ -64,13 +64,13 @@ dependencies {
     implementation(platform("{{this}}")){{/each}}
     {{~#each android-app-dependencies}}
     implementation("{{this}}"){{/each}}
-    implementation("androidx.webkit:webkit:1.14.0")
+    implementation("androidx.webkit:webkit:1.15.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
-    implementation("androidx.activity:activity-ktx:1.10.1")
-    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.activity:activity-ktx:1.12.4")
+    implementation("com.google.android.material:material:1.13.0")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.4")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.0")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 }
 
 apply(from = "tauri.build.gradle.kts")

--- a/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
@@ -52,7 +52,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(24)
 }
 
 rust {

--- a/crates/tauri-cli/templates/mobile/android/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/build.gradle.kts
@@ -4,8 +4,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.11.0")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25")
+        classpath("com.android.tools.build:gradle:9.0.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.10")
         {{~#each android-project-dependencies}}
         classpath("{{this}}"){{/each}}
     }

--- a/crates/tauri-cli/templates/mobile/android/buildSrc/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/buildSrc/build.gradle.kts
@@ -18,6 +18,6 @@ repositories {
 
 dependencies {
     compileOnly(gradleApi())
-    implementation("com.android.tools.build:gradle:8.11.0")
+    implementation("com.android.tools.build:gradle:9.0.1")
 }
 

--- a/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
+++ b/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/BuildTask.kt
@@ -1,12 +1,15 @@
-import java.io.File
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
 
-open class BuildTask : DefaultTask() {
+open class BuildTask @Inject constructor(
+    private val execOperations: ExecOperations
+) : DefaultTask() {
     @Input
     var rootDirRel: String? = null
     @Input
@@ -16,7 +19,7 @@ open class BuildTask : DefaultTask() {
 
     @TaskAction
     fun assemble() {
-        val executable = """{{tauri-binary}}""";
+        val executable = """{{tauri-binary}}"""
         try {
             runTauriCli(executable)
         } catch (e: Exception) {
@@ -39,7 +42,7 @@ open class BuildTask : DefaultTask() {
                 }
                 throw lastException
             } else {
-                throw e;
+                throw e
             }
         }
     }
@@ -48,21 +51,21 @@ open class BuildTask : DefaultTask() {
         val rootDirRel = rootDirRel ?: throw GradleException("rootDirRel cannot be null")
         val target = target ?: throw GradleException("target cannot be null")
         val release = release ?: throw GradleException("release cannot be null")
-        val args = listOf({{quote-and-join tauri-binary-args}});
+        val args = listOf({{quote-and-join tauri-binary-args}})
 
-        project.exec {
-            workingDir(File(project.projectDir, rootDirRel))
+        execOperations.exec {
+            workingDir(rootDirRel)
             executable(executable)
             args(args)
-            if (project.logger.isEnabled(LogLevel.DEBUG)) {
+            if (logger.isEnabled(LogLevel.DEBUG)) {
                 args("-vv")
-            } else if (project.logger.isEnabled(LogLevel.INFO)) {
+            } else if (logger.isEnabled(LogLevel.INFO)) {
                 args("-v")
             }
             if (release) {
                 args("--release")
             }
-            args(listOf("--target", target))
-        }.assertNormalExitValue()
+            args("--target", target)
+        }
     }
 }

--- a/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/RustPlugin.kt
+++ b/crates/tauri-cli/templates/mobile/android/buildSrc/src/main/kotlin/RustPlugin.kt
@@ -17,10 +17,10 @@ open class RustPlugin : Plugin<Project> {
     override fun apply(project: Project) = with(project) {
         config = extensions.create("rust", Config::class.java)
 
-        val defaultAbiList = listOf({{quote-and-join abi-list}});
+        val defaultAbiList = listOf({{quote-and-join abi-list}})
         val abiList = (findProperty("abiList") as? String)?.split(',') ?: defaultAbiList
 
-        val defaultArchList = listOf({{quote-and-join arch-list}});
+        val defaultArchList = listOf({{quote-and-join arch-list}})
         val archList = (findProperty("archList") as? String)?.split(',') ?: defaultArchList
 
         val targetsList = (findProperty("targetList") as? String)?.split(',') ?: listOf({{quote-and-join target-list}})
@@ -69,7 +69,7 @@ open class RustPlugin : Plugin<Project> {
                     ).apply {
                         group = TASK_GROUP
                         description = "Build dynamic library in $profile mode for $targetArch"
-                        rootDirRel = config.rootDirRel
+                        rootDirRel = layout.projectDirectory.dir(config.rootDirRel).toString()
                         target = targetName
                         release = profile == "release"
                     }

--- a/crates/tauri-cli/templates/mobile/android/gradle.properties
+++ b/crates/tauri-cli/templates/mobile/android/gradle.properties
@@ -21,4 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-android.nonFinalResIds=false

--- a/crates/tauri-cli/templates/mobile/android/gradle.properties
+++ b/crates/tauri-cli/templates/mobile/android/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 -Dlint.use.fir.uast=false
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/crates/tauri-cli/templates/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/crates/tauri-cli/templates/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 10 19:22:52 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/crates/tauri-cli/templates/mobile/android/settings.gradle
+++ b/crates/tauri-cli/templates/mobile/android/settings.gradle
@@ -1,3 +1,6 @@
+plugins {
+  id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
 include ':app'
 {{~#each asset-packs}}
 include ':{{this}}'{{/each}}

--- a/crates/tauri-cli/templates/plugin/android/build.gradle.kts
+++ b/crates/tauri-cli/templates/plugin/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {
@@ -11,7 +10,11 @@ android {
         minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
+
+        val proguardFile = file("consumer-rules.pro")
+        if (proguardFile.exists()) {
+            consumerProguardFiles(proguardFile)
+        }
     }
 
     buildTypes {
@@ -23,22 +26,18 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+}
+
+kotlin {
+    jvmToolchain(8)
 }
 
 dependencies {
-
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.6.0")
-    implementation("com.google.android.material:material:1.7.0")
+    implementation("androidx.core:core-ktx:1.17.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("com.google.android.material:material:1.13.0")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
     implementation(project(":tauri-android"))
 }

--- a/crates/tauri-cli/templates/plugin/android/build.gradle.kts
+++ b/crates/tauri-cli/templates/plugin/android/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(24)
 }
 
 dependencies {

--- a/crates/tauri-cli/templates/plugin/android/settings.gradle
+++ b/crates/tauri-cli/templates/plugin/android/settings.gradle
@@ -8,10 +8,7 @@ pluginManagement {
         eachPlugin {
             switch (requested.id.id) {
                 case "com.android.library":
-                    useVersion("8.0.2")
-                    break
-                case "org.jetbrains.kotlin.android":
-                    useVersion("1.8.20")
+                    useVersion("9.0.1")
                     break
             }
         }

--- a/crates/tauri/mobile/android/build.gradle.kts
+++ b/crates/tauri/mobile/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {
@@ -23,25 +22,21 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
     buildFeatures {
         buildConfig = true
     }
 }
 
-dependencies {
+kotlin {
+    jvmToolchain(8)
+}
 
-    implementation("androidx.core:core-ktx:1.7.0")
-    implementation("androidx.appcompat:appcompat:1.6.0")
-    implementation("com.google.android.material:material:1.7.0")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.3")
+dependencies {
+    implementation("androidx.core:core-ktx:1.17.0")
+    implementation("androidx.appcompat:appcompat:1.7.1")
+    implementation("com.google.android.material:material:1.13.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.21.0")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 }

--- a/crates/tauri/mobile/android/build.gradle.kts
+++ b/crates/tauri/mobile/android/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(24)
 }
 
 dependencies {

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/AppPlugin.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/AppPlugin.kt
@@ -15,7 +15,7 @@ import app.tauri.plugin.Invoke
 import app.tauri.plugin.JSObject
 
 @TauriPlugin
-class AppPlugin(private val activity: Activity): Plugin(activity) {
+class AppPlugin(private val activity: AppCompatActivity): Plugin(activity) {
   private val BACK_BUTTON_EVENT = "back-button"
 
   private var webView: WebView? = null
@@ -32,7 +32,7 @@ class AppPlugin(private val activity: Activity): Plugin(activity) {
             this@AppPlugin.webView!!.goBack()
           } else {
             this.isEnabled = false
-            this@AppPlugin.activity.onBackPressed()
+            this@AppPlugin.activity.onBackPressedDispatcher.onBackPressed()
             this.isEnabled = true
           }
         } else {
@@ -43,7 +43,7 @@ class AppPlugin(private val activity: Activity): Plugin(activity) {
         }
       }
     }
-    (activity as AppCompatActivity).onBackPressedDispatcher.addCallback(activity, callback)
+    activity.onBackPressedDispatcher.addCallback(activity, callback)
   }
 
   @Command

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/AppPlugin.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/AppPlugin.kt
@@ -4,7 +4,6 @@
 
 package app.tauri
 
-import android.app.Activity
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginHandle.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginHandle.kt
@@ -143,9 +143,9 @@ class PluginHandle(private val manager: PluginManager, val name: String, val ins
 
   private fun indexMethods() {
     val methods = mutableListOf<Method>()
-    var pluginCursor: Class<*> = instance.javaClass
-    while (pluginCursor.name != Any::class.java.name) {
-      methods.addAll(listOf(*pluginCursor.declaredMethods))
+    var pluginCursor: Class<*>? = instance.javaClass
+    while (pluginCursor != null && pluginCursor != Any::class.java) {
+      methods.addAll(pluginCursor.declaredMethods)
       pluginCursor = pluginCursor.superclass
     }
 

--- a/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
@@ -33,11 +33,11 @@ kotlin {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.6.0")
-    implementation("com.google.android.material:material:1.7.0")
+    implementation("androidx.core:core-ktx:1.17.0")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.13.0")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
     implementation(project(":tauri-android"))
 }

--- a/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(24)
 }
 
 dependencies {

--- a/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android")
 }
 
 android {
@@ -11,7 +10,11 @@ android {
         minSdk = 21
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
+
+        val proguardFile = file("consumer-rules.pro")
+        if (proguardFile.exists()) {
+            consumerProguardFiles(proguardFile)
+        }
     }
 
     buildTypes {
@@ -23,17 +26,13 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
+}
+
+kotlin {
+    jvmToolchain(8)
 }
 
 dependencies {
-
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.0")
     implementation("com.google.android.material:material:1.7.0")

--- a/examples/api/src-tauri/tauri-plugin-sample/android/settings.gradle
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/settings.gradle
@@ -8,10 +8,7 @@ pluginManagement {
         eachPlugin {
             switch (requested.id.id) {
                 case "com.android.library":
-                    useVersion("8.0.2")
-                    break
-                case "org.jetbrains.kotlin.android":
-                    useVersion("1.8.20")
+                    useVersion("9.0.1")
                     break
             }
         }


### PR DESCRIPTION
This PR updates the Android build environment and dependencies to leverage latest tooling and frameworks for improved stability and compatibility.

## What's Changed

### Dependencies
- **Gradle**: 8.14.3 → 9.3.1
- **Android Gradle Plugin**: 8.11.0 → 9.0.1  
- **Kotlin**: 1.9.25 → 2.3.10
- **Kotlin Gradle Plugin**: 1.8.20 → 9.0.1
- `androidx.core:core-ktx`: 1.7.0 → 1.17.0
- `androidx.appcompat:appcompat`: 1.6.0 → 1.7.1
- `androidx.activity:activity-ktx`: 1.10.1 → 1.12.4
- `androidx.webkit:webkit`: 1.14.0 → 1.15.0
- `com.google.android.material:material`: 1.12.0 → 1.13.0
- `androidx.test.ext:junit`: 1.1.4 → 1.3.0
- `androidx.test.espresso:espresso-core`: 3.5.0 → 3.7.0

### Kotlin
- Update JVM target to Java 24

### Gradle
- Add `-Dlint.use.fir.uast=false` flag for FIR compatibility
