### PR TITLE
feat: allow extending protocol handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8849,6 +8849,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "sha1",
  "sha2",
  "strsim",

--- a/crates/tauri-bundler/Cargo.toml
+++ b/crates/tauri-bundler/Cargo.toml
@@ -74,6 +74,9 @@ which = "8"
 name = "tauri_bundler"
 path = "src/lib.rs"
 
+[dev-dependencies]
+serial_test = "3"
+
 [features]
 default = ["rustls", "platform-certs"]
 native-tls = ["ureq/native-tls"]

--- a/crates/tauri-bundler/src/utils/http_utils.rs
+++ b/crates/tauri-bundler/src/utils/http_utils.rs
@@ -189,6 +189,7 @@ pub fn extract_zip(data: &[u8], path: &Path) -> crate::Result<()> {
 #[cfg(test)]
 mod tests {
   use super::generate_github_mirror_url_from_template;
+  use serial_test::serial;
   use std::env;
 
   const GITHUB_ASSET_URL: &str =
@@ -196,6 +197,7 @@ mod tests {
   const NON_GITHUB_ASSET_URL: &str = "https://someotherwebsite.com/somefile.zip";
 
   #[test]
+  #[serial]
   fn test_generate_mirror_url_no_env_var() {
     env::remove_var("TAURI_BUNDLER_TOOLS_GITHUB_MIRROR_TEMPLATE");
 
@@ -203,6 +205,7 @@ mod tests {
   }
 
   #[test]
+  #[serial]
   fn test_generate_mirror_url_non_github_url() {
     env::set_var(
       "TAURI_BUNDLER_TOOLS_GITHUB_MIRROR_TEMPLATE",
@@ -218,6 +221,7 @@ mod tests {
   }
 
   #[test]
+  #[serial]
   fn test_generate_mirror_url_correctly() {
     let test_cases = vec![
             TestCase {

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -210,22 +210,22 @@ pub use self::event::{Event, EventId, EventTarget};
 use self::manager::EmitPayload;
 pub use {
   self::app::{
-    App, AppHandle, AssetResolver, Builder, CloseRequestApi, ExitRequestApi, RESTART_EXIT_CODE,
-    RunEvent, UriSchemeContext, UriSchemeResponder, WebviewEvent, WindowEvent,
+    App, AppHandle, AssetResolver, Builder, CloseRequestApi, ExitRequestApi, RunEvent,
+    UriSchemeContext, UriSchemeResponder, WebviewEvent, WindowEvent, RESTART_EXIT_CODE,
   },
   self::manager::Asset,
   self::runtime::{
-    DeviceEventFilter, UserAttentionType,
     dpi::{
       LogicalPosition, LogicalRect, LogicalSize, LogicalUnit, PhysicalPosition, PhysicalRect,
       PhysicalSize, PhysicalUnit, Pixel, PixelUnit, Position, Rect, Size,
     },
     window::{CursorIcon, DragDropEvent, WindowSizeConstraints},
+    DeviceEventFilter, UserAttentionType,
   },
   self::state::{State, StateManager},
   self::utils::{
-    Env, PackageInfo, Theme,
     config::{Config, WebviewUrl},
+    Env, PackageInfo, Theme,
   },
   self::webview::{Webview, WebviewWindow, WebviewWindowBuilder},
   self::window::{Monitor, Window},
@@ -1101,7 +1101,7 @@ pub mod test;
 
 #[cfg(feature = "specta")]
 const _: () = {
-  use specta::{TypeMap, datatype::DataType, function::FunctionArg};
+  use specta::{datatype::DataType, function::FunctionArg, TypeMap};
 
   impl<T: Send + Sync + 'static> FunctionArg for crate::State<'_, T> {
     fn to_datatype(_: &mut TypeMap) -> Option<DataType> {

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -90,7 +90,7 @@ pub mod ipc;
 mod manager;
 mod pattern;
 pub mod plugin;
-pub(crate) mod protocol;
+pub mod protocol;
 mod resources;
 mod vibrancy;
 pub mod webview;
@@ -210,22 +210,22 @@ pub use self::event::{Event, EventId, EventTarget};
 use self::manager::EmitPayload;
 pub use {
   self::app::{
-    App, AppHandle, AssetResolver, Builder, CloseRequestApi, ExitRequestApi, RunEvent,
-    UriSchemeContext, UriSchemeResponder, WebviewEvent, WindowEvent, RESTART_EXIT_CODE,
+    App, AppHandle, AssetResolver, Builder, CloseRequestApi, ExitRequestApi, RESTART_EXIT_CODE,
+    RunEvent, UriSchemeContext, UriSchemeResponder, WebviewEvent, WindowEvent,
   },
   self::manager::Asset,
   self::runtime::{
+    DeviceEventFilter, UserAttentionType,
     dpi::{
       LogicalPosition, LogicalRect, LogicalSize, LogicalUnit, PhysicalPosition, PhysicalRect,
       PhysicalSize, PhysicalUnit, Pixel, PixelUnit, Position, Rect, Size,
     },
     window::{CursorIcon, DragDropEvent, WindowSizeConstraints},
-    DeviceEventFilter, UserAttentionType,
   },
   self::state::{State, StateManager},
   self::utils::{
-    config::{Config, WebviewUrl},
     Env, PackageInfo, Theme,
+    config::{Config, WebviewUrl},
   },
   self::webview::{Webview, WebviewWindow, WebviewWindowBuilder},
   self::window::{Monitor, Window},
@@ -1101,7 +1101,7 @@ pub mod test;
 
 #[cfg(feature = "specta")]
 const _: () = {
-  use specta::{datatype::DataType, function::FunctionArg, TypeMap};
+  use specta::{TypeMap, datatype::DataType, function::FunctionArg};
 
   impl<T: Send + Sync + 'static> FunctionArg for crate::State<'_, T> {
     fn to_datatype(_: &mut TypeMap) -> Option<DataType> {

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use serde::Serialize;
-use serialize_to_javascript::{DefaultTemplate, Template, default_template};
+use serialize_to_javascript::{default_template, DefaultTemplate, Template};
 use tauri_runtime::{
   webview::{DetachedWebview, InitializationScript, PendingWebview},
   window::DragDropEvent,
@@ -20,19 +20,19 @@ use tauri_utils::config::WebviewUrl;
 use url::Url;
 
 use crate::{
-  EventLoopMessage, EventTarget, Manager, Runtime, Scopes, UriSchemeContext, Webview, Window,
   app::{GlobalWebviewEventListener, OnPageLoad, UriSchemeResponder, WebviewEvent},
   ipc::InvokeHandler,
   pattern::PatternJavascript,
   sealed::ManagerBase,
   webview::PageLoadPayload,
+  EventLoopMessage, EventTarget, Manager, Runtime, Scopes, UriSchemeContext, Webview, Window,
 };
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use crate::app::OnWebContentProcessTerminate;
 
 use super::{
-  window::{DRAG_DROP_EVENT, DRAG_ENTER_EVENT, DRAG_LEAVE_EVENT, DRAG_OVER_EVENT, DragDropPayload},
+  window::{DragDropPayload, DRAG_DROP_EVENT, DRAG_ENTER_EVENT, DRAG_LEAVE_EVENT, DRAG_OVER_EVENT},
   {AppManager, EmitPayload},
 };
 

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use serde::Serialize;
-use serialize_to_javascript::{default_template, DefaultTemplate, Template};
+use serialize_to_javascript::{DefaultTemplate, Template, default_template};
 use tauri_runtime::{
   webview::{DetachedWebview, InitializationScript, PendingWebview},
   window::DragDropEvent,
@@ -20,19 +20,19 @@ use tauri_utils::config::WebviewUrl;
 use url::Url;
 
 use crate::{
+  EventLoopMessage, EventTarget, Manager, Runtime, Scopes, UriSchemeContext, Webview, Window,
   app::{GlobalWebviewEventListener, OnPageLoad, UriSchemeResponder, WebviewEvent},
   ipc::InvokeHandler,
   pattern::PatternJavascript,
   sealed::ManagerBase,
   webview::PageLoadPayload,
-  EventLoopMessage, EventTarget, Manager, Runtime, Scopes, UriSchemeContext, Webview, Window,
 };
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use crate::app::OnWebContentProcessTerminate;
 
 use super::{
-  window::{DragDropPayload, DRAG_DROP_EVENT, DRAG_ENTER_EVENT, DRAG_LEAVE_EVENT, DRAG_OVER_EVENT},
+  window::{DRAG_DROP_EVENT, DRAG_ENTER_EVENT, DRAG_LEAVE_EVENT, DRAG_OVER_EVENT, DragDropPayload},
   {AppManager, EmitPayload},
 };
 
@@ -267,7 +267,7 @@ impl<R: Runtime> WebviewManager<R> {
     if !registered_scheme_protocols.contains(&"tauri".into()) {
       let web_resource_request_handler = pending.web_resource_request_handler.take();
       let protocol = crate::protocol::tauri::get(
-        manager.manager_owned(),
+        manager.app_handle().clone(),
         &window_origin,
         web_resource_request_handler,
       );

--- a/crates/tauri/src/protocol/asset.rs
+++ b/crates/tauri/src/protocol/asset.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+//! Handler for the `asset://` custom protocol, serving local filesystem files
+//! scoped to allowed paths. Supports HTTP range requests for streaming media.
+
 use crate::{path::SafePathBuf, scope, webview::UriSchemeProtocolHandler};
 use http::{header::*, status::StatusCode, Request, Response};
 use http_range::HttpRange;
@@ -10,6 +13,11 @@ use std::io::{Read, Seek, Write};
 use std::{borrow::Cow, io::SeekFrom};
 use tauri_utils::mime_type::MimeType;
 
+/// Creates a URI scheme protocol handler for the `asset://` custom protocol.
+///
+/// This handler serves files from the local filesystem, scoped to the paths
+/// allowed by the provided [`scope`](scope::fs::Scope). Supports range requests
+/// for streaming media.
 pub fn get(scope: scope::fs::Scope, window_origin: String) -> UriSchemeProtocolHandler {
   Box::new(
     move |_, request, responder| match get_response(request, &scope, &window_origin) {

--- a/crates/tauri/src/protocol/isolation.rs
+++ b/crates/tauri/src/protocol/isolation.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+//! Handler for the isolation pattern protocol, serving the isolation iframe
+//! content with CSP enforcement and AES-GCM encrypted IPC.
+
 use crate::Assets;
 use http::header::CONTENT_TYPE;
 use serialize_to_javascript::Template;
@@ -18,6 +21,10 @@ use crate::{
   Runtime,
 };
 
+/// Creates a URI scheme protocol handler for the isolation pattern protocol.
+///
+/// This handler serves the isolation iframe content, applying CSP and encrypting
+/// IPC messages with AES-GCM to enforce the isolation security pattern.
 pub fn get<R: Runtime>(
   manager: Arc<AppManager<R>>,
   schema: &str,

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -7,13 +7,13 @@
 
 use std::borrow::Cow;
 
-use http::{Request, Response as HttpResponse, StatusCode, header::CONTENT_TYPE};
+use http::{header::CONTENT_TYPE, Request, Response as HttpResponse, StatusCode};
 use tauri_utils::config::HeaderAddition;
 
 use crate::{
-  Manager, Runtime,
   manager::webview::PROXY_DEV_SERVER,
   webview::{UriSchemeProtocolHandler, WebResourceRequestHandler},
+  Manager, Runtime,
 };
 
 #[cfg(all(dev, mobile))]

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+//! Handler for the `tauri://` custom protocol, serving bundled app assets
+//! in production and proxying to the dev server on mobile during development.
+
 use std::borrow::Cow;
 
 use http::{Request, Response as HttpResponse, StatusCode, header::CONTENT_TYPE};
@@ -24,6 +27,10 @@ struct CachedResponse {
   body: bytes::Bytes,
 }
 
+/// Creates a URI scheme protocol handler for the `tauri://` custom protocol.
+///
+/// This handler serves your app's bundled assets (HTML, JS, CSS, etc.) in production,
+/// and proxies requests to the dev server on mobile during development.
 pub fn get<M: Manager<R> + Send + Sync + 'static, R: Runtime>(
   #[allow(unused_variables)] manager: M,
   window_origin: &str,

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -39,6 +39,7 @@ pub fn get<M: Manager<R> + Send + Sync + 'static, R: Runtime>(
   #[cfg(all(dev, mobile))]
   let url = {
     let mut url = manager
+      .manager()
       .get_app_url(window_origin.starts_with("https"))
       .as_str()
       .to_string();
@@ -51,7 +52,7 @@ pub fn get<M: Manager<R> + Send + Sync + 'static, R: Runtime>(
   let window_origin = window_origin.to_string();
 
   #[cfg(all(dev, mobile))]
-  let response_cache = Arc::new(Mutex::new(HashMap::new()));
+  let response_cache = std::sync::Arc::new(Mutex::new(HashMap::new()));
 
   Box::new(move |_, request, responder| {
     match get_response(
@@ -82,7 +83,7 @@ fn get_response<M: Manager<R> + Send + Sync + 'static, R: Runtime>(
   web_resource_request_handler: Option<&WebResourceRequestHandler>,
   #[cfg(all(dev, mobile))] (url, response_cache): (
     &str,
-    &Arc<Mutex<HashMap<String, CachedResponse>>>,
+    &std::sync::Arc<Mutex<HashMap<String, CachedResponse>>>,
   ),
 ) -> Result<HttpResponse<Cow<'static, [u8]>>, Box<dyn std::error::Error>> {
   // use the entire URI as we are going to proxy the request

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::Cow;
 
-use http::{header::CONTENT_TYPE, Request, Response as HttpResponse, StatusCode};
+use http::{Request, Response as HttpResponse, StatusCode, header::CONTENT_TYPE};
 use tauri_utils::config::HeaderAddition;
 
 use crate::{
-  manager::{webview::PROXY_DEV_SERVER, AppManager},
+  Manager, Runtime,
+  manager::webview::PROXY_DEV_SERVER,
   webview::{UriSchemeProtocolHandler, WebResourceRequestHandler},
-  Runtime,
 };
 
 #[cfg(all(dev, mobile))]
@@ -24,8 +24,8 @@ struct CachedResponse {
   body: bytes::Bytes,
 }
 
-pub fn get<R: Runtime>(
-  #[allow(unused_variables)] manager: Arc<AppManager<R>>,
+pub fn get<M: Manager<R> + Send + Sync + 'static, R: Runtime>(
+  #[allow(unused_variables)] manager: M,
   window_origin: &str,
   web_resource_request_handler: Option<Box<WebResourceRequestHandler>>,
 ) -> UriSchemeProtocolHandler {
@@ -68,9 +68,9 @@ pub fn get<R: Runtime>(
   })
 }
 
-fn get_response<R: Runtime>(
+fn get_response<M: Manager<R> + Send + Sync + 'static, R: Runtime>(
   #[allow(unused_mut)] mut request: Request<Vec<u8>>,
-  #[allow(unused_variables)] manager: &AppManager<R>,
+  #[allow(unused_variables)] manager: &M,
   window_origin: &str,
   web_resource_request_handler: Option<&WebResourceRequestHandler>,
   #[cfg(all(dev, mobile))] (url, response_cache): (
@@ -100,7 +100,7 @@ fn get_response<R: Runtime>(
     .unwrap_or_default();
 
   let mut builder = HttpResponse::builder()
-    .add_configured_headers(manager.config.app.security.headers.as_ref())
+    .add_configured_headers(manager.config().app.security.headers.as_ref())
     .header("Access-Control-Allow-Origin", window_origin);
 
   #[cfg(all(dev, mobile))]
@@ -212,7 +212,7 @@ fn get_response<R: Runtime>(
   #[cfg(not(all(dev, mobile)))]
   let mut response = {
     let use_https_scheme = request.uri().scheme() == Some(&http::uri::Scheme::HTTPS);
-    let asset = manager.get_asset(path, use_https_scheme)?;
+    let asset = manager.manager().get_asset(path, use_https_scheme)?;
     builder = builder.header(CONTENT_TYPE, &asset.mime_type);
     if let Some(csp) = &asset.csp_header {
       builder = builder.header("Content-Security-Policy", csp);


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This PR exposes the tauri::get handler function in a way that it can be wrapped by callers to augment the functionality of the `tauri:://` protocol. This involved changing the fn signature to accept a publicly accessible `Manager`. 

The changes broke the run ordering of the tests so serial_test was introduced around the breaking test