### PR TITLE
fix(runtime-cef): multiwebview windowing and repaint on Linux/X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9344,6 +9344,7 @@ dependencies = [
  "html5ever 0.29.1",
  "http 1.3.1",
  "kuchikiki",
+ "libc",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit",

--- a/crates/tauri-runtime-cef/Cargo.toml
+++ b/crates/tauri-runtime-cef/Cargo.toml
@@ -54,6 +54,7 @@ objc2-foundation = { version = "0.3", features = ["NSNotification"] }
 gtk = { version = "0.18", features = ["v3_24"] }
 x11-dl = "2.21"
 dlopen2 = { version = "0.8", features = ["derive"] }
+libc = "0.2"
 
 [features]
 default = ["sandbox"]

--- a/crates/tauri-runtime-cef/src/cef_impl.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl.rs
@@ -1534,6 +1534,11 @@ wrap_life_span_handler! {
       // safe to drop - CEF callbacks can borrow windows
       drop(webview);
 
+      #[cfg(target_os = "linux")]
+      if let Some(app_window) = self.context.windows.borrow().get(&self.window_id) {
+        sync_map_watcher_children(app_window);
+      }
+
       if is_last_in_window {
           on_window_destroyed(self.window_id, &self.context);
       }
@@ -2257,6 +2262,9 @@ wrap_window_delegate! {
         inner.set_bounds(Some(&rect));
       }
 
+      #[cfg(target_os = "linux")]
+      raise_window_webviews(self.window_id, &self.windows);
+
       let scale = window_scale_factor(window);
 
       #[cfg(not(windows))]
@@ -2327,6 +2335,15 @@ wrap_window_delegate! {
       _window: Option<&mut Window>,
       active: ::std::os::raw::c_int,
     ) {
+      // Repair the child webviews when the window becomes active again —
+      // showing the window (workspace switch, deminimize) can restack the
+      // Views content surface above them and leave their compositors
+      // stalled without a fresh frame.
+      #[cfg(target_os = "linux")]
+      if active == 1 {
+        refresh_window_webviews(self.window_id, &self.windows);
+      }
+
       send_window_event(
         self.window_id,
         &self.windows,
@@ -2335,6 +2352,93 @@ wrap_window_delegate! {
       );
     }
   }
+}
+
+/// Re-raises every windowed (X11 child) webview of `window_id` above the CEF
+/// Views window's own full-size content surface. Chromium restacks that
+/// surface on top of the child browsers when the window is resized, shown or
+/// activated again (e.g. after a tiling-WM workspace switch), which leaves
+/// the webviews occluded and seemingly unpainted.
+#[cfg(target_os = "linux")]
+fn raise_window_webviews(
+  window_id: WindowId,
+  windows: &Arc<RefCell<HashMap<WindowId, AppWindow>>>,
+) {
+  let Ok(windows_ref) = windows.try_borrow() else {
+    return;
+  };
+  if let Some(app_window) = windows_ref.get(&window_id) {
+    for webview in &app_window.webviews {
+      webview.inner.raise();
+    }
+  }
+}
+
+/// Raises and resize-jiggles every windowed webview of `window_id`: re-raises
+/// them above the Views content surface and forces the renderer to produce a
+/// fresh frame. Used when the window becomes active again after the window
+/// manager hid it (workspace switch, iconify), which leaves the child
+/// browsers stalled/occluded.
+#[cfg(target_os = "linux")]
+fn refresh_window_webviews(
+  window_id: WindowId,
+  windows: &Arc<RefCell<HashMap<WindowId, AppWindow>>>,
+) {
+  let Ok(windows_ref) = windows.try_borrow() else {
+    return;
+  };
+  if let Some(app_window) = windows_ref.get(&window_id) {
+    for webview in &app_window.webviews {
+      webview.inner.raise();
+      webview.inner.refresh_render_target();
+    }
+  }
+}
+
+#[cfg(target_os = "linux")]
+wrap_task! {
+  struct RepairWebviewsTask {
+    children: Vec<u64>,
+  }
+
+  impl Task {
+    fn execute(&self) {
+      log::debug!("cef: repairing {} webviews on the UI thread", self.children.len());
+      for &xid in &self.children {
+        crate::cef_webview::repair_browser_window(xid);
+      }
+    }
+  }
+}
+
+/// Posts a CEF UI task that raises and resize-jiggles the given browser X
+/// windows. Posting (rather than touching X from the calling thread) keeps
+/// the repair serialized with Chromium's own processing of the show
+/// transition's X events — repairs from a separate connection can race ahead
+/// of Chromium's visibility handling and intermittently have no effect.
+///
+/// Callable from any thread; used by [`crate::platform::map_watcher`].
+#[cfg(target_os = "linux")]
+pub(crate) fn post_repair_webviews_task(children: Vec<u64>) {
+  let mut task = RepairWebviewsTask::new(children);
+  cef::post_task(sys::cef_thread_id_t::TID_UI.into(), Some(&mut task));
+}
+
+/// Pushes the current set of X11 child browser windows of `app_window` to the
+/// [`crate::platform::map_watcher`], which repairs them (raise + resize
+/// jiggle) whenever the toplevel is shown again. Call after every change to
+/// the window's webview list.
+#[cfg(target_os = "linux")]
+fn sync_map_watcher_children(app_window: &AppWindow) {
+  let children = app_window
+    .webviews
+    .iter()
+    .filter_map(|webview| match &webview.inner {
+      CefWebview::Browser(browser) => browser.host().map(|host| host.window_handle()),
+      CefWebview::BrowserView(_) => None,
+    })
+    .collect();
+  crate::platform::map_watcher::set_children(app_window.window.window_handle(), children);
 }
 
 fn get_webview<T: UserEvent>(
@@ -2510,6 +2614,11 @@ fn handle_webview_message<T: UserEvent>(
           }
         }
         wrapper.inner.close();
+
+        #[cfg(target_os = "linux")]
+        if let Some(app_window) = context.windows.borrow().get(&window_id) {
+          sync_map_watcher_children(app_window);
+        }
       }
     }
     WebviewMessage::Show => {
@@ -2718,6 +2827,13 @@ fn handle_webview_message<T: UserEvent>(
           let _ = tx.send(Ok(()));
         } else {
           let _ = tx.send(Err(tauri_runtime::Error::FailedToSendMessage));
+        }
+
+        #[cfg(target_os = "linux")]
+        for id in [window_id, target_window_id] {
+          if let Some(app_window) = windows.get(&id) {
+            sync_map_watcher_children(app_window);
+          }
         }
       }
     }
