### PR TITLE
.2385318931605690:159b674189cea7f79dab4117d6a41cba_69f72d24eb4415a9574e62f9.69f7553beb4415a9574e66e3.69f7553a57ba7e50701791e3:Trae CN.T(2026/5/3 22:01:31)

### DIFF
--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -72,6 +72,7 @@ glob = "0.3"
 mime = "0.3"
 data-url = { version = "0.3", optional = true }
 serialize-to-javascript = "0.1.2"
+futures = "0.3"
 image = { version = "0.25", default-features = false, optional = true }
 http-range = { version = "0.1", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/crates/tauri/scripts/persistent-channel.js
+++ b/crates/tauri/scripts/persistent-channel.js
@@ -7,7 +7,6 @@
   const PERSISTENT_CHANNEL_ID_PREFIX = '__PERSISTENT_CHANNEL__:'
 
   const channels = Object.create(null)
-  const pendingConnects = Object.create(null)
 
   const invoke = window.__TAURI_INTERNALS__.invoke
   const transformCallback = window.__TAURI_INTERNALS__.transformCallback
@@ -39,7 +38,6 @@
       this._isClosed = false
       this._messageIndex = 0
       this._pendingAcks = Object.create(null)
-      this._messageQueue = []
       this._isConnected = false
 
       this._callbackId = transformCallback((response) => {
@@ -91,14 +89,16 @@
       }
     }
 
-    async _sendInternal(message) {
+    async _sendInternal(messageType, payload, index) {
       if (this._isClosed) {
         throw new ChannelClosedError()
       }
 
       return invoke('plugin:' + PERSISTENT_CHANNEL_PLUGIN_NAME + '|send_message', {
-        channelId: this._id,
-        message: message
+        userChannelId: this._id,
+        messageType: messageType,
+        payload: payload,
+        index: index
       })
     }
 
@@ -107,35 +107,30 @@
         throw new ChannelClosedError()
       }
 
-      const message = {
-        type: 'data',
-        payload: data,
-        index: this._messageIndex++
-      }
+      const index = this._messageIndex++
 
       if (options.timeout) {
-        return this._sendWithTimeout(message, options.timeout)
+        return this._sendWithTimeout('data', data, index, options.timeout)
       }
 
       if (options.requireAck) {
-        return this._sendWithAck(message, options.timeout || 30000)
+        return this._sendWithAck('data', data, index, options.timeout || 30000)
       }
 
-      return this._sendInternal(message)
+      return this._sendInternal('data', data, index)
     }
 
-    async _sendWithTimeout(message, timeout) {
+    async _sendWithTimeout(messageType, payload, index, timeout) {
       const timeoutPromise = new Promise((_, reject) => {
         setTimeout(() => {
           reject(new ChannelTimeoutError('Send operation timed out'))
         }, timeout)
       })
 
-      return Promise.race([this._sendInternal(message), timeoutPromise])
+      return Promise.race([this._sendInternal(messageType, payload, index), timeoutPromise])
     }
 
-    async _sendWithAck(message, timeout) {
-      const index = message.index
+    async _sendWithAck(messageType, payload, index, timeout) {
       const ackPromise = new Promise((resolve, reject) => {
         const timeoutId = setTimeout(() => {
           delete this._pendingAcks[index]
@@ -156,7 +151,7 @@
         }
       })
 
-      await this._sendInternal(message)
+      await this._sendInternal(messageType, payload, index)
       return ackPromise
     }
 
@@ -184,7 +179,7 @@
       }
 
       return invoke('plugin:' + PERSISTENT_CHANNEL_PLUGIN_NAME + '|send_binary', {
-        channelId: this._id,
+        userChannelId: this._id,
         data: Array.from(bytes)
       })
     }
@@ -207,7 +202,7 @@
         }
       })
 
-      await this._sendInternal({ type: 'ping' })
+      await this._sendInternal('ping', null, null)
       return pongPromise
     }
 
@@ -223,7 +218,7 @@
       }
 
       try {
-        await this._sendInternal({ type: 'close' })
+        await this._sendInternal('close', null, null)
       } catch (e) {
         // Ignore errors during close
       }
