### PR TITLE
chore(renovate): group napi-rs packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,11 @@
       "description": "Group worker-rs crates",
       "groupName": "worker-rs crates",
       "matchSourceUrls": ["https://github.com/cloudflare/workers-rs"]
+    },
+    {
+      "description": "Group napi-rs packages",
+      "groupName": "napi-rs packages",
+      "matchSourceUrls": ["https://github.com/napi-rs/napi-rs"]
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"]


### PR DESCRIPTION
This should probably be merged after the MSRV bump so we can re-evaluate which crates we can get in from the spamming PRs