### PR TITLE
refactor: remove impl clone on inner menus

### DIFF
--- a/crates/tauri/src/menu/mod.rs
+++ b/crates/tauri/src/menu/mod.rs
@@ -83,16 +83,6 @@ macro_rules! gen_wrappers {
 
       impl<R: Runtime> $crate::Resource for $type<R> {}
 
-      impl<R: $crate::Runtime> Clone for $inner<R> {
-        fn clone(&self) -> Self {
-          Self {
-            id: self.id.clone(),
-            inner: self.inner.clone(),
-            app_handle: self.app_handle.clone(),
-          }
-        }
-      }
-
       impl<R: Runtime> Drop for $inner<R> {
         fn drop(&mut self) {
           let inner = self.inner.take();


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->

Removing this so we make sure we always clone the `Arc` in `Menu` not `MenuInner` itself to prevent potential off main thread `Rc` usages

We can always add this back if we need it in the future