### PR TITLE
fix(cli): bump @ohos-rs/ability to resolve white screen issue

### DIFF
--- a/crates/tauri-cli/templates/mobile/open-harmony/entry/oh-package.json5
+++ b/crates/tauri-cli/templates/mobile/open-harmony/entry/oh-package.json5
@@ -7,6 +7,6 @@
   "license": "",
   "dependencies": {
     "libentry.so": "file:./src/main/cpp/types/libentry",
-    "@ohos-rs/ability": "0.2.1"
+    "@ohos-rs/ability": "0.4.0-beta.0"
   }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?
- [x] Bug fix

### What is the current behavior?

When building Tauri for OpenHarmony initialized with`cargo tauri ohos init`, the app shows a white screen after launch due to compatibility issues with the previous version of `@ohos-rs/ability`.

Issue: #15236

![screenshot_20260415_002210_com chest tauri_ohos_test](https://github.com/user-attachments/assets/f6f56518-ff18-47e6-b437-842919cfc255)

### What is the new behavior?

Bumping the version resolves the module initialization failure and ensures the webview renders correctly.

- Updated `@ohos-rs/ability` from 0.2.1 to 0.4.0-beta.0
- Tested on HarmonyOS PC - white screen no longer occurs

![screenshot_20260415_005700_com chest tauri_ohos_test](https://github.com/user-attachments/assets/6bfbd6c1-a528-4e12-b9e0-659aa5cecc53)

### How was this change implemented?

Updated the dependency version in the tauri-cli's OpenHarmony template configuration.

### Additional context

Test repository: https://github.com/Islatri/tauri-ohos-test