### PR TITLE
fix(cli): skip AAB build during `tauri android run`

### DIFF
--- a/crates/tauri-cli/src/mobile/android/run.rs
+++ b/crates/tauri-cli/src/mobile/android/run.rs
@@ -101,7 +101,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
       features: options.features,
       config: options.config.clone(),
       split_per_abi: true,
-      apk: false,
+      apk: true,
       aab: false,
       skip_bundle: false,
       open: options.open,


### PR DESCRIPTION
## Summary

Fixes #15419 — \	auri android run\ builds both APK and AAB even though only the APK is needed for device installation, causing ~50% slower deploys.

## Problem

In \un.rs\, the build options are passed with \pk: false, aab: false, skip_bundle: false\. This triggers the fallback in \uild.rs:253\:

\\\ust
if !(options.skip_bundle || options.apk || options.aab) {
    options.apk = true;
    options.aab = true;  // <- unnecessary for \un\
}
\\\

Result: 3 Gradle invocations (APK build + AAB build + install) instead of 2 (APK build + install).

## Fix

Set \pk: true\ explicitly in \un.rs\ so the fallback doesn't trigger. Only the APK is built, and \ab\ remains \alse\.

## Impact

- Eliminates one full Rust compilation + Gradle invocation during \ndroid run\
- ~50% reduction in deploy time (as measured in the issue)
- No behavior change for \	auri android build\ (which still builds both by default)