### PR TITLE
Improve NSIS installer script

### DIFF
--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -70,7 +70,7 @@ Var NoShortcutMode
 Var WixMode
 Var OldMainBinaryName
 
-Name "${PRODUCTNAME}"
+Name "${PRODUCTNAME} ${VERSION}"
 BrandingText "${COPYRIGHT}"
 OutFile "${OUTFILE}"
 
@@ -82,7 +82,7 @@ InstallDir "${PLACEHOLDER_INSTALL_DIR}"
 
 VIProductVersion "${VERSIONWITHBUILD}"
 VIAddVersionKey "ProductName" "${PRODUCTNAME}"
-VIAddVersionKey "FileDescription" "${PRODUCTNAME}"
+VIAddVersionKey "FileDescription" "${PRODUCTNAME} installer"
 VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"
 VIAddVersionKey "FileVersion" "${VERSION}"
 VIAddVersionKey "ProductVersion" "${VERSION}"


### PR DESCRIPTION
- Add for each installer windows on top left after program name the info about program version (currently show only program name)
- Add in exe file properties for File description "Program name" + "installer" (currently is only program name and is a duplicated info because "Program Name" is also in other place)



