### PR TITLE
fix(macos): traffic_light_position with unstable feature

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4991,8 +4991,19 @@ You may have it installed on another user account, but it is not available for t
   } else {
     #[cfg(feature = "unstable")]
     {
+      #[cfg(target_os = "macos")]
+      let y_offset = webview_attributes
+        .traffic_light_position
+        .map(|p| match p {
+          dpi::Position::Physical(p) => p.y as f64 / window.scale_factor(),
+          dpi::Position::Logical(p) => p.y,
+        })
+        .unwrap_or(0.0);
+      #[cfg(not(target_os = "macos"))]
+      let y_offset = 0.0;
+
       webview_builder = webview_builder.with_bounds(wry::Rect {
-        position: LogicalPosition::new(0, 0).into(),
+        position: LogicalPosition::new(0.0, y_offset).into(),
         size: window.inner_size().into(),
       });
       Some(WebviewBounds {


### PR DESCRIPTION
## Summary

Fixes #14072

### Problem

When the `unstable` feature is enabled on macOS, the `traffic_light_position` property does not affect the traffic light button placement.

### Root Cause

With the `unstable` feature, webviews are created as `WebviewKind::WindowChild` with explicit bounds at `(0, 0)`. The webview fills the entire window content area including the title bar where traffic light buttons are rendered on macOS. The traffic light inset (`with_traffic_light_inset`) is applied to the webview, but when the webview is a child with bounds at (0,0), the inset does not properly affect the window toolbar layout.

### Fix

When `unstable` is enabled and `traffic_light_position` is configured on macOS, the webview bounds y-offset is adjusted to account for the traffic light position. This ensures the inset is properly applied.

On non-macOS platforms, `y_offset` remains `0.0` (no behavioral change).

### Testing

Test case:
```rust
use tauri::WebviewWindowBuilder;

let window = WebviewWindowBuilder::new(app, "main", Default::default())
    .title_bar_style(tauri::TitleBarStyle::Overlay)
    .traffic_light_position(20.0, 20.0)
    .build()?;
```

With `tauri = { version = "2", features = ["unstable"] }` on macOS.

Closes #14072
