### PR TITLE
feat(updater): make pubkey optional in cli + bundler

### DIFF
--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -82,7 +82,7 @@ pub use self::{
   settings::{
     AppImageSettings, BundleBinary, BundleSettings, CustomSignCommandSettings, DebianSettings,
     DmgSettings, Entitlements, IosSettings, MacOsSettings, PackageSettings, PackageType, PlistKind,
-    Position, RpmSettings, Settings, SettingsBuilder, Size, UpdaterSettings,
+    Position, RpmSettings, Settings, SettingsBuilder, Size, UpdaterPubkey, UpdaterSettings,
   },
 };
 pub use settings::{NsisSettings, WindowsSettings, WixLanguage, WixLanguageConfig, WixSettings};

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -156,13 +156,16 @@ pub struct PackageSettings {
   pub default_run: Option<String>,
 }
 
+/// Shared type for updater pubkey
+pub type UpdaterPubkey = Option<String>;
+
 /// The updater settings.
 #[derive(Debug, Default, Clone)]
 pub struct UpdaterSettings {
   /// Should generate v1 compatible zipped updater
   pub v1_compatible: bool,
   /// Signature public key.
-  pub pubkey: String,
+  pub pubkey: UpdaterPubkey,
   /// Args to pass to `msiexec.exe` to run the updater on Windows.
   pub msiexec_args: &'static [&'static str],
 }

--- a/crates/tauri-cli/src/bundle.rs
+++ b/crates/tauri-cli/src/bundle.rs
@@ -258,14 +258,27 @@ fn sign_updaters(
   }
 
   // get the public key
-  let pubkey = &update_settings.pubkey;
-  // check if pubkey points to a file...
-  let maybe_path = Path::new(pubkey);
-  let pubkey = if maybe_path.exists() {
-    std::fs::read_to_string(maybe_path)
-      .fs_context("failed to read pubkey from file", maybe_path.to_path_buf())?
-  } else {
-    pubkey.to_string()
+  let pubkey = match &update_settings.pubkey {
+    // pubkey set in config
+    Some(pubkey) => {
+      // check if pubkey points to a file...
+      let maybe_path = Path::new(pubkey);
+      if maybe_path.exists() {
+        Some(
+          std::fs::read_to_string(maybe_path)
+            .fs_context("failed to read pubkey from file", maybe_path.to_path_buf())?,
+        )
+      } else {
+        Some(pubkey.to_string())
+      }
+    }
+    // pubket not set in config
+    None => {
+      log::warn!(
+        "Updater pubkey not set in tauri config, ensure it's set in the config or at runtime"
+      );
+      None
+    }
   };
 
   // if no password provided we use an empty string
@@ -292,7 +305,11 @@ fn sign_updaters(
   }
   let secret_key =
     updater_signature::secret_key(private_key, password).context("failed to decode secret key")?;
-  let public_key = updater_signature::pub_key(pubkey).context("failed to decode pubkey")?;
+  
+  let public_key = match pubkey {
+    Some(pk) => Some(updater_signature::pub_key(pk).context("failed to decode pubkey")?),
+    None => None,
+  };
 
   let mut signed_paths = Vec::new();
   for bundle in update_enabled_bundles {
@@ -301,8 +318,10 @@ fn sign_updaters(
     for path in &bundle.bundle_paths {
       // sign our path from environment variables
       let (signature_path, signature) = updater_signature::sign_file(&secret_key, path)?;
-      if signature.keynum() != public_key.keynum() {
-        log::warn!("The updater secret key from `TAURI_SIGNING_PRIVATE_KEY` does not match the public key from `plugins > updater > pubkey`. If you are not rotating keys, this means your configuration is wrong and won't be accepted at runtime when performing update.");
+      if let Some(public_key) = &public_key {
+        if signature.keynum() != public_key.keynum() {
+          log::warn!("The updater secret key from `TAURI_SIGNING_PRIVATE_KEY` does not match the public key from `plugins > updater > pubkey`. If you are not rotating keys, this means your configuration is wrong and won't be accepted at runtime when performing update.");
+        }
       }
       signed_paths.push(signature_path);
     }

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -22,8 +22,8 @@ use notify_debouncer_full::new_debouncer;
 use serde::{Deserialize, Deserializer};
 use tauri_bundler::{
   AppCategory, AppImageSettings, BundleBinary, BundleSettings, DebianSettings, DmgSettings,
-  IosSettings, MacOsSettings, PackageSettings, Position, RpmSettings, Size, UpdaterSettings,
-  WindowsSettings,
+  IosSettings, MacOsSettings, PackageSettings, Position, RpmSettings, Size, UpdaterPubkey,
+  UpdaterSettings, WindowsSettings,
 };
 use tauri_utils::config::{parse::is_configuration_file, DeepLinkProtocol, RunnerConfig, Updater};
 
@@ -762,7 +762,7 @@ enum DesktopDeepLinks {
 #[derive(Deserialize)]
 pub struct UpdaterConfig {
   /// Signature public key.
-  pub pubkey: String,
+  pub pubkey: UpdaterPubkey,
   /// The Windows configuration for the updater.
   #[serde(default)]
   pub windows: UpdaterWindowsConfig,


### PR DESCRIPTION
This is the companion PR to https://github.com/tauri-apps/plugins-workspace/pull/3114, addressing https://github.com/tauri-apps/plugins-workspace/issues/2438.
Currently, the Tauri CLI strictly requires the updater `pubkey` to be hardcoded in `tauri.conf.json` so it can verify that the private key matches the public key during the build/bundling process. This prevents developers from securely fetching or providing the public key dynamically at runtime. This PR relaxes that build-time constraint.

### Changes
- Changed `pubkey` to an `Option<String>` in `UpdaterConfig` and `UpdaterSettings`.
- Updated the bundling logic in `tauri-cli/src/bundle.rs` to handle an optional `pubkey`.
- If the `pubkey` is missing from the config, the CLI now skips the public/private key verification step and instead emits a compile-time warning reminding the developer to ensure it is set at runtime.
- The strict requirement for the `pubkey` to be present before performing an update is now handled at runtime in https://github.com/tauri-apps/plugins-workspace/pull/3114
- `cargo test` passes 