@@ -313,7 +308,7 @@
 
       try {
         const response = await invoke('plugin:' + PERSISTENT_CHANNEL_PLUGIN_NAME + '|connect', {
-          channelId: channelId,
+          userChannelId: channelId,
           callbackId: channel._callbackId
         })
 

--- a/crates/tauri/scripts/persistent-channel.js
+++ b/crates/tauri/scripts/persistent-channel.js
@@ -1,0 +1,366 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+;(function () {
+  const PERSISTENT_CHANNEL_PLUGIN_NAME = '__TAURI_PERSISTENT_CHANNEL__'
+  const PERSISTENT_CHANNEL_ID_PREFIX = '__PERSISTENT_CHANNEL__:'
+
+  const channels = Object.create(null)
+  const pendingConnects = Object.create(null)
+
+  const invoke = window.__TAURI_INTERNALS__.invoke
+  const transformCallback = window.__TAURI_INTERNALS__.transformCallback
+
+  class ChannelClosedError extends Error {
+    constructor(message) {
+      super(message || 'Channel is closed')
+      this.name = 'ChannelClosedError'
+    }
+  }
+
+  class ChannelTimeoutError extends Error {
+    constructor(message) {
+      super(message || 'Channel operation timed out')
+      this.name = 'ChannelTimeoutError'
+    }
+  }
+
+  function generateChannelId() {
+    return PERSISTENT_CHANNEL_ID_PREFIX + Date.now() + '-' + Math.random().toString(36).substring(2, 11)
+  }
+
+  class PersistentChannel {
+    constructor(id, onMessage, onError, onClose) {
+      this._id = id
+      this._onMessage = onMessage || (() => {})
+      this._onError = onError || (() => {})
+      this._onClose = onClose || (() => {})
+      this._isClosed = false
+      this._messageIndex = 0
+      this._pendingAcks = Object.create(null)
+      this._messageQueue = []
+      this._isConnected = false
+
+      this._callbackId = transformCallback((response) => {
+        this._handleResponse(response)
+      })
+    }
+
+    get id() {
+      return this._id
+    }
+
+    get isClosed() {
+      return this._isClosed
+    }
+
+    get isConnected() {
+      return this._isConnected
+    }
+
+    _handleResponse(response) {
+      if (this._isClosed) return
+
+      if (response.end) {
+        this._closeInternal('Remote closed the channel')
+        return
+      }
+
+      if (response.message) {
+        this._messageIndex = response.index || this._messageIndex
+        try {
+          const msg = response.message
+          if (msg && typeof msg === 'object' && msg.type) {
+            switch (msg.type) {
+              case 'pong':
+                this._handlePong()
+                break
+              case 'ack':
+                this._handleAck(msg.index)
+                break
+              default:
+                this._onMessage(msg)
+            }
+          } else {
+            this._onMessage(response.message)
+          }
+        } catch (e) {
+          this._onError(e)
+        }
+      }
+    }
+
+    async _sendInternal(message) {
+      if (this._isClosed) {
+        throw new ChannelClosedError()
+      }
+
+      return invoke('plugin:' + PERSISTENT_CHANNEL_PLUGIN_NAME + '|send_message', {
+        channelId: this._id,
+        message: message
+      })
+    }
+
+    async send(data, options = {}) {
+      if (this._isClosed) {
+        throw new ChannelClosedError()
+      }
+
+      const message = {
+        type: 'data',
+        payload: data,
+        index: this._messageIndex++
+      }
+
+      if (options.timeout) {
+        return this._sendWithTimeout(message, options.timeout)
+      }
+
+      if (options.requireAck) {
+        return this._sendWithAck(message, options.timeout || 30000)
+      }
+
+      return this._sendInternal(message)
+    }
+
+    async _sendWithTimeout(message, timeout) {
+      const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => {
+          reject(new ChannelTimeoutError('Send operation timed out'))
+        }, timeout)
+      })
+
+      return Promise.race([this._sendInternal(message), timeoutPromise])
+    }
+
+    async _sendWithAck(message, timeout) {
+      const index = message.index
+      const ackPromise = new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          delete this._pendingAcks[index]
+          reject(new ChannelTimeoutError('Ack not received'))
+        }, timeout)
+
+        this._pendingAcks[index] = {
+          resolve: (response) => {
+            clearTimeout(timeoutId)
+            delete this._pendingAcks[index]
+            resolve(response)
+          },
+          reject: (error) => {
+            clearTimeout(timeoutId)
+            delete this._pendingAcks[index]
+            reject(error)
+          }
+        }
+      })
+
+      await this._sendInternal(message)
+      return ackPromise
+    }
+
+    _handleAck(index) {
+      const ack = this._pendingAcks[index]
+      if (ack) {
+        ack.resolve()
+      }
+    }
+
+    async sendBinary(data) {
+      if (this._isClosed) {
+        throw new ChannelClosedError()
+      }
+
+      let bytes
+      if (data instanceof ArrayBuffer) {
+        bytes = new Uint8Array(data)
+      } else if (data instanceof Uint8Array) {
+        bytes = data
+      } else if (ArrayBuffer.isView(data)) {
+        bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+      } else {
+        throw new Error('Unsupported binary data type. Use ArrayBuffer or TypedArray.')
+      }
+
+      return invoke('plugin:' + PERSISTENT_CHANNEL_PLUGIN_NAME + '|send_binary', {
+        channelId: this._id,
+        data: Array.from(bytes)
+      })
+    }
+
+    async ping(timeout = 5000) {
+      if (this._isClosed) {
+        throw new ChannelClosedError()
+      }
+
+      const pongPromise = new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          this._pongHandler = null
+          reject(new ChannelTimeoutError('Ping timed out'))
+        }, timeout)
+
+        this._pongHandler = () => {
+          clearTimeout(timeoutId)
+          this._pongHandler = null
+          resolve()
+        }
+      })
+
+      await this._sendInternal({ type: 'ping' })
+      return pongPromise
+    }
+
+    _handlePong() {
+      if (this._pongHandler) {
+        this._pongHandler()
+      }
+    }
+
+    async close() {
+      if (this._isClosed) {
+        return
+      }
+
+      try {
+        await this._sendInternal({ type: 'close' })
+      } catch (e) {
+        // Ignore errors during close
+      }
+
+      this._closeInternal('Closed by client')
+    }
+
+    _closeInternal(reason) {
+      if (this._isClosed) {
+        return
+      }
+
+      this._isClosed = true
+      this._isConnected = false
+
+      // Reject all pending acks
+      for (const index in this._pendingAcks) {
+        if (Object.prototype.hasOwnProperty.call(this._pendingAcks, index)) {
+          this._pendingAcks[index].reject(new ChannelClosedError('Channel closed before ack received'))
+        }
+      }
+      this._pendingAcks = Object.create(null)
+
+      // Unregister callback
+      window.__TAURI_INTERNALS__.unregisterCallback(this._callbackId)
+
+      // Remove from channels map
+      delete channels[this._id]
+
+      this._onClose(reason)
+    }
+
+    onMessage(handler) {
+      this._onMessage = handler
+      return this
+    }
+
+    onError(handler) {
+      this._onError = handler
+      return this
+    }
+
+    onClose(handler) {
+      this._onClose = handler
+      return this
+    }
+  }
+
+  class ChannelBuilder {
+    constructor() {
+      this._onMessage = null
+      this._onError = null
+      this._onClose = null
+      this._timeout = 30000
+    }
+
+    onMessage(handler) {
+      this._onMessage = handler
+      return this
+    }
+
+    onError(handler) {
+      this._onError = handler
+      return this
+    }
+
+    onClose(handler) {
+      this._onClose = handler
+      return this
+    }
+
+    timeout(ms) {
+      this._timeout = ms
+      return this
+    }
+
+    async connect() {
+      const channelId = generateChannelId()
+      const channel = new PersistentChannel(
+        channelId,
+        this._onMessage,
+        this._onError,
+        this._onClose
+      )
+
+      channels[channelId] = channel
+
+      try {
+        const response = await invoke('plugin:' + PERSISTENT_CHANNEL_PLUGIN_NAME + '|connect', {
+          channelId: channelId,
+          callbackId: channel._callbackId
+        })
+
+        channel._isConnected = true
+        return channel
+      } catch (e) {
+        delete channels[channelId]
+        window.__TAURI_INTERNALS__.unregisterCallback(channel._callbackId)
+        throw e
+      }
+    }
+  }
+
+  function getChannel(channelId) {
+    return channels[channelId] || null
+  }
+
+  function getAllChannels() {
+    return Object.values(channels)
+  }
+
+  async function broadcast(data) {
+    return invoke('plugin:' + PERSISTENT_CHANNEL_PLUGIN_NAME + '|broadcast', {
+      message: data
+    })
+  }
+
+  function createChannel() {
+    return new ChannelBuilder()
+  }
+
+  Object.defineProperty(window.__TAURI_INTERNALS__, 'persistentChannel', {
+    value: Object.freeze({
+      create: createChannel,
+      get: getChannel,
+      getAll: getAllChannels,
+      broadcast: broadcast,
+      Channel: PersistentChannel,
+      ChannelClosedError,
+      ChannelTimeoutError
+    })
+  })
+
+  window.__TAURI_PERSISTENT_CHANNEL__ = {
+    create: createChannel,
+    get: getChannel,
+    getAll: getAllChannels,
+    broadcast: broadcast
+  }
+})()

