### PR TITLE
emit resumed on resumed

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4166,6 +4166,10 @@ fn handle_event_loop<T: UserEvent>(
       callback(RunEvent::Resumed);
     }
 
+    Event::Resumed => {
+      callback(RunEvent::Resumed);
+    }
+
     Event::MainEventsCleared => {
       callback(RunEvent::MainEventsCleared);
     }


### PR DESCRIPTION
Currently there is not an event emitted out of the tauri wry runtime for app resumed events on ios. This PR forwards the resumed event outwards which allows ios apps to listen to the resume event

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
