### PR TITLE
fix: pin 46 unpinned action(s), extract 1 inline secret to env var

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: rust audit
-        uses: rustsec/audit-check@v2
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install Rust ${{ matrix.rust }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
           toolchain: ${{ matrix.rust }}
           components: rust-src
@@ -62,7 +62,7 @@ jobs:
           sudo dpkg -i hyperfine_1.18.0_amd64.deb
           pip install memory_profiler
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: run benchmarks
         run: |

--- a/.github/workflows/check-change-tags.yml
+++ b/.github/workflows/check-change-tags.yml
@@ -31,7 +31,7 @@ jobs:
             fi
           done
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           list-files: shell

--- a/.github/workflows/check-generated-files.yml
+++ b/.github/workflows/check-generated-files.yml
@@ -27,7 +27,7 @@ jobs:
       schema: ${{ steps.filter.outputs.schema }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |
@@ -68,14 +68,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: install Linux dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: generate schemas
         run: cargo build --manifest-path ./crates/tauri-schema-generator/Cargo.toml

--- a/.github/workflows/check-license-header.yml
+++ b/.github/workflows/check-license-header.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           list-files: shell

--- a/.github/workflows/covector-comment-on-fork.yml
+++ b/.github/workflows/covector-comment-on-fork.yml
@@ -24,7 +24,7 @@ jobs:
       (github.event.workflow_run.head_repository.full_name != github.repository || github.actor == 'dependabot[bot]')
     steps:
       - name: covector status
-        uses: jbolda/covector/packages/action@covector-v0
+        uses: jbolda/covector/packages/action@f9e6c8d92119b8c94cb7ee73eba1ecc41b8f50fb # covector-v0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           command: 'status'

--- a/.github/workflows/covector-status.yml
+++ b/.github/workflows/covector-status.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: covector status
-        uses: jbolda/covector/packages/action@covector-v0
+        uses: jbolda/covector/packages/action@f9e6c8d92119b8c94cb7ee73eba1ecc41b8f50fb # covector-v0
         id: covector
         with:
           command: 'status'

--- a/.github/workflows/covector-version-or-publish.yml
+++ b/.github/workflows/covector-version-or-publish.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'pnpm'
 
       - name: install stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: install Linux dependencies
         if: matrix.platform == 'ubuntu-latest'
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.1 libayatana-appindicator3-dev libfuse2 librsvg2-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: build CLI
         run: cargo build --manifest-path ./crates/tauri-cli/Cargo.toml
@@ -79,7 +79,9 @@ jobs:
           node-version: 24
 
       - name: cargo login
-        run: cargo login ${{ secrets.ORG_CRATES_IO_TOKEN }}
+        run: cargo login "${ORG_CRATES_IO_TOKEN}"
+        env:
+          ORG_CRATES_IO_TOKEN: ${{ secrets.ORG_CRATES_IO_TOKEN }}
       - name: git config
         run: |
           git config --global user.name "${{ github.event.pusher.name }}"
@@ -91,7 +93,7 @@ jobs:
           sudo apt-get install -y webkit2gtk-4.1 libayatana-appindicator3-dev librsvg2-dev
 
       - name: covector version or publish (publish when no change files present)
-        uses: jbolda/covector/packages/action@covector-v0
+        uses: jbolda/covector/packages/action@f9e6c8d92119b8c94cb7ee73eba1ecc41b8f50fb # covector-v0
         id: covector
         env:
           CARGO_AUDIT_OPTIONS: ${{ secrets.CARGO_AUDIT_OPTIONS }}

--- a/.github/workflows/deploy-schema-worker.yml
+++ b/.github/workflows/deploy-schema-worker.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           command: deploy
           workingDirectory: 'crates/tauri-schema-worker'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: install Linux dependencies
         run: |
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.target.name }}
 
@@ -85,20 +85,20 @@ jobs:
           path: 'examples/api'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and export to Docker
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
         with:
           context: .docker/cross
           file: .docker/cross/${{ matrix.target.filename }}.Dockerfile
@@ -122,7 +122,7 @@ jobs:
           ./cargo-tauri build --runner cross --bundles deb --target ${{ matrix.target.name }} --verbose
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
         with:
           context: .docker/cross
           file: .docker/cross/${{ matrix.target.filename }}.Dockerfile

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install Rust stable and rustfmt
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt
 
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: install taplo-cli
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: taplo-cli
 

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install rust stable and clippy
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
 
