### PR TITLE
fix: use relative paths for AppImage .DirIcon and .desktop symlinks

### DIFF
--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -172,11 +172,11 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(format!("{product_name}.png")),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("{product_name}.png")),
+    format!("{product_name}.png"),
     app_dir_path.join(".DirIcon"),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("usr/share/applications/{product_name}.desktop")),
+    format!("usr/share/applications/{product_name}.desktop"),
     app_dir_path.join(format!("{product_name}.desktop")),
   )?;
 


### PR DESCRIPTION
## Summary
- AppImage `.DirIcon` and `.desktop` symlinks use absolute paths that break when mounted
- The symlinks point to the build directory path instead of relative paths within the AppDir

## Root Cause
In `linuxdeploy.rs`, `std::os::unix::fs::symlink` is called with `app_dir_path.join(...)` as the symlink target, producing absolute paths like `/home/user/project/target/.../AppDir/product.png`. When the AppImage is mounted at a different location, these symlinks are broken.

## Fix
Use relative path strings as symlink targets instead of absolute paths:
- `.DirIcon` → `{product_name}.png` (same directory)
- `{product_name}.desktop` → `usr/share/applications/{product_name}.desktop` (relative path)

## Testing
- Verified symlinks are created with relative targets
- AppImage mount point independence is preserved

Fixes #15110

Made with [Cursor](https://cursor.com)