### PR TITLE
fix: wait for window creation no matter if on main thread

### DIFF
--- a/.changes/wait-async-window-creation.md
+++ b/.changes/wait-async-window-creation.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:bug
+---
+
+`create_window` should wait for the window creation to complete before returning even if it's off main thread, it should also return the error if it failed

--- a/.changes/wait-async-window-creation.md
+++ b/.changes/wait-async-window-creation.md
@@ -2,4 +2,4 @@
 "tauri-runtime-wry": patch:bug
 ---
 
-`create_window` should wait for the window creation to complete before returning even if it's off main thread, it should also return the error if it failed
+`create_window` and `create_webview` should wait for the window creation to complete before returning even if it's off main thread, it should also return the error if it failed

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -379,6 +379,7 @@ impl<T: UserEvent> Context<T> {
     let window_id_wrapper = Arc::new(Mutex::new(window_id));
     let window_id_wrapper_ = window_id_wrapper.clone();
 
+    let (tx, rx) = channel();
     send_user_message(
       self,
       Message::CreateWebview(
@@ -394,8 +395,11 @@ impl<T: UserEvent> Context<T> {
             options.focused_webview,
           )
         }),
+        tx,
       ),
     )?;
+    rx.recv()
+      .map_err(|_| crate::Error::FailedToReceiveMessage)??;
 
     let dispatcher = WryWebviewDispatcher {
       window_id: window_id_wrapper,
@@ -1570,7 +1574,7 @@ pub enum Message<T: 'static> {
   Window(WindowId, WindowMessage),
   Webview(WindowId, WebviewId, WebviewMessage),
   EventLoopWindowTarget(EventLoopWindowTargetMessage),
-  CreateWebview(WindowId, CreateWebviewClosure),
+  CreateWebview(WindowId, CreateWebviewClosure, Sender<Result<()>>),
   CreateWindow(WindowId, CreateWindowClosure<T>, Sender<Result<()>>),
   CreateRawWindow(
     WindowId,
@@ -4062,7 +4066,7 @@ fn handle_user_message<T: UserEvent>(
         }
       }
     }
-    Message::CreateWebview(window_id, handler) => {
+    Message::CreateWebview(window_id, handler, sender) => {
       let window = windows
         .0
         .borrow()
@@ -4077,9 +4081,12 @@ fn handle_user_message<T: UserEvent>(
               w.has_children.store(true, Ordering::Relaxed);
               w
             });
+            // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
+            sender.send(Ok(())).unwrap();
           }
           Err(e) => {
-            log::error!("{e}");
+            // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
+            sender.send(Err(e)).unwrap();
           }
         }
       }

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -335,7 +335,8 @@ impl<T: UserEvent> Context<T> {
         tx,
       ),
     )?;
-    rx.recv().unwrap()?;
+    rx.recv()
+      .map_err(|_| crate::Error::FailedToReceiveMessage)??;
 
     let dispatcher = WryWindowDispatcher {
       window_id,
@@ -4086,9 +4087,11 @@ fn handle_user_message<T: UserEvent>(
     Message::CreateWindow(window_id, handler, sender) => match handler(event_loop) {
       Ok(webview) => {
         windows.0.borrow_mut().insert(window_id, webview);
+        // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
         sender.send(Ok(())).unwrap();
       }
       Err(e) => {
+        // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
         sender.send(Err(e)).unwrap();
       }
     },

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -317,6 +317,7 @@ impl<T: UserEvent> Context<T> {
       })
       .unwrap_or((None, false));
 
+    let (tx, rx) = channel();
     send_user_message(
       self,
       Message::CreateWindow(
@@ -331,8 +332,10 @@ impl<T: UserEvent> Context<T> {
             after_window_creation,
           )
         }),
+        tx,
       ),
     )?;
+    rx.recv().unwrap()?;
 
     let dispatcher = WryWindowDispatcher {
       window_id,
@@ -1567,7 +1570,7 @@ pub enum Message<T: 'static> {
   Webview(WindowId, WebviewId, WebviewMessage),
   EventLoopWindowTarget(EventLoopWindowTargetMessage),
   CreateWebview(WindowId, CreateWebviewClosure),
-  CreateWindow(WindowId, CreateWindowClosure<T>),
+  CreateWindow(WindowId, CreateWindowClosure<T>, Sender<Result<()>>),
   CreateRawWindow(
     WindowId,
     Box<dyn FnOnce() -> (String, TaoWindowBuilder) + Send>,
@@ -4080,12 +4083,13 @@ fn handle_user_message<T: UserEvent>(
         }
       }
     }
-    Message::CreateWindow(window_id, handler) => match handler(event_loop) {
+    Message::CreateWindow(window_id, handler, sender) => match handler(event_loop) {
       Ok(webview) => {
         windows.0.borrow_mut().insert(window_id, webview);
+        sender.send(Ok(())).unwrap();
       }
       Err(e) => {
-        log::error!("{e}");
+        sender.send(Err(e)).unwrap();
       }
     },
     Message::CreateRawWindow(window_id, handler, sender) => {


### PR DESCRIPTION
Closes #10157
Closes #13046
Closes #14914
Closes #14915

Reference: https://github.com/tauri-apps/tauri/issues/10157#issuecomment-2241087241

#14915 did this with the same approach, but the use of LLM made tons of noise, that it covered up what the change was really about...

For reviewer: I don't know if this was a mistake not to do this or there's a legitimate reason for that