### PR TITLE
fix(tauri-utils): sort csp/plugin/header config maps during codegen so `generate_context!` is deterministic

### DIFF
--- a/.changes/fix-nondeterministic-context-codegen.md
+++ b/.changes/fix-nondeterministic-context-codegen.md
@@ -1,0 +1,5 @@
+---
+'tauri-utils': 'patch:bug'
+---
+
+Sort csp/plugin/header configs when generating HashMap constructors so that `generate_context!` is deterministic.

--- a/.changes/fix-nondeterministic-context-codegen.md
+++ b/.changes/fix-nondeterministic-context-codegen.md
@@ -3,3 +3,5 @@
 ---
 
 Sort csp/plugin/header configs when generating HashMap constructors so that `generate_context!` is deterministic.
+
+See: https://github.com/tauri-apps/tauri/issues/14978 for more information

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -3842,6 +3842,9 @@ mod build {
           quote!(#prefix::Policy(#policy.into()))
         }
         Self::DirectiveMap(list) => {
+          // Pass a sorted vec so the HashMap constructor is deterministic
+          // see: https://github.com/tauri-apps/tauri/issues/14978
+          // TODO: Remove this in v3, use a BTreeMap instead of a HashMap
           let mut sorted: Vec<_> = list.iter().collect();
           sorted.sort_by_key(|(k, _)| *k);
           let map = map_lit(
@@ -3902,6 +3905,9 @@ mod build {
           quote!(#prefix::List(#list))
         }
         Self::Map(m) => {
+          // Pass a sorted vec so the HashMap constructor is deterministic
+          // see: https://github.com/tauri-apps/tauri/issues/14978
+          // TODO: Remove this in v3, use a BTreeMap instead of a HashMap
           let mut sorted: Vec<_> = m.iter().collect();
           sorted.sort_by_key(|(k, _)| *k);
           let map = map_lit(
@@ -4056,6 +4062,9 @@ mod build {
 
   impl ToTokens for PluginConfig {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+      // Pass a sorted vec so the HashMap constructor is deterministic
+      // see: https://github.com/tauri-apps/tauri/issues/14978
+      // TODO: Remove this in v3, use a BTreeMap instead of a HashMap
       let mut sorted: Vec<_> = self.0.iter().collect();
       sorted.sort_by_key(|(k, _)| *k);
       let config = map_lit(

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -3842,9 +3842,11 @@ mod build {
           quote!(#prefix::Policy(#policy.into()))
         }
         Self::DirectiveMap(list) => {
+          let mut sorted: Vec<_> = list.iter().collect();
+          sorted.sort_by_key(|(k, _)| *k);
           let map = map_lit(
             quote! { ::std::collections::HashMap },
-            list,
+            sorted,
             str_lit,
             identity,
           );
@@ -3900,7 +3902,14 @@ mod build {
           quote!(#prefix::List(#list))
         }
         Self::Map(m) => {
-          let map = map_lit(quote! { ::std::collections::HashMap }, m, str_lit, str_lit);
+          let mut sorted: Vec<_> = m.iter().collect();
+          sorted.sort_by_key(|(k, _)| *k);
+          let map = map_lit(
+            quote! { ::std::collections::HashMap },
+            sorted,
+            str_lit,
+            str_lit,
+          );
           quote!(#prefix::Map(#map))
         }
       })
@@ -4047,9 +4056,11 @@ mod build {
 
   impl ToTokens for PluginConfig {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+      let mut sorted: Vec<_> = self.0.iter().collect();
+      sorted.sort_by_key(|(k, _)| *k);
       let config = map_lit(
         quote! { ::std::collections::HashMap },
-        &self.0,
+        sorted,
         str_lit,
         json_value_lit,
       );


### PR DESCRIPTION
Fixes https://github.com/tauri-apps/tauri/issues/14978

It would be nicer to convert these HashMaps to BTreeMaps, but that would be a breaking change.
