### PR TITLE
feat(runtime-cef): wire the web content process terminate handler

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -1631,6 +1631,7 @@ wrap_client! {
     address_changed_handler: Option<Arc<AddressChangedHandler>>,
     new_window_handler: Option<Arc<tauri_runtime::webview::NewWindowHandler<T, crate::CefRuntime<T>>>>,
     download_handler: Option<Arc<tauri_runtime::webview::DownloadHandler>>,
+    web_content_process_terminate_handler: Option<Arc<dyn Fn() + Send>>,
     devtools_enabled: bool,
     context: Context<T>,
     runtime_context: RuntimeContext<T>,
@@ -1653,6 +1654,7 @@ wrap_client! {
         self.drag_drop_event_target,
         self.drag_drop_handler_enabled,
         self.drag_drop_state.clone(),
+        self.web_content_process_terminate_handler.clone(),
       ))
     }
 
@@ -4364,13 +4366,21 @@ pub(crate) fn create_webview<T: UserEvent>(
     document_title_changed_handler,
     address_changed_handler,
     url,
+    // Consumed by tauri core itself (wrapped into the `tauri` URI scheme
+    // protocol before the pending webview reaches the runtime), so there is
+    // nothing to handle here — tauri-runtime-wry ignores it as well.
     web_resource_request_handler: _,
     mut on_page_load_handler,
     download_handler,
-    // TODO
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-      on_web_content_process_terminate_handler: _,
+    on_web_content_process_terminate_handler,
   } = pending;
+
+  #[cfg(target_os = "macos")]
+  let web_content_process_terminate_handler = on_web_content_process_terminate_handler
+    .map(|handler| Arc::from(handler) as Arc<dyn Fn() + Send>);
+  #[cfg(not(target_os = "macos"))]
+  let web_content_process_terminate_handler: Option<Arc<dyn Fn() + Send>> = None;
 
   let address_changed_handler = address_changed_handler
     .map(|h| Arc::new(move |url: &url::Url| h(url)) as Arc<AddressChangedHandler>);
@@ -4433,6 +4443,7 @@ pub(crate) fn create_webview<T: UserEvent>(
     address_changed_handler,
     new_window_handler,
     download_handler,
+    web_content_process_terminate_handler,
     devtools_enabled,
     context.clone(),
     runtime_context(context),

--- a/crates/tauri-runtime-cef/src/cef_impl/request_handler.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl/request_handler.rs
@@ -151,9 +151,22 @@ wrap_request_handler! {
     drag_drop_event_target: DragDropEventTarget,
     drag_drop_handler_enabled: bool,
     drag_drop_state: Arc<Mutex<DragDropState>>,
+    web_content_process_terminate_handler: Option<Arc<dyn Fn() + Send>>,
   }
 
   impl RequestHandler {
+    fn on_render_process_terminated(
+      &self,
+      _browser: Option<&mut Browser>,
+      _status: TerminationStatus,
+      _error_code: ::std::os::raw::c_int,
+      _error_string: Option<&CefString>,
+    ) {
+      if let Some(handler) = &self.web_content_process_terminate_handler {
+        handler();
+      }
+    }
+
     fn on_before_browse(
       &self,
       _browser: Option<&mut Browser>,


### PR DESCRIPTION
Maps the macOS `on_web_content_process_terminate_handler` webview hook to CEF's `RequestHandler::on_render_process_terminated`, so embedders are notified when a webview's renderer process crashes or is killed, matching the wry runtime's WKWebView behavior.

Also documents that `web_resource_request_handler` is intentionally ignored by the runtime: tauri core consumes it itself (it is wrapped into the `tauri` URI scheme protocol before the pending webview reaches any runtime; tauri-runtime-wry ignores it identically).
