### PR TITLE
Allow child Webviews (on unstable) to correctly set the traffic light position of the parent

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -5028,7 +5028,20 @@ You may have it installed on another user account, but it is not available for t
       target_os = "ios",
       target_os = "android"
     ))]
-    WebviewKind::WindowChild => webview_builder.build_as_child(&window),
+    WebviewKind::WindowChild => {
+      let webview = webview_builder.build_as_child(&window);
+      // wry ignores with_traffic_light_inset() for child webviews, so we set it manually here
+      // if the traffic light configuration was provided. Note that every new child that sets
+      // this overrides the rest, so order of instantiation determines the location.
+      #[cfg(target_os = "macos")]
+      {
+        use tao::platform::macos::WindowExtMacOS;
+        if let Some(position) = webview_attributes.traffic_light_position {
+          window.set_traffic_light_inset(position);
+        }
+      }
+      webview
+    }
     WebviewKind::WindowContent => {
       #[cfg(any(
         target_os = "windows",


### PR DESCRIPTION
On the `unstable` feature, macOS traffic lights don't follow the traffic light configuration. This is because all webviews are added as child webviews that don't affect the parent web view. The fix I added is to set the parent traffic lights if the child has a setting for them.

This fix is somewhat messy -- i'd ideally like guidance on how to not make it such. One idea would be to fit it into the `build` function, but then it would take the webview_attributes, etc.

That said, there are many sites where platform specific functionality is added, so perhaps this is canonical to the codebase.

Fixes #14072