### PR TITLE
Allow Linux WebKit user-media permission requests

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -114,6 +114,13 @@ use wry::{
   target_os = "android"
 )))]
 use wry::{WebViewBuilderExtUnix, WebViewExtUnix};
+#[cfg(not(any(
+  target_os = "windows",
+  target_os = "macos",
+  target_os = "ios",
+  target_os = "android"
+)))]
+use webkit2gtk::{glib::ObjectExt, PermissionRequestExt, UserMediaPermissionRequest, WebViewExt};
 
 #[cfg(target_os = "ios")]
 pub use tao::platform::ios::{WindowBuilderExtIOS, WindowExtIOS};
@@ -5205,6 +5212,24 @@ You may have it installed on another user account, but it is not available for t
     }
   }
   .map_err(|e| Error::CreateWebview(Box::new(e)))?;
+
+  #[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+  ))]
+  {
+    webview.webview().connect_permission_request(|_, request| {
+      if request.is::<UserMediaPermissionRequest>() {
+        request.allow();
+        true
+      } else {
+        false
+      }
+    });
+  }
 
   if kind == WebviewKind::WindowContent {
     #[cfg(any(


### PR DESCRIPTION
## Summary
Allow Linux WebKitGTK user-media permission requests in the Tauri runtime by handling WebKit `permission-request` events for `UserMediaPermissionRequest` and calling `request.allow()`.

## Why
This is a candidate fix for:
- https://github.com/tauri-apps/tauri/issues/15277

Minimal reproducer:
- https://github.com/AmeerJ97/tauri-linux-mic-permission-repro

## What changed
In `tauri-runtime-wry` on Linux, after the webview is created:
- connect to WebKitGTK `permission-request`
- if the request is `UserMediaPermissionRequest`, call `allow()` and return `true`
- otherwise return `false`

## Status
- `cargo build -p tauri-runtime-wry` passes locally
- This PR is draft because it still needs runtime verification against the standalone reproducer
