### PR TITLE
fix(tauri-runtime-wry): stop leaking ObjC retains in with_webview

### DIFF
--- a/.changes/fix-objc-retain-leak.md
+++ b/.changes/fix-objc-retain-leak.md
@@ -1,1 +1,5 @@
-patch tauri-runtime-wry
+---
+"tauri-runtime-wry": patch:bug
+---
+
+Avoid leaking Objective-C objects in `WebviewMessage::WithWebview` on Apple targets by replacing `Retained::into_raw` with scoped retained bindings and `Retained::as_ptr` pointer handoff.

--- a/.changes/fix-objc-retain-leak.md
+++ b/.changes/fix-objc-retain-leak.md
@@ -1,0 +1,1 @@
+patch tauri-runtime-wry

--- a/.changes/fix-objc-retain-leak.md
+++ b/.changes/fix-objc-retain-leak.md
@@ -1,4 +1,5 @@
 ---
+"tauri": patch:bug
 "tauri-runtime-wry": patch:bug
 ---
 

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -3907,12 +3907,9 @@ fn handle_user_message<T: UserEvent>(
               let manager = webview.manager();
               let ns_window = webview.ns_window();
               f(Webview {
-                webview: Retained::as_ptr(&platform_webview) as *const std::ffi::c_void
-                  as *mut std::ffi::c_void,
-                manager: Retained::as_ptr(&manager) as *const std::ffi::c_void
-                  as *mut std::ffi::c_void,
-                ns_window: Retained::as_ptr(&ns_window) as *const std::ffi::c_void
-                  as *mut std::ffi::c_void,
+                webview: Retained::as_ptr(&platform_webview).cast_mut() as *mut std::ffi::c_void,
+                manager: Retained::as_ptr(&manager).cast_mut() as *mut std::ffi::c_void,
+                ns_window: Retained::as_ptr(&ns_window).cast_mut() as *mut std::ffi::c_void,
               });
             }
             #[cfg(target_os = "ios")]
@@ -3922,10 +3919,8 @@ fn handle_user_message<T: UserEvent>(
               let manager = webview.inner.manager();
 
               f(Webview {
-                webview: Retained::as_ptr(&platform_webview) as *const std::ffi::c_void
-                  as *mut std::ffi::c_void,
-                manager: Retained::as_ptr(&manager) as *const std::ffi::c_void
-                  as *mut std::ffi::c_void,
+                webview: Retained::as_ptr(&platform_webview).cast_mut() as *mut std::ffi::c_void,
+                manager: Retained::as_ptr(&manager).cast_mut() as *mut std::ffi::c_void,
                 view_controller: window.ui_view_controller(),
               });
             }

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -3903,25 +3903,28 @@ fn handle_user_message<T: UserEvent>(
             #[cfg(target_os = "macos")]
             {
               use wry::WebViewExtMacOS;
+              let platform_webview = webview.webview();
+              let manager = webview.manager();
+              let ns_window = webview.ns_window();
               f(Webview {
-                webview: Retained::into_raw(webview.webview()) as *mut objc2::runtime::AnyObject
+                webview: Retained::as_ptr(&platform_webview) as *const std::ffi::c_void
                   as *mut std::ffi::c_void,
-                manager: Retained::into_raw(webview.manager()) as *mut objc2::runtime::AnyObject
+                manager: Retained::as_ptr(&manager) as *const std::ffi::c_void
                   as *mut std::ffi::c_void,
-                ns_window: Retained::into_raw(webview.ns_window()) as *mut objc2::runtime::AnyObject
+                ns_window: Retained::as_ptr(&ns_window) as *const std::ffi::c_void
                   as *mut std::ffi::c_void,
               });
             }
             #[cfg(target_os = "ios")]
             {
               use wry::WebViewExtIOS;
+              let platform_webview = webview.inner.webview();
+              let manager = webview.inner.manager();
 
               f(Webview {
-                webview: Retained::into_raw(webview.inner.webview())
-                  as *mut objc2::runtime::AnyObject
+                webview: Retained::as_ptr(&platform_webview) as *const std::ffi::c_void
                   as *mut std::ffi::c_void,
-                manager: Retained::into_raw(webview.inner.manager())
-                  as *mut objc2::runtime::AnyObject
+                manager: Retained::as_ptr(&manager) as *const std::ffi::c_void
                   as *mut std::ffi::c_void,
                 view_controller: window.ui_view_controller(),
               });

--- a/crates/tauri-runtime-wry/src/webview.rs
+++ b/crates/tauri-runtime-wry/src/webview.rs
@@ -17,6 +17,8 @@ mod imp {
 mod imp {
   use std::ffi::c_void;
 
+  // These pointers are borrowed from ObjC `Retained` handles owned elsewhere and must
+  // not be mutated through. TODO: change these to `*const c_void` in v3 (breaking change).
   pub struct Webview {
     pub webview: *mut c_void,
     pub manager: *mut c_void,


### PR DESCRIPTION
fix(tauri-runtime-wry): stop leaking ObjC retains in with_webview

## Problem
`WebviewMessage::WithWebview` used `Retained::into_raw` on Apple targets, transferring ownership to raw pointers in this path without reclaiming it.

## Fix
- Replaced `Retained::into_raw` with scoped retained bindings + `Retained::as_ptr` in the macOS/iOS `WithWebview` branches.
- Added `.changes/fix-objc-retain-leak.md` with valid covector front matter (`"tauri-runtime-wry": patch:bug`).

## Testing
```bash
cargo fmt --check
cargo clippy -p tauri-runtime-wry --all-features -- -D warnings
cargo check -p tauri-runtime-wry --all-features
cargo test -p tauri-runtime-wry --lib
cargo clippy -p tauri-runtime-wry --target aarch64-apple-darwin --all-features -- -D warnings
```

Manual stress run (`with_webview` loop, 3 min) shows stable RSS without unbounded growth: **116.5 MB -> 116.9 MB** (`+0.4 MB`).

## Visual Verification
### App running (active loop)
<table>
  <tr>
    <td align="center"><b>Start</b></td>
    <td align="center"><b>End</b></td>
  </tr>
  <tr>
    <td><img width="480" alt="Stress test start" src="https://github.com/user-attachments/assets/d3d48e63-b6f8-4368-a767-5769e2324573" /></td>
    <td><img width="480" alt="Stress test end" src="https://github.com/user-attachments/assets/5b0fb1d1-dea1-455a-844c-cf37ab8de849" /></td>
  </tr>
</table>

### RSS monitor (terminal)
<img width="600" alt="Terminal RSS log" src="https://github.com/user-attachments/assets/0fa2b835-d441-4655-9c92-6d97f2d4e726" />

Fixes #15210
