### PR TITLE
Fix docs: add missing TAURI_SIGNING_PRIVATE_KEY_PATH environment variable

### DIFF
--- a/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
+++ b/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
@@ -19,7 +19,8 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `TAURI_BUNDLER_TOOLS_GITHUB_MIRROR_TEMPLATE` - Specify a GitHub mirror template to download files and tools used by tauri bundler, for example: `https://mirror.example.com/<owner>/<repo>/releases/download/<version>/<asset>`.
 - `TAURI_BUNDLER_DMG_IGNORE_CI` - Disable the check for `CI: true` in the `.dmg` bundler.
 - `TAURI_SKIP_SIDECAR_SIGNATURE_CHECK` - Skip signing sidecars.
-- `TAURI_SIGNING_PRIVATE_KEY` — Private key used to sign your app bundles, can be either a string or a path to the file.
+- `TAURI_SIGNING_PRIVATE_KEY` — Private key used to sign your app bundles. For the bundle command, can be either a string or a path to the file. For the signer command, this must be the literal key string.
+- `TAURI_SIGNING_PRIVATE_KEY_PATH` — Path to the private key file for the signer command. Mutually exclusive with `TAURI_SIGNING_PRIVATE_KEY` when using the signer command.
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — The signing private key password, see `TAURI_SIGNING_PRIVATE_KEY`.
 - `TAURI_SIGNING_RPM_KEY` — The private GPG key used to sign the RPM bundle, exported to its ASCII-armored format.
 - `TAURI_SIGNING_RPM_KEY_PASSPHRASE` — The GPG key passphrase for `TAURI_SIGNING_RPM_KEY`, if needed.


### PR DESCRIPTION
Fixes #15028. Adds the missing TAURI_SIGNING_PRIVATE_KEY_PATH environment variable to the documentation and clarifies the different behavior between the bundle and signer commands.