### PR TITLE
fix(cli): ignore keystore.properties in Android templates

### DIFF
--- a/crates/tauri-cli/templates/mobile/android/.gitignore
+++ b/crates/tauri-cli/templates/mobile/android/.gitignore
@@ -14,6 +14,7 @@ build
 .cxx
 local.properties
 key.properties
+keystore.properties
 
 /.tauri
 /tauri.settings.gradle


### PR DESCRIPTION
In this pull request, I added `keystore.properties` to the ignore list for the Android templates.
The official tutorial recommends creating this file for app signing, and this change helps prevent it from being accidentally committed to the repository since it contain sensitive information.

Reference: https://v2.tauri.app/distribute/sign/android/#configure-the-signing-key