### PR TITLE
feat(windows): append .rc content support.

### DIFF
--- a/.changes/append-rc-content-support.md
+++ b/.changes/append-rc-content-support.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": minor:feat
+---
+
+Allow users to append extra `.rc` content by `append_rc_content` in `WindowsAttributes`.

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -245,7 +245,7 @@ pub struct WindowsAttributes {
   /// A string containing additional .rc content to be appended to the generated resource file on Windows.
   ///
   /// Defaults to `None`.
-  append_rc_content: Option<String>,
+  append_rc_content: Vec<String>,
 }
 
 impl Default for WindowsAttributes {
@@ -260,7 +260,7 @@ impl WindowsAttributes {
     Self {
       window_icon_path: Default::default(),
       app_manifest: Some(include_str!("windows-app-manifest.xml").into()),
-      append_rc_content: None,
+      append_rc_content: Vec::new(),
     }
   }
 
@@ -270,7 +270,7 @@ impl WindowsAttributes {
     Self {
       app_manifest: None,
       window_icon_path: Default::default(),
-      append_rc_content: None,
+      append_rc_content: Vec::new(),
     }
   }
 
@@ -345,7 +345,7 @@ impl WindowsAttributes {
   /// This can be called multiple times to append multiple contents.
   #[must_use]
   pub fn append_rc_content<S: Into<String>>(mut self, content: S) -> Self {
-    self.append_rc_content = Some(content.into());
+    self.append_rc_content.push(content.into());
     self
   }
 }
@@ -627,8 +627,8 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
       res.set_manifest(&manifest);
     }
 
-    if let Some(append_rc_content) = attributes.windows_attributes.append_rc_content {
-      res.append_rc_content(&append_rc_content);
+    for content in attributes.windows_attributes.append_rc_content {
+      res.append_rc_content(&content);
     }
 
     if let Some(version_str) = &config.version {

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -341,6 +341,8 @@ impl WindowsAttributes {
     self
   }
 
+  /// Append additional .rc content to the generated resource file on Windows.
+  /// This can be called multiple times to append multiple contents.
   #[must_use]
   pub fn append_rc_content<S: AsRef<str>>(mut self, content: S) -> Self {
     self.append_rc_content = Some(content.as_ref().to_string());

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -344,8 +344,8 @@ impl WindowsAttributes {
   /// Append additional .rc content to the generated resource file on Windows.
   /// This can be called multiple times to append multiple contents.
   #[must_use]
-  pub fn append_rc_content<S: AsRef<str>>(mut self, content: S) -> Self {
-    self.append_rc_content = Some(content.as_ref().to_string());
+  pub fn append_rc_content<S: Into<String>>(mut self, content: S) -> Self {
+    self.append_rc_content = Some(content.into());
     self
   }
 }

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -242,6 +242,10 @@ pub struct WindowsAttributes {
   ///
   /// [application manifest]: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests
   app_manifest: Option<String>,
+  /// A string containing additional .rc content to be appended to the generated resource file on Windows.
+  ///
+  /// Defaults to `None`.
+  append_rc_content: Option<String>,
 }
 
 impl Default for WindowsAttributes {
@@ -256,6 +260,7 @@ impl WindowsAttributes {
     Self {
       window_icon_path: Default::default(),
       app_manifest: Some(include_str!("windows-app-manifest.xml").into()),
+      append_rc_content: None,
     }
   }
 
@@ -265,6 +270,7 @@ impl WindowsAttributes {
     Self {
       app_manifest: None,
       window_icon_path: Default::default(),
+      append_rc_content: None,
     }
   }
 
@@ -332,6 +338,12 @@ impl WindowsAttributes {
   #[must_use]
   pub fn app_manifest<S: AsRef<str>>(mut self, manifest: S) -> Self {
     self.app_manifest = Some(manifest.as_ref().to_string());
+    self
+  }
+
+  #[must_use]
+  pub fn append_rc_content<S: AsRef<str>>(mut self, content: S) -> Self {
+    self.append_rc_content = Some(content.as_ref().to_string());
     self
   }
 }
@@ -611,6 +623,10 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
 
     if let Some(manifest) = attributes.windows_attributes.app_manifest {
       res.set_manifest(&manifest);
+    }
+
+    if let Some(append_rc_content) = attributes.windows_attributes.append_rc_content {
+      res.append_rc_content(&append_rc_content);
     }
 
     if let Some(version_str) = &config.version {

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -242,9 +242,7 @@ pub struct WindowsAttributes {
   ///
   /// [application manifest]: https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests
   app_manifest: Option<String>,
-  /// A string containing additional .rc content to be appended to the generated resource file on Windows.
-  ///
-  /// Defaults to `None`.
+  /// A series of strings containing additional .rc content to be appended to the generated resource file on Windows.
   append_rc_content: Vec<String>,
 }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

This pr closes issue #14784 .

Allow users to append extra .rc content by a new api in `WindowsAttributes`.

