### PR TITLE
feat(runtime-cef): invoke the after_window_creation hook

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -3826,8 +3826,14 @@ pub fn handle_message<T: UserEvent>(context: &Context<T>, message: Message<T>) {
       window_id,
       webview_id,
       pending,
-      after_window_creation: _todo,
-    } => create_window(context, window_id, webview_id, *pending),
+      after_window_creation,
+    } => create_window(
+      context,
+      window_id,
+      webview_id,
+      *pending,
+      after_window_creation,
+    ),
     Message::CreateWebview {
       window_id,
       webview_id,
@@ -3898,6 +3904,7 @@ pub(crate) fn create_window<T: UserEvent>(
   window_id: WindowId,
   webview_id: u32,
   pending: PendingWindow<T, CefRuntime<T>>,
+  after_window_creation: Option<crate::AfterWindowCreation>,
 ) {
   let PendingWindow {
     label,
@@ -3922,6 +3929,22 @@ pub(crate) fn create_window<T: UserEvent>(
   );
 
   let window = window_create_top_level(Some(&mut delegate)).expect("Failed to create window");
+
+  if let Some(after_window_creation) = after_window_creation {
+    #[cfg(windows)]
+    after_window_creation(tauri_runtime::window::RawWindow {
+      hwnd: window.window_handle().0 as isize,
+      _marker: &std::marker::PhantomData,
+    });
+    #[cfg(target_os = "macos")]
+    after_window_creation(tauri_runtime::window::RawWindow {
+      _marker: &std::marker::PhantomData,
+    });
+    // On Linux `RawWindow` carries a `gtk::ApplicationWindow`, which CEF
+    // windows don't have, so the hook cannot be invoked there.
+    #[cfg(target_os = "linux")]
+    let _ = after_window_creation;
+  }
 
   context.windows.borrow_mut().insert(
     window_id,

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -132,7 +132,7 @@ macro_rules! window_getter {
   }};
 }
 
-type AfterWindowCreation = Box<dyn Fn(RawWindow) + Send + 'static>;
+pub(crate) type AfterWindowCreation = Box<dyn Fn(RawWindow) + Send + 'static>;
 
 enum Message<T: UserEvent + 'static> {
   Task(Box<dyn FnOnce() + Send>),
@@ -2276,7 +2276,7 @@ impl<T: UserEvent> Runtime<T> for CefRuntime<T> {
   fn create_window<F: Fn(RawWindow<'_>) + Send + 'static>(
     &self,
     pending: PendingWindow<T, Self>,
-    _after_window_creation: Option<F>,
+    after_window_creation: Option<F>,
   ) -> Result<DetachedWindow<T, Self>> {
     let label = pending.label.clone();
     let window_id = self.context.cef_context.next_window_id();
@@ -2297,6 +2297,7 @@ impl<T: UserEvent> Runtime<T> for CefRuntime<T> {
       window_id,
       webview_id.unwrap_or_default(),
       pending,
+      after_window_creation.map(|f| Box::new(f) as AfterWindowCreation),
     );
 
     let dispatcher = CefWindowDispatcher {


### PR DESCRIPTION
The `after_window_creation` callback passed to `create_window` was dropped on both creation paths, so window-setup hooks that tauri core relies on (e.g. applying window effects on Windows) never ran on the CEF runtime.

Invoke it after the CEF window is created, constructing `RawWindow` from the native handle on Windows and the marker-only variant on macOS. On Linux `RawWindow` carries a `gtk::ApplicationWindow` reference, which CEF windows don't have, so the hook cannot be supported there (documented in code).
