### PR TITLE
feat(api): add logical monitor bounds to the Monitor object

### DIFF
--- a/.changes/monitor-logical-bounds.md
+++ b/.changes/monitor-logical-bounds.md
@@ -1,0 +1,5 @@
+---
+"@tauri-apps/api": "minor:feat"
+---
+
+Add `logicalPosition`, `logicalSize` and `logicalWorkArea` to the `Monitor` object returned by `currentMonitor()`, `primaryMonitor()`, `monitorFromPoint()` and `availableMonitors()`. These values are derived from the existing physical bounds and `scaleFactor`, and match the logical units expected by window creation options, removing the need for manual conversion (especially on macOS mixed-DPI setups).

--- a/.changes/monitor-logical-bounds.md
+++ b/.changes/monitor-logical-bounds.md
@@ -1,5 +1,5 @@
 ---
-"@tauri-apps/api": "minor:feat"
+"@tauri-apps/api": "patch:enhance"
 ---
 
-Add `logicalPosition`, `logicalSize` and `logicalWorkArea` to the `Monitor` object returned by `currentMonitor()`, `primaryMonitor()`, `monitorFromPoint()` and `availableMonitors()`. These values are derived from the existing physical bounds and `scaleFactor`, and match the logical units expected by window creation options, removing the need for manual conversion (especially on macOS mixed-DPI setups).
+Document that `Monitor.size`, `Monitor.position` and `Monitor.workArea` are in physical pixels, with examples showing how to convert them to the logical pixels expected by window creation options via `toLogical(monitor.scaleFactor)`.

--- a/packages/api/src/window.ts
+++ b/packages/api/src/window.ts
@@ -47,26 +47,45 @@ import { Image, transformImage } from './image'
 export interface Monitor {
   /** Human-readable name of the monitor */
   name: string | null
-  /** The monitor's resolution. */
+  /**
+   * The monitor's resolution in physical pixels.
+   *
+   * Use {@linkcode Monitor.scaleFactor} to convert to logical pixels:
+   * ```typescript
+   * const logicalSize = monitor.size.toLogical(monitor.scaleFactor);
+   * ```
+   */
   size: PhysicalSize
-  /** the Top-left corner position of the monitor relative to the larger full screen area. */
+  /**
+   * the Top-left corner position of the monitor relative to the larger full screen area, in physical pixels.
+   *
+   * Note that window creation options such as `x`, `y`, `width` and `height` expect
+   * logical pixels, so convert with {@linkcode Monitor.scaleFactor} first:
+   * ```typescript
+   * import { currentMonitor } from '@tauri-apps/api/window';
+   * import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+   *
+   * const monitor = await currentMonitor();
+   * const position = monitor.position.toLogical(monitor.scaleFactor);
+   * const webview = new WebviewWindow('my-label', { x: position.x, y: position.y });
+   * ```
+   */
   position: PhysicalPosition
-  /** The monitor's work area. */
+  /**
+   * The monitor's work area (the monitor area excluding taskbars and docks) in physical pixels.
+   *
+   * Use {@linkcode Monitor.scaleFactor} to convert to logical pixels as shown in
+   * {@linkcode Monitor.position}.
+   */
   workArea: {
     position: PhysicalPosition
     size: PhysicalSize
   }
-  /** The scale factor that can be used to map physical pixels to logical pixels. */
+  /**
+   * The scale factor that can be used to map physical pixels to logical pixels,
+   * e.g. `monitor.position.toLogical(monitor.scaleFactor)`.
+   */
   scaleFactor: number
-  /** The monitor's resolution in logical pixels, matching the units used by window creation options. */
-  logicalSize: LogicalSize
-  /** The Top-left corner position of the monitor in logical pixels, matching the units used by window creation options. */
-  logicalPosition: LogicalPosition
-  /** The monitor's work area in logical pixels. */
-  logicalWorkArea: {
-    position: LogicalPosition
-    size: LogicalSize
-  }
 }
 
 type Theme = 'light' | 'dark'
