### PR TITLE
fix(tauri-utils): preserve resource source file name when dest is empty

### DIFF
--- a/.changes/no-dest-resource-target.md
+++ b/.changes/no-dest-resource-target.md
@@ -1,0 +1,17 @@
+---
+"tauri-utils": "patch:bug"
+---
+
+Fix a regression in tauri-utils 2.8.3 that made empty path an invalid resource target, e.g.
+
+```json
+{
+  "bundle": {
+    "resources": {
+      "README.md": "",
+    }
+  }
+}
+```
+
+(this means `README.md` -> `$RESOURCE/README.md`, note this is a confusing behavior, and will be changed in v3)

--- a/crates/tauri-utils/src/resources.rs
+++ b/crates/tauri-utils/src/resources.rs
@@ -209,7 +209,21 @@ impl ResourcePathsIter<'_> {
             // preserving the file name as it is
             ResourcePathsInnerIter::Glob { .. } => dest.join(path.file_name().unwrap()),
           },
-          None => dest.clone(),
+          None => {
+            if dest.components().count() == 0 {
+              // if current_dest is empty while processing a file pattern
+              // we preserve the file name as it is
+              //
+              // e.g. `{ "README.md": "" }` is `README.md` -> `$RESOURCE/README.md`
+              //
+              // TODO: This behavior is a confusing special case,
+              // remove this in v3 or make other cases like this work
+              // > `{ "README.md": "./folder/" }` is `README.md` -> `$RESOURCE/folder/README.md` (this gives `$RESOURCE/folder` today)
+              PathBuf::from(path.file_name().unwrap())
+            } else {
+              dest.clone()
+            }
+          }
         }
       } else {
         // If [`ResourcePathsIter::pattern_iter`] is a [`PatternIter::Slice`]


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix #15380, regression from #14662

Apparently https://github.com/tauri-apps/tauri/pull/14662#discussion_r2621860377 is possible

This behavior is confusing, but we should still keep it in v2 for the compatibility