### PR TITLE
Fixed vite crawler overreaching into cache, and hanging tauri dev

### DIFF
--- a/crates/tauri-codegen/src/embedded_assets.rs
+++ b/crates/tauri-codegen/src/embedded_assets.rs
@@ -344,12 +344,9 @@ impl EmbeddedAssets {
     // get a hash of the input - allows for caching existing files
     let hash = crate::checksum(&input).map_err(EmbeddedAssetsError::Hex)?;
 
-    // use the content hash to determine filename, keep extensions that exist
-    let out_path = if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-      out_dir.join(format!("{hash}.{ext}"))
-    } else {
-      out_dir.join(hash)
-    };
+    // use only the content hash to determine filename; this prevents frontend
+    // dev tools from crawling generated cache files as source files.
+    let out_path = out_dir.join(hash);
 
     // only compress and write to the file if it doesn't already exist.
     if !out_path.exists() {
@@ -443,4 +440,74 @@ pub(crate) fn ensure_out_dir() -> EmbeddedAssetsResult<PathBuf> {
   // make sure that our output directory is created
   std::fs::create_dir_all(&out_dir).map_err(|_| EmbeddedAssetsError::OutDir)?;
   Ok(out_dir)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::{
+    env, fs,
+    sync::{Mutex, OnceLock},
+  };
+
+  fn out_dir_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+  }
+
+  struct OutDirGuard(Option<std::ffi::OsString>);
+
+  impl OutDirGuard {
+    fn set(value: &Path) -> Self {
+      let previous = env::var_os("OUT_DIR");
+      env::set_var("OUT_DIR", value);
+      Self(previous)
+    }
+  }
+
+  impl Drop for OutDirGuard {
+    fn drop(&mut self) {
+      match self.0.take() {
+        Some(value) => env::set_var("OUT_DIR", value),
+        None => env::remove_var("OUT_DIR"),
+      }
+    }
+  }
+
+  #[test]
+  fn generated_asset_cache_files_do_not_preserve_frontend_extensions() {
+    let _guard = out_dir_lock().lock().unwrap();
+
+    let root = env::temp_dir().join(format!(
+      "tauri-codegen-embedded-assets-{}",
+      uuid::Uuid::new_v4()
+    ));
+    let asset_dir = root.join("dist");
+    let out_dir = root.join("out");
+    fs::create_dir_all(&asset_dir).unwrap();
+    fs::create_dir_all(&out_dir).unwrap();
+    let out_dir = out_dir.canonicalize().unwrap();
+
+    let input_path = asset_dir.join("index.html");
+    fs::write(&input_path, b"<!doctype html><title>Tauri</title>").unwrap();
+
+    let _out_dir = OutDirGuard::set(&out_dir);
+
+    let assets = EmbeddedAssets::new(
+      asset_dir,
+      &AssetOptions::new(PatternKind::Brownfield),
+      |_key, _path, _input, _csp_hashes| Ok(()),
+    )
+    .unwrap();
+
+    let (key, (input, output)) = assets.assets.iter().next().unwrap();
+    assert_eq!(assets.assets.len(), 1);
+    assert_eq!(key.as_ref(), "/index.html");
+    assert_eq!(input, &input_path);
+    assert!(output.starts_with(out_dir.join(TARGET_PATH)));
+    assert!(output.extension().is_none());
+    assert!(!output.ends_with("index.html"));
+
+    fs::remove_dir_all(root).unwrap();
+  }
 }

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -81,8 +81,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-android-arm64')
         const bindingPackageVersion = require('@tauri-apps/cli-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -97,8 +97,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-android-arm-eabi')
         const bindingPackageVersion = require('@tauri-apps/cli-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -118,8 +118,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-win32-x64-gnu')
         const bindingPackageVersion = require('@tauri-apps/cli-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -134,8 +134,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-win32-x64-msvc')
         const bindingPackageVersion = require('@tauri-apps/cli-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-win32-ia32-msvc')
         const bindingPackageVersion = require('@tauri-apps/cli-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-win32-arm64-msvc')
         const bindingPackageVersion = require('@tauri-apps/cli-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@tauri-apps/cli-darwin-universal')
       const bindingPackageVersion = require('@tauri-apps/cli-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-darwin-x64')
         const bindingPackageVersion = require('@tauri-apps/cli-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-darwin-arm64')
         const bindingPackageVersion = require('@tauri-apps/cli-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-freebsd-x64')
         const bindingPackageVersion = require('@tauri-apps/cli-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-freebsd-arm64')
         const bindingPackageVersion = require('@tauri-apps/cli-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-x64-musl')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-x64-gnu')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-arm64-musl')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-arm64-gnu')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-arm-musleabihf')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-loong64-musl')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-loong64-gnu')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -411,8 +411,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-riscv64-musl')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -427,8 +427,8 @@ function requireNative() {
         try {
           const binding = require('@tauri-apps/cli-linux-riscv64-gnu')
           const bindingPackageVersion = require('@tauri-apps/cli-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -444,8 +444,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-linux-ppc64-gnu')
         const bindingPackageVersion = require('@tauri-apps/cli-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -460,8 +460,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-linux-s390x-gnu')
         const bindingPackageVersion = require('@tauri-apps/cli-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -480,8 +480,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-openharmony-arm64')
         const bindingPackageVersion = require('@tauri-apps/cli-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -496,8 +496,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-openharmony-x64')
         const bindingPackageVersion = require('@tauri-apps/cli-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -512,8 +512,8 @@ function requireNative() {
       try {
         const binding = require('@tauri-apps/cli-openharmony-arm')
         const bindingPackageVersion = require('@tauri-apps/cli-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.10.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.10.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.11.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.11.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -540,17 +540,13 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
       wasiBindingError = err
     }
   }
-  if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
+  if (!nativeBinding) {
     try {
       wasiBinding = require('@tauri-apps/cli-wasm32-wasi')
       nativeBinding = wasiBinding
     } catch (err) {
       if (process.env.NAPI_RS_FORCE_WASI) {
-        if (!wasiBindingError) {
-          wasiBindingError = err
-        } else {
-          wasiBindingError.cause = err
-        }
+        wasiBindingError.cause = err
         loadErrors.push(err)
       }
     }


### PR DESCRIPTION
Tauri was generating embedded asset cache files inside `src-tauri/target/**/tauri-codegen-assets/` while preserving original file extension.

This issue affecting frontend serving using `npm run dev` and `npm run tauri dev`

Example: NOT A REAL JS/css/html file, but a binary blob

```text
project/src-tauri/target/release/build/project-91fc920d1289165b/out/tauri-codegen-assets/2de3b7aa36eeec0abc6d73f5fdeeab51e2f99865bbadeab43d14e3be0c1c55e3.js/css/html
```

Vite crawl ended up crawiling them because it though they were real web files, and ended up handing over invalid input

I propose removing extension preservation as it confusing static crawlers, and because those compiled files are not in fact contain any of the extension defined data, but are data blobs.

P.S. The actual asset key is still the same, so Tauri still serves `index.html` normally. Only the internal cache filename changed.


## Before

Cold request timing:

```sh
✗ curl -o /dev/null -s -w '/src/main.tsx -> %{time_total}s\n' \
  http://127.0.0.1:8089/src/main.tsx
/src/main.tsx -> 51.285s
```

## After

```
✗ curl -o /dev/null -s -w '/src/main.tsx -> %{time_total}s\n' \
  http://127.0.0.1:8089/src/main.tsx
/src/main.tsx -> 0.00442s
```


