### PR TITLE
fix(bundler): set linuxdeploy arch to i386

### DIFF
--- a/.changes/linux-deploy-link.md
+++ b/.changes/linux-deploy-link.md
@@ -1,5 +1,5 @@
 ---
-"tauri-bundler": patch:fix
+"tauri-bundler": patch:bug
 ---
 
 Correct GitHub Release URL path for Linux i686 tooling.

--- a/.changes/linux-deploy-link.md
+++ b/.changes/linux-deploy-link.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:fix
+---
+
+Correct GitHub Release URL path for Linux i686 tooling.

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -232,7 +232,7 @@ fn prepare_tools(tools_path: &Path, arch: &str, verbose: bool) -> crate::Result<
     write_and_make_executable(&apprun, data)?;
   }
 
-  let linuxdeploy_arch = if arch == "i686" { "i383" } else { arch };
+  let linuxdeploy_arch = if arch == "i686" { "i386" } else { arch };
   let linuxdeploy = tools_path.join(format!("linuxdeploy-{linuxdeploy_arch}.AppImage"));
   if !linuxdeploy.exists() {
     let data = download(&format!("https://github.com/tauri-apps/binary-releases/releases/download/linuxdeploy/linuxdeploy-{linuxdeploy_arch}.AppImage"))?;


### PR DESCRIPTION
This fixes a regression from https://github.com/tauri-apps/tauri/commit/20b99f9281e3748f0d5300c4d1f522344bcd9666

Actual link: https://github.com/tauri-apps/binary-releases/releases?q=linuxdeploy&expanded=true