### PR TITLE
fix(tauri-runtime-wry): don't panic in undecorated-resizing hit-test when the webview is reparented

### DIFF
--- a/.changes/undecorated-resizing-reparented-webview.md
+++ b/.changes/undecorated-resizing-reparented-webview.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": "patch:bug"
+---
+
+Fix a main-thread panic in the Linux undecorated-resizing hit-test when the webview has been reparented. The button-press and touch handlers assumed the widget hierarchy `webview → GtkBox → GtkWindow` and unwrapped a downcast of the webview's second ancestor; embedding applications that move the webview into another container (e.g. a `GtkPaned`) crashed with ``called `Result::unwrap()` on an `Err` value: … type: GtkBox`` on the first click. The handlers now resolve the webview's toplevel window instead, which behaves identically for the stock hierarchy and works at any nesting depth.

--- a/crates/tauri-runtime-wry/src/undecorated_resizing.rs
+++ b/crates/tauri-runtime-wry/src/undecorated_resizing.rs
@@ -540,10 +540,15 @@ mod gtk {
     webview.connect_button_press_event(
       move |webview: &webkit2gtk::WebView, event: &gtk::gdk::EventButton| {
         if event.button() == 1 {
-          // This one should be GtkBox
-          if let Some(window) = webview.parent().and_then(|w| w.parent()) {
-            // Safe to unwrap unless this is not from tao
-            let window: gtk::Window = window.downcast().unwrap();
+          // Resolve the toplevel window. The webview's ancestry is not
+          // guaranteed to be `webview → GtkBox → GtkWindow`: an embedding
+          // application may reparent the webview into another container
+          // (e.g. a GtkPaned), and unwrapping a downcast of the second
+          // ancestor panics the main thread on the first click.
+          if let Some(window) = webview
+            .toplevel()
+            .and_then(|w| w.downcast::<gtk::Window>().ok())
+          {
             if !window.is_decorated() && window.is_resizable() && !window.is_maximized() {
               if let Some(window) = window.window() {
                 let (root_x, root_y) = event.root();
@@ -580,10 +585,12 @@ mod gtk {
 
     webview.connect_touch_event(
       move |webview: &webkit2gtk::WebView, event: &gtk::gdk::Event| {
-        // This one should be GtkBox
-        if let Some(window) = webview.parent().and_then(|w| w.parent()) {
-          // Safe to unwrap unless this is not from tao
-          let window: gtk::Window = window.downcast().unwrap();
+        // Same toplevel resolution as the button-press handler above — the
+        // two-ancestor downcast panics when the webview was reparented.
+        if let Some(window) = webview
+          .toplevel()
+          .and_then(|w| w.downcast::<gtk::Window>().ok())
+        {
           if !window.is_decorated() && window.is_resizable() && !window.is_maximized() {
             if let Some(window) = window.window() {
               if let Some((root_x, root_y)) = event.root_coords() {


### PR DESCRIPTION
### What

The Linux undecorated-resizing hit-test installs `button-press-event` / `touch-event` handlers on the WebKit webview that walk exactly two ancestors and unwrap a downcast to `gtk::Window`:

```rust
// This one should be GtkBox
if let Some(window) = webview.parent().and_then(|w| w.parent()) {
  // Safe to unwrap unless this is not from tao
  let window: gtk::Window = window.downcast().unwrap();
```

The handlers run on **every** left click (the `is_decorated()` check happens after the unwrap), so any application that reparents the webview inside the window — a legitimate thing for an embedder to do, e.g. packing the webview into a `GtkPaned` to dock a native side panel — panics the main thread on the **first click** anywhere in the page:

```
thread 'main' panicked at tauri-runtime-wry-2.11.0/src/undecorated_resizing.rs:546:57:
called `Result::unwrap()` on an `Err` value: Widget { inner: TypedObjectRef { inner: 0x…, type: GtkBox } }
```

(With `webview → GtkPaned → GtkBox`, the second ancestor is the `GtkBox`, and the downcast fails.)

### Fix

Resolve the webview's **toplevel** (`WidgetExt::toplevel()`) and downcast it gracefully, in both handlers. For the stock tao hierarchy this resolves to exactly the same window; for reparented hierarchies it finds the correct toplevel at any nesting depth — so undecorated drag-resize keeps working there too, instead of merely not crashing.

### How we hit it

Tauri 2 desktop app (decorated window) that embeds a native VTE terminal beside the webview by moving the webview into a `GtkPaned`. Worked fine on X11 sessions for weeks; on a Wayland session the embed path engaged and every session died on the first click. Repro is deterministic: reparent the webview into any container after window creation, click once.

Patch is identical in both call sites; `cargo check -p tauri-runtime-wry` clean; covector changeset included (`patch:bug`).