### PR TITLE
fix(deps): pin time to `<0.3.52`

### DIFF
--- a/.changes/pin-time.md
+++ b/.changes/pin-time.md
@@ -1,8 +1,8 @@
 ---
-tauri: patch
+tauri: patch:deps
 ---
 
-Pinning `time` to `<0.3.52` used by `cookie` to avoid a compilation error, see
+Pinning `time` to `<0.3.52` used by `cookie` to mitigate a compilation error, see
 
 - https://github.com/tauri-apps/tauri/issues/15615
 - https://github.com/rwf2/cookie-rs/issues/255

--- a/.changes/pin-time.md
+++ b/.changes/pin-time.md
@@ -1,0 +1,8 @@
+---
+tauri: patch
+---
+
+Pinning `time` to `<0.3.52` used by `cookie` to avoid a compilation error, see
+
+- https://github.com/tauri-apps/tauri/issues/15615
+- https://github.com/rwf2/cookie-rs/issues/255

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8806,6 +8806,7 @@ dependencies = [
  "tauri-runtime-wry",
  "tauri-utils",
  "thiserror 2.0.12",
+ "time",
  "tokio",
  "tracing",
  "tray-icon",

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -85,6 +85,9 @@ specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, 
 # WARNING: cookie::Cookie is re-exported so bumping this is a breaking change, documented to be done as a minor bump
 cookie = "0.18"
 
+# Pinning `time` used by `cookie` here to avoid a compilation error, see
+# - https://github.com/tauri-apps/tauri/issues/15615
+# - https://github.com/rwf2/cookie-rs/issues/255
 time = ">=0.3, <0.3.52"
 
 # desktop

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -85,6 +85,8 @@ specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, 
 # WARNING: cookie::Cookie is re-exported so bumping this is a breaking change, documented to be done as a minor bump
 cookie = "0.18"
 
+time = ">=0.3, <0.3.52"
+
 # desktop
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows", target_os = "macos"))'.dependencies]
 muda = { version = "0.19", default-features = false, features = [


### PR DESCRIPTION
An attempt to mitigate #15615, since we can't update cookie nor yank the time crate, this is the best we can do for now.