### PR TITLE
feat(bundler): Update rpm-rs to 0.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
+ "bytes",
  "crypto-common",
  "generic-array",
 ]
@@ -351,7 +352,7 @@ checksum = "844e00dc1e665b3cf0bba745aa9c6464292ca512db0c11384511586701eb0335"
 dependencies = [
  "base64 0.21.7",
  "bcder",
- "bzip2",
+ "bzip2 0.4.4",
  "chrono",
  "cryptographic-message-syntax",
  "digest",
@@ -710,10 +711,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
-name = "bitfield"
-version = "0.14.0"
+name = "bitfields"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+checksum = "ef6e59298da389bc0649c7463856b34c6e17fe542f88939426ede4436c6b1195"
+dependencies = [
+ "bitfields-impl",
+]
+
+[[package]]
+name = "bitfields-impl"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c044f98f86f15414668d6c8187c7e4fadab1ad2b31680f648703e0fe07c555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "bitflags"
@@ -992,6 +1008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1101,7 @@ dependencies = [
  "serde",
  "serde_json",
  "textwrap",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "toml 1.0.6+spec-1.1.0",
  "ureq",
  "which",
@@ -1309,7 +1334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1488,12 +1513,6 @@ name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
-
-[[package]]
-name = "cpio"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938e716cb1ade5d6c8f959c13a7248b889c07491fc7e41167c3afe20f8f0de1e"
 
 [[package]]
 name = "cpio-archive"
@@ -1692,7 +1711,7 @@ dependencies = [
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
- "fiat-crypto 0.2.9",
+ "fiat-crypto",
  "rand_core 0.6.4",
  "rustc_version",
  "subtle",
@@ -1708,6 +1727,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "cx448"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c0cf476284b03eb6c10e78787b21c7abb7d7d43cb2f02532ba6b831ed892fa"
+dependencies = [
+ "crypto-bigint",
+ "elliptic-curve",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serdect 0.3.0",
+ "sha3",
+ "signature",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1868,32 +1904,11 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl 2.0.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "unicode-xid",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -1905,6 +1920,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2177,21 +2193,11 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "ed448-goldilocks"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b5fa9e9e3dd5fe1369f380acd3dcdfa766dbd0a1cd5b048fb40e38a6a78e79"
-dependencies = [
- "fiat-crypto 0.1.20",
- "hex",
- "subtle",
 ]
 
 [[package]]
@@ -2213,6 +2219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
+ "base64ct",
  "crypto-bigint",
  "digest",
  "ff",
@@ -2223,7 +2230,10 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serde_json",
+ "serdect 0.2.0",
  "subtle",
+ "tap",
  "zeroize",
 ]
 
@@ -2375,7 +2385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2434,15 +2444,10 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fiat-crypto"
@@ -2904,8 +2909,19 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -3189,7 +3205,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3374,6 +3390,25 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d35805454dc9f8662a98d6d61886ffe26bd465f5960e0e55345c70d5c0d2a9"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
+dependencies = [
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -3905,12 +3940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "iter-read"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071ed4cc1afd86650602c7b11aa2e1ce30762a1c27193201cb5cee9c6ebb1294"
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,6 +3962,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4223,6 +4261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kem"
+version = "0.3.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8645470337db67b01a7f966decf7d0bafedbae74147d33e641c67a91df239f"
+dependencies = [
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4333,6 +4381,12 @@ dependencies = [
  "libloading 0.7.4",
  "once_cell",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -4700,6 +4754,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac4a46643af2001eafebcc37031fc459eb72d45057aac5d7a15b00046a2ad6db"
+dependencies = [
+ "const-oid",
+ "hybrid-array 0.3.1",
+ "num-traits",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha3",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de49b3df74c35498c0232031bb7e85f9389f913e2796169c8ab47a53993a18f"
+dependencies = [
+ "hybrid-array 0.2.3",
+ "kem",
+ "rand_core 0.6.4",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,7 +4800,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -5852,7 +5935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "ucd-trie",
 ]
 
@@ -5892,31 +5975,33 @@ dependencies = [
 
 [[package]]
 name = "pgp"
-version = "0.14.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1877a97fd422433220ad272eb008ec55691944b1200e9eb204e3cb2cb69d34e9"
+checksum = "eaffe1ec22db286599c30ae6be75b37493b558735d86c8e59ec5c38794415fe4"
 dependencies = [
+ "aead",
  "aes",
  "aes-gcm",
  "aes-kw",
  "argon2",
  "base64 0.22.1",
- "bitfield",
+ "bitfields",
  "block-padding",
  "blowfish",
- "bstr",
  "buffer-redux",
  "byteorder",
+ "bytes",
+ "bzip2 0.6.1",
  "camellia",
  "cast5",
  "cfb-mode",
- "chrono",
  "cipher",
  "const-oid",
  "crc24",
  "curve25519-dalek",
+ "cx448",
  "derive_builder",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "des",
  "digest",
  "dsa",
@@ -5929,11 +6014,12 @@ dependencies = [
  "hex",
  "hkdf",
  "idea",
- "iter-read",
  "k256",
  "log",
  "md-5",
- "nom 7.1.3",
+ "ml-dsa",
+ "ml-kem",
+ "nom 8.0.0",
  "num-bigint-dig",
  "num-traits",
  "num_enum",
@@ -5942,6 +6028,8 @@ dependencies = [
  "p384",
  "p521",
  "rand 0.8.6",
+ "regex",
+ "replace_with",
  "ripemd",
  "rsa",
  "sha1",
@@ -5949,11 +6037,11 @@ dependencies = [
  "sha2",
  "sha3",
  "signature",
+ "slh-dsa",
  "smallvec",
- "thiserror 1.0.69",
+ "snafu 0.8.9",
  "twofish",
  "x25519-dalek",
- "x448",
  "zeroize",
 ]
 
@@ -6499,9 +6587,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -6511,6 +6599,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -6657,7 +6751,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rasn-derive",
- "snafu",
+ "snafu 0.7.5",
 ]
 
 [[package]]
@@ -6788,7 +6882,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6862,6 +6956,12 @@ checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
+
+[[package]]
+name = "replace_with"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "reqwest"
@@ -7078,33 +7178,42 @@ dependencies = [
 
 [[package]]
 name = "rpm"
-version = "0.16.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1630639f4dbc1c71ad7b704cda2171584c80735c502efae94804d02763fc6f7d"
+checksum = "3a5c5d43b95d73d6f0a1b8fbeab72a7ebebf618cdc99f2b9a28f269ee343766e"
 dependencies = [
+ "base64 0.22.1",
  "bitflags 2.7.0",
- "bzip2",
+ "bzip2 0.6.1",
  "chrono",
- "cpio",
  "digest",
  "enum-display-derive",
  "enum-primitive-derive",
  "flate2",
+ "getrandom 0.4.3",
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
- "md-5",
- "nom 7.1.3",
+ "memchr",
+ "nom 8.0.0",
  "num",
  "num-derive",
  "num-traits",
  "pgp",
+ "rpm-version",
  "sha1",
  "sha2",
- "thiserror 2.0.12",
- "xz2",
+ "sha3",
+ "thiserror 2.0.18",
+ "zeroize",
  "zstd",
 ]
+
+[[package]]
+name = "rpm-version"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56568fb1bf1d2c0a640aac216b3d84d65e210ca1997df922bf124f2bfaf9efd9"
 
 [[package]]
 name = "rsa"
@@ -7206,7 +7315,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7219,7 +7328,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7570,6 +7679,7 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -7866,6 +7976,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8135,6 +8265,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "slh-dsa"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2f20f4049197e03db1104a6452f4d9e96665d79f880198dce4a7026ba5f267"
+dependencies = [
+ "const-oid",
+ "digest",
+ "hmac",
+ "hybrid-array 0.3.1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "sha3",
+ "signature",
+ "typenum",
+ "zerocopy",
+]
+
+[[package]]
 name = "slotmap"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8163,7 +8312,16 @@ checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
 dependencies = [
  "backtrace",
  "doc-comment",
- "snafu-derive",
+ "snafu-derive 0.7.5",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive 0.8.9",
 ]
 
 [[package]]
@@ -8176,6 +8334,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8775,7 +8945,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tray-icon",
@@ -8842,7 +9012,7 @@ dependencies = [
  "tauri-macos-sign",
  "tauri-utils",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
  "ureq",
  "url",
@@ -8922,7 +9092,7 @@ dependencies = [
  "tauri-macos-sign",
  "tauri-utils",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "toml 1.0.6+spec-1.1.0",
  "toml_edit 0.25.4+spec-1.1.0",
@@ -8964,7 +9134,7 @@ dependencies = [
  "sha2",
  "syn 2.0.117",
  "tauri-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -9030,7 +9200,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "x509-certificate 0.23.1",
 ]
 
@@ -9078,7 +9248,7 @@ dependencies = [
  "swift-rs",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -9090,7 +9260,7 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9109,7 +9279,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webview2-com",
@@ -9203,7 +9373,7 @@ dependencies = [
  "swift-rs",
  "tauri",
  "tempfile",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "toml 1.0.6+spec-1.1.0",
  "url",
  "urlpattern",
@@ -9244,7 +9414,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "rustix 0.38.43",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9310,11 +9480,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -9330,9 +9500,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9751,7 +9921,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
 
@@ -9805,7 +9975,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -10511,7 +10681,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "windows 0.61.1",
  "windows-core 0.61.0",
 ]
@@ -10571,7 +10741,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11195,7 +11365,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "webkit2gtk",
@@ -11247,17 +11417,6 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "x448"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd07d4fae29e07089dbcacf7077cd52dce7760125ca9a4dd5a35ca603ffebb"
-dependencies = [
- "ed448-goldilocks",
- "hex",
- "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/crates/tauri-bundler/Cargo.toml
+++ b/crates/tauri-bundler/Cargo.toml
@@ -66,7 +66,13 @@ heck = "0.5"
 ar = "0.9"
 md5 = "0.8"
 # TODO: xz-compression's `lzma` conflicts with apple-codesign's `xz`
-rpm = { version = "0.25.1", default-features = false, features = ["gzip-compression", "payload", "signature-pgp", "zstd-compression", "bzip2-compression"] }
+rpm = { version = "0.25.1", default-features = false, features = [
+  "gzip-compression",
+  "payload",
+  "signature-pgp",
+  "zstd-compression",
+  "bzip2-compression",
+] }
 
 [target."cfg(unix)".dependencies]
 which = "8"

--- a/crates/tauri-bundler/Cargo.toml
+++ b/crates/tauri-bundler/Cargo.toml
@@ -65,7 +65,8 @@ tauri-macos-sign = { version = "2.3.4", path = "../tauri-macos-sign" }
 heck = "0.5"
 ar = "0.9"
 md5 = "0.8"
-rpm = { version = "0.16", features = ["bzip2-compression"] }
+# TODO: xz-compression's `lzma` conflicts with apple-codesign's `xz`
+rpm = { version = "0.25.1", default-features = false, features = ["gzip-compression", "payload", "signature-pgp", "zstd-compression", "bzip2-compression"] }
 
 [target."cfg(unix)".dependencies]
 which = "8"

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -5,10 +5,10 @@
 
 use crate::{bundle::settings::Arch, error::ErrorExt, Settings};
 
-use rpm::{self, signature::pgp, Dependency, FileMode, FileOptions};
+use rpm::{self, Dependency, FileOptions, signature::pgp};
 use std::{
   env,
-  fs::{self, File},
+  fs,
   path::{Path, PathBuf},
 };
 use tauri_utils::config::RpmCompression;
@@ -71,26 +71,26 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
       RpmCompression::Bzip2 { level } => rpm::CompressionWithLevel::Bzip2(level),
       _ => rpm::CompressionWithLevel::None,
     })
-    // This matches .deb compression. On a 240MB source binary the bundle will be 100KB larger than rpm's default while reducing build times by ~25%.
-    // TODO: Default to Zstd in v3 to match rpm-rs new default in 0.16
-    .unwrap_or(rpm::CompressionWithLevel::Gzip(6));
+    .unwrap_or_default();
 
-  let mut builder = rpm::PackageBuilder::new(&name, version, &license, arch, summary)
+  let build_config = rpm::BuildConfig::default().compression(compression);
+
+  let mut builder = rpm::PackageBuilder::new(&name, version, &license, arch, summary);
+    builder.using_config(build_config)
     .epoch(epoch)
-    .release(release)
-    .compression(compression);
+    .release(release);
 
   if let Some(description) = settings.long_description() {
-    builder = builder.description(description);
+    builder.description(description);
   }
 
   if let Some(homepage) = settings.homepage_url() {
-    builder = builder.url(homepage);
+    builder.url(homepage);
   }
 
   // Add requirements
   for dep in settings.rpm().depends.as_ref().cloned().unwrap_or_default() {
-    builder = builder.requires(Dependency::any(dep));
+    builder.requires(Dependency::any(dep));
   }
 
   // Add provides
@@ -101,7 +101,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     .cloned()
     .unwrap_or_default()
   {
-    builder = builder.provides(Dependency::any(dep));
+    builder.provides(Dependency::any(dep));
   }
 
   // Add recommends
@@ -112,7 +112,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     .cloned()
     .unwrap_or_default()
   {
-    builder = builder.recommends(Dependency::any(dep));
+    builder.recommends(Dependency::any(dep));
   }
 
   // Add conflicts
@@ -123,7 +123,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     .cloned()
     .unwrap_or_default()
   {
-    builder = builder.conflicts(Dependency::any(dep));
+    builder.conflicts(Dependency::any(dep));
   }
 
   // Add obsoletes
@@ -134,14 +134,14 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     .cloned()
     .unwrap_or_default()
   {
-    builder = builder.obsoletes(Dependency::any(dep));
+    builder.obsoletes(Dependency::any(dep));
   }
 
   // Add binaries
   for bin in settings.binaries() {
     let src = settings.binary_path(bin);
     let dest = Path::new("/usr/bin").join(bin.name());
-    builder = builder.with_file(src, FileOptions::new(dest.to_string_lossy()))?;
+    builder.with_file(src, FileOptions::new(dest.to_string_lossy()))?;
   }
 
   // Add external binaries
@@ -154,81 +154,74 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
         .to_string_lossy()
         .replace(&format!("-{}", settings.target()), ""),
     );
-    builder = builder.with_file(&src, FileOptions::new(dest.to_string_lossy()))?;
+    builder.with_file(&src, FileOptions::new(dest.to_string_lossy()))?;
   }
 
   // Add scripts
   if let Some(script_path) = &settings.rpm().pre_install_script {
     let script = fs::read_to_string(script_path)?;
-    builder = builder.pre_install_script(script);
+    builder.pre_install_script(script);
   }
 
   if let Some(script_path) = &settings.rpm().post_install_script {
     let script = fs::read_to_string(script_path)?;
-    builder = builder.post_install_script(script);
+    builder.post_install_script(script);
   }
 
   if let Some(script_path) = &settings.rpm().pre_remove_script {
     let script = fs::read_to_string(script_path)?;
-    builder = builder.pre_uninstall_script(script);
+    builder.pre_uninstall_script(script);
   }
 
   if let Some(script_path) = &settings.rpm().post_remove_script {
     let script = fs::read_to_string(script_path)?;
-    builder = builder.post_uninstall_script(script);
+    builder.post_uninstall_script(script);
   }
 
   // Add resources
   if settings.resource_files().count() > 0 {
     let resource_dir = Path::new("/usr/lib").join(settings.product_name());
-    // Create an empty file, needed to add a directory to the RPM package
-    // (cf https://github.com/rpm-rs/rpm/issues/177)
-    let empty_file_path = &package_dir.join("empty");
-    File::create(empty_file_path)?;
-    // Then add the resource directory `/usr/lib/<product_name>` to the package.
-    builder = builder.with_file(
-      empty_file_path,
-      FileOptions::new(resource_dir.to_string_lossy()).mode(FileMode::Dir { permissions: 0o755 }),
+    builder.with_dir_entry(
+      FileOptions::dir(resource_dir.to_string_lossy()).permissions(0o755),
     )?;
     // Then add the resources files in that directory
     for resource in settings.resource_files().iter() {
       let resource = resource?;
       let dest = resource_dir.join(resource.target());
-      builder = builder.with_file(resource.path(), FileOptions::new(dest.to_string_lossy()))?;
+      builder.with_file(resource.path(), FileOptions::new(dest.to_string_lossy()))?;
     }
   }
 
   // Add Desktop entry file
   let (desktop_src_path, desktop_dest_path) =
     freedesktop::generate_desktop_file(settings, &settings.rpm().desktop_template, &package_dir)?;
-  builder = builder.with_file(
+  builder.with_file(
     desktop_src_path,
     FileOptions::new(desktop_dest_path.to_string_lossy()),
   )?;
 
   // Add icons
   for (icon, src) in &freedesktop::list_icon_files(settings, &PathBuf::from("/"))? {
-    builder = builder.with_file(src, FileOptions::new(icon.path.to_string_lossy()))?;
+    builder.with_file(src, FileOptions::new(icon.path.to_string_lossy()))?;
   }
 
   // Add custom files
   for (rpm_path, src_path) in settings.rpm().files.iter() {
     if src_path.is_file() {
-      builder = builder.with_file(src_path, FileOptions::new(rpm_path.to_string_lossy()))?;
+      builder.with_file(src_path, FileOptions::new(rpm_path.to_string_lossy()))?;
     } else {
       for entry in walkdir::WalkDir::new(src_path) {
         let entry_path = entry?.into_path();
         if entry_path.is_file() {
           let dest_path = rpm_path.join(entry_path.strip_prefix(src_path).unwrap());
-          builder =
-            builder.with_file(&entry_path, FileOptions::new(dest_path.to_string_lossy()))?;
+          builder.with_file(&entry_path, FileOptions::new(dest_path.to_string_lossy()))?;
         }
       }
     }
   }
 
   let pkg = if let Ok(raw_secret_key) = env::var("TAURI_SIGNING_RPM_KEY") {
-    let mut signer = pgp::Signer::load_from_asc(&raw_secret_key)?;
+    let mut signer = pgp::Signer::from_asc(&raw_secret_key)?;
     if let Ok(passphrase) = env::var("TAURI_SIGNING_RPM_KEY_PASSPHRASE") {
       signer = signer.with_key_passphrase(passphrase);
     }

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -5,10 +5,9 @@
 
 use crate::{bundle::settings::Arch, error::ErrorExt, Settings};
 
-use rpm::{self, Dependency, FileOptions, signature::pgp};
+use rpm::{self, signature::pgp, Dependency, FileOptions};
 use std::{
-  env,
-  fs,
+  env, fs,
   path::{Path, PathBuf},
 };
 use tauri_utils::config::RpmCompression;
@@ -76,7 +75,8 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   let build_config = rpm::BuildConfig::default().compression(compression);
 
   let mut builder = rpm::PackageBuilder::new(&name, version, &license, arch, summary);
-    builder.using_config(build_config)
+  builder
+    .using_config(build_config)
     .epoch(epoch)
     .release(release);
 
@@ -181,9 +181,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   // Add resources
   if settings.resource_files().count() > 0 {
     let resource_dir = Path::new("/usr/lib").join(settings.product_name());
-    builder.with_dir_entry(
-      FileOptions::dir(resource_dir.to_string_lossy()).permissions(0o755),
-    )?;
+    builder.with_dir_entry(FileOptions::dir(resource_dir.to_string_lossy()).permissions(0o755))?;
     // Then add the resources files in that directory
     for resource in settings.resource_files().iter() {
       let resource = resource?;

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -3503,7 +3503,7 @@
           ]
         },
         "compression": {
-          "description": "Compression algorithm and level. Defaults to `Gzip` with level 6.",
+          "description": "Compression algorithm and level. Defaults to Zstd(19).\n The default can change across versions and follows [rpm-rs](<https://github.com/rpm-rs/rpm-rs/blob/master/src/rpm/compressor.rs>).",
           "anyOf": [
             {
               "$ref": "#/definitions/RpmCompression"

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -3503,7 +3503,7 @@
           ]
         },
         "compression": {
-          "description": "Compression algorithm and level. Defaults to `Gzip` with level 6.",
+          "description": "Compression algorithm and level. Defaults to Zstd(19).\n The default can change across versions and follows [rpm-rs](<https://github.com/rpm-rs/rpm-rs/blob/master/src/rpm/compressor.rs>).",
           "anyOf": [
             {
               "$ref": "#/definitions/RpmCompression"

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -477,7 +477,8 @@ pub struct RpmConfig {
   /// <http://ftp.rpm.org/max-rpm/s1-rpm-inside-scripts.html>
   #[serde(alias = "post-remove-script")]
   pub post_remove_script: Option<PathBuf>,
-  /// Compression algorithm and level. Defaults to `Gzip` with level 6.
+  /// Compression algorithm and level. Defaults to Zstd(19).
+  /// The default can change across versions and follows [rpm-rs](<https://github.com/rpm-rs/rpm-rs/blob/master/src/rpm/compressor.rs>).
   pub compression: Option<RpmCompression>,
 }
 


### PR DESCRIPTION
This either has to wait for a new apple-codesign / apple-xar version or we silently drop xz compression. apple-xar is already updated on git https://github.com/indygreg/apple-platform-rs/blob/main/apple-xar/Cargo.toml#L35 but not published yet.