### PR TITLE
perf(mobile): reuse dev reqwest client

### DIFF
--- a/.changes/reuse-mobile-dev-reqwest-client.md
+++ b/.changes/reuse-mobile-dev-reqwest-client.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:perf
+---
+
+Reuse proxy reqwest client in mobile dev, improving the dev load speed

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -29,22 +29,59 @@ pub fn get<R: Runtime>(
   window_origin: &str,
   web_resource_request_handler: Option<Box<WebResourceRequestHandler>>,
 ) -> UriSchemeProtocolHandler {
-  #[cfg(all(dev, mobile))]
-  let url = {
-    let mut url = manager
-      .get_app_url(window_origin.starts_with("https"))
-      .as_str()
-      .to_string();
-    if url.ends_with('/') {
-      url.pop();
-    }
-    url
-  };
-
   let window_origin = window_origin.to_string();
 
   #[cfg(all(dev, mobile))]
-  let response_cache = Arc::new(Mutex::new(HashMap::new()));
+  let (url, client, response_cache) = {
+    let use_https = window_origin.starts_with("https");
+    let mut url = manager.get_app_url(use_https).as_str().to_string();
+    if url.ends_with('/') {
+      url.pop();
+    }
+
+    let mut client_builder = reqwest::ClientBuilder::new();
+    if use_https {
+      #[cfg(feature = "rustls-tls")]
+      if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+      }
+
+      // we can't load env vars at runtime, gotta embed them in the lib
+      if let Some(cert_pem) = option_env!("TAURI_DEV_ROOT_CERTIFICATE") {
+        #[cfg(any(
+          feature = "native-tls",
+          feature = "native-tls-vendored",
+          feature = "rustls-tls"
+        ))]
+        {
+          log::info!("adding dev server root certificate");
+          let certificate = reqwest::Certificate::from_pem(cert_pem.as_bytes())
+            .expect("failed to parse TAURI_DEV_ROOT_CERTIFICATE");
+          client_builder = client_builder.tls_certs_merge([certificate]);
+        }
+
+        #[cfg(not(any(
+          feature = "native-tls",
+          feature = "native-tls-vendored",
+          feature = "rustls-tls"
+        )))]
+        {
+          log::warn!(
+            "the dev root-certificate-path option was provided, but you must enable one of the following Tauri features in Cargo.toml: native-tls, native-tls-vendored, rustls-tls"
+          );
+        }
+      } else {
+        log::warn!(
+          "loading HTTPS URL; you might need to provide a certificate via the `dev --root-certificate-path` option. You must enable one of the following Tauri features in Cargo.toml: native-tls, native-tls-vendored, rustls-tls"
+        );
+      }
+    }
+    let client = client_builder.build().unwrap();
+
+    let response_cache = Arc::new(Mutex::new(HashMap::new()));
+
+    (url, client, response_cache)
+  };
 
   Box::new(move |_, request, responder| {
     match get_response(
@@ -53,7 +90,7 @@ pub fn get<R: Runtime>(
       &window_origin,
       web_resource_request_handler.as_deref(),
       #[cfg(all(dev, mobile))]
-      (&url, &response_cache),
+      (&url, &client, &response_cache),
     ) {
       Ok(response) => responder.respond(response),
       Err(e) => responder.respond(
@@ -73,8 +110,9 @@ fn get_response<R: Runtime>(
   #[allow(unused_variables)] manager: &AppManager<R>,
   window_origin: &str,
   web_resource_request_handler: Option<&WebResourceRequestHandler>,
-  #[cfg(all(dev, mobile))] (url, response_cache): (
+  #[cfg(all(dev, mobile))] (url, client, response_cache): (
     &str,
+    &reqwest::Client,
     &Arc<Mutex<HashMap<String, CachedResponse>>>,
   ),
 ) -> Result<HttpResponse<Cow<'static, [u8]>>, Box<dyn std::error::Error>> {
@@ -114,50 +152,7 @@ fn get_response<R: Runtime>(
       decoded_path.trim_start_matches('/')
     );
 
-    #[cfg(feature = "rustls-tls")]
-    if rustls::crypto::CryptoProvider::get_default().is_none() {
-      let _ = rustls::crypto::ring::default_provider().install_default();
-    }
-
-    let mut client = reqwest::ClientBuilder::new();
-
-    if url.starts_with("https://") {
-      // we can't load env vars at runtime, gotta embed them in the lib
-      if let Some(cert_pem) = option_env!("TAURI_DEV_ROOT_CERTIFICATE") {
-        #[cfg(any(
-          feature = "native-tls",
-          feature = "native-tls-vendored",
-          feature = "rustls-tls"
-        ))]
-        {
-          log::info!("adding dev server root certificate");
-          let certificate = reqwest::Certificate::from_pem(cert_pem.as_bytes())
-            .expect("failed to parse TAURI_DEV_ROOT_CERTIFICATE");
-          client = client.tls_certs_merge([certificate]);
-        }
-
-        #[cfg(not(any(
-          feature = "native-tls",
-          feature = "native-tls-vendored",
-          feature = "rustls-tls"
-        )))]
-        {
-          log::warn!(
-            "the dev root-certificate-path option was provided, but you must enable one of the following Tauri features in Cargo.toml: native-tls, native-tls-vendored, rustls-tls"
-          );
-        }
-      } else {
-        log::warn!(
-          "loading HTTPS URL; you might need to provide a certificate via the `dev --root-certificate-path` option. You must enable one of the following Tauri features in Cargo.toml: native-tls, native-tls-vendored, rustls-tls"
-        );
-      }
-    }
-
-    let mut proxy_builder = client
-      .build()
-      .unwrap()
-      .request(request.method().clone(), &url);
-    proxy_builder = proxy_builder.body(std::mem::take(request.body_mut()));
+    let mut proxy_builder = client.request(request.method().clone(), &url);
     for (name, value) in request.headers() {
       proxy_builder = proxy_builder.header(name, value);
     }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Reference #14097

This allows the reqwest connection pool  to work and making thing a lot faster. I still don't quite understand why it takes so much time on the first request though (close to 1 sec to me)

Example timing logs on Android emulator:

```
05-28 10:05:00.752  7952  8008 I RustStdoutStderr: [tauri/crates/tauri/src/protocol/tauri.rs:209:3] now.elapsed() = 686.1753ms
05-28 10:05:01.231  7952  8008 I RustStdoutStderr: [tauri/crates/tauri/src/protocol/tauri.rs:209:3] now.elapsed() = 12.1876ms
05-28 10:05:01.634  7952  8008 I RustStdoutStderr: [tauri/crates/tauri/src/protocol/tauri.rs:209:3] now.elapsed() = 13.5335ms
05-28 10:05:01.946  7952  8008 I RustStdoutStderr: [tauri/crates/tauri/src/protocol/tauri.rs:209:3] now.elapsed() = 8.8892ms
```