### PR TITLE
feat(bundler): allow customizing DMG detach attempts via env vars

### DIFF
--- a/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
@@ -35,7 +35,8 @@ HDIUTIL_VERBOSITY=""
 SANDBOX_SAFE=0
 BLESS=0
 SKIP_JENKINS=0
-MAXIMUM_UNMOUNTING_ATTEMPTS=3
+MAXIMUM_UNMOUNTING_ATTEMPTS="${TAURI_DMG_DETACH_ATTEMPTS:-3}"
+DMG_DETACH_DELAY="${TAURI_DMG_DETACH_DELAY:-1}"
 SIGNATURE=""
 NOTARIZE=""
 
@@ -58,7 +59,7 @@ function hdiutil_detach_retry() {
 	do
 		(( unmounting_attempts == MAXIMUM_UNMOUNTING_ATTEMPTS )) && exit 16  # patience exhausted, exit with code EBUSY
 		echo "Wait a moment..."
-		sleep $(( 1 * (2 ** unmounting_attempts) ))
+		sleep $(( DMG_DETACH_DELAY * (2 ** unmounting_attempts) ))
 	done
 	unset unmounting_attempts
 }


### PR DESCRIPTION
close #14686

On CI with large DMG files, `hdiutil detach` frequently times out with `EBUSY` (exit code 16). The retry loop in `hdiutil_detach_retry` had both the attempt count and the sleep base delay hardcoded.

## Changes

Two env vars with backward-compatible defaults:
- `TAURI_DMG_DETACH_ATTEMPTS` — max retries (default: `3`)
- `TAURI_DMG_DETACH_DELAY` — base delay in seconds for exponential backoff (default: `1`)

## Usage

```bash
TAURI_DMG_DETACH_ATTEMPTS=10 TAURI_DMG_DETACH_DELAY=2 cargo tauri build
```

No behavior change when env vars are unset.