### PR TITLE
chore(cli): enable iOS scenes lifecycle by default

### DIFF
--- a/crates/tauri-cli/templates/mobile/ios/project.yml
+++ b/crates/tauri-cli/templates/mobile/ios/project.yml
@@ -60,6 +60,8 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: {{apple.bundle-version-short}}
         CFBundleVersion: "{{apple.bundle-version}}"
+        UIApplicationSupportsMultipleScenes: true
+        UISceneConfigurations: {}
         {{~#each apple.plist-pairs}}
         {{this.key}}: {{this.value}}{{/each}}
     entitlements:


### PR DESCRIPTION
this will be enforced on iOS 27