--- a/crates/tauri/src/error.rs
+++ b/crates/tauri/src/error.rs
@@ -166,6 +166,12 @@ pub enum Error {
   /// tokio oneshot channel failed to receive message
   #[error(transparent)]
   TokioOneshotRecv(#[from] tokio::sync::oneshot::error::RecvError),
+  /// Persistent channel is closed
+  #[error("persistent channel is closed")]
+  ChannelClosed,
+  /// Persistent channel not found
+  #[error("persistent channel not found: {0}")]
+  ChannelNotFound(u64),
 }
 
 impl From<getrandom::Error> for Error {

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -26,20 +26,19 @@ use super::{
 };
 
 pub const IPC_PAYLOAD_PREFIX: &str = "__CHANNEL__:";
-// TODO: Change this to `channel` in v3
 pub const CHANNEL_PLUGIN_NAME: &str = "__TAURI_CHANNEL__";
-// TODO: Change this to `plugin:channel|fetch` in v3
 pub const FETCH_CHANNEL_DATA_COMMAND: &str = "plugin:__TAURI_CHANNEL__|fetch";
-const CHANNEL_ID_HEADER_NAME: &str = "Tauri-Channel-Id";
+pub const CHANNEL_ID_HEADER_NAME: &str = "Tauri-Channel-Id";
 
-/// Maximum size a JSON we should send directly without going through the fetch process
-// 8192 byte JSON payload runs roughly 2x faster through eval than through fetch on WebView2 v135
-const MAX_JSON_DIRECT_EXECUTE_THRESHOLD: usize = 8192;
-// 1024 byte payload runs  roughly 30% faster through eval than through fetch on macOS
-const MAX_RAW_DIRECT_EXECUTE_THRESHOLD: usize = 1024;
+pub(crate) const MAX_JSON_DIRECT_EXECUTE_THRESHOLD: usize = 8192;
+pub(crate) const MAX_RAW_DIRECT_EXECUTE_THRESHOLD: usize = 1024;
 
 static CHANNEL_COUNTER: AtomicU32 = AtomicU32::new(0);
 static CHANNEL_DATA_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+pub(crate) fn next_channel_data_id() -> u32 {
+  CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
 
 /// Maps a channel id to a pending data that must be send to the JavaScript side via the IPC.
 #[derive(Default, Clone)]
@@ -343,4 +342,69 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
       fetch
     ])
     .build()
+}
+
+pub(crate) fn send_channel_response<R: Runtime>(
+  webview: &Webview<R>,
+  callback_id: u32,
+  body: InvokeResponseBody,
+  extra_js: Option<&str>,
+) -> crate::Result<()> {
+  match body {
+    InvokeResponseBody::Json(json_string)
+      if json_string.len() < MAX_JSON_DIRECT_EXECUTE_THRESHOLD =>
+    {
+      let js = if let Some(extra) = extra_js {
+        if extra.is_empty() {
+          json_string
+        } else {
+          format!(
+            "{{ message: {json_string}, {extra} }}"
+          )
+        }
+      } else {
+        json_string
+      };
+      webview.eval(format_raw_js(callback_id, js))?;
+    }
+    InvokeResponseBody::Raw(bytes) if bytes.len() < MAX_RAW_DIRECT_EXECUTE_THRESHOLD => {
+      let bytes_as_json_array = serde_json::to_string(&bytes)?;
+      let js = if let Some(extra) = extra_js {
+        if extra.is_empty() {
+          format!("new Uint8Array({bytes_as_json_array}).buffer")
+        } else {
+          format!(
+            "{{ message: new Uint8Array({bytes_as_json_array}).buffer, {extra} }}"
+          )
+        }
+      } else {
+        format!("new Uint8Array({bytes_as_json_array}).buffer")
+      };
+      webview.eval(format_raw_js(callback_id, js))?;
+    }
+    _ => {
+      let data_id = next_channel_data_id();
+
+      webview
+        .state::<ChannelDataIpcQueue>()
+        .0
+        .lock()
+        .unwrap()
+        .insert(data_id, body);
+
+      let extra = extra_js.unwrap_or("");
+      let fetch_and_run = if extra.is_empty() {
+        format!(
+          "window.__TAURI_INTERNALS__.invoke('{FETCH_CHANNEL_DATA_COMMAND}', null, {{ headers: {{ '{CHANNEL_ID_HEADER_NAME}': '{data_id}' }} }}).then((response) => window.__TAURI_INTERNALS__.runCallback({callback_id}, response)).catch(console.error)"
+        )
+      } else {
+        format!(
+          "window.__TAURI_INTERNALS__.invoke('{FETCH_CHANNEL_DATA_COMMAND}', null, {{ headers: {{ '{CHANNEL_ID_HEADER_NAME}': '{data_id}' }} }}).then((response) => window.__TAURI_INTERNALS__.runCallback({callback_id}, {{ message: response, {extra} }})).catch(console.error)"
+        )
+      };
+      webview.eval(fetch_and_run)?;
+    }
+  }
+
+  Ok(())
 }

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -165,7 +165,7 @@ impl JavaScriptChannelId {
           }
           // use the fetch API to speed up larger response payloads
           _ => {
-            let data_id = CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let data_id = next_channel_data_id();
 
             webview
               .state::<ChannelDataIpcQueue>()
@@ -190,6 +190,18 @@ impl JavaScriptChannelId {
         ));
       })),
     )
+  }
+
+  pub(crate) fn from_callback(callback: CallbackFn) -> Self {
+    Self(callback)
+  }
+
+  pub(crate) fn callback(&self) -> CallbackFn {
+    self.0
+  }
+
+  pub(crate) fn callback_id(&self) -> u32 {
+    self.0 .0
   }
 }
 

--- a/crates/tauri/src/ipc/mod.rs
+++ b/crates/tauri/src/ipc/mod.rs
@@ -29,6 +29,8 @@ mod capability_builder;
 pub(crate) mod channel;
 mod command;
 pub(crate) mod format_callback;
