### PR TITLE
Add WebAssembly build support for the JS CLI

### DIFF
--- a/.github/workflows/publish-cli-js.yml
+++ b/.github/workflows/publish-cli-js.yml
@@ -150,6 +150,38 @@ jobs:
           name: bindings-${{ matrix.settings.target }}
           path: packages/cli/${{ env.APP_NAME }}.*.node
           if-no-files-found: error
+  build-web:
+    name: stable - wasm32-wasip1-threads - web
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm i -g --force corepack
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1-threads
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile --ignore-scripts
+      - name: Build WebAssembly binding
+        run: pnpm build:web
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-wasm32-wasip1-threads
+          path: |
+            packages/cli/cli.wasi-browser.js
+            packages/cli/cli.wasi.cjs
+            packages/cli/cli.wasi.d.ts
+            packages/cli/cli.wasm32-wasi.debug.wasm
+            packages/cli/cli.wasm32-wasi.wasm
+            packages/cli/wasi-worker-browser.mjs
+            packages/cli/wasi-worker.mjs
+          if-no-files-found: error
   #  build-freebsd:
   #    runs-on: macos-10.15
   #    name: Build FreeBSD
@@ -366,6 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       #- build-freebsd
+      - build-web
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
       - test-linux-x64-musl-binding

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -9,6 +9,9 @@ test
 rustfmt.toml
 *.node
 __tests__
+artifacts
 src
 Cargo.toml
 build.rs
+build-web.js
+collect-artifacts.js

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -11,13 +11,18 @@ napi = "=3.4"
 napi-sys = "=3.0"
 napi-derive-backend = "=3.0.0"
 napi-derive = "=3.3.0"
-tauri-cli = { path = "../../crates/tauri-cli", default-features = false }
 log = "0.4.21"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+tauri-cli = { path = "../../crates/tauri-cli", default-features = false, optional = true }
 
 [build-dependencies]
 napi-build = "=2.2"
 
 [features]
-default = ["tauri-cli/default"]
-native-tls = ["tauri-cli/native-tls"]
-native-tls-vendored = ["tauri-cli/native-tls-vendored"]
+default = ["native-cli", "rustls", "platform-certs"]
+native-cli = ["dep:tauri-cli"]
+native-tls = ["native-cli", "tauri-cli?/native-tls"]
+native-tls-vendored = ["native-cli", "tauri-cli?/native-tls-vendored"]
+rustls = ["native-cli", "tauri-cli?/rustls"]
+platform-certs = ["native-cli", "tauri-cli?/platform-certs"]

--- a/packages/cli/build-web.js
+++ b/packages/cli/build-web.js
@@ -1,0 +1,75 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+const { existsSync } = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const target = 'wasm32-wasip1-threads'
+
+function command(name) {
+  return process.platform === 'win32' ? `${name}.cmd` : name
+}
+
+function output(command, args) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  })
+
+  if (result.status !== 0) {
+    process.exit(result.status || 1)
+  }
+
+  return result.stdout.trim()
+}
+
+const sysroot = output('rustc', ['--print', 'sysroot'])
+const crtReactor = path.join(
+  sysroot,
+  'lib',
+  'rustlib',
+  target,
+  'lib',
+  'self-contained',
+  'crt1-reactor.o',
+)
+
+const env = { ...process.env, TARGET: 'web' }
+if (!existsSync(crtReactor)) {
+  console.error(`Missing ${crtReactor}. Install the ${target} Rust target.`)
+  process.exit(1)
+}
+
+env.RUSTFLAGS = [
+  env.RUSTFLAGS,
+  `-C link-arg=${crtReactor}`,
+  '-C link-arg=--export=_initialize',
+]
+  .filter(Boolean)
+  .join(' ')
+
+const args = [
+  'build',
+  '--platform',
+  '--target',
+  target,
+  '--no-default-features',
+  '--no-js',
+  '--dts',
+  'cli.wasi.d.ts',
+  ...process.argv.slice(2),
+]
+
+const result = spawnSync(command('napi'), args, {
+  env,
+  stdio: 'inherit',
+})
+
+if (result.error) {
+  console.error(result.error.message)
+  process.exit(1)
+}
+
+process.exit(result.status ?? 1)

