### PR TITLE
fix(cli): normalize NDK_HOME path to use forward slashes on Windows

### DIFF
--- a/crates/tauri-cli/src/mobile/android/mod.rs
+++ b/crates/tauri-cli/src/mobile/android/mod.rs
@@ -603,7 +603,10 @@ fn ensure_ndk(non_interactive: bool) -> Result<()> {
 
   if let Some(ndk) = installed_ndks.last() {
     log::info!("Using installed NDK: {}", ndk.display());
-    std::env::set_var("NDK_HOME", ndk);
+    // Normalize path to use forward slashes on Windows to avoid mixed separators
+    // when the path is later used in shell commands or concatenated with other paths
+    let ndk_str = ndk.to_string_lossy().replace('\\', "/");
+    std::env::set_var("NDK_HOME", ndk_str);
   } else if non_interactive {
     crate::error::bail!("Android NDK not found. Make sure the NDK is installed and the NDK_HOME environment variable is set.");
   } else {
@@ -663,7 +666,9 @@ fn ensure_ndk(non_interactive: bool) -> Result<()> {
 
     let ndk_path = android_home.join("ndk").join(NDK_VERSION);
     log::info!("Installed NDK: {}", ndk_path.display());
-    std::env::set_var("NDK_HOME", ndk_path);
+    // Normalize path to use forward slashes on Windows to avoid mixed separators
+    let ndk_str = ndk_path.to_string_lossy().replace('\\', "/");
+    std::env::set_var("NDK_HOME", ndk_str);
   }
 
   Ok(())


### PR DESCRIPTION
## Description

Fixes #15345

This PR fixes a critical issue where Android builds fail on Windows due to mixed path separators in the NDK path.

## Problem

When building Tauri apps for Android on Windows, the NDK path gets constructed with **mixed forward and backward slashes**, causing shell commands to fail with "No such file or directory" errors.

**Example from the issue:**

```
User sets:     ANDROID_HOME = "C:/Users/Administrator/AppData/Local/Android/Sdk"
Tauri reports: Using installed NDK: C:/Users/Administrator/AppData/Local/Android/Sdk\ndk\29.0.14206865
Compiler fails: C:/Users/Administrator/AppData/Local/Android/Sdkndk29.0.14206865toolchains/llvm/...
                                                                    ^^^^ backslashes removed by shell
```

The error message shows:
```
/bin/sh: line 1: C:/Users/Administrator/AppData/Local/Android/Sdkndk29.0.14206865toolchains/llvm/prebuilt/windows-x86_64binclang.exe: No such file or directory
```

## Root Cause

When Tauri detects or installs the NDK, it uses `PathBuf::join()` to construct the NDK path:

```rust
let ndk_path = android_home.join("ndk").join(NDK_VERSION);
std::env::set_var("NDK_HOME", ndk_path);
```

On Windows, `PathBuf::join()` uses **backslashes** as the path separator. When this `PathBuf` is set as the `NDK_HOME` environment variable and later used in shell commands, the mixed separators cause the path to be malformed.

**Why this happens:**
1. User's `ANDROID_HOME` may use forward slashes (valid on Windows): `C:/Users/.../Sdk`
2. `PathBuf::join()` adds backslashes (Windows default): `C:/Users/.../Sdk\ndk\29.0.14206865`
3. The resulting mixed-separator path breaks when passed to shell commands
4. Shell interprets backslashes as escape characters, corrupting the path

## Solution

Normalize the NDK path to use **forward slashes** before setting the `NDK_HOME` environment variable.

Forward slashes work correctly on Windows in all contexts:
- ✅ Native Windows APIs
- ✅ Shell commands (bash, sh, cmd)
- ✅ Cross-platform toolchains (clang, gcc, cargo)

Backslashes can cause issues in shell contexts where they're interpreted as escape characters.

## Changes

**`crates/tauri-cli/src/mobile/android/mod.rs`**

1. **Line 606** (detected NDK):
   ```rust
   // Before
   std::env::set_var("NDK_HOME", ndk);
   
   // After
   let ndk_str = ndk.to_string_lossy().replace('\\', "/");
   std::env::set_var("NDK_HOME", ndk_str);
   ```

2. **Line 666** (installed NDK):
   ```rust
   // Before
   std::env::set_var("NDK_HOME", ndk_path);
   
   // After
   let ndk_str = ndk_path.to_string_lossy().replace('\\', "/");
   std::env::set_var("NDK_HOME", ndk_str);
   ```

## Impact

- ✅ **Fixes Android builds on Windows** (primary use case from #15345)
- ✅ **No impact on Linux/macOS** (paths already use forward slashes)
- ✅ **No breaking changes** (forward slashes work on all platforms)
- ✅ **Prevents mixed separator issues** in downstream tooling

## Example

**Before:**
```
NDK_HOME = "C:/Users/.../Sdk\ndk\29.0.14206865"  ❌ Mixed separators
```

**After:**
```
NDK_HOME = "C:/Users/.../Sdk/ndk/29.0.14206865"  ✅ Consistent forward slashes
```

Both formats work in Windows native APIs, but only the normalized version works correctly in shell commands and cross-platform toolchains.

## Testing

Tested scenarios:
- ✅ Windows with forward-slash `ANDROID_HOME` (primary fix)
- ✅ Windows with backslash `ANDROID_HOME` (normalized to forward slashes)
- ✅ Linux/macOS (no change, already uses forward slashes)

## Related

- Fixes #15345
- Similar to path normalization issues in other cross-platform build tools