### PR TITLE
docs: fix fs scope comment typo

### DIFF
--- a/crates/tauri/src/scope/fs.rs
+++ b/crates/tauri/src/scope/fs.rs
@@ -77,7 +77,7 @@ fn push_pattern<P: AsRef<Path>, F: Fn(&str) -> Result<Pattern, glob::PatternErro
   pattern: P,
   f: F,
 ) -> crate::Result<()> {
-  // Reconstruct pattern path components with appropraite separator
+  // Reconstruct pattern path components with appropriate separator
   // so `some\path/to/dir/**\*` would be `some/path/to/dir/**/*` on Unix
   // and  `some\path\to\dir\**\*` on Windows.
   let path: PathBuf = pattern.as_ref().components().collect();


### PR DESCRIPTION
## Summary
- fix a typo in a file scope comment

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- Reviewed `README.md` and `.github/CONTRIBUTING.md`
- Signed the commit as requested by the repo guide
- Kept the change to one non-behavioral comment line

## Validation
- `git diff --check`