### PR TITLE
Follow up to PR15262

### DIFF
--- a/.changes/cleanup-cow-use.md
+++ b/.changes/cleanup-cow-use.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+Remove unused `std::borrow::Cow`, no user facing changes.

--- a/crates/tauri-utils/src/pattern/isolation.rs
+++ b/crates/tauri-utils/src/pattern/isolation.rs
@@ -104,7 +104,7 @@ impl Keys {
   /// Decrypts a message using the generated keys.
   pub fn decrypt(&self, raw: RawIsolationPayload<'_>) -> Result<Vec<u8>, Error> {
     let RawIsolationPayload { nonce, payload, .. } = raw;
-    let nonce: [u8; 12] = nonce.as_ref().try_into()?;
+    let nonce: [u8; 12] = nonce.try_into()?;
     self
       .aes_gcm
       .key
@@ -117,8 +117,8 @@ impl Keys {
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RawIsolationPayload<'a> {
-  nonce: Cow<'a, [u8]>,
-  payload: Cow<'a, [u8]>,
+  nonce: &'a [u8],
+  payload: &'a [u8],
   content_type: Cow<'a, str>,
 }
 

--- a/crates/tauri/src/ipc/protocol.rs
+++ b/crates/tauri/src/ipc/protocol.rs
@@ -251,6 +251,7 @@ fn handle_ipc_message<R: Runtime>(request: Request<String>, manager: &AppManager
         cmd: String,
         callback: CallbackFn,
         error: CallbackFn,
+        #[serde(borrow)]
         payload: crate::utils::pattern::isolation::RawIsolationPayload<'a>,
         options: Option<RequestOptions>,
         #[serde(rename = "__TAURI_INVOKE_KEY__")]


### PR DESCRIPTION
Follow up #15262. Most in the structs in `tauri-utils/isolation.rs` are only used in `tauri`, could be a candidate to split and move for v3.