### PR TITLE
fix(core): purge Rust event listeners when window/webview is destroyed

### DIFF
--- a/.changes/event-listener-cleanup-on-destroy.md
+++ b/.changes/event-listener-cleanup-on-destroy.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+Remove Rust-side event listeners bound to a window or webview when that target is destroyed, so `listen`/`once` handlers registered on a `Window`, `Webview` or `WebviewWindow` no longer leak after it is closed.

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -190,11 +190,8 @@ impl Listeners {
 
   /// Removes every Rust-side event listener registered for the exact given target.
   ///
-  /// Called when a window or webview is destroyed so its listeners don't leak. Matching
-  /// is done on the full [`EventTarget`] (kind + label) rather than the label alone,
-  /// since in multi-webview mode a window and its webviews can carry the same label while
-  /// referring to different targets. Global targets such as [`EventTarget::App`],
-  /// [`EventTarget::Any`] and [`EventTarget::AnyLabel`] are never matched here.
+  /// Called when a window or webview is destroyed so its listeners don't leak.
+  /// Global targets such as [`EventTarget::App`], [`EventTarget::Any`] and [`EventTarget::AnyLabel`] are never matched here.
   pub(crate) fn remove_listeners_for_target(&self, target: EventTarget) {
     match self.inner.handlers.try_lock() {
       Err(_) => self.insert_pending(Pending::RemoveForTarget(target)),

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -25,6 +25,7 @@ enum Pending {
     handler: Handler,
   },
   Emit(EmitArgs),
+  RemoveForTarget(EventTarget),
 }
 
 /// Stored in [`Listeners`] to be called upon, when the event that stored it, is triggered.
@@ -128,6 +129,7 @@ impl Listeners {
         Pending::Unlisten(id) => self.unlisten(id),
         Pending::Listen { id, event, handler } => self.listen_with_id(id, event, handler),
         Pending::Emit(args) => self.emit(args)?,
+        Pending::RemoveForTarget(target) => self.remove_listeners_for_target(target),
       }
     }
 
@@ -183,6 +185,25 @@ impl Listeners {
       Ok(mut lock) => lock.values_mut().for_each(|handler| {
         handler.remove(&id);
       }),
+    }
+  }
+
+  /// Removes every Rust-side event listener registered for the exact given target.
+  ///
+  /// Called when a window or webview is destroyed so its listeners don't leak. Matching
+  /// is done on the full [`EventTarget`] (kind + label) rather than the label alone,
+  /// since in multi-webview mode a window and its webviews can carry the same label while
+  /// referring to different targets. Global targets such as [`EventTarget::App`],
+  /// [`EventTarget::Any`] and [`EventTarget::AnyLabel`] are never matched here.
+  pub(crate) fn remove_listeners_for_target(&self, target: EventTarget) {
+    match self.inner.handlers.try_lock() {
+      Err(_) => self.insert_pending(Pending::RemoveForTarget(target)),
+      Ok(mut lock) => {
+        for handlers in lock.values_mut() {
+          handlers.retain(|_, handler| handler.target != target);
+        }
+        lock.retain(|_, handlers| !handlers.is_empty());
+      }
     }
   }
 
@@ -395,6 +416,38 @@ mod test {
       // assert that the key is contained in the listeners map
       assert!(l.contains_key(&key));
     }
