### PR TITLE
fix(driver): strip BiDi webSocketUrl capability before forwarding (fix #15415)

### DIFF
--- a/.changes/fix-tauri-driver-strip-bidi.md
+++ b/.changes/fix-tauri-driver-strip-bidi.md
@@ -1,0 +1,5 @@
+---
+'tauri-driver': 'patch:bug'
+---
+
+Strip the WebDriver BiDi `webSocketUrl` capability before forwarding a new session to the native driver. WebdriverIO 9+ auto-injects `webSocketUrl: true` to negotiate BiDi, but tauri-driver does not proxy the BiDi websocket and pre-2.46 WebKitGTK (shipped on current Ubuntu LTS) rejects sessions that request it, so the session failed to start. The capability is removed from both `alwaysMatch` and every `firstMatch` entry; BiDi is additive, so clients fall back to classic WebDriver.

--- a/crates/tauri-driver/src/server.rs
+++ b/crates/tauri-driver/src/server.rs
@@ -26,6 +26,13 @@ use tokio::net::TcpListener;
 
 const TAURI_OPTIONS: &str = "tauri:options";
 
+// WebDriver BiDi capability auto-injected by WebdriverIO 9+. tauri-driver does
+// not proxy the BiDi websocket, and the bundled WebKitWebDriver on pre-2.46
+// WebKitGTK rejects sessions that request it, so we strip it before forwarding
+// to the native driver. BiDi is additive, so clients fall back to classic
+// WebDriver seamlessly.
+const BIDI_CAPABILITY: &str = "webSocketUrl";
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TauriOptions {
@@ -152,6 +159,8 @@ fn map_capabilities(mut json: Value) -> Value {
         }
       }
     }
+
+    strip_bidi_capabilities(capabilities);
   }
 
   if let Some(native) = native {
@@ -164,6 +173,31 @@ fn map_capabilities(mut json: Value) -> Value {
   }
 
   json
+}
+
+/// Removes WebDriver BiDi capabilities the inner native driver cannot honor.
+///
+/// `webSocketUrl` is auto-injected by WebdriverIO 9+ to negotiate BiDi, but
+/// tauri-driver does not proxy the BiDi websocket and pre-2.46 WebKitGTK rejects
+/// it, so it is stripped from both `alwaysMatch` and every `firstMatch` entry.
+fn strip_bidi_capabilities(capabilities: &mut Value) {
+  if let Some(always_match) = capabilities
+    .get_mut("alwaysMatch")
+    .and_then(Value::as_object_mut)
+  {
+    always_match.remove(BIDI_CAPABILITY);
+  }
+
+  if let Some(first_match) = capabilities
+    .get_mut("firstMatch")
+    .and_then(Value::as_array_mut)
+  {
+    for entry in first_match.iter_mut() {
+      if let Some(entry) = entry.as_object_mut() {
+        entry.remove(BIDI_CAPABILITY);
+      }
+    }
+  }
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -242,4 +276,29 @@ pub async fn run(args: Args, mut _driver: Child) -> Result<(), Error> {
   }
 
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+
+  #[test]
+  fn strips_bidi_from_always_match_and_first_match() {
+    let json = json!({
+      "capabilities": {
+        "alwaysMatch": { "browserName": "wry", "webSocketUrl": true },
+        "firstMatch": [{ "webSocketUrl": true }, { "browserName": "wry" }]
+      }
+    });
+
+    let mapped = map_capabilities(json);
+    let capabilities = &mapped["capabilities"];
+
+    assert!(capabilities["alwaysMatch"].get("webSocketUrl").is_none());
+    assert_eq!(capabilities["alwaysMatch"]["browserName"], "wry");
+    for entry in capabilities["firstMatch"].as_array().unwrap() {
+      assert!(entry.get("webSocketUrl").is_none());
+    }
+  }
 }


### PR DESCRIPTION
Closes #15415.

WebdriverIO 9+ defaults to WebDriver BiDi and auto-injects `webSocketUrl: true` into `alwaysMatch` to negotiate it. `tauri-driver` forwards capabilities verbatim to the native driver but does **not** proxy the BiDi websocket, and the `WebKitWebDriver` bundled with pre-2.46 WebKitGTK (current Ubuntu LTS / noble) rejects sessions that request BiDi — so session creation fails for every wdio 9+ user unless they manually set `wdio:enforceWebDriverClassic`.

Since tauri-driver has no BiDi support to forward to in the first place, `webSocketUrl` can never be honored. Strip it from `alwaysMatch` and every `firstMatch` entry in `map_capabilities` so the inner driver gets a capability set it accepts. BiDi is additive, so clients fall back to classic WebDriver seamlessly — no regression for WebKit ≥2.46.

Added a unit test covering the strip on both `alwaysMatch` and `firstMatch`.

Note: `tauri-driver`'s `server` module is `#[cfg(any(target_os = "linux", windows))]`, so the test does not build on a macOS host; verified with `cargo check/clippy -p tauri-driver --tests --target x86_64-unknown-linux-gnu` (clean) and it runs under CI on Linux/Windows.