### PR TITLE
fix: `set_as_windows_menu_for_nsapp` command wrongly called `set_as_help_menu_for_nsapp`

### DIFF
--- a/.changes/fix-window-menu-nsapp-command.md
+++ b/.changes/fix-window-menu-nsapp-command.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+Fixed `Submenu.setAsWindowsMenuForNSApp()` calling the Help menu setter instead of the Window menu setter.

--- a/crates/tauri/src/menu/plugin.rs
+++ b/crates/tauri/src/menu/plugin.rs
@@ -815,7 +815,7 @@ fn set_as_windows_menu_for_nsapp<R: Runtime>(
   {
     let resources_table = webview.resources_table();
     let submenu = resources_table.get::<Submenu<R>>(rid)?;
-    submenu.set_as_help_menu_for_nsapp()?;
+    submenu.set_as_windows_menu_for_nsapp()?;
   }
 
   let _ = rid;


### PR DESCRIPTION
## What changed

Fixes the `plugin:menu|set_as_windows_menu_for_nsapp` command handler so it calls `Submenu::set_as_windows_menu_for_nsapp()` instead of `Submenu::set_as_help_menu_for_nsapp()`. This was probably a typo.

## Why

`Submenu.setAsWindowsMenuForNSApp()` currently invokes the correct JavaScript command name, but the Rust command implementation routes it to the Help menu setter. As a result, apps using the JS API do not register their Window submenu as the AppKit Window menu, so macOS cannot attach native Window menu behavior such as the system window/tiling entries.

The app-menu auto-registration path for `WINDOW_SUBMENU_ID` already calls the correct method; this patch makes the JS command path consistent with it.

## Related

- Addresses #13605
- Relevant blame: https://github.com/tauri-apps/tauri/blame/dev/crates/tauri/src/menu/plugin.rs#L818
- Related to tauri-apps/muda#335, which fixed `muda::Submenu::set_as_windows_menu_for_nsapp`; this PR fixes Tauri’s JS command path so it calls that corrected native method.

## Validation

- `cargo fmt --check --all`
- `cargo check -p tauri --lib`