### PR TITLE
fix(acl): map NaN/\u00b1Infinity to JSON null instead of panicking

### DIFF
--- a/.changes/acl-nonfinite-float-null-instead-of-panic.md
+++ b/.changes/acl-nonfinite-float-null-instead-of-panic.md
@@ -1,0 +1,7 @@
+---
+"tauri-utils": "patch:bug"
+---
+
+Fix panic when converting `Number::Float(NaN)` or `Number::Float(±Infinity)` to `serde_json::Value`.
+
+`From<Value> for serde_json::Value` was calling `serde_json::Number::from_f64(f).unwrap()`, which panics for non-finite floats because the JSON specification (RFC 8259) does not permit them. Non-finite values now map to `serde_json::Value::Null` instead of panicking.

--- a/crates/tauri-utils/src/acl/value.rs
+++ b/crates/tauri-utils/src/acl/value.rs
@@ -66,7 +66,10 @@ impl From<Value> for serde_json::Value {
       Value::Null => serde_json::Value::Null,
       Value::Bool(b) => serde_json::Value::Bool(b),
       Value::Number(Number::Float(f)) => {
-        serde_json::Value::Number(serde_json::Number::from_f64(f).unwrap())
+        match serde_json::Number::from_f64(f) {
+          Some(n) => serde_json::Value::Number(n),
+          None => serde_json::Value::Null, // NaN / ±Infinity are not valid JSON
+        }
       }
       Value::Number(Number::Int(i)) => serde_json::Value::Number(i.into()),
       Value::String(s) => serde_json::Value::String(s),


### PR DESCRIPTION
closes #15477

 What changed

 From<Value> for serde_json::Value in crates/tauri-utils/src/acl/value.rs was calling serde_json::Number::from_f64(f).unwrap(). The JSON spec (RFC 8259 §6) does not permit non-finite
 floats, so from_f64 returns None for NaN, +Infinity, and -Infinity — and the .unwrap() turns that into an unconditional panic.

 ```rust
   // before — panics for non-finite f64
   Value::Number(Number::Float(f)) => {
       serde_json::Value::Number(serde_json::Number::from_f64(f).unwrap())
   }

   // after — non-finite maps to null
   Value::Number(Number::Float(f)) => {
       match serde_json::Number::from_f64(f) {
           Some(n) => serde_json::Value::Number(n),
           None => serde_json::Value::Null, // NaN / ±Infinity are not valid JSON
       }
   }
 ```

 Number::Float accepts any f64 via From<f64>, so non-finite values are constructible without error and the panic was the first signal that anything was wrong — potentially surfacing
 at an unrelated call site well after the bad value was created.

 Non-finite floats now produce serde_json::Value::Null, consistent with the IEEE 754 null-substitution convention used by many JSON serializers.
