### PR TITLE
fix(ios): fix deadlock during Swift plugin command handling

### DIFF
--- a/crates/tauri/src/plugin/mobile.rs
+++ b/crates/tauri/src/plugin/mobile.rs
@@ -373,12 +373,12 @@ pub(crate) fn run_command<R: Runtime, C: AsRef<str>, F: FnOnce(PluginResponse) +
         CStr::from_ptr(payload)
       };
 
-      if let Some(handler) = PENDING_PLUGIN_CALLS
+      let handler = PENDING_PLUGIN_CALLS
         .get_or_init(Default::default)
         .lock()
         .unwrap()
-        .remove(&id)
-      {
+        .remove(&id);
+      if let Some(handler) = handler {
         let json = payload.to_str().unwrap();
         match serde_json::from_str(json) {
           Ok(payload) => {


### PR DESCRIPTION
Hi!

I was developing a Tauri plugin in Swift for iOS, and after changing a number of commands to be `async`, I noticed my entire app started freezing.
After some debugging, it seemed like there was a deadlock happening between two threads running `tauri::plugin::run_command` and its nested `plugin_command_response_handler` function.

I haven't had time to do a full investigation (it's a little difficult to reproduce with a simple example), but this fixes the issue by just making sure the `PENDING_PLUGIN_CALLS` mutex lock is held for just long enough to remove the handler, whereas previously Rust was implicitly extending the lifetime of the lock to cover the entire `if let` block.

I didn't immediately see any issues talking about this, but happy to tag them if there are any.