### PR TITLE
fix(bundler): use relative symlinks for AppImage .DirIcon and .desktop

### DIFF
--- a/.changes/fix-appimage-relative-symlinks.md
+++ b/.changes/fix-appimage-relative-symlinks.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:bug
+---
+
+Fix AppImage `.DirIcon` and `.desktop` symlinks using absolute paths instead of relative paths, which broke icon display in file managers and appimaged.

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -171,12 +171,15 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(larger_icon_path),
     app_dir_path.join(format!("{product_name}.png")),
   )?;
+
+  // The Symlink to `.DirIcon` must use a relative target within the AppDir, not an absolute path to the build directory.
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("{product_name}.png")),
+    format!("{product_name}.png"),
     app_dir_path.join(".DirIcon"),
   )?;
+  // The Symlink to `.desktop` must use a relative target within the AppDir, not an absolute path to the build directory.
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("usr/share/applications/{product_name}.desktop")),
+    format!("usr/share/applications/{product_name}.desktop"),
     app_dir_path.join(format!("{product_name}.desktop")),
   )?;
 


### PR DESCRIPTION
The symlink targets were created using app_dir_path.join() which produced absolute paths pointing to the build directory. When the AppImage is mounted at runtime, these symlinks are broken, preventing appimaged and file managers from extracting the application icon.

Fixes #15110 
Confirms #15122 without using AI.

* `cargo test` passed all tests
* `cargo clippy` finished with no errors