+pub(crate) mod persistent_channel;
+pub(crate) mod persistent_channel_plugin;
 pub(crate) mod protocol;
 
 pub use authority::{
@@ -38,6 +40,12 @@ pub use authority::{
 pub use capability_builder::{CapabilityBuilder, RuntimeCapability};
 pub use channel::{Channel, JavaScriptChannelId};
 pub use command::{private, CommandArg, CommandItem};
+pub use persistent_channel::{
+  async_channel, ChannelEvent, ChannelMessage, ChannelMessageType, MessageReceiver,
+  MessageSender, PersistentChannel, PersistentChannelId, PersistentChannelManager,
+  PersistentChannelStore, StreamSender,
+};
+pub use persistent_channel_plugin::{builder, init, PersistentChannelPluginBuilder};
 
 /// A closure that is run every time Tauri receives a message it doesn't explicitly handle.
 pub type InvokeHandler<R> = dyn Fn(Invoke<R>) -> bool + Send + Sync + 'static;

--- a/crates/tauri/src/ipc/persistent_channel.rs
+++ b/crates/tauri/src/ipc/persistent_channel.rs
@@ -1,0 +1,454 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{
+  collections::HashMap,
+  sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc, Weak,
+  },
+};
+
+use futures::stream::Stream;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, Mutex, RwLock};
+
+use crate::{
+  ipc::{InvokeResponseBody, IpcResponse},
+  AppHandle, Manager, Runtime, Webview,
+};
+
+use super::{
+  format_callback::format_raw_js, ChannelDataIpcQueue, JavaScriptChannelId,
+  MAX_JSON_DIRECT_EXECUTE_THRESHOLD, MAX_RAW_DIRECT_EXECUTE_THRESHOLD,
+};
+
+static PERSISTENT_CHANNEL_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+pub type PersistentChannelId = u64;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ChannelMessageType {
+  Data,
+  Error,
+  Close,
+  Ping,
+  Pong,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelMessage {
+  pub channel_id: PersistentChannelId,
+  pub message_type: ChannelMessageType,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub payload: Option<serde_json::Value>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub index: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ChannelEvent {
+  Message(serde_json::Value),
+  Binary(Vec<u8>),
+  Error(String),
+  Close,
+}
+
+pub type MessageSender = mpsc::UnboundedSender<ChannelEvent>;
+pub type MessageReceiver = mpsc::UnboundedReceiver<ChannelEvent>;
+
+struct PersistentChannelInner<R: Runtime> {
+  id: PersistentChannelId,
+  app_handle: AppHandle<R>,
+  webview_label: String,
+  tx: MessageSender,
+  rx: Arc<Mutex<MessageReceiver>>,
+  callback_fn: u32,
+  message_index: AtomicU64,
+  is_closed: AtomicU64,
+}
+
+pub struct PersistentChannel<R: Runtime = crate::Wry> {
+  inner: Arc<PersistentChannelInner<R>>,
+}
+
+impl<R: Runtime> Clone for PersistentChannel<R> {
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+    }
+  }
+}
+
+#[cfg(feature = "specta")]
+const _: () = {
+  #[derive(specta::Type)]
+  #[specta(remote = super::PersistentChannel)]
+  #[allow(dead_code, non_camel_case_types)]
+  struct TAURI_PERSISTENT_CHANNEL<R: Runtime>(std::marker::PhantomData<R>);
+};
+
+#[derive(Default)]
+pub struct PersistentChannelStore<R: Runtime> {
+  channels: RwLock<HashMap<PersistentChannelId, Weak<PersistentChannelInner<R>>>>,
+}
+
+pub struct PersistentChannelManager<R: Runtime = crate::Wry> {
+  store: Arc<PersistentChannelStore<R>>,
+  on_connect: Option<Box<dyn Fn(PersistentChannel<R>) + Send + Sync + 'static>>,
+}
+
+impl<R: Runtime> Clone for PersistentChannelManager<R> {
+  fn clone(&self) -> Self {
+    Self {
+      store: self.store.clone(),
+      on_connect: None,
+    }
+  }
+}
+
+impl<R: Runtime> PersistentChannel<R> {
+  pub fn new(webview: &Webview<R>, callback_fn: u32) -> Self {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let id = PERSISTENT_CHANNEL_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let inner = Arc::new(PersistentChannelInner {
+      id,
+      app_handle: webview.app_handle.clone(),
+      webview_label: webview.label().to_string(),
+      tx,
+      rx: Arc::new(Mutex::new(rx)),
+      callback_fn,
+      message_index: AtomicU64::new(0),
+      is_closed: AtomicU64::new(0),
+    });
+
+    Self { inner }
+  }
+
+  pub fn id(&self) -> PersistentChannelId {
+    self.inner.id
+  }
+
+  pub fn is_closed(&self) -> bool {
+    self.inner.is_closed.load(Ordering::Relaxed) != 0
+  }
+
+  pub fn send<T: Serialize>(&self, data: T) -> crate::Result<()> {
+    self.send_inner(serde_json::to_value(data)?)
+  }
+
+  pub fn send_bytes(&self, bytes: Vec<u8>) -> crate::Result<()> {
+    self.send_bytes_inner(bytes)
+  }
+
+  fn send_inner(&self, value: serde_json::Value) -> crate::Result<()> {
+    if self.is_closed() {
+      return Err(crate::Error::ChannelClosed);
+    }
+
+    let json_string = serde_json::to_string(&value)?;
+    let body = InvokeResponseBody::Json(json_string);
+
+    self.send_response(body)
+  }
+
+  fn send_bytes_inner(&self, bytes: Vec<u8>) -> crate::Result<()> {
+    if self.is_closed() {
+      return Err(crate::Error::ChannelClosed);
+    }
+
+    let body = InvokeResponseBody::Raw(bytes);
+    self.send_response(body)
+  }
+
+  fn get_webview(&self) -> crate::Result<Webview<R>> {
+    self
+      .inner
+      .app_handle
+      .get_webview(&self.inner.webview_label)
+      .ok_or_else(|| crate::Error::WebviewNotFound)
+  }
+
+  fn send_response(&self, body: InvokeResponseBody) -> crate::Result<()> {
+    let webview = self.get_webview()?;
+
+    let index = self.inner.message_index.fetch_add(1, Ordering::Relaxed);
+
+    match body {
+      InvokeResponseBody::Json(json_string)
+        if json_string.len() < MAX_JSON_DIRECT_EXECUTE_THRESHOLD =>
+      {
+        webview.eval(format_raw_js(
+          self.inner.callback_fn,
+          format!(
+            "{{ message: {json_string}, index: {index}, channelId: {} }}",
+            self.inner.id
+          ),
+        ))?;
+      }
+      InvokeResponseBody::Raw(bytes) if bytes.len() < MAX_RAW_DIRECT_EXECUTE_THRESHOLD => {
+        let bytes_as_json_array = serde_json::to_string(&bytes)?;
+        webview.eval(format_raw_js(
+          self.inner.callback_fn,
+          format!(
+            "{{ message: new Uint8Array({bytes_as_json_array}).buffer, index: {index}, channelId: {} }}",
+            self.inner.id
+          ),
+        ))?;
+      }
+      _ => {
+        use super::CHANNEL_DATA_COUNTER;
+        let data_id = CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+        use super::FETCH_CHANNEL_DATA_COMMAND;
+        use super::CHANNEL_ID_HEADER_NAME;
+
+        webview
+          .state::<ChannelDataIpcQueue>()
+          .0
+          .lock()
+          .unwrap()
+          .insert(data_id, body);
+
+        webview.eval(format!(
+          "window.__TAURI_INTERNALS__.invoke('{FETCH_CHANNEL_DATA_COMMAND}', null, {{ headers: {{ '{CHANNEL_ID_HEADER_NAME}': '{data_id}' }} }}).then((response) => window.__TAURI_INTERNALS__.runCallback({}, {{ message: response, index: {index}, channelId: {} }})).catch(console.error)",
+          self.inner.callback_fn,
+          self.inner.id
+        ))?;
+      }
+    }
+
+    Ok(())
+  }
+
+  pub fn send_error(&self, error: String) -> crate::Result<()> {
+    self.send(serde_json::json!({
+      "error": error
+    }))
+  }
+
+  pub fn close(&self) -> crate::Result<()> {
+    if self
+      .inner
+      .is_closed
+      .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
+      .is_ok()
+    {
+      self.inner.tx.send(ChannelEvent::Close).ok();
+
+      if let Ok(webview) = self.get_webview() {
+        let index = self.inner.message_index.load(Ordering::Relaxed);
+        let _ = webview.eval(format_raw_js(
+          self.inner.callback_fn,
+          format!(
+            "{{ end: true, index: {index}, channelId: {} }}",
+            self.inner.id
+          ),
+        ));
+      }
+    }
+    Ok(())
+  }
+
+  pub fn receiver(&self) -> Arc<Mutex<MessageReceiver>> {
+    self.inner.rx.clone()
+  }
+
+  pub fn incoming_tx(&self) -> MessageSender {
+    self.inner.tx.clone()
+  }
+
+  pub async fn recv(&self) -> Option<ChannelEvent> {
+    let mut rx = self.inner.rx.lock().await;
+    rx.recv().await
+  }
+
+  pub fn into_stream(self) -> impl Stream<Item = ChannelEvent> {
+    futures::stream::unfold(self, |channel| async move {
+      let event = channel.recv().await;
+      event.map(|e| (e, channel))
+    })
+  }
+}
+
+impl<R: Runtime> Drop for PersistentChannelInner<R> {
+  fn drop(&mut self) {
+    let _ = self.is_closed.store(1, Ordering::Relaxed);
+  }
+}
+
+impl<R: Runtime> PersistentChannelStore<R> {
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  pub async fn register(&self, channel: &PersistentChannel<R>) {
+    let mut channels = self.channels.write().await;
+    channels.insert(channel.id(), Arc::downgrade(&channel.inner));
+  }
+
+  pub async fn unregister(&self, channel_id: PersistentChannelId) {
+    let mut channels = self.channels.write().await;
+    channels.remove(&channel_id);
+  }
+
+  pub async fn get(&self, channel_id: PersistentChannelId) -> Option<PersistentChannel<R>> {
+    let channels = self.channels.read().await;
+    channels
+      .get(&channel_id)
+      .and_then(|weak| weak.upgrade())
+      .map(|inner| PersistentChannel { inner })
+  }
+
+  pub async fn get_all(&self) -> Vec<PersistentChannel<R>> {
+    let channels = self.channels.read().await;
+    channels
+      .values()
+      .filter_map(|weak| weak.upgrade())
+      .map(|inner| PersistentChannel { inner })
+      .collect()
+  }
+
+  pub async fn cleanup(&self) {
+    let mut channels = self.channels.write().await;
+    channels.retain(|_, weak| weak.strong_count() > 0);
+  }
+}
+
+impl<R: Runtime> PersistentChannelManager<R> {
+  pub fn new() -> Self {
+    Self {
+      store: Arc::new(PersistentChannelStore::new()),
+      on_connect: None,
+    }
+  }
+
+  pub fn with_on_connect<F>(mut self, f: F) -> Self
+  where
+    F: Fn(PersistentChannel<R>) + Send + Sync + 'static,
+  {
+    self.on_connect = Some(Box::new(f));
+    self
+  }
+
+  pub async fn create_channel(
+    &self,
+    webview: &Webview<R>,
+    callback_channel_id: JavaScriptChannelId,
+  ) -> PersistentChannel<R> {
+    let callback_fn = callback_channel_id.0 .0;
+    let channel = PersistentChannel::new(webview, callback_fn);
+    self.store.register(&channel).await;
+
+    if let Some(on_connect) = &self.on_connect {
+      on_connect(channel.clone());
+    }
+
+    channel
+  }
+
+  pub async fn get_channel(&self, channel_id: PersistentChannelId) -> Option<PersistentChannel<R>> {
+    self.store.get(channel_id).await
+  }
+
+  pub async fn handle_incoming_message(&self, message: ChannelMessage) -> crate::Result<()> {
+    let channel = self
+      .store
+      .get(message.channel_id)
+      .await
+      .ok_or_else(|| crate::Error::ChannelNotFound(message.channel_id))?;
+
+    match message.message_type {
+      ChannelMessageType::Data => {
+        if let Some(payload) = message.payload {
+          channel
+            .incoming_tx()
+            .send(ChannelEvent::Message(payload))
+            .map_err(|_| crate::Error::ChannelClosed)?;
+        }
+      }
+      ChannelMessageType::Error => {
+        if let Some(payload) = message.payload {
+          let error_msg = payload
+            .as_str()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| payload.to_string());
+          channel
+            .incoming_tx()
+            .send(ChannelEvent::Error(error_msg))
+            .map_err(|_| crate::Error::ChannelClosed)?;
+        }
+      }
+      ChannelMessageType::Close => {
+        channel.close()?;
+        self.store.unregister(message.channel_id).await;
+      }
+      ChannelMessageType::Ping => {
+        channel.send(serde_json::json!({ "type": "pong" }))?;
+      }
+      ChannelMessageType::Pong => {}
+    }
+
+    Ok(())
+  }
+
+  pub async fn broadcast<T: Serialize + Clone>(&self, data: T) -> crate::Result<()> {
+    let channels = self.store.get_all().await;
+    for channel in channels {
+      let _ = channel.send(data.clone());
+    }
+    Ok(())
+  }
+
+  pub fn store(&self) -> Arc<PersistentChannelStore<R>> {
+    self.store.clone()
+  }
+}
+
+impl<R: Runtime> Default for PersistentChannelManager<R> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+pub struct StreamSender<T: IpcResponse, R: Runtime = crate::Wry> {
+  channel: PersistentChannel<R>,
+  _phantom: std::marker::PhantomData<T>,
+}
+
+impl<R: Runtime, T: IpcResponse> StreamSender<T, R> {
+  pub fn new(channel: PersistentChannel<R>) -> Self {
+    Self {
+      channel,
+      _phantom: std::marker::PhantomData,
+    }
+  }
+
+  pub fn send(&self, item: T) -> crate::Result<()> {
+    let body = item.body()?;
+    match body {
+      InvokeResponseBody::Json(json) => {
+        self.channel.send_inner(serde_json::from_str(&json)?)
+      }
+      InvokeResponseBody::Raw(bytes) => self.channel.send_bytes_inner(bytes),
+    }
+  }
+
+  pub fn close(&self) -> crate::Result<()> {
+    self.channel.close()
+  }
+
+  pub fn channel(&self) -> &PersistentChannel<R> {
+    &self.channel
+  }
+}
+
+impl<R: Runtime> IpcResponse for ChannelMessage {
+  fn body(self) -> crate::Result<InvokeResponseBody> {
+    serde_json::to_string(&self)
+      .map(InvokeResponseBody::Json)
+      .map_err(Into::into)
+  }
+}