+  }
+
+  #[test]
+  fn remove_listeners_for_target_drops_only_exact_target() {
+    let listeners = Listeners::default();
+    let event = crate::EventName::new("test-event".to_owned()).unwrap();
+
+    let window = listeners.listen(event.clone(), EventTarget::window("main"), event_fn);
+    // Same label as the window, but a different target kind (multi-webview mode).
+    let webview = listeners.listen(event.clone(), EventTarget::webview("main"), event_fn);
+    let webview_window =
+      listeners.listen(event.clone(), EventTarget::webview_window("main"), event_fn);
+    let other = listeners.listen(event.clone(), EventTarget::webview("other"), event_fn);
+    let app = listeners.listen(event.clone(), EventTarget::App, event_fn);
+    let any = listeners.listen(event.clone(), EventTarget::Any, event_fn);
+    let labeled = listeners.listen(event.clone(), EventTarget::labeled("main"), event_fn);
+
+    listeners.remove_listeners_for_target(EventTarget::webview("main"));
+
+    let lock = listeners.inner.handlers.lock().unwrap();
+    let remaining: HashSet<EventId> = lock.get(&event).unwrap().keys().copied().collect();
+
+    // only the exact `Webview { label: "main" }` listener is gone
+    assert!(!remaining.contains(&webview));
+    // same label but different kind is kept
+    assert!(remaining.contains(&window));
+    assert!(remaining.contains(&webview_window));
+    // unrelated and global listeners are kept
+    assert!(remaining.contains(&other));
+    assert!(remaining.contains(&app));
+    assert!(remaining.contains(&any));
+    assert!(remaining.contains(&labeled));
   }
 
   #[test]

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -192,7 +192,7 @@ impl Listeners {
   ///
   /// Called when a window or webview is destroyed so its listeners don't leak.
   /// Global targets such as [`EventTarget::App`], [`EventTarget::Any`] and [`EventTarget::AnyLabel`] are never matched here.
-  pub(crate) fn remove_listeners_for_target(&self, target: EventTarget) {
+  fn remove_listeners_for_target(&self, target: EventTarget) {
     match self.inner.handlers.try_lock() {
       Err(_) => self.insert_pending(Pending::RemoveForTarget(target)),
       Ok(mut lock) => {
@@ -270,17 +270,25 @@ impl Listeners {
   }
 
   /// Removes all JS event listeners registered from the given webview.
-  ///
-  /// Called when a webview is destroyed: its JavaScript runtime no longer
-  /// exists, so the listeners keyed by its label can never be delivered and
-  /// would otherwise leak in the map until the app exits.
-  pub(crate) fn remove_webview_js_listeners(&self, webview_label: &str) {
+  fn remove_webview_js_listeners(&self, webview_label: &str) {
     self
       .inner
       .js_event_listeners
       .lock()
       .unwrap()
       .remove(webview_label);
+  }
+
+  /// Removes all event listeners associated with a destroyed webview.
+  pub(crate) fn remove_webview_listeners(&self, label: &str) {
+    self.remove_webview_js_listeners(label);
+    self.remove_listeners_for_target(EventTarget::webview(label));
+  }
+
+  /// Removes all event listeners associated with a destroyed window.
+  pub(crate) fn remove_window_listeners(&self, label: &str) {
+    self.remove_listeners_for_target(EventTarget::window(label));
+    self.remove_listeners_for_target(EventTarget::webview_window(label));
   }
 
   pub(crate) fn has_js_listener<F: Fn(&EventTarget) -> bool>(
@@ -459,8 +467,7 @@ mod test {
     );
     assert!(listeners.has_js_listener(event.as_str_event(), |_| true));
 
-    listeners.remove_webview_js_listeners(webview_label);
-    listeners.remove_listeners_for_target(EventTarget::webview(webview_label));
+    listeners.remove_webview_listeners(webview_label);
 
     assert!(!listeners.has_js_listener(event.as_str_event(), |_| true));
 

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -416,38 +416,6 @@ mod test {
   }
 
   #[test]
-  fn remove_listeners_for_target_drops_only_exact_target() {
-    let listeners = Listeners::default();
-    let event = crate::EventName::new("test-event".to_owned()).unwrap();
-
-    let window = listeners.listen(event.clone(), EventTarget::window("main"), event_fn);
-    // Same label as the window, but a different target kind (multi-webview mode).
-    let webview = listeners.listen(event.clone(), EventTarget::webview("main"), event_fn);
-    let webview_window =
-      listeners.listen(event.clone(), EventTarget::webview_window("main"), event_fn);
-    let other = listeners.listen(event.clone(), EventTarget::webview("other"), event_fn);
-    let app = listeners.listen(event.clone(), EventTarget::App, event_fn);
-    let any = listeners.listen(event.clone(), EventTarget::Any, event_fn);
-    let labeled = listeners.listen(event.clone(), EventTarget::labeled("main"), event_fn);
-
-    listeners.remove_listeners_for_target(EventTarget::webview("main"));
-
-    let lock = listeners.inner.handlers.lock().unwrap();
-    let remaining: HashSet<EventId> = lock.get(&event).unwrap().keys().copied().collect();
-
-    // only the exact `Webview { label: "main" }` listener is gone
-    assert!(!remaining.contains(&webview));
-    // same label but different kind is kept
-    assert!(remaining.contains(&window));
-    assert!(remaining.contains(&webview_window));
-    // unrelated and global listeners are kept
-    assert!(remaining.contains(&other));
-    assert!(remaining.contains(&app));
-    assert!(remaining.contains(&any));
-    assert!(remaining.contains(&labeled));
-  }
-
-  #[test]
   fn event_no_deadlocks() {
     let listeners = Listeners::default();
     let listeners_clone = listeners.clone();
@@ -464,24 +432,50 @@ mod test {
   }
 
   #[test]
-  fn js_listeners_removed_on_webview_close() {
+  fn listeners_removed_on_webview_close() {
     let listeners = Listeners::default();
-    let event = crate::EventName::new("some-event".to_owned()).unwrap();
+    let event = crate::EventName::new("test-event".to_owned()).unwrap();
     let webview_label = "main";
+
+    let window = listeners.listen(event.clone(), EventTarget::window(webview_label), event_fn);
+    // Same label as the window, but a different target kind (multi-webview mode).
+    let webview = listeners.listen(event.clone(), EventTarget::webview(webview_label), event_fn);
+    let webview_window = listeners.listen(
+      event.clone(),
+      EventTarget::webview_window(webview_label),
+      event_fn,
+    );
+    let other = listeners.listen(event.clone(), EventTarget::webview("other"), event_fn);
+    let app = listeners.listen(event.clone(), EventTarget::App, event_fn);
+    let any = listeners.listen(event.clone(), EventTarget::Any, event_fn);
+    let labeled = listeners.listen(event.clone(), EventTarget::labeled(webview_label), event_fn);
 
     let id = listeners.next_event_id();
     listeners.listen_js(
       event.as_str_event(),
       webview_label,
-      EventTarget::Webview {
-        label: webview_label.to_owned(),
-      },
+      EventTarget::webview(webview_label),
       id,
     );
     assert!(listeners.has_js_listener(event.as_str_event(), |_| true));
 
-    // dropping the source webview must drop its JS listeners.
     listeners.remove_webview_js_listeners(webview_label);
+    listeners.remove_listeners_for_target(EventTarget::webview(webview_label));
+
     assert!(!listeners.has_js_listener(event.as_str_event(), |_| true));
+
+    let lock = listeners.inner.handlers.lock().unwrap();
+    let remaining: HashSet<EventId> = lock.get(&event).unwrap().keys().copied().collect();
+
+    // only the exact `Webview { label: "main" }` listener is gone
+    assert!(!remaining.contains(&webview));
+    // same label but different kind is kept
+    assert!(remaining.contains(&window));
+    assert!(remaining.contains(&webview_window));
+    // unrelated and global listeners are kept
+    assert!(remaining.contains(&other));
+    assert!(remaining.contains(&app));
+    assert!(remaining.contains(&any));
+    assert!(remaining.contains(&labeled));
   }
 }

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -663,21 +663,15 @@ impl<R: Runtime> AppManager<R> {
           .remove_webview_js_listeners(webview.label());
         self
           .listeners()
-          .remove_listeners_for_target(EventTarget::Webview {
-            label: webview.label().to_string(),
-          });
+          .remove_listeners_for_target(EventTarget::webview(webview.label()));
       }
     }
     self
       .listeners()
-      .remove_listeners_for_target(EventTarget::Window {
-        label: label.to_string(),
-      });
+      .remove_listeners_for_target(EventTarget::window(label));
     self
       .listeners()
-      .remove_listeners_for_target(EventTarget::WebviewWindow {
-        label: label.to_string(),
-      });
+      .remove_listeners_for_target(EventTarget::webview_window(label));
   }
 
   #[cfg(desktop)]
@@ -686,9 +680,7 @@ impl<R: Runtime> AppManager<R> {
     self.listeners().remove_webview_js_listeners(label);
     self
       .listeners()
-      .remove_listeners_for_target(EventTarget::Webview {
-        label: label.to_string(),
-      });
+      .remove_listeners_for_target(EventTarget::webview(label));
   }
 
   pub fn windows(&self) -> HashMap<String, Window<R>> {

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -658,29 +658,16 @@ impl<R: Runtime> AppManager<R> {
     if let Some(window) = window {
       for webview in window.webviews() {
         self.webview.webviews_lock().remove(webview.label());
-        self
-          .listeners()
-          .remove_webview_js_listeners(webview.label());
-        self
-          .listeners()
-          .remove_listeners_for_target(EventTarget::webview(webview.label()));
+        self.listeners().remove_webview_listeners(webview.label());
       }
     }
-    self
-      .listeners()
-      .remove_listeners_for_target(EventTarget::window(label));
-    self
-      .listeners()
-      .remove_listeners_for_target(EventTarget::webview_window(label));
+    self.listeners().remove_window_listeners(label);
   }
 
   #[cfg(desktop)]
   pub(crate) fn on_webview_close(&self, label: &str) {
     self.webview.webviews_lock().remove(label);
-    self.listeners().remove_webview_js_listeners(label);
-    self
-      .listeners()
-      .remove_listeners_for_target(EventTarget::webview(label));
+    self.listeners().remove_webview_listeners(label);
   }
 
   pub fn windows(&self) -> HashMap<String, Window<R>> {

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -661,14 +661,34 @@ impl<R: Runtime> AppManager<R> {
         self
           .listeners()
           .remove_webview_js_listeners(webview.label());
+        self
+          .listeners()
+          .remove_listeners_for_target(EventTarget::Webview {
+            label: webview.label().to_string(),
+          });
       }
     }
+    self
+      .listeners()
+      .remove_listeners_for_target(EventTarget::Window {
+        label: label.to_string(),
+      });
+    self
+      .listeners()
+      .remove_listeners_for_target(EventTarget::WebviewWindow {
+        label: label.to_string(),
+      });
   }
 
   #[cfg(desktop)]
   pub(crate) fn on_webview_close(&self, label: &str) {
     self.webview.webviews_lock().remove(label);
     self.listeners().remove_webview_js_listeners(label);
+    self
+      .listeners()
+      .remove_listeners_for_target(EventTarget::Webview {
+        label: label.to_string(),
+      });
   }
 
   pub fn windows(&self) -> HashMap<String, Window<R>> {


### PR DESCRIPTION
Closes #15613 (Rust-side follow-up to the listener-leak discussion in #15583).

Rust-side listeners registered via `listen`/`once` on a `Window`, `Webview` or `WebviewWindow` were never removed when that target was destroyed, so the handlers leaked for the lifetime of the app.

### Change

- Add `Listeners::remove_listeners_for_label`, which retains only handlers whose `EventTarget` is not bound to the destroyed label. It follows the existing `try_lock` + `Pending` queue convention so it stays safe if called mid-emit.
- Wire it into `AppManager::on_window_close` (window label + each child webview label) and `on_webview_close`.

`App`, `Any` and `AnyLabel` listeners are kept — only `Window`/`Webview`/`WebviewWindow` targets matching the closed label are dropped.

### Open question

I left `AnyLabel { label }` listeners intact, treating them as explicit cross-target subscriptions rather than something owned by a single window/webview. Happy to also purge those on matching label if you think that fits the intended semantics better.

This is scoped to the native (`handlers`) map only; the JS-side `js_event_listeners` cleanup is a separate concern.

### Test

Added `remove_listeners_for_label_drops_only_owned_targets` verifying that `Window`/`Webview`/`WebviewWindow` listeners for the closed label are removed while unrelated-label, `App`, `Any` and `AnyLabel` listeners survive.