@@ -3923,6 +4039,11 @@ pub(crate) fn create_window<T: UserEvent>(
 
   let window = window_create_top_level(Some(&mut delegate)).expect("Failed to create window");
 
+  // Watch the toplevel for show transitions so multiwebview children can be
+  // repaired when a window manager hides and re-shows the window.
+  #[cfg(target_os = "linux")]
+  crate::platform::map_watcher::watch(window.window_handle());
+
   context.windows.borrow_mut().insert(
     window_id,
     AppWindow {
@@ -4315,6 +4436,9 @@ fn on_window_destroyed<T: UserEvent>(window_id: WindowId, context: &Context<T>) 
   };
 
   if let Some(ref app_window) = removed_window {
+    #[cfg(target_os = "linux")]
+    crate::platform::map_watcher::unwatch(app_window.window.window_handle());
+
     let mut registry = context.scheme_handler_registry.lock().unwrap();
     for webview in &app_window.webviews {
       let browser_id = *webview.browser_id.borrow();
@@ -4510,10 +4634,25 @@ pub(crate) fn create_webview<T: UserEvent>(
         #[cfg(target_os = "macos")]
         let window_handle = ensure_valid_content_view(window_handle);
 
-        let mut window_info = cef::WindowInfo::default().set_as_child(
-          window_handle,
-          bounds.as_ref().unwrap_or(&cef::Rect::default()),
-        );
+        let child_bounds = bounds.clone().unwrap_or_default();
+        // On Linux the child browser is a raw X11 window, so `WindowInfo`
+        // bounds are physical pixels, while `bounds` is in DIP like the rest
+        // of the CEF Views APIs.
+        #[cfg(target_os = "linux")]
+        let child_bounds = {
+          let scale = window
+            .display()
+            .map(|d| d.device_scale_factor() as f64)
+            .unwrap_or(1.0);
+          cef::Rect {
+            x: (child_bounds.x as f64 * scale).round() as i32,
+            y: (child_bounds.y as f64 * scale).round() as i32,
+            width: (child_bounds.width as f64 * scale).round() as i32,
+            height: (child_bounds.height as f64 * scale).round() as i32,
+          }
+        };
+
+        let mut window_info = cef::WindowInfo::default().set_as_child(window_handle, &child_bounds);
         window_info.runtime_style = cef_runtime_style;
 
         let Some(browser_host) = browser_host_create_browser_sync(
@@ -4569,16 +4708,13 @@ pub(crate) fn create_webview<T: UserEvent>(
 
         browser.set_bounds(bounds.as_ref());
 
-        // On Linux, explicitly set parent after creation as set_as_child may not work correctly
+        // On Linux, make sure the browser's X11 window is mapped and raised
+        // above the Views window's own full-size content surface — otherwise
+        // the surface occludes the webview and it is never painted.
         #[cfg(target_os = "linux")]
         {
-          // Try to set parent - if window handle isn't available yet, this will be a no-op
-          // but the browser should become visible once the handle is available
-          browser.set_parent(&window);
-          // Ensure browser is visible after setting parent
           browser.set_visible(1);
-          // Set bounds again after reparenting to ensure correct size
-          browser.set_bounds(bounds.as_ref());
+          browser.raise();
         }
 
         let auto_resize = webview_attributes.borrow().auto_resize;
@@ -4607,6 +4743,11 @@ pub(crate) fn create_webview<T: UserEvent>(
             devtools_observer_registration,
             webview_attributes,
           });
+
+        #[cfg(target_os = "linux")]
+        if let Some(app_window) = context.windows.borrow().get(&window_id) {
+          sync_map_watcher_children(app_window);
+        }
       } else {
         let browser_id = Arc::new(RefCell::new(0));
         let uri_scheme_protocols = Arc::new(uri_scheme_protocols);

--- a/crates/tauri-runtime-cef/src/cef_webview.rs
+++ b/crates/tauri-runtime-cef/src/cef_webview.rs
@@ -9,6 +9,9 @@ mod windows;
 #[cfg(target_os = "linux")]
 mod linux;
 
+#[cfg(target_os = "linux")]
+pub(crate) use linux::repair_browser_window;
+
 #[derive(Clone)]
 pub enum CefWebview {
   BrowserView(cef::BrowserView),
@@ -101,6 +104,28 @@ impl CefWebview {
       CefWebview::Browser(browser) => browser.set_parent(parent),
     }
   }
+
+  /// Raises the browser's X window above its siblings — most importantly above
+  /// the CEF Views window's own full-size content surface, which Chromium
+  /// restacks on top of the child browsers when the window is resized or
+  /// shown again (e.g. tiling-WM workspace switches), leaving the webviews
+  /// unpainted/occluded.
+  #[cfg(target_os = "linux")]
+  pub fn raise(&self) {
+    if let CefWebview::Browser(browser) = self {
+      browser.raise();
+    }
+  }
+
+  /// Forces the browser's compositor to produce a fresh frame after the
+  /// window manager hid and re-showed the toplevel. See the Linux
+  /// `refresh_render_target` implementation for details.
+  #[cfg(target_os = "linux")]
+  pub fn refresh_render_target(&self) {
+    if let CefWebview::Browser(browser) = self {
+      browser.refresh_render_target();
+    }
+  }
 }
 
 trait CefBrowserExt {
@@ -117,4 +142,8 @@ trait CefBrowserExt {
   fn hwnd(&self) -> Option<::windows::Win32::Foundation::HWND>;
   #[cfg(target_os = "linux")]
   fn xid(&self) -> Option<u64>;
+  #[cfg(target_os = "linux")]
+  fn raise(&self);
+  #[cfg(target_os = "linux")]
+  fn refresh_render_target(&self);
 }

--- a/crates/tauri-runtime-cef/src/cef_webview/linux.rs
+++ b/crates/tauri-runtime-cef/src/cef_webview/linux.rs
@@ -1,10 +1,121 @@
 use cef::*;
+use std::os::raw::c_ulong;
 use std::sync::LazyLock;
 use x11_dl::xlib;
 
 use crate::cef_webview::CefBrowserExt;
 
 static X11: LazyLock<Option<xlib::Xlib>> = LazyLock::new(|| xlib::Xlib::open().ok());
+
+/// Runs `f` with the Xlib handle and CEF's own X11 display connection.
+///
+/// cefclient performs every operation on a windowed browser's X window through
+/// the display returned by `cef_get_xdisplay()` (see
+/// `tests/cefclient/browser/browser_window_std_gtk.cc`). Using CEF's
+/// connection keeps our requests ordered with Chromium's own X11 traffic and
+/// avoids the cost of opening (and the races of flushing/closing) a throwaway
+/// connection per call.
+///
+/// Must only be called on the CEF UI thread — which is where all webview
+/// messages are handled.
+fn with_cef_display<R>(default: R, f: impl FnOnce(&xlib::Xlib, *mut xlib::Display) -> R) -> R {
+  let Some(xlib) = X11.as_ref() else {
+    return default;
+  };
+  let display = cef::get_xdisplay() as *mut xlib::Display;
+  if display.is_null() {
+    return default;
+  }
+  let result = f(xlib, display);
+  // Flush so the request is processed now; never close CEF's display.
+  unsafe { (xlib.XFlush)(display) };
+  result
+}
+
+fn atom(xlib: &xlib::Xlib, display: *mut xlib::Display, name: &str) -> c_ulong {
+  let cname = std::ffi::CString::new(name).unwrap();
+  unsafe { (xlib.XInternAtom)(display, cname.as_ptr(), 0) }
+}
+
+/// Repairs a browser X window after its toplevel was hidden and shown again
+/// by the window manager: raises it above the Views content surface and
+/// forces the renderer to produce a fresh frame.
+///
+/// Must run on the CEF UI thread — that serializes the repair with
+/// Chromium's own processing of the X events that accompany the show
+/// transition, so the jiggle cannot race ahead of the visibility handling.
+pub(crate) fn repair_browser_window(xid: u64) {
+  with_cef_display((), |xlib, display| {
+    unsafe { (xlib.XRaiseWindow)(display, xid as xlib::Window) };
+    resize_jiggle(xlib, display, xid as xlib::Window);
+  });
+}
+
+/// Resizes the browser's X window by one pixel and back.
+///
+/// Forces the renderer to redraw: in Chromium's surface synchronization,
+/// every size change allocates a new viz `LocalSurfaceId`, which obligates
+/// the renderer to submit a fresh `CompositorFrame` — for both the shrink
+/// and the restore. This recovers from the stalled state window managers
+/// leave child browsers in after hiding the toplevel (workspace switch,
+/// iconify): the GPU presentation surfaces are recreated on show, but no new
+/// frame is produced until the renderer redraws, which otherwise happens
+/// only on focus or input. CEF's `CefWindowX11` observes both
+/// `ConfigureNotify` events and propagates the sizes to the inner Chromium
+/// widget.
+pub(crate) fn resize_jiggle(xlib: &xlib::Xlib, display: *mut xlib::Display, window: xlib::Window) {
+  unsafe {
+    let mut root: xlib::Window = 0;
+    let mut x: i32 = 0;
+    let mut y: i32 = 0;
+    let mut width: u32 = 0;
+    let mut height: u32 = 0;
+    let mut border_width: u32 = 0;
+    let mut depth: u32 = 0;
+    if (xlib.XGetGeometry)(
+      display,
+      window,
+      &mut root,
+      &mut x,
+      &mut y,
+      &mut width,
+      &mut height,
+      &mut border_width,
+      &mut depth,
+    ) == 0
+      || width == 0
+      || height == 0
+    {
+      return;
+    }
+
+    (xlib.XResizeWindow)(display, window, width, height.max(2) - 1);
+    (xlib.XFlush)(display);
+    (xlib.XResizeWindow)(display, window, width, height);
+    (xlib.XFlush)(display);
+  }
+}
+
+/// The browser's X window lives in raw X11 coordinates (physical pixels) while
+/// the `CefBrowserExt` contract — like the CEF Views APIs used everywhere else
+/// in this runtime — is DIP. These helpers convert between the two.
+fn logical_to_physical(rect: &cef::Rect, scale: f64) -> cef::Rect {
+  cef::Rect {
+    x: (rect.x as f64 * scale).round() as i32,
+    y: (rect.y as f64 * scale).round() as i32,
+    width: (rect.width as f64 * scale).round() as i32,
+    height: (rect.height as f64 * scale).round() as i32,
+  }
+}
+
+fn physical_to_logical(rect: &cef::Rect, scale: f64) -> cef::Rect {
+  cef::Rect {
+    x: (rect.x as f64 / scale).round() as i32,
+    y: (rect.y as f64 / scale).round() as i32,
+    width: (rect.width as f64 / scale).round() as i32,
+    height: (rect.height as f64 / scale).round() as i32,
+  }
+}
 
 impl CefBrowserExt for cef::Browser {
   fn xid(&self) -> Option<u64> {
@@ -18,16 +129,7 @@ impl CefBrowserExt for cef::Browser {
       return cef::Rect::default();
     };
 
-    let Some(xlib) = X11.as_ref() else {
-      return cef::Rect::default();
-    };
-
-    unsafe {
-      let display = (xlib.XOpenDisplay)(std::ptr::null());
-      if display.is_null() {
-        return cef::Rect::default();
-      }
-
+    let physical = with_cef_display(cef::Rect::default(), |xlib, display| unsafe {
       let mut root: xlib::Window = 0;
       let mut x: i32 = 0;
       let mut y: i32 = 0;
@@ -48,8 +150,6 @@ impl CefBrowserExt for cef::Browser {
         &mut depth,
       );
 
-      (xlib.XCloseDisplay)(display);
-
       if status == 0 {
         return cef::Rect::default();
       }
@@ -61,7 +161,9 @@ impl CefBrowserExt for cef::Browser {
         width: width as i32,
         height: height as i32,
       }
-    }
+    });
+
+    physical_to_logical(&physical, self.scale_factor())
   }
 
   fn set_bounds(&self, rect: Option<&cef::Rect>) {
@@ -73,29 +175,21 @@ impl CefBrowserExt for cef::Browser {
       return;
     };
 
-    let Some(xlib) = X11.as_ref() else {
-      return;
-    };
+    let physical = logical_to_physical(rect, self.scale_factor());
 
-    unsafe {
-      let display = (xlib.XOpenDisplay)(std::ptr::null());
-      if display.is_null() {
-        return;
-      }
-
+    with_cef_display((), |xlib, display| unsafe {
+      // CEF's `CefWindowX11` observes the resulting ConfigureNotify and
+      // resizes the inner Chromium widget to match. No map/raise here: doing
+      // that on every resize churns the z-order between sibling webviews.
       (xlib.XMoveResizeWindow)(
         display,
         xid as xlib::Window,
-        rect.x,
-        rect.y,
-        rect.width as u32,
-        rect.height as u32,
+        physical.x,
+        physical.y,
+        physical.width.max(1) as u32,
+        physical.height.max(1) as u32,
       );
-      // Ensure window is mapped and raised after setting bounds
-      (xlib.XMapRaised)(display, xid as xlib::Window);
-      (xlib.XFlush)(display);
-      (xlib.XCloseDisplay)(display);
-    }
+    });
   }
 
   fn scale_factor(&self) -> f64 {
@@ -112,45 +206,76 @@ impl CefBrowserExt for cef::Browser {
       return;
     };
 
-    let Some(xlib) = X11.as_ref() else {
-      return;
-    };
-
-    unsafe {
-      let display = (xlib.XOpenDisplay)(std::ptr::null());
-      if display.is_null() {
-        return;
-      }
+    with_cef_display((), |xlib, display| unsafe {
+      // Mirror cefclient's `SetXWindowVisible`: toggle `_NET_WM_STATE_HIDDEN`
+      // on the browser window. CEF's `CefWindowX11` forwards the state to the
+      // inner Chromium widget so rendering resources are released while
+      // hidden. The window must additionally be mapped/unmapped for the
+      // visual effect, since its parent stays mapped.
+      let net_wm_state = atom(xlib, display, "_NET_WM_STATE");
+      const PROP_MODE_REPLACE: i32 = 0;
 
       if visible != 0 {
+        (xlib.XChangeProperty)(
+          display,
+          xid as xlib::Window,
+          net_wm_state,
+          xlib::XA_ATOM,
+          32,
+          PROP_MODE_REPLACE,
+          std::ptr::null(),
+          0,
+        );
         (xlib.XMapWindow)(display, xid as xlib::Window);
       } else {
+        let hidden: [c_ulong; 1] = [atom(xlib, display, "_NET_WM_STATE_HIDDEN")];
+        (xlib.XChangeProperty)(
+          display,
+          xid as xlib::Window,
+          net_wm_state,
+          xlib::XA_ATOM,
+          32,
+          PROP_MODE_REPLACE,
+          hidden.as_ptr() as *const u8,
+          1,
+        );
         (xlib.XUnmapWindow)(display, xid as xlib::Window);
       }
-      (xlib.XFlush)(display);
-      (xlib.XCloseDisplay)(display);
-    }
+    });
   }
 
   fn close(&self) {
+    // Destroying the X window behind CEF's back (the previous behavior,
+    // `XDestroyWindow`) leaves `CefWindowX11` unaware — it has no
+    // DestroyNotify handling — so the browser never goes through
+    // `OnBeforeClose`, leaking the renderer process and hanging
+    // `cef::shutdown` on exit. Drive CEF's regular close lifecycle instead,
+    // matching the macOS implementation: CEF itself sends WM_DELETE_WINDOW to
+    // its `CefWindowX11` and tears the window down.
+    let Some(host) = self.host() else {
+      return;
+    };
+    let _ = host.try_close_browser();
+  }
+
+  fn raise(&self) {
     let Some(xid) = self.xid() else {
       return;
     };
 
-    let Some(xlib) = X11.as_ref() else {
+    with_cef_display((), |xlib, display| unsafe {
+      (xlib.XRaiseWindow)(display, xid as xlib::Window);
+    });
+  }
+
+  fn refresh_render_target(&self) {
+    let Some(xid) = self.xid() else {
       return;
     };
 
-    unsafe {
-      let display = (xlib.XOpenDisplay)(std::ptr::null());
-      if display.is_null() {
-        return;
-      }
-
-      (xlib.XDestroyWindow)(display, xid as xlib::Window);
-      (xlib.XFlush)(display);
-      (xlib.XCloseDisplay)(display);
-    }
+    with_cef_display((), |xlib, display| {
+      resize_jiggle(xlib, display, xid as xlib::Window);
+    });
   }
 
   fn set_parent(&self, parent: &cef::Window) {
@@ -163,34 +288,9 @@ impl CefBrowserExt for cef::Browser {
       return;
     }
 
-    let Some(xlib) = X11.as_ref() else {
-      return;
-    };
-
-    unsafe {
-      let display = (xlib.XOpenDisplay)(std::ptr::null());
-      if display.is_null() {
-        return;
-      }
-
-      // Check if window exists before reparenting
-      let mut root: xlib::Window = 0;
-      let mut parent_window: xlib::Window = 0;
-      let mut children: *mut xlib::Window = std::ptr::null_mut();
-      let mut nchildren: u32 = 0;
-      let status = (xlib.XQueryTree)(
-        display,
-        xid as xlib::Window,
-        &mut root,
-        &mut parent_window,
-        &mut children,
-        &mut nchildren,
-      );
-
-      if status != 0 && !children.is_null() {
-        (xlib.XFree)(children as *mut std::ffi::c_void);
-      }
-
+    with_cef_display((), |xlib, display| unsafe {
+      // cefclient's `ShowPopup` pattern: reparent, then make sure the window
+      // is mapped (the caller re-applies bounds afterwards).
       (xlib.XReparentWindow)(
         display,
         xid as xlib::Window,
@@ -198,11 +298,7 @@ impl CefBrowserExt for cef::Browser {
         0,
         0,
       );
-
-      // Ensure window is mapped and raised after reparenting
       (xlib.XMapRaised)(display, xid as xlib::Window);
-      (xlib.XFlush)(display);
-      (xlib.XCloseDisplay)(display);
-    }
+    });
   }
 }

--- a/crates/tauri-runtime-cef/src/platform_linux.rs
+++ b/crates/tauri-runtime-cef/src/platform_linux.rs
@@ -544,3 +544,401 @@ pub fn start_resize_dragging(window: &cef::Window, direction: ResizeDirection) {
     );
   });
 }
+
+/// Watches CEF Views toplevel windows for hidden→visible transitions and
+/// "repairs" their child browser windows when the toplevel is shown again.
+///
+/// When a window manager hides a window (workspace switch in i3/sway,
+/// iconification, ...), Chromium pauses the toplevel's compositing, and once
+/// shown again the child browsers' compositors stay paused, leaving every
+/// webview blank until something else (a refocus, a resize) forces a new
+/// frame. CEF offers no callback for any of this — it is only observable at
+/// the X11 level — so a small watcher thread with its own X connection
+/// listens for it.
+///
+/// Two distinct signals cover the WM landscape:
+/// - `MapNotify`: WMs that unmap the client window directly.
+/// - `PropertyNotify` for `WM_STATE` / `_NET_WM_STATE`: reparenting WMs like
+///   i3 never unmap the client — they hide the frame and only flip
+///   `WM_STATE` to Iconic and add `_NET_WM_STATE_HIDDEN` on the client. The
+///   watcher tracks the combined hidden state and reacts to the
+///   hidden→visible transition.
+///
+/// On either signal the watcher, for every registered child browser window:
+/// 1. raises it above the Views window's own full-size content surface
+///    (which Chromium restacks on top of the children when the window is
+///    shown), and
+/// 2. cycles the `_NET_WM_STATE_HIDDEN` property off/on — the cefclient
+///    `SetXWindowVisible` protocol, which CEF's `CefWindowX11` forwards to
+///    the inner Chromium widget, pausing and resuming its compositor so a
+///    fresh frame is produced.
+pub mod map_watcher {
+  use super::*;
+  use std::os::unix::io::RawFd;
+  use std::sync::{Mutex, OnceLock, mpsc};
+
+  enum Control {
+    Watch {
+      toplevel: c_ulong,
+    },
+    Unwatch {
+      toplevel: c_ulong,
+    },
+    SetChildren {
+      toplevel: c_ulong,
+      children: Vec<c_ulong>,
+    },
+  }
+
+  struct Watcher {
+    tx: Mutex<mpsc::Sender<Control>>,
+    wake_fd: RawFd,
+  }
+
+  static WATCHER: OnceLock<Option<Watcher>> = OnceLock::new();
+
+  /// Starts watching `toplevel` for map events.
+  pub fn watch(toplevel: u64) {
+    send(Control::Watch {
+      toplevel: toplevel as c_ulong,
+    });
+  }
+
+  /// Stops watching `toplevel` (e.g. when the window is destroyed).
+  pub fn unwatch(toplevel: u64) {
+    send(Control::Unwatch {
+      toplevel: toplevel as c_ulong,
+    });
+  }
+
+  /// Replaces the set of child browser windows repaired on `MapNotify`.
+  pub fn set_children(toplevel: u64, children: Vec<u64>) {
+    send(Control::SetChildren {
+      toplevel: toplevel as c_ulong,
+      children: children.into_iter().map(|c| c as c_ulong).collect(),
+    });
+  }
+
+  fn send(msg: Control) {
+    let Some(watcher) = WATCHER.get_or_init(spawn).as_ref() else {
+      return;
+    };
+    if watcher.tx.lock().unwrap().send(msg).is_ok() {
+      // Wake the watcher thread out of poll().
+      unsafe {
+        let byte = 1u8;
+        libc::write(watcher.wake_fd, &byte as *const u8 as *const _, 1);
+      }
+    }
+  }
+
+  fn spawn() -> Option<Watcher> {
+    let xlib = xlib::Xlib::open().ok()?;
+    let mut fds = [0; 2];
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+      return None;
+    }
+    let (read_fd, wake_fd) = (fds[0], fds[1]);
+
+    let (tx, rx) = mpsc::channel();
+    std::thread::Builder::new()
+      .name("cef-x11-map-watcher".into())
+      .spawn(move || run(xlib, rx, read_fd))
+      .ok()?;
+
+    Some(Watcher {
+      tx: Mutex::new(tx),
+      wake_fd,
+    })
+  }
+
+  fn run(xlib: xlib::Xlib, rx: mpsc::Receiver<Control>, wake_rx: RawFd) {
+    let display = unsafe { (xlib.XOpenDisplay)(std::ptr::null()) };
+    if display.is_null() {
+      return;
+    }
+    let x_fd = unsafe { (xlib.XConnectionNumber)(display) };
+
+    struct Watched {
+      children: Vec<c_ulong>,
+      hidden: bool,
+      /// Rate limiter for `VisibilityNotify`-driven repairs.
+      last_visibility_repair: Option<std::time::Instant>,
+    }
+
+    let net_wm_state = atom(&xlib, display, "_NET_WM_STATE");
+    let net_wm_state_hidden = atom(&xlib, display, "_NET_WM_STATE_HIDDEN");
+    let wm_state = atom(&xlib, display, "WM_STATE");
+
+    let mut watched: HashMap<c_ulong, Watched> = HashMap::new();
+    // Repairs scheduled for watched toplevels after a show transition.
+    // Chromium recreates its presentation surfaces asynchronously, so a
+    // single fixed delay races with it — run several passes instead. The
+    // cycle is idempotent: extra passes on an already-repaired window are
+    // no-ops visually.
+    const REPAIR_DELAYS: [std::time::Duration; 4] = [
+      std::time::Duration::from_millis(50),
+      std::time::Duration::from_millis(250),
+      std::time::Duration::from_millis(750),
+      std::time::Duration::from_millis(1500),
+    ];
+    let mut pending_repairs: Vec<(std::time::Instant, c_ulong)> = Vec::new();
+    let schedule_repairs = |pending: &mut Vec<(std::time::Instant, c_ulong)>, toplevel: c_ulong| {
+      let now = std::time::Instant::now();
+      pending.retain(|(_, t)| *t != toplevel);
+      pending.extend(REPAIR_DELAYS.iter().map(|d| (now + *d, toplevel)));
+    };
+
+    loop {
+      // Apply registration changes.
+      while let Ok(msg) = rx.try_recv() {
+        match msg {
+          Control::Watch { toplevel } => {
+            unsafe {
+              (xlib.XSelectInput)(
+                display,
+                toplevel,
+                xlib::StructureNotifyMask | xlib::PropertyChangeMask | xlib::VisibilityChangeMask,
+              );
+              (xlib.XFlush)(display);
+            }
+            let hidden = window_hidden(
+              &xlib,
+              display,
+              toplevel,
+              net_wm_state,
+              net_wm_state_hidden,
+              wm_state,
+            );
+            log::debug!("cef map watcher: watching 0x{toplevel:x}, hidden={hidden}");
+            watched.entry(toplevel).or_insert(Watched {
+              children: Vec::new(),
+              hidden,
+              last_visibility_repair: None,
+            });
+          }
+          Control::Unwatch { toplevel } => {
+            watched.remove(&toplevel);
+            pending_repairs.retain(|(_, t)| *t != toplevel);
+          }
+          Control::SetChildren { toplevel, children } => {
+            watched
+              .entry(toplevel)
+              .or_insert(Watched {
+                children: Vec::new(),
+                hidden: false,
+                last_visibility_repair: None,
+              })
+              .children = children;
+          }
+        }
+      }
+
+      // Drain X events.
+      while unsafe { (xlib.XPending)(display) } > 0 {
+        let mut event: xlib::XEvent = unsafe { std::mem::zeroed() };
+        unsafe { (xlib.XNextEvent)(display, &mut event) };
+        match unsafe { event.type_ } {
+          // WMs that unmap the client window directly.
+          xlib::MapNotify => {
+            let map: &xlib::XMapEvent = unsafe { &event.map };
+            if let Some(state) = watched.get_mut(&map.window) {
+              state.hidden = false;
+              schedule_repairs(&mut pending_repairs, map.window);
+            }
+          }
+          // Reparenting WMs (i3, ...) never unmap the client — they only
+          // flip WM_STATE to Iconic / add _NET_WM_STATE_HIDDEN while the
+          // window's workspace is not visible.
+          xlib::PropertyNotify => {
+            let property: &xlib::XPropertyEvent = unsafe { &event.property };
+            if (property.atom == net_wm_state || property.atom == wm_state)
+              && let Some(state) = watched.get_mut(&property.window)
+            {
+              let hidden = window_hidden(
+                &xlib,
+                display,
+                property.window,
+                net_wm_state,
+                net_wm_state_hidden,
+                wm_state,
+              );
+              log::trace!(
+                "cef map watcher: WM state change on 0x{:x}, hidden {} -> {}",
+                property.window,
+                state.hidden,
+                hidden
+              );
+              if state.hidden && !hidden {
+                schedule_repairs(&mut pending_repairs, property.window);
+              }
+              state.hidden = hidden;
+            }
+          }
+          // The catch-all: X always generates a VisibilityNotify when a
+          // window transitions back to viewable, even when the window
+          // manager hid it without unmapping the client or flipping its WM
+          // state (i3 workspace switches hide only the frame). Becoming
+          // unviewable generates no event, so this cannot track the hidden
+          // state — instead, any non-fully-obscured visibility event
+          // triggers a (rate-limited) repair. Spurious repairs from plain
+          // uncover events are harmless: the resize jiggle is a 1px
+          // resize-and-restore.
+          xlib::VisibilityNotify => {
+            let visibility: &xlib::XVisibilityEvent = unsafe { &event.visibility };
+            if visibility.state != xlib::VisibilityFullyObscured
+              && let Some(state) = watched.get_mut(&visibility.window)
+            {
+              let now = std::time::Instant::now();
+              let recently_repaired = state
+                .last_visibility_repair
+                .is_some_and(|last| now.duration_since(last) < std::time::Duration::from_secs(1));
+              log::trace!(
+                "cef map watcher: visibility change on 0x{:x} (state {}), recently_repaired={recently_repaired}",
+                visibility.window,
+                visibility.state,
+              );
+              if !recently_repaired {
+                state.last_visibility_repair = Some(now);
+                state.hidden = false;
+                schedule_repairs(&mut pending_repairs, visibility.window);
+              }
+            }
+          }
+          _ => {}
+        }
+      }
+
+      // Run due repairs.
+      let now = std::time::Instant::now();
+      pending_repairs.retain(|(deadline, toplevel)| {
+        if *deadline <= now {
+          if let Some(state) = watched.get(toplevel) {
+            repair_children(&state.children);
+          }
+          false
+        } else {
+          true
+        }
+      });
+
+      // Sleep until the X connection or the control pipe has data, or the
+      // next scheduled repair is due.
+      let timeout = pending_repairs
+        .iter()
+        .map(|(deadline, _)| *deadline)
+        .min()
+        .map(|deadline| {
+          deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .as_millis()
+            .min(i32::MAX as u128) as i32
+            + 1
+        })
+        .unwrap_or(-1);
+      let mut poll_fds = [
+        libc::pollfd {
+          fd: x_fd,
+          events: libc::POLLIN,
+          revents: 0,
+        },
+        libc::pollfd {
+          fd: wake_rx,
+          events: libc::POLLIN,
+          revents: 0,
+        },
+      ];
+      unsafe {
+        libc::poll(poll_fds.as_mut_ptr(), 2, timeout);
+      }
+      if poll_fds[1].revents & libc::POLLIN != 0 {
+        let mut buf = [0u8; 32];
+        unsafe {
+          libc::read(wake_rx, buf.as_mut_ptr() as *mut _, buf.len());
+        }
+      }
+    }
+  }
+
+  /// Reports whether the window manager currently considers `window` hidden:
+  /// either `_NET_WM_STATE` contains `_NET_WM_STATE_HIDDEN` (EWMH) or
+  /// `WM_STATE` is anything other than Normal (ICCCM). The latter covers
+  /// i3, which sets `WM_STATE` to Withdrawn — not Iconic — for windows on
+  /// invisible workspaces, without adding `_NET_WM_STATE_HIDDEN`.
+  fn window_hidden(
+    xlib: &xlib::Xlib,
+    display: *mut xlib::Display,
+    window: c_ulong,
+    net_wm_state: c_ulong,
+    net_wm_state_hidden: c_ulong,
+    wm_state: c_ulong,
+  ) -> bool {
+    const NORMAL_STATE: c_ulong = 1;
+
+    unsafe fn read_property(
+      xlib: &xlib::Xlib,
+      display: *mut xlib::Display,
+      window: c_ulong,
+      property: c_ulong,
+    ) -> Option<Vec<c_ulong>> {
+      let mut actual_type: c_ulong = 0;
+      let mut actual_format: i32 = 0;
+      let mut nitems: c_ulong = 0;
+      let mut bytes_after: c_ulong = 0;
+      let mut prop: *mut u8 = std::ptr::null_mut();
+      let status = unsafe {
+        (xlib.XGetWindowProperty)(
+          display,
+          window,
+          property,
+          0,
+          1024,
+          xlib::False,
+          0, // AnyPropertyType
+          &mut actual_type,
+          &mut actual_format,
+          &mut nitems,
+          &mut bytes_after,
+          &mut prop,
+        )
+      };
+      if status != 0 || prop.is_null() {
+        return None;
+      }
+      let values = if actual_format == 32 {
+        unsafe { std::slice::from_raw_parts(prop as *const c_ulong, nitems as usize).to_vec() }
+      } else {
+        Vec::new()
+      };
+      unsafe { (xlib.XFree)(prop as *mut _) };
+      Some(values)
+    }
+
+    if let Some(atoms) = unsafe { read_property(xlib, display, window, net_wm_state) }
+      && atoms.contains(&net_wm_state_hidden)
+    {
+      return true;
+    }
+
+    if let Some(state) = unsafe { read_property(xlib, display, window, wm_state) }
+      && let Some(&value) = state.first()
+      && value != NORMAL_STATE
+    {
+      return true;
+    }
+
+    false
+  }
+
+  fn repair_children(children: &[c_ulong]) {
+    log::debug!(
+      "cef map watcher: posting repair task for {} webviews",
+      children.len()
+    );
+    // Run the actual repair on the CEF UI thread so it is serialized with
+    // Chromium's processing of the show transition's X events; doing the X
+    // work from this thread's connection can race ahead of Chromium's
+    // visibility handling and intermittently have no effect.
+    crate::cef_impl::post_repair_webviews_task(children.to_vec());
+  }
+}


### PR DESCRIPTION
Reworks how child (multiwebview) browsers are managed on X11, fixing several windowing bugs:

- Perform every operation on a browser's X window through CEF's own display connection (`cef_get_xdisplay`, the pattern used by cefclient) instead of opening and closing a throwaway connection per call, which raced with Chromium's own X11 traffic.
- Convert between DIP and physical pixels at the X11 boundary: CEF Views coordinates are DIP while raw X11 child windows use physical pixels, so webview bounds were wrong on HiDPI displays (both at creation via `WindowInfo::set_as_child` and on every `set_bounds`).
- Drive `webview.close()` through `try_close_browser` instead of `XDestroyWindow`: CEF's `CefWindowX11` has no DestroyNotify handling, so destroying the window behind its back leaked the browser/renderer process and hung `cef::shutdown` on exit.
- Toggle `_NET_WM_STATE_HIDDEN` in `webview.hide()/show()` (cefclient's `SetXWindowVisible` protocol) so Chromium releases rendering resources while a webview is hidden.
- Stop raising the window on every `set_bounds`, which churned the z-order between sibling webviews during resizes.

It also fixes webviews rendering blank until focused after the window manager hides and re-shows the window (e.g. i3 workspace switches):

- Chromium recreates its GPU presentation surfaces when the window is shown again, but the child browsers' renderers never submit a new frame (that otherwise only happens on focus or input), leaving every webview blank. The repair resize-jiggles the browser window by one pixel and back: each size change allocates a new viz LocalSurfaceId, obligating the renderer to produce a fresh CompositorFrame.
- CEF exposes no callback for WM-level visibility (`WasHidden` / `Invalidate` are windowless-only), so a small watcher thread with its own X connection listens for MapNotify, WM_STATE/_NET_WM_STATE changes (i3 marks hidden-workspace windows Withdrawn) and VisibilityNotify, and posts the repair as a CEF UI task so it is serialized with Chromium's processing of the show transition. The window-activation callback runs the same repair for focus-driven shows.
- Child browsers are also re-raised above the Views window's full-size content surface on creation, bounds changes and activation; Chromium restacks that surface above them when the window is shown, occluding the webviews.
