### PR TITLE
User-Agent support for cef runtime

### DIFF
--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -37,7 +37,7 @@ use walkdir::WalkDir;
 use std::{
   fs::{self, File, OpenOptions},
   io::{self, Write},
-  os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt, symlink},
+  os::unix::fs::{MetadataExt, OpenOptionsExt, symlink},
   path::{Path, PathBuf},
   process::Command,
 };

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -2031,6 +2031,7 @@ impl<T: UserEvent> CefRuntime<T> {
     let settings = cef::Settings {
       no_sandbox: !cfg!(feature = "sandbox") as i32,
       cache_path: cache_path.to_string_lossy().to_string().as_str().into(),
+      user_agent: runtime_args.user_agent.as_ref().unwrap_or(&"".to_owned()).as_str().into(),
       ..Default::default()
     };
     assert_eq!(

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -2031,7 +2031,12 @@ impl<T: UserEvent> CefRuntime<T> {
     let settings = cef::Settings {
       no_sandbox: !cfg!(feature = "sandbox") as i32,
       cache_path: cache_path.to_string_lossy().to_string().as_str().into(),
-      user_agent: runtime_args.user_agent.as_ref().unwrap_or(&"".to_owned()).as_str().into(),
+      user_agent: runtime_args
+        .user_agent
+        .as_ref()
+        .unwrap_or(&"".to_owned())
+        .as_str()
+        .into(),
       ..Default::default()
     };
     assert_eq!(

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -393,6 +393,7 @@ pub struct RuntimeInitArgs<A> {
   pub msg_hook: Option<Box<dyn FnMut(*const std::ffi::c_void) -> bool + 'static>>,
   pub identifier: String,
   pub custom_schemes: Vec<String>,
+  pub user_agent: Option<String>,
   pub platform_specific_attributes: Vec<A>,
 }
 

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -2229,12 +2229,17 @@ tauri::Builder::<tauri::Wry>::new()
       custom_schemes.push(schema.clone());
     }
 
-    let user_agents: Vec<&String> = manager.config.app.windows
+    let user_agents: Vec<&String> = manager
+      .config
+      .app
+      .windows
       .iter()
       .filter_map(|w| w.user_agent.as_ref())
       .collect();
     if user_agents.windows(2).any(|ua| ua[0] != ua[1]) {
-      eprintln!("The CEF runtime only supports setting a single user agent - the first user agent defined in the app windows config will be used");
+      eprintln!(
+        "The CEF runtime only supports setting a single user agent - the first user agent defined in the app windows config will be used"
+      );
     }
     let user_agent = user_agents.first().map(|ua| ua.as_str().to_owned());
 

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -1558,12 +1558,14 @@ impl<R: Runtime> Builder<R> {
       target_os = "openbsd"
     ))]
     app_id: Option<String>,
+    user_agent: Option<String>,
     #[cfg(windows)] msg_hook: Option<Box<dyn FnMut(*const std::ffi::c_void) -> bool + 'static>>,
   ) -> RuntimeInitArgs<R::PlatformSpecificInitAttribute> {
     RuntimeInitArgs {
       identifier: identifier.to_string(),
       custom_schemes,
       platform_specific_attributes,
+      user_agent,
       #[cfg(any(
         target_os = "linux",
         target_os = "dragonfly",
@@ -2227,6 +2229,15 @@ tauri::Builder::<tauri::Wry>::new()
       custom_schemes.push(schema.clone());
     }
 
+    let user_agents: Vec<&String> = manager.config.app.windows
+      .iter()
+      .filter_map(|w| w.user_agent.as_ref())
+      .collect();
+    if user_agents.windows(2).any(|ua| ua[0] != ua[1]) {
+      eprintln!("The CEF runtime only supports setting a single user agent - the first user agent defined in the app windows config will be used");
+    }
+    let user_agent = user_agents.first().map(|ua| ua.as_str().to_owned());
+
     let runtime_args = Self::build_runtime_init_args(
       &manager.config.identifier,
       custom_schemes,
@@ -2239,6 +2250,7 @@ tauri::Builder::<tauri::Wry>::new()
         target_os = "openbsd"
       ))]
       app_id,
+      user_agent,
       #[cfg(windows)]
       {
         let menus = manager.menu.menus.clone();


### PR DESCRIPTION
The code change in this PR reads custom user agent options from the tauri windows configuration (picks first one if there are multiple different ones), and passes it into the CEF runtime settings.