### PR TITLE
docs: fix runtime comment typo

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -818,7 +818,7 @@ impl WindowBuilder for WindowBuilderWrapper {
     #[cfg(target_os = "macos")]
     {
       // TODO: find a proper way to prevent webview being pushed out of the window.
-      // Workround for issue: https://github.com/tauri-apps/tauri/issues/10225
+      // Workaround for issue: https://github.com/tauri-apps/tauri/issues/10225
       // The window requires `NSFullSizeContentViewWindowMask` flag to prevent devtools
       // pushing the content view out of the window.
       // By setting the default style to `TitleBarStyle::Visible` should fix the issue for most of the users.


### PR DESCRIPTION
## Summary
- fix a typo in a runtime workaround comment

## Related issue
- N/A (trivial docs typo)

## Guideline alignment
- Reviewed `README.md` and `.github/CONTRIBUTING.md`
- Signed the commit as requested by the repo guide
- Kept the change to one non-behavioral comment line

## Validation
- `git diff --check`