--- a/crates/tauri/src/ipc/persistent_channel.rs
+++ b/crates/tauri/src/ipc/persistent_channel.rs
@@ -12,6 +12,7 @@ use std::{
 
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
+use tauri_macros::default_runtime;
 use tokio::sync::{mpsc, Mutex, RwLock};
 
 use crate::{
@@ -20,8 +21,9 @@ use crate::{
 };
 
 use super::{
-  format_callback::format_raw_js, ChannelDataIpcQueue, JavaScriptChannelId,
-  MAX_JSON_DIRECT_EXECUTE_THRESHOLD, MAX_RAW_DIRECT_EXECUTE_THRESHOLD,
+  channel::{next_channel_data_id, send_channel_response, ChannelDataIpcQueue},
+  format_callback::format_raw_js,
+  JavaScriptChannelId,
 };
 
 static PERSISTENT_CHANNEL_COUNTER: AtomicU64 = AtomicU64::new(1);
@@ -69,7 +71,8 @@ struct PersistentChannelInner<R: Runtime> {
   is_closed: AtomicU64,
 }
 
-pub struct PersistentChannel<R: Runtime = crate::Wry> {
+#[default_runtime(crate::Wry, wry)]
+pub struct PersistentChannel<R: Runtime> {
   inner: Arc<PersistentChannelInner<R>>,
 }
 
@@ -94,7 +97,8 @@ pub struct PersistentChannelStore<R: Runtime> {
   channels: RwLock<HashMap<PersistentChannelId, Weak<PersistentChannelInner<R>>>>,
 }
 
-pub struct PersistentChannelManager<R: Runtime = crate::Wry> {
+#[default_runtime(crate::Wry, wry)]
+pub struct PersistentChannelManager<R: Runtime> {
   store: Arc<PersistentChannelStore<R>>,
   on_connect: Option<Box<dyn Fn(PersistentChannel<R>) + Send + Sync + 'static>>,
 }
@@ -175,52 +179,9 @@ impl<R: Runtime> PersistentChannel<R> {
     let webview = self.get_webview()?;
 
     let index = self.inner.message_index.fetch_add(1, Ordering::Relaxed);
+    let extra_js = format!("index: {index}, channelId: {}", self.inner.id);
 
-    match body {
-      InvokeResponseBody::Json(json_string)
-        if json_string.len() < MAX_JSON_DIRECT_EXECUTE_THRESHOLD =>
-      {
-        webview.eval(format_raw_js(
-          self.inner.callback_fn,
-          format!(
-            "{{ message: {json_string}, index: {index}, channelId: {} }}",
-            self.inner.id
-          ),
-        ))?;
-      }
-      InvokeResponseBody::Raw(bytes) if bytes.len() < MAX_RAW_DIRECT_EXECUTE_THRESHOLD => {
-        let bytes_as_json_array = serde_json::to_string(&bytes)?;
-        webview.eval(format_raw_js(
-          self.inner.callback_fn,
-          format!(
-            "{{ message: new Uint8Array({bytes_as_json_array}).buffer, index: {index}, channelId: {} }}",
-            self.inner.id
-          ),
-        ))?;
-      }
-      _ => {
-        use super::CHANNEL_DATA_COUNTER;
-        let data_id = CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed);
-
-        use super::FETCH_CHANNEL_DATA_COMMAND;
-        use super::CHANNEL_ID_HEADER_NAME;
-
-        webview
-          .state::<ChannelDataIpcQueue>()
-          .0
-          .lock()
-          .unwrap()
-          .insert(data_id, body);
-
-        webview.eval(format!(
-          "window.__TAURI_INTERNALS__.invoke('{FETCH_CHANNEL_DATA_COMMAND}', null, {{ headers: {{ '{CHANNEL_ID_HEADER_NAME}': '{data_id}' }} }}).then((response) => window.__TAURI_INTERNALS__.runCallback({}, {{ message: response, index: {index}, channelId: {} }})).catch(console.error)",
-          self.inner.callback_fn,
-          self.inner.id
-        ))?;
-      }
-    }
-
-    Ok(())
+    send_channel_response(&webview, self.inner.callback_fn, body, Some(&extra_js))
   }
 
   pub fn send_error(&self, error: String) -> crate::Result<()> {
@@ -353,16 +314,21 @@ impl<R: Runtime> PersistentChannelManager<R> {
     self.store.get(channel_id).await
   }
 
-  pub async fn handle_incoming_message(&self, message: ChannelMessage) -> crate::Result<()> {
+  pub async fn handle_incoming_message(
+    &self,
+    channel_id: PersistentChannelId,
+    message_type: ChannelMessageType,
+    payload: Option<serde_json::Value>,
+  ) -> crate::Result<()> {
     let channel = self
       .store
-      .get(message.channel_id)
+      .get(channel_id)
       .await
-      .ok_or_else(|| crate::Error::ChannelNotFound(message.channel_id))?;
+      .ok_or_else(|| crate::Error::ChannelNotFound(channel_id))?;
 
-    match message.message_type {
+    match message_type {
       ChannelMessageType::Data => {
-        if let Some(payload) = message.payload {
+        if let Some(payload) = payload {
           channel
             .incoming_tx()
             .send(ChannelEvent::Message(payload))
@@ -370,7 +336,7 @@ impl<R: Runtime> PersistentChannelManager<R> {
         }
       }
       ChannelMessageType::Error => {
-        if let Some(payload) = message.payload {
+        if let Some(payload) = payload {
           let error_msg = payload
             .as_str()
             .map(|s| s.to_string())
@@ -383,7 +349,7 @@ impl<R: Runtime> PersistentChannelManager<R> {
       }
       ChannelMessageType::Close => {
         channel.close()?;
-        self.store.unregister(message.channel_id).await;
+        self.store.unregister(channel_id).await;
       }
       ChannelMessageType::Ping => {
         channel.send(serde_json::json!({ "type": "pong" }))?;
@@ -413,7 +379,8 @@ impl<R: Runtime> Default for PersistentChannelManager<R> {
   }
 }
 
-pub struct StreamSender<T: IpcResponse, R: Runtime = crate::Wry> {
+#[default_runtime(crate::Wry, wry)]
+pub struct StreamSender<T: IpcResponse, R: Runtime> {
   channel: PersistentChannel<R>,
   _phantom: std::marker::PhantomData<T>,
 }
@@ -450,5 +417,44 @@ impl<R: Runtime> IpcResponse for ChannelMessage {
     serde_json::to_string(&self)
       .map(InvokeResponseBody::Json)
       .map_err(Into::into)
+  }
+}
+
+pub mod async_channel {
+  use super::*;
+
+  #[default_runtime(crate::Wry, wry)]
+  pub struct AsyncChannel<R: Runtime> {
+    channel: PersistentChannel<R>,
+  }
+
+  impl<R: Runtime> AsyncChannel<R> {
+    pub fn new(channel: PersistentChannel<R>) -> Self {
+      Self { channel }
+    }
+
+    pub async fn send<T: Serialize>(&self, data: T) -> crate::Result<()> {
+      self.channel.send(data)
+    }
+
+    pub async fn send_bytes(&self, bytes: Vec<u8>) -> crate::Result<()> {
+      self.channel.send_bytes(bytes)
+    }
+
+    pub async fn recv(&self) -> Option<ChannelEvent> {
+      self.channel.recv().await
+    }
+
+    pub fn close(&self) -> crate::Result<()> {
+      self.channel.close()
+    }
+
+    pub fn id(&self) -> PersistentChannelId {
+      self.channel.id()
+    }
+
+    pub fn into_inner(self) -> PersistentChannel<R> {
+      self.channel
+    }
   }
 }

--- a/crates/tauri/src/ipc/persistent_channel.rs
+++ b/crates/tauri/src/ipc/persistent_channel.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use super::{
-  channel::{next_channel_data_id, send_channel_response, ChannelDataIpcQueue},
+  channel::send_channel_response,
   format_callback::format_raw_js,
   JavaScriptChannelId,
 };
@@ -299,7 +299,7 @@ impl<R: Runtime> PersistentChannelManager<R> {
     webview: &Webview<R>,
     callback_channel_id: JavaScriptChannelId,
   ) -> PersistentChannel<R> {
-    let callback_fn = callback_channel_id.0 .0;
+    let callback_fn = callback_channel_id.callback_id();
     let channel = PersistentChannel::new(webview, callback_fn);
     self.store.register(&channel).await;
 

--- a/crates/tauri/src/ipc/persistent_channel_plugin.rs
+++ b/crates/tauri/src/ipc/persistent_channel_plugin.rs
@@ -6,19 +6,18 @@ use std::{
   collections::HashMap,
   sync::{
     atomic::{AtomicBool, Ordering},
-    Arc,
   },
 };
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tauri_macros::default_runtime;
 use tokio::sync::Mutex;
 
 use crate::{
   command,
-  ipc::{ChannelEvent, ChannelMessageType, JavaScriptChannelId, PersistentChannel},
+  ipc::{CallbackFn, ChannelEvent, ChannelMessageType, JavaScriptChannelId, PersistentChannel},
   plugin::{Builder as PluginBuilder, TauriPlugin},
-  AppHandle, Manager, Runtime, State, Webview,
+  AppHandle, Runtime, State, Webview,
 };
 
 use super::PersistentChannelManager;
@@ -27,7 +26,7 @@ pub const PERSISTENT_CHANNEL_PLUGIN_NAME: &str = "__TAURI_PERSISTENT_CHANNEL__";
 
 static CHANNEL_MANAGER_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ChannelInfo {
   pub id: u64,
   pub connected: bool,
@@ -92,7 +91,7 @@ async fn connect<R: Runtime>(
   let manager = app.state::<PersistentChannelManager<R>>();
   let registry = app.state::<ConnectionRegistry<R>>();
 
-  let callback_channel_id = JavaScriptChannelId(crate::ipc::CallbackFn(callback_id));
+  let callback_channel_id = JavaScriptChannelId::from_callback(CallbackFn(callback_id));
 
   let channel = manager.create_channel(&webview, callback_channel_id).await;
 

--- a/crates/tauri/src/ipc/persistent_channel_plugin.rs
+++ b/crates/tauri/src/ipc/persistent_channel_plugin.rs
@@ -11,39 +11,21 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
+use tauri_macros::default_runtime;
 use tokio::sync::Mutex;
 
 use crate::{
   command,
-  ipc::{
-    ChannelEvent, ChannelMessage, ChannelMessageType, JavaScriptChannelId, PersistentChannel,
-    PersistentChannelManager,
-  },
+  ipc::{ChannelEvent, ChannelMessageType, JavaScriptChannelId, PersistentChannel},
   plugin::{Builder as PluginBuilder, TauriPlugin},
   AppHandle, Manager, Runtime, State, Webview,
 };
 
+use super::PersistentChannelManager;
+
 pub const PERSISTENT_CHANNEL_PLUGIN_NAME: &str = "__TAURI_PERSISTENT_CHANNEL__";
 
 static CHANNEL_MANAGER_INITIALIZED: AtomicBool = AtomicBool::new(false);
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConnectRequest {
-  pub channel_id: String,
-  pub callback_id: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SendMessageRequest {
-  pub channel_id: String,
-  pub message: serde_json::Value,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SendBinaryRequest {
-  pub channel_id: String,
-  pub data: Vec<u8>,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChannelInfo {
@@ -104,17 +86,18 @@ impl<R: Runtime> ConnectionRegistry<R> {
 async fn connect<R: Runtime>(
   app: AppHandle<R>,
   webview: Webview<R>,
-  request: ConnectRequest,
+  user_channel_id: String,
+  callback_id: u32,
 ) -> crate::Result<ChannelInfo> {
   let manager = app.state::<PersistentChannelManager<R>>();
   let registry = app.state::<ConnectionRegistry<R>>();
 
-  let callback_channel_id = JavaScriptChannelId(crate::ipc::CallbackFn(request.callback_id));
+  let callback_channel_id = JavaScriptChannelId(crate::ipc::CallbackFn(callback_id));
 
   let channel = manager.create_channel(&webview, callback_channel_id).await;
 
   registry
-    .register(request.channel_id.clone(), channel.clone())
+    .register(user_channel_id.clone(), channel.clone())
     .await;
 
   Ok(ChannelInfo {
@@ -126,58 +109,42 @@ async fn connect<R: Runtime>(
 #[command(root = "crate")]
 async fn send_message<R: Runtime>(
   app: AppHandle<R>,
-  request: SendMessageRequest,
+  user_channel_id: String,
+  message_type: String,
+  payload: Option<serde_json::Value>,
+  index: Option<u64>,
 ) -> crate::Result<()> {
+  let manager = app.state::<PersistentChannelManager<R>>();
   let registry = app.state::<ConnectionRegistry<R>>();
 
   let channel = registry
-    .get(&request.channel_id)
+    .get(&user_channel_id)
     .await
     .ok_or_else(|| crate::Error::ChannelNotFound(0))?;
 
-  let msg = request.message;
+  let channel_id = channel.id();
 
-  if let Some(msg_type) = msg.get("type").and_then(|t| t.as_str()) {
-    match msg_type {
-      "close" => {
-        registry.unregister(&request.channel_id).await;
-        return Ok(());
-      }
-      "ping" => {
-        let manager = app.state::<PersistentChannelManager<R>>();
-        let channel_msg = ChannelMessage {
-          channel_id: channel.id(),
-          message_type: ChannelMessageType::Ping,
-          payload: None,
-          index: None,
-        };
-        return manager.handle_incoming_message(channel_msg).await;
-      }
-      _ => {}
+  let msg_type = match message_type.as_str() {
+    "data" => ChannelMessageType::Data,
+    "error" => ChannelMessageType::Error,
+    "close" => {
+      registry.unregister(&user_channel_id).await;
+      return Ok(());
     }
-  }
+    "ping" => ChannelMessageType::Ping,
+    "pong" => ChannelMessageType::Pong,
+    _ => ChannelMessageType::Data,
+  };
 
-  if let Some(payload) = msg.get("payload") {
-    let index = msg.get("index").and_then(|i| i.as_u64());
+  manager
+    .handle_incoming_message(channel_id, msg_type, payload)
+    .await?;
 
-    let message = ChannelEvent::Message(payload.clone());
-    channel
-      .incoming_tx()
-      .send(message)
-      .map_err(|_| crate::Error::ChannelClosed)?;
-
-    if let Some(idx) = index {
-      let _ = channel.send(serde_json::json!({
-        "type": "ack",
-        "index": idx
-      }));
-    }
-  } else {
-    let message = ChannelEvent::Message(msg);
-    channel
-      .incoming_tx()
-      .send(message)
-      .map_err(|_| crate::Error::ChannelClosed)?;
+  if let Some(idx) = index {
+    let _ = channel.send(serde_json::json!({
+      "type": "ack",
+      "index": idx
+    }));
   }
 
   Ok(())
@@ -186,16 +153,17 @@ async fn send_message<R: Runtime>(
 #[command(root = "crate")]
 async fn send_binary<R: Runtime>(
   app: AppHandle<R>,
-  request: SendBinaryRequest,
+  user_channel_id: String,
+  data: Vec<u8>,
 ) -> crate::Result<()> {
   let registry = app.state::<ConnectionRegistry<R>>();
 
   let channel = registry
-    .get(&request.channel_id)
+    .get(&user_channel_id)
     .await
     .ok_or_else(|| crate::Error::ChannelNotFound(0))?;
 
-  let message = ChannelEvent::Binary(request.data);
+  let message = ChannelEvent::Binary(data);
   channel
     .incoming_tx()
     .send(message)
@@ -229,6 +197,7 @@ async fn list_channels<R: Runtime>(app: AppHandle<R>) -> crate::Result<Vec<Chann
   )
 }
 
+#[default_runtime(crate::Wry, wry)]
 pub struct PersistentChannelPluginBuilder<R: Runtime> {
   on_connect: Option<Box<dyn Fn(AppHandle<R>, PersistentChannel<R>) + Send + Sync + 'static>>,
 }
@@ -297,7 +266,8 @@ pub mod async_channel {
   use super::*;
   use futures::Stream;
 
-  pub struct AsyncChannel<R: Runtime = crate::Wry> {
+  #[default_runtime(crate::Wry, wry)]
+  pub struct AsyncChannel<R: Runtime> {
     inner: PersistentChannel<R>,
   }
 

--- a/crates/tauri/src/ipc/persistent_channel_plugin.rs
+++ b/crates/tauri/src/ipc/persistent_channel_plugin.rs
@@ -1,0 +1,355 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use std::{
+  collections::HashMap,
+  sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+  },
+};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+use crate::{
+  command,
+  ipc::{
+    ChannelEvent, ChannelMessage, ChannelMessageType, JavaScriptChannelId, PersistentChannel,
+    PersistentChannelManager,
+  },
+  plugin::{Builder as PluginBuilder, TauriPlugin},
+  AppHandle, Manager, Runtime, State, Webview,
+};
+
+pub const PERSISTENT_CHANNEL_PLUGIN_NAME: &str = "__TAURI_PERSISTENT_CHANNEL__";
+
+static CHANNEL_MANAGER_INITIALIZED: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConnectRequest {
+  pub channel_id: String,
+  pub callback_id: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendMessageRequest {
+  pub channel_id: String,
+  pub message: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendBinaryRequest {
+  pub channel_id: String,
+  pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelInfo {
+  pub id: u64,
+  pub connected: bool,
+}
+
+struct ChannelConnection<R: Runtime> {
+  user_channel_id: String,
+  channel: PersistentChannel<R>,
+}
+
+#[derive(Default)]
+struct ConnectionRegistry<R: Runtime> {
+  connections: Mutex<HashMap<String, ChannelConnection<R>>>,
+}
+
+impl<R: Runtime> ConnectionRegistry<R> {
+  fn new() -> Self {
+    Self::default()
+  }
+
+  async fn register(&self, user_channel_id: String, channel: PersistentChannel<R>) {
+    let mut connections = self.connections.lock().await;
+    connections.insert(
+      user_channel_id.clone(),
+      ChannelConnection {
+        user_channel_id,
+        channel,
+      },
+    );
+  }
+
+  async fn unregister(&self, user_channel_id: &str) {
+    let mut connections = self.connections.lock().await;
+    if let Some(conn) = connections.remove(user_channel_id) {
+      let _ = conn.channel.close();
+    }
+  }
+
+  async fn get(&self, user_channel_id: &str) -> Option<PersistentChannel<R>> {
+    let connections = self.connections.lock().await;
+    connections
+      .get(user_channel_id)
+      .map(|conn| conn.channel.clone())
+  }
+
+  async fn get_all(&self) -> Vec<PersistentChannel<R>> {
+    let connections = self.connections.lock().await;
+    connections
+      .values()
+      .map(|conn| conn.channel.clone())
+      .collect()
+  }
+}
+
+#[command(root = "crate")]
+async fn connect<R: Runtime>(
+  app: AppHandle<R>,
+  webview: Webview<R>,
+  request: ConnectRequest,
+) -> crate::Result<ChannelInfo> {
+  let manager = app.state::<PersistentChannelManager<R>>();
+  let registry = app.state::<ConnectionRegistry<R>>();
+
+  let callback_channel_id = JavaScriptChannelId(crate::ipc::CallbackFn(request.callback_id));
+
+  let channel = manager.create_channel(&webview, callback_channel_id).await;
+
+  registry
+    .register(request.channel_id.clone(), channel.clone())
+    .await;
+
+  Ok(ChannelInfo {
+    id: channel.id(),
+    connected: !channel.is_closed(),
+  })
+}
+
+#[command(root = "crate")]
+async fn send_message<R: Runtime>(
+  app: AppHandle<R>,
+  request: SendMessageRequest,
+) -> crate::Result<()> {
+  let registry = app.state::<ConnectionRegistry<R>>();
+
+  let channel = registry
+    .get(&request.channel_id)
+    .await
+    .ok_or_else(|| crate::Error::ChannelNotFound(0))?;
+
+  let msg = request.message;
+
+  if let Some(msg_type) = msg.get("type").and_then(|t| t.as_str()) {
+    match msg_type {
+      "close" => {
+        registry.unregister(&request.channel_id).await;
+        return Ok(());
+      }
+      "ping" => {
+        let manager = app.state::<PersistentChannelManager<R>>();
+        let channel_msg = ChannelMessage {
+          channel_id: channel.id(),
+          message_type: ChannelMessageType::Ping,
+          payload: None,
+          index: None,
+        };
+        return manager.handle_incoming_message(channel_msg).await;
+      }
+      _ => {}
+    }
+  }
+
+  if let Some(payload) = msg.get("payload") {
+    let index = msg.get("index").and_then(|i| i.as_u64());
+
+    let message = ChannelEvent::Message(payload.clone());
+    channel
+      .incoming_tx()
+      .send(message)
+      .map_err(|_| crate::Error::ChannelClosed)?;
+
+    if let Some(idx) = index {
+      let _ = channel.send(serde_json::json!({
+        "type": "ack",
+        "index": idx
+      }));
+    }
+  } else {
+    let message = ChannelEvent::Message(msg);
+    channel
+      .incoming_tx()
+      .send(message)
+      .map_err(|_| crate::Error::ChannelClosed)?;
+  }
+
+  Ok(())
+}
+
+#[command(root = "crate")]
+async fn send_binary<R: Runtime>(
+  app: AppHandle<R>,
+  request: SendBinaryRequest,
+) -> crate::Result<()> {
+  let registry = app.state::<ConnectionRegistry<R>>();
+
+  let channel = registry
+    .get(&request.channel_id)
+    .await
+    .ok_or_else(|| crate::Error::ChannelNotFound(0))?;
+
+  let message = ChannelEvent::Binary(request.data);
+  channel
+    .incoming_tx()
+    .send(message)
+    .map_err(|_| crate::Error::ChannelClosed)?;
+
+  Ok(())
+}
+
+#[command(root = "crate")]
+async fn broadcast<R: Runtime>(
+  app: AppHandle<R>,
+  message: serde_json::Value,
+) -> crate::Result<()> {
+  let manager = app.state::<PersistentChannelManager<R>>();
+  manager.broadcast(message).await
+}
+
+#[command(root = "crate")]
+async fn list_channels<R: Runtime>(app: AppHandle<R>) -> crate::Result<Vec<ChannelInfo>> {
+  let registry = app.state::<ConnectionRegistry<R>>();
+  let channels = registry.get_all().await;
+
+  Ok(
+    channels
+      .into_iter()
+      .map(|c| ChannelInfo {
+        id: c.id(),
+        connected: !c.is_closed(),
+      })
+      .collect(),
+  )
+}
+
+pub struct PersistentChannelPluginBuilder<R: Runtime> {
+  on_connect: Option<Box<dyn Fn(AppHandle<R>, PersistentChannel<R>) + Send + Sync + 'static>>,
+}
+
+impl<R: Runtime> Default for PersistentChannelPluginBuilder<R> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<R: Runtime> PersistentChannelPluginBuilder<R> {
+  pub fn new() -> Self {
+    Self { on_connect: None }
+  }
+
+  pub fn on_connect<F>(mut self, f: F) -> Self
+  where
+    F: Fn(AppHandle<R>, PersistentChannel<R>) + Send + Sync + 'static,
+  {
+    self.on_connect = Some(Box::new(f));
+    self
+  }
+
+  pub fn build(self) -> TauriPlugin<R> {
+    let on_connect = self.on_connect;
+
+    PluginBuilder::new(PERSISTENT_CHANNEL_PLUGIN_NAME)
+      .setup(move |app, _api| {
+        if !CHANNEL_MANAGER_INITIALIZED.swap(true, Ordering::SeqCst) {
+          let manager = if let Some(f) = on_connect {
+            let app_clone = app.clone();
+            PersistentChannelManager::new().with_on_connect(move |channel| {
+              f(app_clone.clone(), channel);
+            })
+          } else {
+            PersistentChannelManager::new()
+          };
+
+          app.manage(manager);
+          app.manage(ConnectionRegistry::<R>::new());
+        }
+        Ok(())
+      })
+      .js_init_script(include_str!("../../scripts/persistent-channel.js"))
+      .invoke_handler(crate::generate_handler![
+        #![plugin(__TAURI_PERSISTENT_CHANNEL__)]
+        connect,
+        send_message,
+        send_binary,
+        broadcast,
+        list_channels
+      ])
+      .build()
+  }
+}
+
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+  PersistentChannelPluginBuilder::new().build()
+}
+
+pub fn builder<R: Runtime>() -> PersistentChannelPluginBuilder<R> {
+  PersistentChannelPluginBuilder::new()
+}
+
+pub mod async_channel {
+  use super::*;
+  use futures::Stream;
+
+  pub struct AsyncChannel<R: Runtime = crate::Wry> {
+    inner: PersistentChannel<R>,
+  }
+
+  impl<R: Runtime> Clone for AsyncChannel<R> {
+    fn clone(&self) -> Self {
+      Self {
+        inner: self.inner.clone(),
+      }
+    }
+  }
+
+  impl<R: Runtime> AsyncChannel<R> {
+    pub fn new(inner: PersistentChannel<R>) -> Self {
+      Self { inner }
+    }
+
+    pub fn id(&self) -> u64 {
+      self.inner.id()
+    }
+
+    pub fn is_closed(&self) -> bool {
+      self.inner.is_closed()
+    }
+
+    pub async fn send<T: Serialize>(&self, data: T) -> crate::Result<()> {
+      self.inner.send(data)
+    }
+
+    pub async fn send_bytes(&self, bytes: Vec<u8>) -> crate::Result<()> {
+      self.inner.send_bytes(bytes)
+    }
+
+    pub async fn recv(&self) -> Option<ChannelEvent> {
+      self.inner.recv().await
+    }
+
+    pub fn into_stream(self) -> impl Stream<Item = ChannelEvent> {
+      self.inner.into_stream()
+    }
+
+    pub fn close(&self) -> crate::Result<()> {
+      self.inner.close()
+    }
+
+    pub fn into_inner(self) -> PersistentChannel<R> {
+      self.inner
+    }
+  }
+
+  impl<R: Runtime> From<PersistentChannel<R>> for AsyncChannel<R> {
+    fn from(channel: PersistentChannel<R>) -> Self {
+      Self::new(channel)
+    }
+  }
+}


### PR DESCRIPTION
refactor(ipc): 优化 JavaScriptChannelId 的使用方式

重构 JavaScriptChannelId 相关代码，提取公共方法并简化调用方式：
1. 新增 from_callback、callback 和 callback_id 方法
2. 替换直接访问内部字段的代码为方法调用
3. 清理未使用的导入和简化结构体定义