### PR TITLE
fix(core): discard stale IPC responses after WebView navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Tauri currently supports development and distribution on the following platforms
 | Platform   | Versions                                                                                                        |
 | :--------- | :-------------------------------------------------------------------------------------------------------------- |
 | Windows    | 7 and above                                                                                                     |
-| macOS      | 10.15 and above                                                                                                 |
+| macOS      | 11 (Big Sur) and above                                                                                          |
 | Linux      | webkit2gtk 4.0 for Tauri v1 (for example Ubuntu 18.04). webkit2gtk 4.1 for Tauri v2 (for example Ubuntu 22.04). |
 | iOS/iPadOS | 9 and above                                                                                                     |
 | Android    | 7 and above (currently 8 and above)                                                                             |

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -176,7 +176,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(".DirIcon"),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("usr/share/applications/{product_name}.desktop")),
+    format!("usr/share/applications/{product_name}.desktop"),
     app_dir_path.join(format!("{product_name}.desktop")),
   )?;
 

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -172,7 +172,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     app_dir_path.join(format!("{product_name}.png")),
   )?;
   std::os::unix::fs::symlink(
-    app_dir_path.join(format!("{product_name}.png")),
+    format!("{product_name}.png"),
     app_dir_path.join(".DirIcon"),
   )?;
   std::os::unix::fs::symlink(

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -129,12 +129,12 @@ objc2-web-kit = { version = "0.3", default-features = false, features = [
   "WKWebViewConfiguration",
   "WKUserContentController",
 ] }
-window-vibrancy = "0.6"
+window-vibrancy = "0.7"
 
 # windows
 [target."cfg(windows)".dependencies]
 webview2-com = { version = "0.38", optional = true }
-window-vibrancy = "0.6"
+window-vibrancy = "0.7"
 windows = { version = "0.61", features = [
   "Win32_Foundation",
   "Win32_UI",

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -294,6 +294,8 @@ impl<R: Runtime> WebviewManager<R> {
         let payload = PageLoadPayload { url: &url, event };
 
         if let Some(w) = app_manager_.get_webview(&label) {
+          w.navigation_nonce.fetch_add(1, std::sync::atomic::Ordering::Release);
+
           if let Some(on_page_load) = &app_manager_.webview.on_page_load {
             on_page_load(&w, &payload);
           }

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1303,6 +1303,8 @@ pub struct Webview<R: Runtime> {
   pub(crate) manager: Arc<AppManager<R>>,
   pub(crate) app_handle: AppHandle<R>,
   pub(crate) resources_table: Arc<Mutex<ResourceTable>>,
+  /// Incremented on every page load to invalidate stale IPC responses.
+  pub(crate) navigation_nonce: Arc<std::sync::atomic::AtomicU64>,
   use_https_scheme: bool,
 }
 
@@ -1324,6 +1326,7 @@ impl<R: Runtime> Clone for Webview<R> {
       manager: self.manager.clone(),
       app_handle: self.app_handle.clone(),
       resources_table: self.resources_table.clone(),
+      navigation_nonce: self.navigation_nonce.clone(),
       use_https_scheme: self.use_https_scheme,
     }
   }
@@ -1358,6 +1361,7 @@ impl<R: Runtime> Webview<R> {
       window: Arc::new(Mutex::new(window)),
       webview,
       resources_table: Default::default(),
+      navigation_nonce: Default::default(),
       use_https_scheme,
     }
   }
@@ -1761,10 +1765,16 @@ tauri::Builder::default()
       return;
     }
 
+    let nonce = self.navigation_nonce.load(std::sync::atomic::Ordering::Acquire);
+
     let resolver = InvokeResolver::new(
       self.clone(),
       Arc::new(Mutex::new(Some(Box::new(
         move |webview: Webview<R>, cmd, response, callback, error| {
+          let current_nonce = webview.navigation_nonce.load(std::sync::atomic::Ordering::Acquire);
+          if current_nonce != nonce {
+            return;
+          }
           responder(webview, cmd, response, callback, error);
         },
       )))),


### PR DESCRIPTION
When a WebView navigates or reloads while an async command is running,
the command's response would be sent to the new page with stale callback
IDs, causing `runCallback` to log warnings.

This adds a `navigation_nonce` counter to each Webview that is
incremented on every page load. The IPC responder captures the nonce
at invocation time and checks it before sending the response — if
the page has navigated, the stale response is silently discarded.

Fixes #14154