### PR TITLE
Revert "fix(deps): pin time to `<0.3.52`"

### DIFF
--- a/.changes/revert-time-pin.md
+++ b/.changes/revert-time-pin.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:deps
+---
+
+Unpin `time` as a new fixed version `0.3.53` has been published

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8806,7 +8806,6 @@ dependencies = [
  "tauri-runtime-wry",
  "tauri-utils",
  "thiserror 2.0.12",
- "time",
  "tokio",
  "tracing",
  "tray-icon",

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -85,11 +85,6 @@ specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, 
 # WARNING: cookie::Cookie is re-exported so bumping this is a breaking change, documented to be done as a minor bump
 cookie = "0.18"
 
-# Pinning `time` used by `cookie` here to avoid a compilation error, see
-# - https://github.com/tauri-apps/tauri/issues/15615
-# - https://github.com/rwf2/cookie-rs/issues/255
-time = ">=0.3, <0.3.52"
-
 # desktop
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows", target_os = "macos"))'.dependencies]
 muda = { version = "0.19", default-features = false, features = [


### PR DESCRIPTION
Reverts tauri-apps/tauri#15616

time 0.3.53 has been published which fixed the complication error