### PR TITLE
test: regenerate stale macOS acl snapshot for has_app_acl

### DIFF
--- a/crates/tests/acl/fixtures/snapshots/macOS/acl_tests__tests__platform-specific-permissions.snap
+++ b/crates/tests/acl/fixtures/snapshots/macOS/acl_tests__tests__platform-specific-permissions.snap
@@ -3,6 +3,7 @@ source: crates/tests/acl/src/lib.rs
 expression: resolved
 ---
 Resolved {
+    has_app_acl: false,
     allowed_commands: {
         "plugin:os|spawn": [
             ResolvedCommand {


### PR DESCRIPTION
PR #13418 added the has_app_acl field to the Resolved struct and regenerated the linux and windows snapshots but missed macOS. CI does not run this insta test on macOS, so cargo test fails on a fresh clone of dev. This adds the missing field to match the other platforms.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
