### PR TITLE
feat(bundler): allow customizing DMG detach retry attempts and delay

### DIFF
--- a/.changes/dmg-detach-env-vars.md
+++ b/.changes/dmg-detach-env-vars.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch:feat
+---
+
+Allow customizing DMG detach retry behavior via environment variables `TAURI_DMG_DETACH_RETRIES` (default: 3) and `TAURI_DMG_DETACH_DELAY` (default: 1s base for exponential backoff). Fixes CI timeouts caused by `hdiutil detach` DiskArbitration expiration.

--- a/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
@@ -35,7 +35,7 @@ HDIUTIL_VERBOSITY=""
 SANDBOX_SAFE=0
 BLESS=0
 SKIP_JENKINS=0
-MAXIMUM_UNMOUNTING_ATTEMPTS=3
+MAXIMUM_UNMOUNTING_ATTEMPTS=${TAURI_DMG_DETACH_RETRIES:-3}
 SIGNATURE=""
 NOTARIZE=""
 
@@ -58,7 +58,7 @@ function hdiutil_detach_retry() {
 	do
 		(( unmounting_attempts == MAXIMUM_UNMOUNTING_ATTEMPTS )) && exit 16  # patience exhausted, exit with code EBUSY
 		echo "Wait a moment..."
-		sleep $(( 1 * (2 ** unmounting_attempts) ))
+		sleep $(( ${TAURI_DMG_DETACH_DELAY:-1} * (2 ** unmounting_attempts) ))
 	done
 	unset unmounting_attempts
 }


### PR DESCRIPTION
Adds env vars to customize DMG detach behavior:
- `TAURI_DMG_DETACH_RETRIES` (default: 3)
- `TAURI_DMG_DETACH_DELAY` (default: 1s)

Fixes #14686