### PR TITLE
fix(bundler): add missing MULTIUSER LangString translations for Korean NSIS

### DIFF
--- a/.changes/nsis-korean-multiuser-strings.md
+++ b/.changes/nsis-korean-multiuser-strings.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Add missing `MULTIUSER_*` LangString translations to Korean NSIS language file (`MULTIUSER_TEXT_INSTALLMODE_TITLE`, `MULTIUSER_TEXT_INSTALLMODE_SUBTITLE`, `MULTIUSER_INNERTEXT_INSTALLMODE_TOP`, `MULTIUSER_INNERTEXT_INSTALLMODE_ALLUSERS`, `MULTIUSER_INNERTEXT_INSTALLMODE_CURRENTUSER`). Previously these fell back to English when a Korean installer used `installMode: both`.

--- a/.changes/nsis-korean-multiuser-strings.md
+++ b/.changes/nsis-korean-multiuser-strings.md
@@ -1,5 +1,5 @@
 ---
-"tauri-bundler": patch
+"tauri-bundler": patch:bug
 ---
 
 Add missing `MULTIUSER_*` LangString translations to Korean NSIS language file (`MULTIUSER_TEXT_INSTALLMODE_TITLE`, `MULTIUSER_TEXT_INSTALLMODE_SUBTITLE`, `MULTIUSER_INNERTEXT_INSTALLMODE_TOP`, `MULTIUSER_INNERTEXT_INSTALLMODE_ALLUSERS`, `MULTIUSER_INNERTEXT_INSTALLMODE_CURRENTUSER`). Previously these fell back to English when a Korean installer used `installMode: both`.

--- a/crates/tauri-bundler/src/bundle/windows/nsis/languages/Korean.nsh
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/languages/Korean.nsh
@@ -25,3 +25,8 @@ LangString webview2Downloading ${LANG_KOREAN} "WebView2 부트스트래퍼 다�
 LangString webview2InstallError ${LANG_KOREAN} "오류: 종료 코드 $1로 WebView2를 설치하지 못했습니다."
 LangString webview2InstallSuccess ${LANG_KOREAN} "WebView2가 성공적으로 설치되었습니다."
 LangString deleteAppData ${LANG_KOREAN} "애플리케이션 데이터 삭제하기"
+LangString MULTIUSER_TEXT_INSTALLMODE_TITLE ${LANG_KOREAN} "설치 모드 선택"
+LangString MULTIUSER_TEXT_INSTALLMODE_SUBTITLE ${LANG_KOREAN} "모든 사용자용 또는 현재 사용자용으로만 설치"
+LangString MULTIUSER_INNERTEXT_INSTALLMODE_TOP ${LANG_KOREAN} "이 애플리케이션을 누구를 위해 설치하시겠습니까?"
+LangString MULTIUSER_INNERTEXT_INSTALLMODE_ALLUSERS ${LANG_KOREAN} "이 컴퓨터를 사용하는 모든 사용자(모든 사용자)"
+LangString MULTIUSER_INNERTEXT_INSTALLMODE_CURRENTUSER ${LANG_KOREAN} "현재 사용자만"


### PR DESCRIPTION
## Summary

Adds the 5 missing `MULTIUSER_*` LangString translations to `Korean.nsh` so Korean installers built with \`installMode: \"both\"\` no longer fall back to English for the install-mode dialog.

Currently, building a Tauri app with NSIS bundle that lists \`Korean\` in \`bundle.windows.nsis.languages\` and uses \`installMode: \"both\"\` produces these warnings:

\`\`\`
warning: !warning: LangString \"MULTIUSER_TEXT_INSTALLMODE_TITLE\" for language Korean is missing, using fallback from \"...\\English.nsh\"
warning: !warning: LangString \"MULTIUSER_TEXT_INSTALLMODE_SUBTITLE\" for language Korean is missing, ...
warning: !warning: LangString \"MULTIUSER_INNERTEXT_INSTALLMODE_TOP\" for language Korean is missing, ...
warning: !warning: LangString \"MULTIUSER_INNERTEXT_INSTALLMODE_ALLUSERS\" for language Korean is missing, ...
warning: !warning: LangString \"MULTIUSER_INNERTEXT_INSTALLMODE_CURRENTUSER\" for language Korean is missing, ...
\`\`\`

This PR adds Korean translations for those 5 strings.

## Notes for reviewers

The translations were derived from the English equivalents. Native Korean speaker review would be appreciated to confirm naturalness — happy to amend.

## Test plan

- [ ] Build a sample Tauri app with NSIS bundle, \`installMode: \"both\"\`, and \`Korean\` in \`languages\` — verify no \`MULTIUSER_*\` LangString warnings.
- [ ] Run installer with Korean selected — verify the install-mode picker dialog shows Korean text.