### PR TITLE
Revert "fix(deps): update specta in lockfile"

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - '.github/workflows/lint-rust.yml'
       - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/test-cli-rs.yml
+++ b/.github/workflows/test-cli-rs.yml
@@ -14,6 +14,8 @@ on:
       - 'crates/tauri-utils/**'
       - 'crates/tauri-bundler/**'
       - 'crates/tauri-cli/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 env:
   RUST_BACKTRACE: 1

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -12,6 +12,8 @@ on:
     paths:
       - '.github/workflows/test-core.yml'
       - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - '!crates/tauri/scripts/**'
       - '!crates/tauri-cli/**'
       - '!crates/tauri-bundler/**'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8325,20 +8325,20 @@ dependencies = [
 
 [[package]]
 name = "specta"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f320c7dd82008b6958f43f6257c95319c407d1c17ade43686e50ea520c28bb26"
+checksum = "4ccbb212565d2dc177bc15ecb7b039d66c4490da892436a4eee5b394d620c9bc"
 dependencies = [
  "paste",
- "rustc_version",
  "specta-macros",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "specta-macros"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153f185d0051a64d81977bab5012809d5c9d9db8792406a0997352e05494f711"
+checksum = "68999d29816965eb9e5201f60aec02a76512139811661a7e8e653abc810b8f72"
 dependencies = [
  "Inflector",
  "proc-macro2",


### PR DESCRIPTION
Reverts tauri-apps/tauri#15303

Looking at https://docs.rs/crate/tauri/latest/builds/2963776, it seems to be pulling in `specta-2.0.0-rc.23` which is not in the lockfile 🤷‍♂️