### PR TITLE
fix(nsis): embed signed copies of stock plugins, not unsigned system DLLs

### DIFF
--- a/.changes/nsis-stock-plugins-embed-signed.md
+++ b/.changes/nsis-stock-plugins-embed-signed.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": "patch:bug"
+---
+
+Fix NSIS stock plugins (`NSISdl.dll`, `StartMenu.dll`, `System.dll`, `nsDialogs.dll`) being embedded in the final installer as unsigned despite the signing step succeeding. The signed local copies under `<output>/Plugins/x86-unicode/` were not on makensis' plugin search path, so makensis fell back to the unsigned DLLs from the NSIS toolset directory. The fix adds `!addplugindir` for the signed plugin directory before any plugin command is parsed in the script.

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -13,6 +13,12 @@ ManifestDPIAwareness PerMonitorV2
   SetCompressor /SOLID "{{compression}}"
 !endif
 
+; Keep above !include to stay ahead of any plugin command
+; see https://github.com/tauri-apps/tauri/pull/15422#discussion_r3289239624
+{{#if signed_plugins_path}}
+!addplugindir "{{signed_plugins_path}}"
+{{/if}}
+
 !include MUI2.nsh
 !include FileFunc.nsh
 !include x64.nsh
@@ -22,9 +28,6 @@ ManifestDPIAwareness PerMonitorV2
 !include "Win\COM.nsh"
 !include "Win\Propkey.nsh"
 !include "StrFunc.nsh"
-{{#if signed_plugins_path}}
-!addplugindir "{{signed_plugins_path}}"
-{{/if}}
 ${StrCase}
 ${StrLoc}
 

--- a/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/installer.nsi
@@ -22,6 +22,9 @@ ManifestDPIAwareness PerMonitorV2
 !include "Win\COM.nsh"
 !include "Win\Propkey.nsh"
 !include "StrFunc.nsh"
+{{#if signed_plugins_path}}
+!addplugindir "{{signed_plugins_path}}"
+{{/if}}
 ${StrCase}
 ${StrLoc}
 

--- a/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
@@ -282,6 +282,13 @@ fn build_nsis_app_installer(
     to_json(&additional_plugins_path),
   );
 
+  if let Some(plugin_copy_path) = &maybe_plugin_copy_path {
+    data.insert(
+      "signed_plugins_path",
+      to_json(plugin_copy_path.join("x86-unicode")),
+    );
+  }
+
   data.insert("arch", to_json(arch));
   data.insert("bundle_id", to_json(bundle_id));
   data.insert("manufacturer", to_json(manufacturer));
@@ -682,10 +689,6 @@ fn build_nsis_app_installer(
   let mut nsis_cmd = Command::new(nsis_toolset_path.join("makensis.exe"));
   #[cfg(not(target_os = "windows"))]
   let mut nsis_cmd = Command::new("makensis");
-
-  if let Some(plugins_path) = &maybe_plugin_copy_path {
-    nsis_cmd.env("NSISPLUGINS", plugins_path);
-  }
 
   nsis_cmd
     .args(["-INPUTCHARSET", "UTF8", "-OUTPUTCHARSET", "UTF8"])


### PR DESCRIPTION
## Summary

closes #14147

When an NSIS bundle is produced with `signCommand` configured, the stock plugin DLLs (`NSISdl.dll`, `StartMenu.dll`, `System.dll`, `nsDialogs.dll`) unpacked into `$PLUGINSDIR` at install time end up **unsigned**. PR #14627 made the sign step itself run, but the signed local copies were never embedded into the resulting setup.exe.

## Root cause

When `signCommand` is enabled, the bundler copies the system NSIS plugins to `<output>/Plugins/x86-unicode/` and signs them in place. However, `installer.nsi` only has an `!addplugindir` for the `additional/` subdirectory — nothing points makensis at the directory holding the signed stock plugins. makensis therefore falls back to `${NSISDIR}/Plugins/<arch>/` and embeds the unsigned originals.

The signed local copies are never referenced by makensis, so the unsigned versions are what end up inside setup.exe.

## Fix

- `installer.nsi`: between `!include "StrFunc.nsh"` and `${StrCase}`, add an `!addplugindir` for the signed plugin directory (gated on signing being enabled)
- `mod.rs`: expose the matching `signed_plugins_path` template variable only when signing is enabled

## Also: drop the `NSISPLUGINS` env line

Before launching makensis, `mod.rs` set `nsis_cmd.env("NSISPLUGINS", plugins_path)`, but `NSISPLUGINS` is not an environment variable that NSIS recognizes. Grepping the entire `NSIS-Dev/nsis` source tree and running `gh search code --owner NSIS-Dev 'NSISPLUGINS'` both return zero hits — the line was a complete no-op.

The intent was presumably to communicate the local-copy plugin directory to makensis, but the proper route is now established by the `!addplugindir` change above, so this dead line is removed as well.