--- a/packages/cli/collect-artifacts.js
+++ b/packages/cli/collect-artifacts.js
@@ -1,0 +1,62 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+const { copyFileSync, existsSync } = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const webArtifactsDir = path.join(
+  'artifacts',
+  'bindings-wasm32-wasip1-threads',
+)
+const wasmPackageDir = path.join('npm', 'wasm32-wasi')
+
+function command(name) {
+  return process.platform === 'win32' ? `${name}.cmd` : name
+}
+
+function copyRequiredFile(from, to) {
+  if (!existsSync(from)) {
+    console.error(`Missing artifact: ${from}`)
+    process.exit(1)
+  }
+
+  copyFileSync(from, to)
+}
+
+const result = spawnSync(
+  command('napi'),
+  ['artifacts', '--build-output-dir', webArtifactsDir],
+  {
+    stdio: 'inherit',
+  },
+)
+
+if (result.error) {
+  console.error(result.error.message)
+  process.exit(1)
+}
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1)
+}
+
+for (const file of [
+  'cli.wasi-browser.js',
+  'cli.wasi.cjs',
+  'cli.wasi.d.ts',
+  'cli.wasm32-wasi.debug.wasm',
+  'cli.wasm32-wasi.wasm',
+  'wasi-worker-browser.mjs',
+  'wasi-worker.mjs',
+]) {
+  copyRequiredFile(path.join(webArtifactsDir, file), file)
+}
+
+for (const file of ['cli.wasi.d.ts', 'cli.wasm32-wasi.debug.wasm']) {
+  copyRequiredFile(
+    path.join(webArtifactsDir, file),
+    path.join(wasmPackageDir, file),
+  )
+}

--- a/packages/cli/main.browser.js
+++ b/packages/cli/main.browser.js
@@ -1,0 +1,19 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+import { logError, run as bindingRun } from './cli.wasi-browser.js'
+
+export function run(args, binName) {
+  return new Promise((resolve, reject) => {
+    bindingRun(args, binName, (error, res) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve(res)
+      }
+    })
+  })
+}
+
+export { logError }

--- a/packages/cli/npm/wasm32-wasi/README.md
+++ b/packages/cli/npm/wasm32-wasi/README.md
@@ -1,0 +1,3 @@
+# `@tauri-apps/cli-wasm32-wasi`
+
+This is the **wasm32-wasip1-threads** WebAssembly binary for `@tauri-apps/cli`.

--- a/packages/cli/npm/wasm32-wasi/package.json
+++ b/packages/cli/npm/wasm32-wasi/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@tauri-apps/cli-wasm32-wasi",
+  "version": "0.0.0",
+  "cpu": [
+    "wasm32"
+  ],
+  "main": "cli.wasi.cjs",
+  "browser": "cli.wasi-browser.js",
+  "types": "cli.wasi.d.ts",
+  "files": [
+    "cli.wasi.cjs",
+    "cli.wasi-browser.js",
+    "cli.wasi.d.ts",
+    "cli.wasm32-wasi.wasm",
+    "cli.wasm32-wasi.debug.wasm",
+    "wasi-worker.mjs",
+    "wasi-worker-browser.mjs"
+  ],
+  "description": "Command line interface for building Tauri apps",
+  "homepage": "https://github.com/tauri-apps/tauri#readme",
+  "contributors": [
+    "Tauri Programme within The Commons Conservancy"
+  ],
+  "license": "Apache-2.0 OR MIT",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tauri-apps/tauri.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tauri-apps/tauri/issues"
+  },
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "main": "main.js",
+  "browser": "main.browser.js",
   "types": "main.d.ts",
   "napi": {
     "binaryName": "cli",
@@ -37,8 +38,12 @@
       "x86_64-unknown-linux-musl",
       "riscv64gc-unknown-linux-gnu",
       "i686-pc-windows-msvc",
-      "aarch64-pc-windows-msvc"
+      "aarch64-pc-windows-msvc",
+      "wasm32-wasip1-threads"
     ]
+  },
+  "dependencies": {
+    "@napi-rs/wasm-runtime": "^1.1.0"
   },
   "devDependencies": {
     "@napi-rs/cli": "3.4.1",
@@ -53,11 +58,13 @@
     "tauri": "./tauri.js"
   },
   "scripts": {
-    "artifacts": "napi artifacts",
+    "artifacts": "node collect-artifacts.js",
     "build": "cross-env TARGET=node napi build --platform --profile release-size-optimized",
     "postbuild": "node append-headers.js",
+    "build:web": "node build-web.js --profile release-size-optimized",
     "build:debug": "cross-env TARGET=node napi build --platform",
     "postbuild:debug": "node append-headers.js",
+    "build:web:debug": "node build-web.js",
     "prepublishOnly": "napi prepublish -t npm --gh-release-id $RELEASE_ID",
     "prepack": "cp ../../crates/tauri-schema-generator/schemas/config.schema.json .",
     "version": "napi version",

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-#![cfg(any(target_os = "macos", target_os = "linux", windows))]
-
 use std::sync::Arc;
 
-use napi::{
-  threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
-  Error, Result, Status,
-};
+#[cfg(not(target_family = "wasm"))]
+use napi::threadsafe_function::ThreadsafeFunctionCallMode;
+use napi::{threadsafe_function::ThreadsafeFunction, Error, Result, Status};
 
+#[cfg(not(target_family = "wasm"))]
 #[napi_derive::napi]
 pub fn run(
   args: Vec<String>,
@@ -45,6 +43,19 @@ pub fn run(
   });
 
   Ok(())
+}
+
+#[cfg(target_family = "wasm")]
+#[napi_derive::napi]
+pub fn run(
+  _args: Vec<String>,
+  _bin_name: Option<String>,
+  _callback: Arc<ThreadsafeFunction<bool>>,
+) -> Result<()> {
+  Err(Error::new(
+    Status::GenericFailure,
+    "The Tauri CLI WebAssembly binding can be loaded in web/WASI environments, but running Tauri commands requires native toolchains and process spawning.",
+  ))
 }
 
 #[napi_derive::napi]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,10 @@ importers:
         version: 8.58.2(eslint@10.0.2(jiti@2.6.1))(typescript@6.0.2)
 
   packages/cli:
