### PR TITLE
fix(android): escape special characters in `strings.xml`

### DIFF
--- a/.changes/android-escape-product-name.md
+++ b/.changes/android-escape-product-name.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Escape special characters in `productName` when generating Android `strings.xml`

--- a/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
+++ b/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">{{html-escape app.stylized-name}}</string>
-    <string name="main_activity_title">{{html-escape app.stylized-name}}</string>
+    <string name="app_name">"{{html-escape app.stylized-name}}"</string>
+    <string name="main_activity_title">"{{html-escape app.stylized-name}}"</string>
 </resources>

--- a/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
+++ b/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">{{app.stylized-name}}</string>
-    <string name="main_activity_title">{{app.stylized-name}}</string>
+    <string name="app_name">{{html-escape app.stylized-name}}</string>
+    <string name="main_activity_title">{{html-escape app.stylized-name}}</string>
 </resources>


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Fixes #14634
Closes #14640
Closes #14920

Android string resource XMLs have some pretty weird escape rules, it requires you to put `""` around standard escaped XML strings or it fails to compile. (even though this is not mentioned in the docs)

> https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes