### PR TITLE
fix: ensure kill-children script has execute permission on macOS (fix #15098)

### DIFF
--- a/.changes/fix-kill-script-permissions.md
+++ b/.changes/fix-kill-script-permissions.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix `tauri-stop-dev-processes.sh` created without execute permission on macOS, causing `beforeDevCommand` child processes to survive after closing the app.

--- a/crates/tauri-cli/src/dev.rs
+++ b/crates/tauri-cli/src/dev.rs
@@ -353,13 +353,21 @@ pub fn kill_before_dev_process() {
       let mut kill_children_script_path = std::env::temp_dir();
       kill_children_script_path.push("tauri-stop-dev-processes.sh");
 
-      if !kill_children_script_path.exists() {
-        if let Ok(mut file) = std::fs::File::create(&kill_children_script_path) {
-          use std::os::unix::fs::PermissionsExt;
-          let _ = file.write_all(KILL_CHILDREN_SCRIPT);
-          let mut permissions = file.metadata().unwrap().permissions();
-          permissions.set_mode(0o770);
-          let _ = file.set_permissions(permissions);
+      // Always re-create the script to self-heal from broken permissions
+      // (see https://github.com/tauri-apps/tauri/issues/15098).
+      if let Ok(mut file) = std::fs::File::create(&kill_children_script_path) {
+        if let Err(e) = file.write_all(KILL_CHILDREN_SCRIPT) {
+          log::warn!("failed to write kill-children script: {e}");
+        }
+        // Flush and drop the file handle before setting permissions on the path,
+        // as set_permissions on an open file handle can silently fail on macOS.
+        let _ = file.flush();
+        drop(file);
+
+        use std::os::unix::fs::PermissionsExt;
+        let permissions = std::fs::Permissions::from_mode(0o770);
+        if let Err(e) = std::fs::set_permissions(&kill_children_script_path, permissions) {
+          log::warn!("failed to set execute permission on kill-children script: {e}");
         }
       }
       let _ = Command::new(&kill_children_script_path)


### PR DESCRIPTION
## Summary

Fixes #15098

The `tauri-stop-dev-processes.sh` script was created without the execute bit on macOS, causing `beforeDevCommand` child processes (e.g. Vite dev server) to survive after closing the app and hold the port on subsequent runs.

### Root cause

In `kill_before_dev_process()`, the original code had three compounding issues:

1. **`set_permissions` called on a still-open file handle** -- on macOS, calling `file.set_permissions(...)` on an open `File` can silently fail to persist the mode bits.
2. **Errors silently swallowed** -- both `file.write_all()` and `file.set_permissions()` were wrapped with `let _ =`, so failures were never reported.
3. **`!exists()` guard prevented self-healing** -- once the script was created (with broken permissions), subsequent runs would skip re-creation entirely.

### Fix

- **Always re-create the script** so that previously broken permissions are corrected on the next run.
- **Flush and drop the file handle** before setting permissions via `std::fs::set_permissions()` on the *path*, which reliably persists the mode on all Unix platforms.
- **Log warnings** on write/permission failures instead of silently ignoring them, making future issues easier to diagnose.

## Test plan

- [x] Manual: verified on macOS that `$TMPDIR/tauri-stop-dev-processes.sh` is created with `0o770` (rwxrwx---) after the fix
- [x] Manual: verified that `tauri dev` properly cleans up `beforeDevCommand` child processes on exit
- [x] Verified the fix is backward-compatible: if the script already exists with correct permissions, it is simply overwritten with identical content