+    dependencies:
+      '@napi-rs/wasm-runtime':
+        specifier: ^1.1.0
+        version: 1.1.2(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
     devDependencies:
       '@napi-rs/cli':
         specifier: 3.4.1
@@ -2809,17 +2813,14 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@epic-web/invariant@1.0.0': {}
 
@@ -3413,7 +3414,6 @@ snapshots:
       '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
-    optional: true
 
   '@napi-rs/wasm-tools-android-arm-eabi@1.0.1':
     optional: true
@@ -3814,7 +3814,6 @@ snapshots:
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@types/chai@5.2.3':
     dependencies:


### PR DESCRIPTION
# Web Build Support Changes

This note summarizes the `add web build` commit that adds WebAssembly/WASI build
support for the `@tauri-apps/cli` package.

## Summary

The change adds a web build path for the JavaScript CLI package so it can produce
NAPI-RS WebAssembly artifacts in addition to the existing native Node.js
bindings. The new target is `wasm32-wasip1-threads`, and the package exposes a
browser entry that can load the generated WASI binding in web-compatible
environments.

## Main Changes

- Added `wasm32-wasip1-threads` to the CLI package's NAPI targets.
- Added `build:web` and `build:web:debug` scripts for producing the WASI
  artifacts.
- Added a small `build-web.js` helper so the WASI reactor object is linked
  correctly and the generated module does not hang during load.
- Added `collect-artifacts.js` so release artifacts are copied into both the
  root CLI package and the `@tauri-apps/cli-wasm32-wasi` optional package.
- Added `main.browser.js` as the browser-facing wrapper so the public API keeps
  the same Promise-based shape as `main.js`.
- Added package metadata for `@tauri-apps/cli-wasm32-wasi`.
- Updated the publish workflow to build and upload the web artifacts before the
  publish job runs.
- Kept native CLI behavior unchanged by gating the native `tauri-cli`
  dependency and native `run` implementation away from wasm targets.

## Runtime Behavior

The WebAssembly binding can be imported and loaded in web/WASI environments. The
native Tauri CLI commands still require native toolchains and process spawning,
so the wasm `run` export returns a clear error instead of trying to execute
native-only behavior:

> The Tauri CLI WebAssembly binding can be loaded in web/WASI environments, but
> running Tauri commands requires native toolchains and process spawning.

## Validation Performed

- Ran the new web build path with `pnpm --dir packages/cli build:web`.
- Confirmed the generated WASI binding can be loaded from Node.js without
  hanging.
- Confirmed the wasm `run` export returns the expected native-toolchain guard
  error.
- Ran the native CLI package check with `cargo check -p tauri-cli-node`.
- Ran `cargo fmt -p tauri-cli-node --check`.
- Temporarily created and ran a small Tauri/Vite showcase app to verify the
  browser entry loads the WASI binding with the required cross-origin isolation
  headers.

## Review Notes

The new JavaScript and Rust source files include the standard Tauri header:

```text
Copyright 2019-2024 Tauri Programme within The Commons Conservancy
SPDX-License-Identifier: Apache-2.0
SPDX-License-Identifier: MIT
```

I found that the repository has a `check license headers` workflow that requires
this header on new `.rs`, `.js`, `.ts`, `.yml`, `.swift`, and `.kt` files. If
the wording, year range, or placement needs to be changed for this contribution,
I can update the new files to match the maintainers' preferred licensing policy.

Please also let me know if any of the code needs to be adjusted to better match
project conventions, naming, review expectations, or contributor conduct
guidelines. I am able to change the helper script names, package metadata,
workflow shape, feature naming, error message wording, or browser wrapper
structure if a different style would fit the project better.
