### PR TITLE
fix(acl): preserve Number::Int on serde_json round-trip

### DIFF
--- a/.changes/acl-number-int-preserved-on-serdejson-roundtrip.md
+++ b/.changes/acl-number-int-preserved-on-serdejson-roundtrip.md
@@ -4,4 +4,4 @@
 
 Fix `Number::Int` being silently coerced to `Number::Float` on `serde_json` round-trip.
 
-`From<serde_json::Value> for Value` was checking `as_f64()` first, which succeeds for every integer that fits in an f64, so integer JSON numbers were always deserialized as `Number::Float`. The check order is now `as_i64()` → `as_u64()` (falling back to `Float` for values above `i64::MAX` to avoid silent wrapping) → `as_f64()`, matching serde_json's own visitor convention.
+`From<serde_json::Value> for Value` was checking `as_f64()` first, which succeeds for every integer that fits in an f64, so integer JSON numbers were always deserialized as `Number::Float`. The check order is now `as_i64()` → `as_u64()` (cast to `i64`, wrapping for values above `i64::MAX`) → `as_f64()`, matching serde_json's own visitor convention.

--- a/.changes/acl-number-int-preserved-on-serdejson-roundtrip.md
+++ b/.changes/acl-number-int-preserved-on-serdejson-roundtrip.md
@@ -1,0 +1,7 @@
+---
+"tauri-utils": "patch:bug"
+---
+
+Fix `Number::Int` being silently coerced to `Number::Float` on `serde_json` round-trip.
+
+`From<serde_json::Value> for Value` was checking `as_f64()` first, which succeeds for every integer that fits in an f64, so integer JSON numbers were always deserialized as `Number::Float`. The check order is now `as_i64()` → `as_u64()` (falling back to `Float` for values above `i64::MAX` to avoid silent wrapping) → `as_f64()`, matching serde_json's own visitor convention.

--- a/crates/tauri-utils/src/acl/value.rs
+++ b/crates/tauri-utils/src/acl/value.rs
@@ -86,12 +86,14 @@ impl From<serde_json::Value> for Value {
     match value {
       serde_json::Value::Null => Value::Null,
       serde_json::Value::Bool(b) => Value::Bool(b),
-      serde_json::Value::Number(n) => Value::Number(if let Some(f) = n.as_f64() {
+      serde_json::Value::Number(n) => Value::Number(if let Some(i) = n.as_i64() {
+        Number::Int(i)
+      } else if let Some(u) = n.as_u64() {
+        // u64 values that exceed i64::MAX cannot be represented as Int without
+        // wrapping; fall back to Float to preserve approximate magnitude.
+        Number::Float(u as f64)
+      } else if let Some(f) = n.as_f64() {
         Number::Float(f)
-      } else if let Some(n) = n.as_u64() {
-        Number::Int(n as i64)
-      } else if let Some(n) = n.as_i64() {
-        Number::Int(n)
       } else {
         Number::Int(0)
       }),

--- a/crates/tauri-utils/src/acl/value.rs
+++ b/crates/tauri-utils/src/acl/value.rs
@@ -89,9 +89,7 @@ impl From<serde_json::Value> for Value {
       serde_json::Value::Number(n) => Value::Number(if let Some(i) = n.as_i64() {
         Number::Int(i)
       } else if let Some(u) = n.as_u64() {
-        // u64 values that exceed i64::MAX cannot be represented as Int without
-        // wrapping; fall back to Float to preserve approximate magnitude.
-        Number::Float(u as f64)
+        Number::Int(u as i64)
       } else if let Some(f) = n.as_f64() {
         Number::Float(f)
       } else {


### PR DESCRIPTION
closes #15480

 What changed

 From<serde_json::Value> for Value in crates/tauri-utils/src/acl/value.rs was checking as_f64() before as_i64(). Because serde_json::Number::as_f64() succeeds for any integer that
 fits in an f64, every integer JSON number was silently deserialized as Number::Float — the as_i64() branch was never reached for typical values.

 The check order is now:
 1. as_i64() → Number::Int(i) — handles all signed integers
 2. as_u64() → Number::Float(u as f64) — u64 values above i64::MAX can't be represented without wrapping, so Float preserves approximate magnitude
 3. as_f64() → Number::Float(f) — genuine floating-point numbers
 4. fallback → Number::Int(0)

 This matches serde_json's own visitor convention of preferring integer representations when the number has no decimal component.

 Impact

 - ACL scopes that compare integer values (e.g. { "port": 8080 }) now correctly match Number::Int instead of silently failing against Number::Float(8080.0).
 - TOML integers parsed as Number::Int via From<toml::Value> no longer lose that distinction when passed through serde_json.