@@ -2552,31 +2571,18 @@ interface WindowOptions {
 }
 
 function mapMonitor(m: Monitor | null): Monitor | null {
-  if (m === null) {
-    return null
-  }
-
-  const position = new PhysicalPosition(m.position)
-  const size = new PhysicalSize(m.size)
-  const workAreaPosition = new PhysicalPosition(m.workArea.position)
-  const workAreaSize = new PhysicalSize(m.workArea.size)
-
-  return {
-    name: m.name,
-    scaleFactor: m.scaleFactor,
-    position,
-    size,
-    workArea: {
-      position: workAreaPosition,
-      size: workAreaSize
-    },
-    logicalPosition: position.toLogical(m.scaleFactor),
-    logicalSize: size.toLogical(m.scaleFactor),
-    logicalWorkArea: {
-      position: workAreaPosition.toLogical(m.scaleFactor),
-      size: workAreaSize.toLogical(m.scaleFactor)
-    }
-  }
+  return m === null
+    ? null
+    : {
+        name: m.name,
+        scaleFactor: m.scaleFactor,
+        position: new PhysicalPosition(m.position),
+        size: new PhysicalSize(m.size),
+        workArea: {
+          position: new PhysicalPosition(m.workArea.position),
+          size: new PhysicalSize(m.workArea.size)
+        }
+      }
 }
 
 /**

--- a/packages/api/src/window.ts
+++ b/packages/api/src/window.ts
@@ -58,6 +58,15 @@ export interface Monitor {
   }
   /** The scale factor that can be used to map physical pixels to logical pixels. */
   scaleFactor: number
+  /** The monitor's resolution in logical pixels, matching the units used by window creation options. */
+  logicalSize: LogicalSize
+  /** The Top-left corner position of the monitor in logical pixels, matching the units used by window creation options. */
+  logicalPosition: LogicalPosition
+  /** The monitor's work area in logical pixels. */
+  logicalWorkArea: {
+    position: LogicalPosition
+    size: LogicalSize
+  }
 }
 
 type Theme = 'light' | 'dark'
@@ -2543,18 +2552,31 @@ interface WindowOptions {
 }
 
 function mapMonitor(m: Monitor | null): Monitor | null {
-  return m === null
-    ? null
-    : {
-        name: m.name,
-        scaleFactor: m.scaleFactor,
-        position: new PhysicalPosition(m.position),
-        size: new PhysicalSize(m.size),
-        workArea: {
-          position: new PhysicalPosition(m.workArea.position),
-          size: new PhysicalSize(m.workArea.size)
-        }
-      }
+  if (m === null) {
+    return null
+  }
+
+  const position = new PhysicalPosition(m.position)
+  const size = new PhysicalSize(m.size)
+  const workAreaPosition = new PhysicalPosition(m.workArea.position)
+  const workAreaSize = new PhysicalSize(m.workArea.size)
+
+  return {
+    name: m.name,
+    scaleFactor: m.scaleFactor,
+    position,
+    size,
+    workArea: {
+      position: workAreaPosition,
+      size: workAreaSize
+    },
+    logicalPosition: position.toLogical(m.scaleFactor),
+    logicalSize: size.toLogical(m.scaleFactor),
+    logicalWorkArea: {
+      position: workAreaPosition.toLogical(m.scaleFactor),
+      size: workAreaSize.toLogical(m.scaleFactor)
+    }
+  }
 }
 
 /**

--- a/packages/api/src/window.ts
+++ b/packages/api/src/window.ts
@@ -66,8 +66,10 @@ export interface Monitor {
    * import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
    *
    * const monitor = await currentMonitor();
-   * const position = monitor.position.toLogical(monitor.scaleFactor);
-   * const webview = new WebviewWindow('my-label', { x: position.x, y: position.y });
+   * if (monitor) {
+   *   const position = monitor.position.toLogical(monitor.scaleFactor);
+   *   const webview = new WebviewWindow('my-label', { x: position.x, y: position.y });
+   * }
    * ```
    */
   position: PhysicalPosition


### PR DESCRIPTION
Adds `logicalPosition`, `logicalSize` and `logicalWorkArea` to the `Monitor` object returned by `currentMonitor()`, `primaryMonitor()`, `monitorFromPoint()` and `availableMonitors()`.

The values are derived in `mapMonitor()` from the existing physical bounds via `toLogical(scaleFactor)`, so they match the logical units expected by `WebviewWindow` creation options. This removes the need for manual physical-to-logical conversion in userland, which is easy to miss on macOS mixed-DPI setups.

Existing `position`, `size`, `workArea` and `scaleFactor` fields are unchanged, so the change is non-breaking.

closes #15519 