### PR TITLE
fix(cli): skip building bundles when using `tauri android run`

### DIFF
--- a/.changes/android-run-build-bundles.md
+++ b/.changes/android-run-build-bundles.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+Skip building bundles when using `tauri android run`

--- a/crates/tauri-cli/src/mobile/android/run.rs
+++ b/crates/tauri-cli/src/mobile/android/run.rs
@@ -103,7 +103,7 @@ pub fn command(options: Options, noise_level: NoiseLevel) -> Result<()> {
       split_per_abi: true,
       apk: false,
       aab: false,
-      skip_bundle: false,
+      skip_bundle: true,
       open: options.open,
       ci: false,
       args: options.args,


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fixes #15419
Closes #15470

Seems like #14629 added a new `skip_bundle` option but set it to `false` in `tauri android run` which is not the behavior in #14120