### PR TITLE
fix(cef): panic when relaunched with empty arguments

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -672,13 +672,15 @@ wrap_browser_process_handler! {
       let mut list = CefStringList::new();
       command_line.arguments(Some(&mut list));
       let args: Vec<String> = list.into_iter().collect();
-      if let Ok(url) = url::Url::parse(&args[0]) {
-        let scheme = url.scheme().to_string();
-        if self.deep_link_schemes.iter().any(|s| s == &scheme) {
-          (self.context.callback.borrow())(RunEvent::Opened {
-            urls: vec![url],
-          });
-          return 1;
+      if let Some(first_arg) = args.first() {
+        if let Ok(url) = url::Url::parse(first_arg) {
+          let scheme = url.scheme().to_string();
+          if self.deep_link_schemes.iter().any(|s| s == &scheme) {
+            (self.context.callback.borrow())(RunEvent::Opened {
+              urls: vec![url],
+            });
+            return 1;
+          }
         }
       }
       // TODO: add event


### PR DESCRIPTION
Currently at least on my machine (macOS 26.0.1), if you try to launch a second instance of the cef runtime, it will crash the first instance. This change fixes it so it instead results in a no-op, so you still can't launch a second instance but it at least prevents the first instance from hard crashing.