### PR TITLE
docs(cli): document signing private key path env var

### DIFF
--- a/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
+++ b/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
@@ -20,6 +20,7 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `TAURI_BUNDLER_DMG_IGNORE_CI` - Disable the check for `CI: true` in the `.dmg` bundler.
 - `TAURI_SKIP_SIDECAR_SIGNATURE_CHECK` - Skip signing sidecars.
 - `TAURI_SIGNING_PRIVATE_KEY` — Private key used to sign your app bundles, can be either a string or a path to the file.
+- `TAURI_SIGNING_PRIVATE_KEY_PATH` — Path to the private key file used by the standalone `tauri signer sign` command.
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — The signing private key password, see `TAURI_SIGNING_PRIVATE_KEY`.
 - `TAURI_SIGNING_RPM_KEY` — The private GPG key used to sign the RPM bundle, exported to its ASCII-armored format.
 - `TAURI_SIGNING_RPM_KEY_PASSPHRASE` — The GPG key passphrase for `TAURI_SIGNING_RPM_KEY`, if needed.


### PR DESCRIPTION
## Summary
- document `TAURI_SIGNING_PRIVATE_KEY_PATH` in the CLI environment variables reference
- clarify that it is used by the standalone `tauri signer sign` command

Related to tauri-apps/tauri-docs#3890.

## Verification
- `git diff --check`

Note: `pnpm exec prettier --check crates/tauri-cli/ENVIRONMENT_VARIABLES.md` could not run in this checkout because `prettier` is not installed locally.