### PR TITLE
Add AI tool policy to contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Hi! We, the maintainers, are really excited that you are interested in contribut
 - [Issue Reporting Guidelines](#issue-reporting-guidelines)
 - [Pull Request Guidelines](#pull-request-guidelines)
 - [Development Guide](#development-guide)
+- [AI Tool Policy](#ai-tool-policy)
 
 ## Issue Reporting Guidelines
 
@@ -103,6 +104,16 @@ $ cargo +nightly doc --all-features --open
 
 The JS API provides bindings between the developer's JS in the Webview and the built-in Tauri APIs, written in Rust. Its code is located in [/packages/api](https://github.com/tauri-apps/tauri/tree/dev/packages/api).
 After making changes to the code, run `pnpm build` to build it. To test your changes, we recommend using the API example app, located in [/examples/api](https://github.com/tauri-apps/tauri/tree/dev/examples/api). It will automatically use your local copy of the JS API and provides a helpful UI to test the various commands.
+
+## AI Tool Policy
+
+It takes a lot of time to review a Pull Request while too easy to make a nonsense but plausible looking one using AI tools.
+It is unfair for other contributors and the reviewers to spend much of the time dealing with this, hence these rules:
+
+1. Review and test all LLM-generated content before submitting, you're the one responsible for it, not the AI.
+2. Don't use AI to respond to review comments (execpt only for translations)
+
+We will close the Pull Request with a `ai-slop` tag if you failed to do so.
 
 ## Financial Contribution
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,7 +107,7 @@ After making changes to the code, run `pnpm build` to build it. To test your cha
 
 ## AI Tool Policy
 
-It takes a lot of time to review a Pull Request while it's very easy to make a nonsense but plausible looking one using AI tools.
+It takes a lot of time to review a Pull Request while it's very easy to make a nonsensical but plausible looking one using AI tools.
 It is unfair for other contributors and the reviewers to spend much of the time dealing with this, hence these rules:
 
 1. Review and test all LLM-generated content before submitting, you're the one responsible for it, not the AI.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -107,11 +107,11 @@ After making changes to the code, run `pnpm build` to build it. To test your cha
 
 ## AI Tool Policy
 
-It takes a lot of time to review a Pull Request while too easy to make a nonsense but plausible looking one using AI tools.
+It takes a lot of time to review a Pull Request while it's very easy to make a nonsense but plausible looking one using AI tools.
 It is unfair for other contributors and the reviewers to spend much of the time dealing with this, hence these rules:
 
 1. Review and test all LLM-generated content before submitting, you're the one responsible for it, not the AI.
-2. Don't use AI to respond to review comments (execpt only for translations)
+2. Don't use AI to respond to review comments (except for translations).
 
 We will close the Pull Request with a `ai-slop` tag if you failed to do so.
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

We have seen a big rise on fully AI/LLM generated Pull Requests in the past month. It is a huge waste of time for us and unfair to PRs wrote by actual people 

This is a draft for a policy that will allow us to justifiable closing such PRs

Very much open to suggestions on this one