### PR TITLE
fix(android): re-register activity result launchers on activity recreation

### DIFF
--- a/.changes/android-reregister-activity-launchers.md
+++ b/.changes/android-reregister-activity-launchers.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+Re-register the Android `ActivityResultLauncher`s (permission requests, `startActivityForResult`, `startIntentSenderForResult`) whenever the activity is recreated, instead of keeping the ones bound to the previous activity. This fixes an `IllegalStateException: Attempting to launch an unregistered ActivityResultLauncher` crash that happened after the activity was recreated (e.g. on rotation or theme changes).

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginManager.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginManager.kt
@@ -56,10 +56,12 @@ object PluginManager {
   }
 
   fun onActivityCreate(activity: AppCompatActivity) {
-    // TODO: on destroy, we should change to a different activity
-    if (::activity.isInitialized) {
-      return
-    }
+    // Android can recreate the activity after launch (configuration changes such as
+    // rotation or light/dark mode, the system reclaiming memory, etc.). When that
+    // happens `onActivityCreate` runs again with the new activity, so we must rebind
+    // to it and re-register the launchers. Bailing out early would keep the launchers
+    // tied to the destroyed activity, causing `launch()` to throw
+    // "Attempting to launch an unregistered ActivityResultLauncher".
     this.activity = activity
     startActivityForResultLauncher =
       activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()


### PR DESCRIPTION
Closes #15506

`PluginManager.onActivityCreate` returned early once `activity` was set, so the `ActivityResultLauncher`s stayed registered against the first activity. When Android recreates the activity (rotation, light/dark switch, process death, …), `onActivityCreate` runs again with the new activity but the early return kept the stale launchers. The next `requestPermissions` / `startActivityForResult` / `startIntentSenderForResult` then crashed:

```
java.lang.IllegalStateException: Attempting to launch an unregistered ActivityResultLauncher ...
You must ensure the ActivityResultLauncher is registered before calling launch().
```

`onActivityCreate` is invoked from `TauriActivity.onCreate`, which is the correct place to call `registerForActivityResult`, so this just rebinds `activity` and re-registers the three launchers on every call instead of bailing out. Removes the pre-existing `// TODO: on destroy, we should change to a different activity`.

Reported repro: request runtime permissions after the activity has been recreated.