### PR TITLE
feat(runtime-cef): implement run_return

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -615,6 +615,10 @@ pub struct Context<T: UserEvent> {
   /// emissions are suppressed so the public event sequence stays at
   /// `ExitRequested -> Exit` for direct exits.
   pub is_shutting_down: Arc<AtomicBool>,
+  /// Exit code requested through [`Message::RequestExit`], reported by
+  /// `run_return`. `None` (mapped to 0) when the app exits by closing its
+  /// last window.
+  pub exit_code: Arc<Mutex<Option<i32>>>,
 }
 
 impl<T: UserEvent> Context<T> {
@@ -3868,6 +3872,7 @@ pub fn handle_message<T: UserEvent>(context: &Context<T>, message: Message<T>) {
       let should_prevent = matches!(recv, Ok(ExitRequestedEventAction::Prevent));
 
       if !should_prevent {
+        *context.exit_code.lock().unwrap() = Some(code);
         context.is_shutting_down.store(true, Ordering::SeqCst);
         in_callback(|| (context.callback.borrow())(RunEvent::Exit));
       }

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -2042,6 +2042,7 @@ impl<T: UserEvent> CefRuntime<T> {
       cache_path: Arc::new(cache_path.clone()),
       theme: Default::default(),
       is_shutting_down: Default::default(),
+      exit_code: Default::default(),
     };
 
     // Promote `NSApp` to our `SimpleApplication` subclass *before* CEF (or
@@ -2418,8 +2419,11 @@ impl<T: UserEvent> Runtime<T> for CefRuntime<T> {
     callback(RunEvent::MainEventsCleared);
   }
 
-  fn run_return<F: FnMut(RunEvent<T>) + 'static>(self, _callback: F) -> i32 {
-    0
+  fn run_return<F: FnMut(RunEvent<T>) + 'static>(self, callback: F) -> i32 {
+    let exit_code = self.context.cef_context.exit_code.clone();
+    self.run(callback);
+    let code = exit_code.lock().unwrap().take();
+    code.unwrap_or(0)
   }
 
   fn run<F: FnMut(RunEvent<T>) + 'static>(self, callback: F) {


### PR DESCRIPTION
`Runtime::run_return` was a stub that returned 0 without running the event loop, so `App::run_return` did nothing on the CEF runtime.

Run the event loop and report the exit code requested through `RequestExit` (e.g. `app.exit(code)`); exiting by closing the last window reports 0, matching the wry runtime's behavior.
