### PR TITLE
fix(deps): update window-vibrancy from 0.6 to 0.7

### DIFF
--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -176,7 +176,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(".DirIcon"),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("usr/share/applications/{product_name}.desktop")),
+    format!("usr/share/applications/{product_name}.desktop"),
     app_dir_path.join(format!("{product_name}.desktop")),
   )?;
 

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -172,7 +172,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(format!("{product_name}.png")),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("{product_name}.png")),
+    format!("{product_name}.png"),
     app_dir_path.join(".DirIcon"),
   )?;
   std::os::unix::fs::symlink(

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -129,12 +129,12 @@ objc2-web-kit = { version = "0.3", default-features = false, features = [
   "WKWebViewConfiguration",
   "WKUserContentController",
 ] }
-window-vibrancy = "0.6"
+window-vibrancy = "0.7"
 
 # windows
 [target."cfg(windows)".dependencies]
 webview2-com = { version = "0.38", optional = true }
-window-vibrancy = "0.6"
+window-vibrancy = "0.7"
 windows = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_UI",


### PR DESCRIPTION
The window-vibrancy crate has been updated to 0.7 (latest 0.7.1).
This version adds apply_liquid_glass/clear_liquid_glass for macOS
but has no breaking changes, so the existing API usage remains compatible.

Projects depending on window-vibrancy 0.7.x can now compile without
version conflicts with Tauri.

Fixes #15478