### PR TITLE
fix: `Listeners::once` can be called multiple times

### DIFF
--- a/.changes/fs-event-once-multiple-times.md
+++ b/.changes/fs-event-once-multiple-times.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+Fix `WebviewWindow::once` can be called multiple times if they trigger `emit`(s) inside the handler

--- a/.changes/fs-event-once-multiple-times.md
+++ b/.changes/fs-event-once-multiple-times.md
@@ -1,5 +1,0 @@
----
-"tauri": "patch:bug"
----
-
-Fix `WebviewWindow::once` can be called multiple times if they trigger `emit`(s) inside the handler

--- a/.changes/listener-event-once-multiple-times.md
+++ b/.changes/listener-event-once-multiple-times.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+Fix `Listener::once` can be called multiple times if they trigger `emit`(s) inside the handler

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -168,11 +168,11 @@ impl Listeners {
 
     self.listen(event, target, move |event| {
       let id = event.id;
+      self_.unlisten(id);
       let handler = handler
         .take()
         .expect("attempted to call handler more than once");
       handler(event);
-      self_.unlisten(id);
     })
   }
 
@@ -381,5 +381,21 @@ mod test {
       // assert that the key is contained in the listeners map
       assert!(l.contains_key(&key));
     }
+  }
+
+  #[test]
+  fn event_no_deadlocks() {
+    let listeners = Listeners::default();
+    let listeners_clone = listeners.clone();
+    let event = crate::EventName::new("test-event".to_owned()).unwrap();
+    let event_clone = event.clone();
+    listeners.once(event.clone(), EventTarget::Any, move |_event| {
+      listeners_clone
+        .emit(EmitArgs::new(event_clone.as_str_event(), &()).unwrap())
+        .unwrap();
+    });
+    listeners
+      .emit(EmitArgs::new(event.as_str_event(), &()).unwrap())
+      .unwrap();
   }
 }


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fix `Listeners::once` can be called multiple times if they trigger `emit`(s) inside the handler