### PR TITLE
feat(macos): expose compact control size metrics option

### DIFF
--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -456,6 +456,11 @@
             }
           ]
         },
+        "prefersCompactControlSizeMetrics": {
+          "description": "Whether the window prefers compact control size metrics on macOS.\n\n On macOS 26 with SDK 26 or newer this can restore the older compact\n traffic light metrics for windows using overlay title bars.",
+          "default": false,
+          "type": "boolean"
+        },
         "hiddenTitle": {
           "description": "If `true`, sets the window title to be hidden on macOS.",
           "default": false,

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -861,7 +861,9 @@ impl WindowBuilder for WindowBuilderWrapper {
     {
       window = window
         .hidden_title(config.hidden_title)
-        .title_bar_style(config.title_bar_style);
+        .title_bar_style(config.title_bar_style)
+        .prefers_compact_control_size_metrics(config.prefers_compact_control_size_metrics);
+
       if let Some(identifier) = &config.tabbing_identifier {
         window = window.tabbing_identifier(identifier);
       }
@@ -1221,6 +1223,14 @@ impl WindowBuilder for WindowBuilderWrapper {
   #[cfg(target_os = "macos")]
   fn traffic_light_position<P: Into<Position>>(mut self, position: P) -> Self {
     self.inner = self.inner.with_traffic_light_inset(position.into());
+    self
+  }
+
+  #[cfg(target_os = "macos")]
+  fn prefers_compact_control_size_metrics(mut self, enabled: bool) -> Self {
+    self.inner = self
+      .inner
+      .with_prefers_compact_control_size_metrics(enabled);
     self
   }
 

--- a/crates/tauri-runtime/src/window.rs
+++ b/crates/tauri-runtime/src/window.rs
@@ -471,6 +471,11 @@ pub trait WindowBuilder: WindowBuilderBase {
   #[must_use]
   fn traffic_light_position<P: Into<dpi::Position>>(self, position: P) -> Self;
 
+  /// Whether the window prefers compact control size metrics on macOS.
+  #[cfg(target_os = "macos")]
+  #[must_use]
+  fn prefers_compact_control_size_metrics(self, enabled: bool) -> Self;
+
   /// Hide the window title.
   #[cfg(target_os = "macos")]
   #[must_use]

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -456,6 +456,11 @@
             }
           ]
         },
+        "prefersCompactControlSizeMetrics": {
+          "description": "Whether the window prefers compact control size metrics on macOS.\n\n On macOS 26 with SDK 26 or newer this can restore the older compact\n traffic light metrics for windows using overlay title bars.",
+          "default": false,
+          "type": "boolean"
+        },
         "hiddenTitle": {
           "description": "If `true`, sets the window title to be hidden on macOS.",
           "default": false,

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -2063,6 +2063,12 @@ pub struct WindowConfig {
   /// Requires titleBarStyle: Overlay and decorations: true.
   #[serde(default, alias = "traffic-light-position")]
   pub traffic_light_position: Option<LogicalPosition>,
+  /// Whether the window prefers compact control size metrics on macOS.
+  ///
+  /// On macOS 26 with SDK 26 or newer this can restore the older compact
+  /// traffic light metrics for windows using overlay title bars.
+  #[serde(default, alias = "prefers-compact-control-size-metrics")]
+  pub prefers_compact_control_size_metrics: bool,
   /// If `true`, sets the window title to be hidden on macOS.
   #[serde(default, alias = "hidden-title")]
   pub hidden_title: bool,
@@ -2330,6 +2336,7 @@ impl Default for WindowConfig {
       theme: None,
       title_bar_style: Default::default(),
       traffic_light_position: None,
+      prefers_compact_control_size_metrics: false,
       hidden_title: false,
       accept_first_mouse: false,
       tabbing_identifier: None,
@@ -3876,6 +3883,7 @@ mod build {
       let theme = opt_lit(self.theme.as_ref());
       let title_bar_style = &self.title_bar_style;
       let traffic_light_position = opt_lit(self.traffic_light_position.as_ref());
+      let prefers_compact_control_size_metrics = self.prefers_compact_control_size_metrics;
       let hidden_title = self.hidden_title;
       let accept_first_mouse = self.accept_first_mouse;
       let tabbing_identifier = opt_str_lit(self.tabbing_identifier.as_ref());
@@ -3941,6 +3949,7 @@ mod build {
         theme,
         title_bar_style,
         traffic_light_position,
+        prefers_compact_control_size_metrics,
         hidden_title,
         accept_first_mouse,
         tabbing_identifier,

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -741,6 +741,16 @@ impl<'a, R: Runtime, M: Manager<R>> WebviewWindowBuilder<'a, R, M> {
     self
   }
 
+  /// Whether the window prefers compact control size metrics on macOS.
+  #[cfg(target_os = "macos")]
+  #[must_use]
+  pub fn prefers_compact_control_size_metrics(mut self, enabled: bool) -> Self {
+    self.window_builder = self
+      .window_builder
+      .prefers_compact_control_size_metrics(enabled);
+    self
+  }
+
   /// Whether to show a link preview when long pressing on links. Available on macOS and iOS only.
   ///
   /// Default is true.

--- a/crates/tauri/src/window/mod.rs
+++ b/crates/tauri/src/window/mod.rs
@@ -770,6 +770,16 @@ impl<'a, R: Runtime, M: Manager<R>> WindowBuilder<'a, R, M> {
     self
   }
 
+  /// Whether the window prefers compact control size metrics on macOS.
+  #[cfg(target_os = "macos")]
+  #[must_use]
+  pub fn prefers_compact_control_size_metrics(mut self, enabled: bool) -> Self {
+    self.window_builder = self
+      .window_builder
+      .prefers_compact_control_size_metrics(enabled);
+    self
+  }
+
   /// Hide the window title.
   #[cfg(target_os = "macos")]
   #[must_use]


### PR DESCRIPTION
## Summary

Exposes a macOS window configuration option for AppKit’s compact control size metrics and adds prefers compact control size metrics to Tauri window config and exposes the matching Rust builder API

Depends on tauri-apps/tao#1227

Fixes #15434