### PR TITLE
fix(runtime-cef): panic on app relaunch without arguments

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -708,7 +708,9 @@ wrap_browser_process_handler! {
       let mut list = CefStringList::new();
       command_line.arguments(Some(&mut list));
       let args: Vec<String> = list.into_iter().collect();
-      if let Ok(url) = url::Url::parse(&args[0]) {
+      if let Some(first_arg) = args.first()
+        && let Ok(url) = url::Url::parse(first_arg)
+      {
         let scheme = url.scheme().to_string();
         if self.deep_link_schemes.iter().any(|s| s == &scheme) {
           (self.context.callback.borrow())(RunEvent::Opened {


### PR DESCRIPTION
`on_already_running_app_relaunch` indexed the relaunched instance's first command line argument unconditionally, panicking when a second instance is started with no arguments. Use a checked lookup instead.
