### PR TITLE
Audit CI fix, RUSTSEC advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,4 +8,17 @@ ignore = [
   "RUSTSEC-2024-0370",
   # time crate can't be updated in the repo because of MSRV, users are unaffected
   "RUSTSEC-2026-0009",
+  # rand unsoundness, fixed when we remove kuchikiki from deps in v3, currently
+  # remains for semver reasons but is not built in default configuration
+  "RUSTSEC-2026-0097",
+  # glib 0.18.5 unsoundness, fixed by updating to gtk4
+  "RUSTSEC-2024-0429",
+  # rustls, fixed when updating to apple-codesign 0.28.0
+  "RUSTSEC-2026-0049",
+  # rustls, fixed when updating to apple-codesign 0.28.0
+  "RUSTSEC-2026-0098",
+  # rustls, fixed when updating to apple-codesign 0.28.0
+  "RUSTSEC-2026-0099",
+  # rustls, fixed when updating to apple-codesign 0.28.0
+  "RUSTSEC-2026-0104"
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -20,5 +20,5 @@ ignore = [
   # rustls, fixed when updating to apple-codesign 0.28.0
   "RUSTSEC-2026-0099",
   # rustls, fixed when updating to apple-codesign 0.28.0
-  "RUSTSEC-2026-0104"
+  "RUSTSEC-2026-0104",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7483,9 +7483,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e1c91382686d21b5ac7959341fcb9780fa7c03773646995a87c950fa7be640"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
 ]
@@ -7574,9 +7574,9 @@ dependencies = [
 
 [[package]]
 name = "sdd"
-version = "3.0.5"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478f121bb72bbf63c52c93011ea1791dca40140dfe13f8336c4c5ac952c33aa9"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7282,7 +7282,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7365,7 +7365,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.13",
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7401,9 +7401,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "plist",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rasn",
  "rayon",
  "regex",
@@ -359,7 +359,7 @@ dependencies = [
  "flate2",
  "log",
  "md-5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest 0.11.27",
  "scroll",
  "serde",
@@ -4142,7 +4142,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -5014,7 +5014,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "smallvec",
  "zeroize",
@@ -5978,7 +5978,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ripemd",
  "rsa",
  "sha1",
@@ -6082,7 +6082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6092,7 +6092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6440,7 +6440,7 @@ dependencies = [
  "bitflags 2.7.0",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
@@ -6507,7 +6507,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6558,9 +6558,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6725,7 +6725,7 @@ dependencies = [
  "once_cell",
  "paste",
  "profiling",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "simd_helpers",
  "system-deps",
@@ -7170,7 +7170,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -8266,7 +8266,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -9822,7 +9822,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-native-certs 0.7.3",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6569,9 +6569,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -8909,7 +8909,7 @@ dependencies = [
  "phf 0.11.3",
  "plist",
  "pretty_assertions",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "resvg",
@@ -9027,7 +9027,7 @@ dependencies = [
  "os_pipe",
  "p12",
  "plist",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex",
  "serde",
  "serde_json",
@@ -9843,7 +9843,7 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.3",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.12",
  "utf-8",


### PR DESCRIPTION
Related to #15215 , unblocks activating branch protection.

Fixes #15227, fixes #15228, fixes #15229, fixes #15248, fixes #15249

The remaining advisories are triaged and ignored in CI for now.

2024-0429 glib 0.18.5 unsoundness, fixed by moving to gtk4
2026-0097 rand unsoundness, fixed by removing kuchikiki from deps in v3 --> have to skip because remains in lockfile, but is no longer a dependency of the default configuration, so can close #15227.
2026-0049 rustls, fixed by updating apple-codesign to 0.28.0
2026-0098 rustls, fixed by updating apple-codesign to 0.28.0
2026-0099 rustls, fixed by updating apple-codesign to 0.28.0

Updating `apple-codesign` would deal with #15244, #15245, #15246, #15247