### PR TITLE
fix(core): purge JS event listeners when source webview is destroyed (fix #15583)

### DIFF
--- a/.changes/fix-js-listeners-leak-on-webview-close.md
+++ b/.changes/fix-js-listeners-leak-on-webview-close.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Remove a webview's JS event listeners from the backend `Listeners` map when that webview is destroyed. Previously the entries keyed by the source webview label lingered after the webview was dropped, so they could never be delivered and leaked until the app exited — forcing apps to manually `unlisten()` before closing a window.

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -256,7 +256,7 @@ impl Listeners {
   /// Called when a webview is destroyed: its JavaScript runtime no longer
   /// exists, so the listeners keyed by its label can never be delivered and
   /// would otherwise leak in the map until the app exits.
-  pub(crate) fn remove_webview_events(&self, webview_label: &str) {
+  pub(crate) fn remove_webview_js_listeners(&self, webview_label: &str) {
     self
       .inner
       .js_event_listeners
@@ -431,7 +431,7 @@ mod test {
     assert!(listeners.has_js_listener(event.as_str_event(), |_| true));
 
     // dropping the source webview must drop its JS listeners.
-    listeners.remove_webview_events(webview_label);
+    listeners.remove_webview_js_listeners(webview_label);
     assert!(!listeners.has_js_listener(event.as_str_event(), |_| true));
   }
 }

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -251,6 +251,20 @@ impl Listeners {
     }
   }
 
+  /// Removes all JS event listeners registered from the given webview.
+  ///
+  /// Called when a webview is destroyed: its JavaScript runtime no longer
+  /// exists, so the listeners keyed by its label can never be delivered and
+  /// would otherwise leak in the map until the app exits.
+  pub(crate) fn remove_webview_events(&self, webview_label: &str) {
+    self
+      .inner
+      .js_event_listeners
+      .lock()
+      .unwrap()
+      .remove(webview_label);
+  }
+
   pub(crate) fn has_js_listener<F: Fn(&EventTarget) -> bool>(
     &self,
     event: crate::EventName<&str>,
@@ -397,5 +411,27 @@ mod test {
     listeners
       .emit(EmitArgs::new(event.as_str_event(), &()).unwrap())
       .unwrap();
+  }
+
+  #[test]
+  fn js_listeners_removed_on_webview_close() {
+    let listeners = Listeners::default();
+    let event = crate::EventName::new("some-event".to_owned()).unwrap();
+    let webview_label = "main";
+
+    let id = listeners.next_event_id();
+    listeners.listen_js(
+      event.as_str_event(),
+      webview_label,
+      EventTarget::Webview {
+        label: webview_label.to_owned(),
+      },
+      id,
+    );
+    assert!(listeners.has_js_listener(event.as_str_event(), |_| true));
+
+    // dropping the source webview must drop its JS listeners.
+    listeners.remove_webview_events(webview_label);
+    assert!(!listeners.has_js_listener(event.as_str_event(), |_| true));
   }
 }

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -655,6 +655,7 @@ impl<R: Runtime> AppManager<R> {
     if let Some(window) = window {
       for webview in window.webviews() {
         self.webview.webviews_lock().remove(webview.label());
+        self.listeners().remove_webview_events(webview.label());
       }
     }
   }
@@ -662,6 +663,7 @@ impl<R: Runtime> AppManager<R> {
   #[cfg(desktop)]
   pub(crate) fn on_webview_close(&self, label: &str) {
     self.webview.webviews_lock().remove(label);
+    self.listeners().remove_webview_events(label);
   }
 
   pub fn windows(&self) -> HashMap<String, Window<R>> {

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -655,7 +655,7 @@ impl<R: Runtime> AppManager<R> {
     if let Some(window) = window {
       for webview in window.webviews() {
         self.webview.webviews_lock().remove(webview.label());
-        self.listeners().remove_webview_events(webview.label());
+        self.listeners().remove_webview_js_listeners(webview.label());
       }
     }
   }
@@ -663,7 +663,7 @@ impl<R: Runtime> AppManager<R> {
   #[cfg(desktop)]
   pub(crate) fn on_webview_close(&self, label: &str) {
     self.webview.webviews_lock().remove(label);
-    self.listeners().remove_webview_events(label);
+    self.listeners().remove_webview_js_listeners(label);
   }
 
   pub fn windows(&self) -> HashMap<String, Window<R>> {

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -655,7 +655,9 @@ impl<R: Runtime> AppManager<R> {
     if let Some(window) = window {
       for webview in window.webviews() {
         self.webview.webviews_lock().remove(webview.label());
-        self.listeners().remove_webview_js_listeners(webview.label());
+        self
+          .listeners()
+          .remove_webview_js_listeners(webview.label());
       }
     }
   }


### PR DESCRIPTION
Closes #15583.

JS event listeners registered from a webview are stored in `Listeners::js_event_listeners`, keyed by the source webview label. When the webview is destroyed the manager removes its handle from the store but leaves the listener entries behind. Since the webview's JavaScript runtime is gone, those callbacks can never be delivered — the entries just leak until the app exits, and apps are forced to call `unlisten()` from `onCloseRequested` before closing a window just to keep the backend map clean.

Add `Listeners::remove_webview_events(label)` and call it from `on_webview_close` and `on_window_close` (for each webview of the closing window), so a destroyed webview's JS listeners are dropped alongside its handle.

Added a unit test (`js_listeners_removed_on_webview_close`) covering register → close → gone.

Note: @Legend-Master pointed out the Rust-side `handlers` map may leak similarly. That one is keyed by `EventTarget` rather than the owning webview, so purging it correctly has to account for `Window` vs `Webview` targets and multi-webview windows. Left out of this PR to keep it focused on the reported JS-listener leak — happy to follow up if you'd like it handled here.

Tested: `cargo test -p tauri --lib event::listener` (5 passing), fmt + clippy clean.