### PR TITLE
fix(linux): position multi-webview children via gtk::Fixed (#10420)

### DIFF
--- a/.changes/linux-multiwebview-fixed-positioning.md
+++ b/.changes/linux-multiwebview-fixed-positioning.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch
+---
+
+On Linux, build child webviews (`WebviewKind::WindowChild`) into the window's `gtk::Fixed` overlay layer (`WindowExtUnix::content_fixed`) instead of the default vertical `gtk::Box`, so `set_bounds` positions them over the window instead of GTK stacking them. Fixes multi-webview positioning on Linux (tauri-apps/tauri#10420). Requires the corresponding `tao` change that adds `content_fixed`.

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -5232,9 +5232,12 @@ You may have it installed on another user account, but it is not available for t
       target_os = "android"
     )))]
     WebviewKind::WindowChild => {
-      // only way to account for menu bar height, and also works for multiwebviews :)
-      let vbox = window.default_vbox().unwrap();
-      webview_builder.build_gtk(vbox)
+      // Build child webviews into the window's `gtk::Fixed` overlay layer (not the
+      // default vertical `gtk::Box`) so wry honors their bounds and they overlay
+      // the window instead of stacking. Fixes multi-webview positioning on Linux
+      // (tauri-apps/tauri#10420). Requires tao's `WindowExtUnix::content_fixed`.
+      let fixed = window.content_fixed().unwrap();
+      webview_builder.build_gtk(fixed)
     }
     #[cfg(any(
       target_os = "windows",


### PR DESCRIPTION
## What

On Linux, build child webviews (`WebviewKind::WindowChild`) into the window's `gtk::Fixed` overlay layer (`WindowExtUnix::content_fixed`) instead of the default vertical `gtk::Box`. This makes `set_bounds` / `set_position` / `set_size` position child webviews over the window instead of GTK stacking them — fixing multi-webview positioning on Linux ([#10420](https://github.com/tauri-apps/tauri/issues/10420)).

## Depends on

- **tao** — `WindowExtUnix::content_fixed` ([tauri-apps/tao#1232](https://github.com/tauri-apps/tao/pull/1232)). This won't compile until that lands and releases, so this PR is a **draft** until then. (Validated locally against the patched tao: `tauri-runtime-wry` compiles clean.)
- **wry** — `set_bounds` → `gtk::Fixed::move_` ([tauri-apps/wry#1745](https://github.com/tauri-apps/wry/pull/1745)), so the position persists across relayouts.

## Changes

- `create_webview` Linux `WindowChild` arm: `build_gtk(window.content_fixed())` instead of `default_vbox()`.
- `.changes` entry (`tauri-runtime-wry: patch`).

## Testing

Validated (with the tao + wry changes applied) in a Tauri v2 app on WSLg (Ubuntu 22.04, WebKitGTK 2.50.4): content webviews render full-window and hold their bounds across tab-switch, multi-tab, drawer-resize, and window-resize. Single-webview windows are unchanged.

Full root cause + the three-part fix: #10420.
