### PR TITLE
enhance: remove `T: Send + Sync` requirement from `State<'r, T>`

### DIFF
--- a/.changes/change-pr-15578.md
+++ b/.changes/change-pr-15578.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:enhance
+---
+
+`State` had `Send` and `Sync` trait bounds that were already implied, remove them from the struct definition.

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -742,7 +742,7 @@ impl ScopeManager {
     key: &str,
   ) -> crate::Result<ScopeValue<T>> {
     match self.global_scope_cache.try_get::<ScopeValue<T>>() {
-      Some(cached) => Ok(cached.inner().clone()),
+      Some(cached) => Ok(cached.clone()),
       None => {
         let mut allow = Vec::new();
         let mut deny = Vec::new();
@@ -779,7 +779,7 @@ impl ScopeManager {
   ) -> crate::Result<ScopeValue<T>> {
     let cache = self.command_cache.get(key).unwrap();
     match cache.try_get::<ScopeValue<T>>() {
-      Some(cached) => Ok(cached.inner().clone()),
+      Some(cached) => Ok(cached.clone()),
       None => {
         let resolved_scope = self
           .command_scope

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -742,7 +742,7 @@ impl ScopeManager {
     key: &str,
   ) -> crate::Result<ScopeValue<T>> {
     match self.global_scope_cache.try_get::<ScopeValue<T>>() {
-      Some(cached) => Ok(cached.clone()),
+      Some(cached) => Ok((*cached).clone()),
       None => {
         let mut allow = Vec::new();
         let mut deny = Vec::new();
@@ -779,7 +779,7 @@ impl ScopeManager {
   ) -> crate::Result<ScopeValue<T>> {
     let cache = self.command_cache.get(key).unwrap();
     match cache.try_get::<ScopeValue<T>>() {
-      Some(cached) => Ok(cached.clone()),
+      Some(cached) => Ok((*cached).clone()),
       None => {
         let resolved_scope = self
           .command_scope

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -663,7 +663,7 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
   ///
   /// #[tauri::command]
   /// fn string_command<'r>(state: State<'r, MyString>) {
-  ///     println!("state: {}", state.inner().0);
+  ///     println!("state: {}", state.0);
   /// }
   ///
   /// tauri::Builder::default()
@@ -753,13 +753,14 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
 
   /// Gets the managed [`Env`].
   fn env(&self) -> Env {
-    self.state::<Env>().inner().clone()
+    use std::ops::Deref;
+    self.state::<Env>().deref().clone()
   }
 
   /// Gets the scope for the asset protocol.
   #[cfg(feature = "protocol-asset")]
   fn asset_protocol_scope(&self) -> scope::fs::Scope {
-    self.state::<Scopes>().inner().asset_protocol.clone()
+    self.state::<Scopes>().asset_protocol.clone()
   }
 
   /// The path resolver.

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -6,7 +6,6 @@ use std::{
   any::{Any, TypeId},
   collections::HashMap,
   hash::BuildHasherDefault,
-  pin::Pin,
   sync::Mutex,
 };
 
@@ -100,7 +99,7 @@ impl std::hash::Hasher for IdentHash {
 /// Safety:
 /// - The `key` must equal to `(*value).type_id()`, see the safety doc in methods of [StateManager] for details.
 /// - Once you insert a value, you can't remove/mutated/move it anymore, see [StateManager::try_get] for details.
-type TypeIdMap = HashMap<TypeId, Pin<Box<dyn Any + Sync + Send>>, BuildHasherDefault<IdentHash>>;
+type TypeIdMap = HashMap<TypeId, Box<dyn Any + Sync + Send>, BuildHasherDefault<IdentHash>>;
 
 /// The Tauri state manager.
 #[derive(Debug)]
@@ -120,13 +119,12 @@ impl StateManager {
     let type_id = TypeId::of::<T>();
     let already_set = map.contains_key(&type_id);
     if !already_set {
-      let ptr = Box::new(state) as Box<dyn Any + Sync + Send>;
-      let pinned_ptr = Box::into_pin(ptr);
+      let state = Box::new(state) as Box<dyn Any + Sync + Send>;
       map.insert(
         type_id,
         // SAFETY: keep the type of the key is the same as the type of the value，
         // see [try_get] methods for details.
-        pinned_ptr,
+        state,
       );
     }
     !already_set
@@ -137,11 +135,9 @@ impl StateManager {
   pub(crate) unsafe fn unmanage<T: Send + Sync + 'static>(&self) -> Option<T> {
     let mut map = self.map.lock().unwrap();
     let type_id = TypeId::of::<T>();
-    let pinned_ptr = map.remove(&type_id)?;
-    // SAFETY: The caller decides to break the immovability/safety here, then OK, just let it go.
-    let ptr = unsafe { Pin::into_inner_unchecked(pinned_ptr) };
+    let state = map.remove(&type_id)?;
     let value = unsafe {
-      ptr
+      state
         .downcast::<T>()
         // SAFETY: the type of the key is the same as the type of the value
         .unwrap_unchecked()
@@ -160,9 +156,9 @@ impl StateManager {
   pub fn try_get<T: Send + Sync + 'static>(&self) -> Option<State<'_, T>> {
     let map = self.map.lock().unwrap();
     let type_id = TypeId::of::<T>();
-    let ptr = map.get(&type_id)?;
+    let state = map.get(&type_id)?;
     let value = unsafe {
-      ptr
+      state
         .downcast_ref::<T>()
         // SAFETY: the type of the key is the same as the type of the value
         .unwrap_unchecked()

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -120,12 +120,7 @@ impl StateManager {
     let already_set = map.contains_key(&type_id);
     if !already_set {
       let state = Box::new(state) as Box<dyn Any + Sync + Send>;
-      map.insert(
-        type_id,
-        // SAFETY: keep the type of the key is the same as the type of the value，
-        // see [try_get] methods for details.
-        state,
-      );
+      map.insert(type_id, state);
     }
     !already_set
   }
@@ -136,12 +131,9 @@ impl StateManager {
     let mut map = self.map.lock().unwrap();
     let type_id = TypeId::of::<T>();
     let state = map.remove(&type_id)?;
-    let value = unsafe {
-      state
-        .downcast::<T>()
-        // SAFETY: the type of the key is the same as the type of the value
-        .unwrap_unchecked()
-    };
+    let value = state
+      .downcast::<T>()
+      .expect("the type of the key should be same as the type of the value");
     Some(*value)
   }
 
@@ -157,12 +149,9 @@ impl StateManager {
     let map = self.map.lock().unwrap();
     let type_id = TypeId::of::<T>();
     let state = map.get(&type_id)?;
-    let value = unsafe {
-      state
-        .downcast_ref::<T>()
-        // SAFETY: the type of the key is the same as the type of the value
-        .unwrap_unchecked()
-    };
+    let value = state
+      .downcast_ref::<T>()
+      .expect("the type of the key should be same as the type of the value");
     // SAFETY: We ensure the lifetime of `value` is the same as [StateManager] and `value` will not be mutated/moved.
     let v_ref = unsafe { &*(value as *const T) };
     Some(State(v_ref))

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -17,9 +17,9 @@ use crate::{
 /// A guard for a state value.
 ///
 /// See [`Manager::manage`](`crate::Manager::manage`) for usage examples.
-pub struct State<'r, T: Send + Sync + 'static>(&'r T);
+pub struct State<'r, T>(&'r T);
 
-impl<'r, T: Send + Sync + 'static> State<'r, T> {
+impl<'r, T> State<'r, T> {
   /// Retrieve a borrow to the underlying value with a lifetime of `'r`.
   /// Using this method is typically unnecessary as `State` implements
   /// [`std::ops::Deref`] with a [`std::ops::Deref::Target`] of `T`.
@@ -29,7 +29,7 @@ impl<'r, T: Send + Sync + 'static> State<'r, T> {
   }
 }
 
-impl<T: Send + Sync + 'static> std::ops::Deref for State<'_, T> {
+impl<T> std::ops::Deref for State<'_, T> {
   type Target = T;
 
   #[inline(always)]
@@ -38,25 +38,25 @@ impl<T: Send + Sync + 'static> std::ops::Deref for State<'_, T> {
   }
 }
 
-impl<T: Send + Sync + 'static> Clone for State<'_, T> {
+impl<T> Clone for State<'_, T> {
   fn clone(&self) -> Self {
     State(self.0)
   }
 }
 
-impl<T: Send + Sync + 'static + PartialEq> PartialEq for State<'_, T> {
+impl<T: PartialEq> PartialEq for State<'_, T> {
   fn eq(&self, other: &Self) -> bool {
     self.0 == other.0
   }
 }
 
-impl<T: Send + Sync + std::fmt::Debug> std::fmt::Debug for State<'_, T> {
+impl<T: std::fmt::Debug> std::fmt::Debug for State<'_, T> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_tuple("State").field(&self.0).finish()
   }
 }
 
-impl<'r, 'de: 'r, T: Send + Sync + 'static, R: Runtime> CommandArg<'de, R> for State<'r, T> {
+impl<'r, 'de: 'r, T: 'static, R: Runtime> CommandArg<'de, R> for State<'r, T> {
   /// Grabs the [`State`] from the [`CommandItem`]. This will never fail.
   fn from_command(command: CommandItem<'de, R>) -> Result<Self, InvokeError> {
     command.message.state_ref().try_get().ok_or_else(|| {
@@ -138,14 +138,14 @@ impl StateManager {
   }
 
   /// Gets the state associated with the specified type.
-  pub fn get<T: Send + Sync + 'static>(&self) -> State<'_, T> {
+  pub fn get<T: 'static>(&self) -> State<'_, T> {
     self
       .try_get()
       .unwrap_or_else(|| panic!("state not found for type {}", std::any::type_name::<T>()))
   }
 
   /// Gets the state associated with the specified type.
-  pub fn try_get<T: Send + Sync + 'static>(&self) -> Option<State<'_, T>> {
+  pub fn try_get<T: 'static>(&self) -> Option<State<'_, T>> {
     let map = self.map.lock().unwrap();
     let type_id = TypeId::of::<T>();
     let state = map.get(&type_id)?;

--- a/examples/api/src-tauri/tauri-plugin-sample/src/lib.rs
+++ b/examples/api/src-tauri/tauri-plugin-sample/src/lib.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 use tauri::{
   plugin::{Builder, TauriPlugin},
-  Manager, Runtime,
+  Manager, Runtime, State,
 };
 
 pub use models::*;
@@ -28,12 +28,12 @@ pub use error::*;
 
 /// Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the sample APIs.
 pub trait SampleExt<R: Runtime> {
-  fn sample(&self) -> &Sample<R>;
+  fn sample(&self) -> State<'_, Sample<R>>;
 }
 
 impl<R: Runtime, T: Manager<R>> crate::SampleExt<R> for T {
-  fn sample(&self) -> &Sample<R> {
-    self.state::<Sample<R>>().inner()
+  fn sample(&self) -> State<'_, Sample<R>> {
+    self.state::<Sample<R>>()
   }
 }
 

--- a/examples/commands/commands.rs
+++ b/examples/commands/commands.rs
@@ -23,7 +23,7 @@ pub fn simple_command(the_argument: String) {
 
 #[command]
 pub fn stateful_command(the_argument: Option<String>, state: State<'_, super::MyState>) {
-  println!("{:?} {:?}", the_argument, state.inner());
+  println!("{:?} {:?}", the_argument, *state);
 }
 
 #[command(rename = "renamed_command_in_mod_new")]

--- a/examples/commands/main.rs
+++ b/examples/commands/main.rs
@@ -51,7 +51,7 @@ async fn async_stateful_command(
   the_argument: Option<String>,
   state: State<'_, MyState>,
 ) -> Result<(), ()> {
-  println!("{:?} {:?}", the_argument, state.inner());
+  println!("{:?} {:?}", the_argument, *state);
   Ok(())
 }
 // ------------------------ Raw future commands ------------------------
@@ -141,7 +141,7 @@ fn stateful_command_with_result(
   the_argument: Option<String>,
   state: State<'_, MyState>,
 ) -> Result<String, MyError> {
-  println!("{:?} {:?}", the_argument, state.inner());
+  println!("{:?} {:?}", the_argument, *state);
   dbg!(the_argument.ok_or(MyError::FooError))
 }
 
@@ -160,7 +160,7 @@ fn stateful_command_with_result_snake(
   the_argument: Option<String>,
   state: State<'_, MyState>,
 ) -> Result<String, MyError> {
-  println!("{:?} {:?}", the_argument, state.inner());
+  println!("{:?} {:?}", the_argument, *state);
   dbg!(the_argument.ok_or(MyError::FooError))
 }
 
@@ -177,7 +177,7 @@ async fn async_stateful_command_with_result(
   the_argument: Option<String>,
   state: State<'_, MyState>,
 ) -> Result<String, MyError> {
-  println!("{:?} {:?}", the_argument, state.inner());
+  println!("{:?} {:?}", the_argument, *state);
   Ok(the_argument.unwrap_or_default())
 }
 


### PR DESCRIPTION
#13257 isn't getting any majorities.

This includes just the removal of some unsafe blocks and a bit of cleanup.