### PR TITLE
fix(runtime-cef): avoid busy-looping the shutdown drain

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -30,9 +30,9 @@ use tauri_utils::TitleBarStyle;
 use tauri_utils::html::normalize_script_for_csp;
 
 use crate::{
-  AppWebview, AppWindow, CefRuntime, CefWebviewDispatcher, CefWindowBuilder,
-  DevToolsProtocolHandler, Message, RuntimeContext, RuntimeStyle as CefRuntimeStyle, Webview,
-  WebviewAtribute, WebviewMessage, WindowMessage, cef_webview::CefWebview,
+  AppWebview, AppWindow, CefRuntime, CefWebviewDispatcher, DevToolsProtocolHandler, Message,
+  RuntimeContext, RuntimeStyle as CefRuntimeStyle, Webview, WebviewAtribute, WebviewMessage,
+  WindowMessage, cef_webview::CefWebview,
 };
 
 use std::cell::Cell;
@@ -4894,10 +4894,10 @@ where
 /// Block the calling thread until `flag` is `true`.
 ///
 /// Browser creation goes through `RequestContextHandler::on_request_context_initialized`,
-/// which CEF always dispatches via `CEF_POST_TASK(CEF_UIT, ...)`. Tauri runs
-/// CEF with an external message pump (see `cef::do_message_loop_work` in the
-/// runtime's main loop), so the only way for that posted task to actually
-/// execute is for someone on the CEF UI thread to keep pumping the loop.
+/// which CEF always dispatches via `CEF_POST_TASK(CEF_UIT, ...)`. When this
+/// runs on the CEF UI thread (inside `cef::run_message_loop`'s dispatch or
+/// before the loop starts), that posted task can only execute if we pump the
+/// loop ourselves while waiting.
 ///
 /// Two cases:
 ///

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -2489,6 +2489,9 @@ impl<T: UserEvent> Runtime<T> for CefRuntime<T> {
     cef_impl::close_all_windows(&self.context.cef_context.windows);
     while !self.context.cef_context.windows.borrow().is_empty() {
       cef::do_message_loop_work();
+      // The browser tear-down involves cross-process round trips; yield
+      // between iterations instead of pumping at 100% CPU.
+      std::thread::sleep(std::time::Duration::from_millis(1));
     }
 
     cef::shutdown();


### PR DESCRIPTION
After `run_message_loop` returns, the runtime pumps `do_message_loop_work` until every window has gone through `OnBeforeClose` before calling `cef::shutdown`. That drain spun a full CPU core while waiting on the browsers' cross-process tear-down; yield between iterations instead.

Also updates a stale `wait_for_deferred_init` doc comment that still described the pre-`run_message_loop` external pump, and drops an unused import.
