### PR TITLE
feat(cef): add WebviewBuilder::on_address_change

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -441,7 +441,7 @@ wrap_load_handler! {
 wrap_display_handler! {
   struct BrowserDisplayHandler {
     document_title_changed_handler: Option<Arc<tauri_runtime::webview::DocumentTitleChangedHandler>>,
-    navigation_handler: Option<Arc<tauri_runtime::webview::NavigationHandler>>,
+    address_changed_handler: Option<Arc<dyn Fn(&url::Url) + Send + Sync>>,
   }
 
   impl DisplayHandler {
@@ -464,14 +464,15 @@ wrap_display_handler! {
     ) {
       // Only fire for main frame URL changes (matches on_before_browse behavior)
       if let Some(frame) = frame {
-        if frame.is_main() == 0 { return; }
+        if frame.is_main() == 0 {
+          return;
+        }
       }
-      let Some(handler) = &self.navigation_handler else { return };
+      let Some(handler) = &self.address_changed_handler else { return };
       let Some(url) = url else { return };
       let url_str = url.to_string();
-      if let Ok(parsed) = url::Url::parse(&url_str) {
-        let _ = handler(&parsed);
-      }
+      let Ok(parsed) = url::Url::parse(&url_str) else { return };
+      handler(&parsed);
     }
   }
 }
@@ -939,6 +940,7 @@ wrap_client! {
     on_page_load_handler: Option<Arc<tauri_runtime::webview::OnPageLoadHandler>>,
     document_title_changed_handler: Option<Arc<tauri_runtime::webview::DocumentTitleChangedHandler>>,
     navigation_handler: Option<Arc<tauri_runtime::webview::NavigationHandler>>,
+    address_changed_handler: Option<Arc<dyn Fn(&url::Url) + Send + Sync>>,
     new_window_handler: Option<Arc<tauri_runtime::webview::NewWindowHandler<T, crate::CefRuntime<T>>>>,
     download_handler: Option<Arc<tauri_runtime::webview::DownloadHandler>>,
     devtools_enabled: bool,
@@ -976,14 +978,10 @@ wrap_client! {
     }
 
     fn display_handler(&self) -> Option<DisplayHandler> {
-      if self.document_title_changed_handler.is_some() || self.navigation_handler.is_some() {
-        Some(BrowserDisplayHandler::new(
-          self.document_title_changed_handler.clone(),
-          self.navigation_handler.clone(),
-        ))
-      } else {
-        None
-      }
+      Some(BrowserDisplayHandler::new(
+        self.document_title_changed_handler.clone(),
+        self.address_changed_handler.clone(),
+      ))
     }
 
     fn download_handler(&self) -> Option<DownloadHandler> {
@@ -3016,7 +3014,7 @@ fn create_browser_window<T: UserEvent>(
     label: webview_label,
     opener: _,
     mut webview_attributes,
-    platform_specific_attributes: _,
+    platform_specific_attributes,
     uri_scheme_protocols,
     ipc_handler: _,
     navigation_handler,
@@ -3027,6 +3025,16 @@ fn create_browser_window<T: UserEvent>(
     mut on_page_load_handler,
     download_handler,
   } = webview;
+
+  let address_changed_handler: Option<Arc<dyn Fn(&url::Url) + Send + Sync>> =
+    platform_specific_attributes
+      .into_iter()
+      .find_map(|attr| match attr {
+        WebviewAtribute::AddressChangedHandler(f) => {
+          Some(Arc::new(move |url: &url::Url| f(url)) as Arc<dyn Fn(&url::Url) + Send + Sync>)
+        }
+        _ => None,
+      });
 
   let initialization_scripts = std::mem::take(&mut webview_attributes.initialization_scripts)
     .into_iter()
@@ -3088,6 +3096,7 @@ fn create_browser_window<T: UserEvent>(
     on_page_load_handler,
     document_title_changed_handler,
     navigation_handler,
+    address_changed_handler,
     new_window_handler,
     download_handler,
     devtools_enabled,
@@ -3463,6 +3472,21 @@ pub(crate) fn create_webview<T: UserEvent>(
   let document_title_changed_handler = document_title_changed_handler.map(Arc::from);
   let navigation_handler = navigation_handler.map(Arc::from);
   let new_window_handler = new_window_handler.map(Arc::from);
+  let (address_changed_handler, platform_specific_attributes) = {
+    let mut handler = None;
+    let attrs: Vec<_> = platform_specific_attributes
+      .into_iter()
+      .filter_map(|attr| match attr {
+        WebviewAtribute::AddressChangedHandler(f) => {
+          handler =
+            Some(Arc::new(move |url: &url::Url| f(url)) as Arc<dyn Fn(&url::Url) + Send + Sync>);
+          None
+        }
+        other => Some(other),
+      })
+      .collect();
+    (handler, attrs)
+  };
 
   let devtools_enabled = (cfg!(debug_assertions) || cfg!(feature = "devtools"))
     && webview_attributes.devtools.unwrap_or(true);
@@ -3489,6 +3513,7 @@ pub(crate) fn create_webview<T: UserEvent>(
     on_page_load_handler,
     document_title_changed_handler,
     navigation_handler,
+    address_changed_handler,
     new_window_handler,
     download_handler,
     devtools_enabled,
@@ -3641,10 +3666,10 @@ pub(crate) fn create_webview<T: UserEvent>(
       browser_id.clone(),
       platform_specific_attributes
         .iter()
-        .map(|attr| match attr {
-          WebviewAtribute::RuntimeStyle { style } => *style,
+        .find_map(|attr| match attr {
+          WebviewAtribute::RuntimeStyle { style } => Some(*style),
+          WebviewAtribute::AddressChangedHandler(_) => None,
         })
-        .next()
         .unwrap_or(if matches!(kind, WebviewKind::WindowChild) {
           CefRuntimeStyle::Alloy
         } else {

--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -441,6 +441,7 @@ wrap_load_handler! {
 wrap_display_handler! {
   struct BrowserDisplayHandler {
     document_title_changed_handler: Option<Arc<tauri_runtime::webview::DocumentTitleChangedHandler>>,
+    navigation_handler: Option<Arc<tauri_runtime::webview::NavigationHandler>>,
   }
 
   impl DisplayHandler {
@@ -453,6 +454,24 @@ wrap_display_handler! {
       let Some(title) = title else { return };
       let title_str = title.to_string();
       handler(title_str);
+    }
+
+    fn on_address_change(
+      &self,
+      _browser: Option<&mut Browser>,
+      frame: Option<&mut Frame>,
+      url: Option<&CefString>,
+    ) {
+      // Only fire for main frame URL changes (matches on_before_browse behavior)
+      if let Some(frame) = frame {
+        if frame.is_main() == 0 { return; }
+      }
+      let Some(handler) = &self.navigation_handler else { return };
+      let Some(url) = url else { return };
+      let url_str = url.to_string();
+      if let Ok(parsed) = url::Url::parse(&url_str) {
+        let _ = handler(&parsed);
+      }
     }
   }
 }
@@ -957,9 +976,10 @@ wrap_client! {
     }
 
     fn display_handler(&self) -> Option<DisplayHandler> {
-      if self.document_title_changed_handler.is_some() {
+      if self.document_title_changed_handler.is_some() || self.navigation_handler.is_some() {
         Some(BrowserDisplayHandler::new(
           self.document_title_changed_handler.clone(),
+          self.navigation_handler.clone(),
         ))
       } else {
         None

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -2124,6 +2124,8 @@ impl InitAttribute for RuntimeInitAttribute {
 pub enum WebviewAtribute {
   /// Sets the browser runtime style.
   RuntimeStyle { style: RuntimeStyle },
+  /// Callback invoked when the webview's address (URL) changes.
+  AddressChangedHandler(Box<dyn Fn(&Url) + Send + Sync>),
 }
 
 /// The browser runtime style.

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -304,6 +304,14 @@ impl WebviewBuilder<crate::Cef> {
       .push(tauri_runtime_cef::WebviewAtribute::RuntimeStyle { style });
     self
   }
+
+  /// Register a callback to be invoked when the webview's address (URL) changes.
+  pub fn on_address_change<F: Fn(&Url) + Send + Sync + 'static>(mut self, f: F) -> Self {
+    self.platform_specific_attributes.push(
+      tauri_runtime_cef::WebviewAtribute::AddressChangedHandler(Box::new(f)),
+    );
+    self
+  }
 }
 
 #[cfg_attr(not(feature = "unstable"), allow(dead_code))]

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -73,6 +73,12 @@ impl<'a, M: Manager<crate::Cef>> WebviewWindowBuilder<'a, crate::Cef, M> {
     self.window_builder.window_builder = self.window_builder.window_builder.browser_window();
     self
   }
+
+  /// Register a callback to be invoked when the webview's address (URL) changes.
+  pub fn on_address_change<F: Fn(&Url) + Send + Sync + 'static>(mut self, f: F) -> Self {
+    self.webview_builder = self.webview_builder.on_address_change(f);
+    self
+  }
 }
 
 impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {

--- a/examples/api/src-tauri/src/lib.rs
+++ b/examples/api/src-tauri/src/lib.rs
@@ -112,6 +112,13 @@ pub fn run_app<F: FnOnce(&App<TauriRuntime>) + Send + 'static>(
           });
       }
 
+      #[cfg(feature = "cef")]
+      {
+        window_builder = window_builder.on_address_change(|url| {
+          println!("CEF address changed: {url}");
+        });
+      }
+
       let webview = window_builder.build()?;
 
       #[cfg(debug_assertions)]


### PR DESCRIPTION
The current `on_navigation` callback only fires before full page loads. CEF `DisplayHandler::on_address_change` fires for ALL URL changes including `pushState`

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
