### PR TITLE
docs: update minimum macOS version from 10.15 to 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Tauri currently supports development and distribution on the following platforms
 | Platform   | Versions                                                                                                        |
 | :--------- | :-------------------------------------------------------------------------------------------------------------- |
 | Windows    | 7 and above                                                                                                     |
-| macOS      | 10.15 and above                                                                                                 |
+| macOS      | 11 (Big Sur) and above                                                                                          |
 | Linux      | webkit2gtk 4.0 for Tauri v1 (for example Ubuntu 18.04). webkit2gtk 4.1 for Tauri v2 (for example Ubuntu 22.04). |
 | iOS/iPadOS | 9 and above                                                                                                     |
 | Android    | 7 and above (currently 8 and above)                                                                             |

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -176,7 +176,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(".DirIcon"),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("usr/share/applications/{product_name}.desktop")),
+    format!("usr/share/applications/{product_name}.desktop"),
     app_dir_path.join(format!("{product_name}.desktop")),
   )?;
 

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -172,7 +172,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(format!("{product_name}.png")),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("{product_name}.png")),
+    format!("{product_name}.png"),
     app_dir_path.join(".DirIcon"),
   )?;
   std::os::unix::fs::symlink(

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -129,12 +129,12 @@ objc2-web-kit = { version = "0.3", default-features = false, features = [
   "WKWebViewConfiguration",
   "WKUserContentController",
 ] }
-window-vibrancy = "0.6"
+window-vibrancy = "0.7"
 
 # windows
 [target."cfg(windows)".dependencies]
 webview2-com = { version = "0.38", optional = true }
-window-vibrancy = "0.6"
+window-vibrancy = "0.7"
 windows = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_UI",


### PR DESCRIPTION
macOS Catalina (10.15) is not supported by Tauri due to missing WebKit
APIs (objc2). Updated the README to reflect the correct minimum version.

Fixes #15431