### PR TITLE
fix(driver): enable `eq-separator` feature for `pico-args`.

### DIFF
--- a/.changes/driver-arg-eq-separator.md
+++ b/.changes/driver-arg-eq-separator.md
@@ -1,0 +1,5 @@
+---
+"tauri-driver": patch
+---
+
+Support `eq-separator` for `tauri-driver`.

--- a/crates/tauri-driver/Cargo.toml
+++ b/crates/tauri-driver/Cargo.toml
@@ -24,7 +24,7 @@ hyper-util = { version = "0.1", features = [
   "server",
   "tokio",
 ] }
-pico-args = "0.5"
+pico-args = { version = "0.5", features = ["eq-separator"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros"] }


### PR DESCRIPTION
Fixes #15155 