### PR TITLE
fix: resources after empty directory not copied

### DIFF
--- a/.changes/resources-after-empty-diretory.md
+++ b/.changes/resources-after-empty-diretory.md
@@ -15,4 +15,4 @@ Fix a regression in tauri-utils 2.8.3 that made an empty directory makes it skip
 }
 ```
 
-ff `empty-directory` is empty, the `README.md` will not be copied to the resource directory (skipped)
+if `empty-directory` is empty, the `README.md` will not be copied to the resource directory (skipped)

--- a/.changes/resources-after-empty-diretory.md
+++ b/.changes/resources-after-empty-diretory.md
@@ -1,0 +1,18 @@
+---
+"tauri-utils": "patch:bug"
+---
+
+Fix a regression in tauri-utils 2.8.3 that made an empty directory makes it skip all the following entries, e.g.
+
+```json
+{
+  "bundle": {
+    "resources": [
+      "empty-directory",
+      "README.md"
+    ]
+  }
+}
+```
+
+ff `empty-directory` is empty, the `README.md` will not be copied to the resource directory (skipped)

--- a/crates/tauri-utils/src/resources.rs
+++ b/crates/tauri-utils/src/resources.rs
@@ -359,6 +359,7 @@ mod tests {
       fs::create_dir_all(path.parent().unwrap()).unwrap();
       fs::write(path, "").unwrap();
     }
+    fs::create_dir_all("empty-directory").unwrap();
   }
 
   fn resources_map(literal: &[(&str, &str)]) -> HashMap<String, String> {
@@ -378,6 +379,8 @@ mod tests {
 
     let resources = ResourcePaths::new(
       &[
+        // `empty-directory` should not affect anything
+        "../empty-directory".into(),
         "../src/script.js".into(),
         "../src/assets".into(),
         "../src/index.html".into(),

--- a/crates/tauri-utils/src/resources.rs
+++ b/crates/tauri-utils/src/resources.rs
@@ -221,6 +221,7 @@ impl ResourcePathsIter<'_> {
 
   fn next_pattern(&mut self) -> Option<crate::Result<Resource>> {
     self.current_dest = None;
+    self.current_iter = None;
 
     let pattern = match &mut self.pattern_iter {
       PatternIter::Slice(iter) => iter.next()?,
@@ -237,10 +238,10 @@ impl ResourcePathsIter<'_> {
         Err(error) => return Some(Err(error.into())),
       };
       match self.next_current_iter() {
-        Some(r) => return Some(r),
+        Some(r) => Some(r),
         None => {
           self.current_iter = None;
-          return Some(Err(crate::Error::GlobPathNotFound(pattern.clone())));
+          Some(Err(crate::Error::GlobPathNotFound(pattern.clone())))
         }
       }
     } else {
@@ -257,12 +258,12 @@ impl ResourcePathsIter<'_> {
             None
           },
         });
+        // If the directory is empty, skip and continue to the next pattern
+        self.next_current_iter().or_else(|| self.next_pattern())
       } else {
-        return Some(self.resource_from_path(path));
+        Some(self.resource_from_path(path))
       }
     }
-
-    self.next_current_iter()
   }
 }
 


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Regression from #14662, reference: https://github.com/tauri-apps/tauri/issues/15380#issuecomment-4463733991, and probably related to the behavior described in https://github.com/tauri-apps/tauri/issues/15342#issuecomment-4378283421

Essentially, I didn't copy the last part of https://github.com/tauri-apps/tauri/pull/14662/changes#diff-05b40af0733ae504151e101f8975697c3af733653b9b546a86294305500b2a96L212-L217