### PR TITLE
fix(tauri-build): set Windows FileVersion/ProductVersion strings from tauri config

### DIFF
--- a/.changes/windows-versioninfo-strings.md
+++ b/.changes/windows-versioninfo-strings.md
@@ -1,0 +1,5 @@
+---
+"tauri-build": "patch:bug"
+---
+
+Set the correct Windows `FileVersion` and `ProductVersion` string values using the version from the Tauri config.

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -634,6 +634,8 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
         let version = (v.major << 48) | (v.minor << 32) | (v.patch << 16);
         res.set_version_info(VersionInfo::FILEVERSION, version);
         res.set_version_info(VersionInfo::PRODUCTVERSION, version);
+        res.set("FileVersion", version_str);
+        res.set("ProductVersion", version_str);
       }
     }
 


### PR DESCRIPTION
## Summary

This PR sets the Windows `FileVersion` and `ProductVersion` string values from `config.version` in `tauri-build`.

The current `dev` branch sets the numeric `FILEVERSION` / `PRODUCTVERSION` fixed fields from the Tauri config, but does not set the corresponding `FileVersion` / `ProductVersion` string values. In that case those strings fall back to whatever `tauri-winres` inferred from `Cargo.toml`.

That can leave the built `.exe` with mixed version sources:

- `FILEVERSION` / `PRODUCTVERSION` fixed fields come from `config.version`
- `FileVersion` / `ProductVersion` strings come from `Cargo.toml`

This PR restores the missing string setters so that Windows VERSIONINFO uses the version from the Tauri config consistently.

## Why this is safe

- matches the existing `tauri-build` changelog entry that says these fields come from `tauri.conf.json`
- changes only a single existing block in `crates/tauri-build/src/lib.rs`
- adds no new API surface
- changes behavior only for undocumented transitive `tauri-winres` Cargo metadata overrides

## Verification

- `cargo build -p tauri-build`
- manually verified the diff is limited to restoring the two missing string setters plus the `.changes` entry