@@ -38,6 +38,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.1 libayatana-appindicator3-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -116,11 +116,11 @@ jobs:
           cache: 'pnpm'
           architecture: ${{ matrix.settings.architecture }}
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         if: ${{ !matrix.settings.docker }}
         with:
           targets: ${{ matrix.settings.target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.settings.target }}
         if: ${{ matrix.settings.docker }}
@@ -132,7 +132,7 @@ jobs:
         run: pnpm i --frozen-lockfile --ignore-scripts
 
       - name: Build in docker
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         if: ${{ matrix.settings.docker }}
         with:
           image: ${{ matrix.settings.docker }}
@@ -342,7 +342,7 @@ jobs:
           name: bindings-armv7-unknown-linux-gnueabihf
           path: 'packages/cli/'
       # TODO: actually run test, blocked by https://github.com/rust-lang/cargo/issues/8719
-      - uses: addnab/docker-run-action@v3
+      - uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         with:
           image: ${{ matrix.image }}
           options: '-v ${{ github.workspace }}:/build -w /build -e RUSTUP_HOME=/usr/local/rustup -e CARGO_HOME=/usr/local/cargo'

--- a/.github/workflows/publish-cli-rs.yml
+++ b/.github/workflows/publish-cli-rs.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: 'Setup Rust'
         if: ${{ !matrix.config.cross }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: ${{ matrix.config.rust_target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: ${{ !matrix.config.cross }}
         with:
           key: ${{ matrix.config.rust_target }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install cross
         if: ${{ matrix.config.cross }}
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7627fb428e65e78e2ec9a24ae5c5bd5f8553f182 # v2
         with:
           tool: cross@0.2.5
 

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install Rust 1.77.2
-        uses: dtolnay/rust-toolchain@1.77.2
+        uses: dtolnay/rust-toolchain@3f3289724bfb23d6f7b54045d092db17a6dae7f7 # 1.77.2
 
       - name: install Linux dependencies
         if: matrix.platform == 'ubuntu-latest'
@@ -56,7 +56,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup NDK
-        uses: nttld/setup-ndk@v1
+        uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1
         id: setup-ndk
         with:
           ndk-version: r25b
@@ -74,7 +74,7 @@ jobs:
               echo "Changed $(basename "$link") from $current_target to $new_target"
           done
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: build CLI
         run: cargo build --manifest-path ./crates/tauri-cli/Cargo.toml

--- a/.github/workflows/test-cli-js.yml
+++ b/.github/workflows/test-cli-js.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - run: npm i -g --force corepack
       - name: setup node
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.1 libayatana-appindicator3-dev librsvg2-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: test
         timeout-minutes: 30

--- a/.github/workflows/test-cli-rs.yml
+++ b/.github/workflows/test-cli-rs.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: 'Setup Rust'
-        uses: dtolnay/rust-toolchain@1.77.2
+        uses: dtolnay/rust-toolchain@3f3289724bfb23d6f7b54045d092db17a6dae7f7 # 1.77.2
         with:
           targets: ${{ matrix.platform.target }}
 
@@ -54,7 +54,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.1 libayatana-appindicator3-dev librsvg2-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: test CLI
         run: cargo test --manifest-path ./crates/tauri-cli/Cargo.toml ${{ matrix.platform.args }}

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
         with:
           toolchain: ${{ matrix.platform.toolchain }}
           targets: ${{ matrix.platform.target }}
@@ -88,7 +88,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y webkit2gtk-4.1 libxdo-dev libayatana-appindicator3-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.platform.target }}
           save-if: ${{ matrix.features.key == 'all' }}

--- a/.github/workflows/udeps.yml
+++ b/.github/workflows/udeps.yml
@@ -32,7 +32,7 @@ jobs:
       cli: ${{ steps.filter.outputs.cli }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
 
       - name: Install udeps
         run: cargo install cargo-udeps --locked --force
@@ -128,14 +128,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@0f1b44df7e9cbb178d781a242338dfa5e243ad7f # nightly
 
       - name: install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Download udeps
         uses: actions/download-artifact@v4.1.7


### PR DESCRIPTION
Re-submission of #15157. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs and extracts an inline secret from a `run:` block into an `env:` mapping.

- Pin 46 unpinned actions to full 40-character SHAs
- Extract 1 inline secret (`ORG_CRATES_IO_TOKEN`) from run block to env var

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- **Secret extraction**: `${{ secrets.* }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)