### PR TITLE
fix(ci): bump rustsec/audit-check to v2 and ignore time audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,4 +6,6 @@ ignore = [
   "RUSTSEC-2020-0095",
   # proc-macro-error is unmaintained
   "RUSTSEC-2024-0370",
+  # time crate can't be updated in the repo because of MSRV, users are unaffected
+  "RUSTSEC-2026-0009",
 ]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: rust audit
-        uses: rustsec/audit-check@v1
+        uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+  pull_request:
+    paths:
+      - '.github/workflows/audit.yml'
+      - '**/Cargo.lock'
+      - '**/Cargo.toml'
+      - '**/package.json'
+      - '**/pnpm-lock.yaml'
   push:
     paths:
       - '.github/workflows/audit.yml'


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Use the change made in https://github.com/rustsec/audit-check/pull/20 to prevent things like
https://github.com/tauri-apps/tauri/actions/runs/22661517484/job/65685733208

Also adding RUSTSEC-2026-0009 to the ignore list

> time crate can't be updated in the repo because of MSRV, users are unaffected