### PR TITLE
fix(cli): Honor a specified NDK version by setting NDK_HOME, if set (#14860)

### DIFF
--- a/.changes/fix-ndk-home-not-honor.md
+++ b/.changes/fix-ndk-home-not-honor.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix NDK_HOME environment variable not honored when set

--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -591,14 +591,27 @@ fn ensure_ndk(non_interactive: bool) -> Result<()> {
     .or_else(|| std::env::var_os("ANDROID_SDK_ROOT"))
     .map(PathBuf::from)
     .context("Failed to locate Android SDK")?;
-  let mut installed_ndks = read_dir(android_home.join("ndk"))
-    .map(|dir| {
-      dir
-        .into_iter()
-        .flat_map(|e| e.ok().map(|e| e.path()))
-        .collect::<Vec<_>>()
-    })
-    .unwrap_or_default();
+
+  // check NDK_HOME
+  let mut installed_ndks = if let Some(ndk_home) = std::env::var_os("NDK_HOME") {
+    let ndk_path = PathBuf::from(ndk_home);
+    if ndk_path.is_dir() {
+      vec![ndk_path]
+    } else {
+      crate::error::bail!(
+        "Android NDK invalid. Make sure the NDK_HOME environment variable has correct value."
+      );
+    }
+  } else {
+    read_dir(android_home.join("ndk"))
+      .map(|dir| {
+        dir
+          .into_iter()
+          .flat_map(|e| e.ok().map(|e| e.path()))
+          .collect::<Vec<_>>()
+      })
+      .unwrap_or_default()
+  };
   installed_ndks.sort();
 
   if let Some(ndk) = installed_ndks.last() {


### PR DESCRIPTION
Previously, if the NDK_HOME environment variable is set or not, the NDK used by the cli is  the lastest version installed at ANDROID_HOME/ndk directory. And if the cli cannot find any ndk inside the ANDROID_HOME/ndk, it try to install the version 29.0.13846066.
We got always this type of output even we set NDK_HOME or not, where the version is the latest or 29.0.13846066:
```
Info Using installed NDK: ~/Android/Sdk/ndk/29.0.13846066
```

Now, after this update, when we launch for example:
```
$  NDK_HOME=/custom/Android/Sdk/ndk/xx.xxxxxx cargo tauri android dev
```
we get the output:
```
Info Using installed NDK: /custom/Android/Sdk/ndk/xx.xxxxxxx
```

Fixes #14860 
Closes #14398