### PR TITLE
fix(cli): prevent malformed tauri.conf.json from unsanitized user input

### DIFF
--- a/crates/tauri-cli/src/helpers/prompts.rs
+++ b/crates/tauri-cli/src/helpers/prompts.rs
@@ -6,6 +6,27 @@ use std::{fmt::Display, str::FromStr};
 
 use crate::{error::Context, Result};
 
+fn strip_surrounding_quotes(input: &str) -> &str {
+  let bytes = input.as_bytes();
+  if bytes.len() >= 2 {
+    let first = bytes[0];
+    let last = bytes[bytes.len() - 1];
+    if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+      return &input[1..input.len() - 1];
+    }
+  }
+  input
+}
+
+fn validate_common(input: &str) -> std::result::Result<(), String> {
+  if let Some(c) = input.chars().find(|c| c.is_control() && *c != '\t') {
+    return Err(format!(
+      "invalid input: control characters are not allowed (found {c:?})"
+    ));
+  }
+  Ok(())
+}
+
 pub fn input<T>(
   prompt: &str,
   initial: Option<T>,
@@ -13,27 +34,47 @@ pub fn input<T>(
   allow_empty: bool,
 ) -> Result<Option<T>>
 where
-  T: Clone + FromStr + Display + ToString,
-  T::Err: Display + std::fmt::Debug,
-  T: PartialEq<str>,
+    T: Clone + FromStr + Display + ToString,
+    T::Err: Display + std::fmt::Debug,
+    T: PartialEq<str>,
 {
   if skip {
-    Ok(initial)
-  } else {
-    let theme = dialoguer::theme::ColorfulTheme::default();
-    let mut builder = dialoguer::Input::with_theme(&theme)
-      .with_prompt(prompt)
-      .allow_empty(allow_empty);
-
-    if let Some(v) = initial {
-      builder = builder.with_initial_text(v.to_string());
-    }
-
-    builder
-      .interact_text()
-      .map(|t: T| if t.ne("") { Some(t) } else { None })
-      .context("failed to prompt input")
+    return Ok(initial);
   }
+
+  let theme = dialoguer::theme::ColorfulTheme::default();
+  let mut builder = dialoguer::Input::with_theme(&theme)
+      .with_prompt(prompt)
+      .allow_empty(allow_empty)
+      .validate_with(|input: &T| -> std::result::Result<(), String> {
+        let raw = input.to_string();
+        let normalized = strip_surrounding_quotes(&raw);
+        validate_common(normalized)
+      });
+
+  if let Some(v) = &initial {
+    builder = builder.with_initial_text(v.to_string());
+  }
+
+  let value = builder.interact_text().context("failed to prompt input")?;
+
+  let raw = value.to_string();
+  let normalized = strip_surrounding_quotes(&raw);
+
+  if normalized.is_empty() {
+    return Ok(None);
+  }
+
+  if normalized == raw {
+    return Ok(Some(value));
+  }
+
+  T::from_str(normalized)
+      .ok()
+      .context(format!(
+        "invalid value {normalized:?} (after removing surrounding quotes)"
+      ))
+      .map(Some)
 }
 
 pub fn confirm(prompt: &str, default: Option<bool>) -> Result<bool> {
@@ -52,10 +93,25 @@ pub fn multiselect<T: ToString>(
 ) -> Result<Vec<usize>> {
   let theme = dialoguer::theme::ColorfulTheme::default();
   let mut builder = dialoguer::MultiSelect::with_theme(&theme)
-    .with_prompt(prompt)
-    .items(items);
+      .with_prompt(prompt)
+      .items(items);
   if let Some(defaults) = defaults {
     builder = builder.defaults(defaults);
   }
   builder.interact().context("failed to prompt multi-select")
+}
+
+pub fn validate_url(value: &str) -> std::result::Result<(), String> {
+  if value.trim().is_empty() {
+    return Ok(());
+  }
+  if value.chars().any(char::is_whitespace) {
+    return Err(format!("the URL {value:?} must not contain whitespace"));
+  }
+  if !value.contains("://") {
+    return Err(format!(
+      "the URL {value:?} is missing a scheme, e.g. http:// or https://"
+    ));
+  }
+  Ok(())
 }

--- a/crates/tauri-cli/src/init.rs
+++ b/crates/tauri-cli/src/init.rs
@@ -79,9 +79,9 @@ impl Options {
 
     let init_defaults = if package_json_path.exists() {
       let package_json_text =
-        read_to_string(&package_json_path).fs_context("failed to read", &package_json_path)?;
+          read_to_string(&package_json_path).fs_context("failed to read", &package_json_path)?;
       let package_json: crate::PackageJson =
-        serde_json::from_str(&package_json_text).context("failed to parse JSON")?;
+          serde_json::from_str(&package_json_text).context("failed to parse JSON")?;
       let (framework, _) = infer_framework(&package_json_text);
       InitDefaults {
         app_name: package_json.product_name.or(package_json.name),
@@ -96,9 +96,9 @@ impl Options {
         "What is your app name?",
         Some(
           init_defaults
-            .app_name
-            .clone()
-            .unwrap_or_else(|| "Tauri App".to_string()),
+              .app_name
+              .clone()
+              .unwrap_or_else(|| "Tauri App".to_string()),
         ),
         self.ci,
         true,
@@ -110,9 +110,9 @@ impl Options {
         "What should the window title be?",
         Some(
           init_defaults
-            .app_name
-            .clone()
-            .unwrap_or_else(|| "Tauri".to_string()),
+              .app_name
+              .clone()
+              .unwrap_or_else(|| "Tauri".to_string()),
         ),
         self.ci,
         true,
@@ -135,31 +135,37 @@ impl Options {
       )
     })?;
 
+    if let Some(dev_url) = &self.dev_url {
+      if let Err(reason) = prompts::validate_url(dev_url) {
+        None::<()>.context(reason)?;
+      }
+    }
+
     let detected_package_manager = PackageManager::from_project(&self.directory);
 
     self.before_dev_command = self
-      .before_dev_command
-      .map(|s| Ok(Some(s)))
-      .unwrap_or_else(|| {
-        prompts::input(
-          "What is your frontend dev command?",
-          Some(default_dev_command(detected_package_manager).into()),
-          self.ci,
-          true,
-        )
-      })?;
+        .before_dev_command
+        .map(|s| Ok(Some(s)))
+        .unwrap_or_else(|| {
+          prompts::input(
+            "What is your frontend dev command?",
+            Some(default_dev_command(detected_package_manager).into()),
+            self.ci,
+            true,
+          )
+        })?;
 
     self.before_build_command = self
-      .before_build_command
-      .map(|s| Ok(Some(s)))
-      .unwrap_or_else(|| {
-        prompts::input(
-          "What is your frontend build command?",
-          Some(default_build_command(detected_package_manager).into()),
-          self.ci,
-          true,
-        )
-      })?;
+        .before_build_command
+        .map(|s| Ok(Some(s)))
+        .unwrap_or_else(|| {
+          prompts::input(
+            "What is your frontend build command?",
+            Some(default_build_command(detected_package_manager).into()),
+            self.ci,
+            true,
+          )
+        })?;
 
     Ok(self)
   }
@@ -187,12 +193,30 @@ fn default_build_command(pm: PackageManager) -> &'static str {
   }
 }
 
+fn escape_json_string(input: &str) -> String {
+  let mut escaped = String::with_capacity(input.len());
+  for c in input.chars() {
+    match c {
+      '"' => escaped.push_str("\\\""),
+      '\\' => escaped.push_str("\\\\"),
+      '\n' => escaped.push_str("\\n"),
+      '\r' => escaped.push_str("\\r"),
+      '\t' => escaped.push_str("\\t"),
+      c if (c as u32) < 0x20 => {
+        escaped.push_str(&format!("\\u{:04x}", c as u32));
+      }
+      c => escaped.push(c),
+    }
+  }
+  escaped
+}
+
 pub fn command(mut options: Options) -> Result<()> {
   options = options.load()?;
 
   let template_target_path = PathBuf::from(&options.directory).join("src-tauri");
   let metadata = serde_json::from_str::<VersionMetadata>(include_str!("../metadata-v2.json"))
-    .context("failed to parse version metadata")?;
+      .context("failed to parse version metadata")?;
 
   if template_target_path.exists() && !options.force {
     log::warn!(
@@ -201,33 +225,33 @@ pub fn command(mut options: Options) -> Result<()> {
     );
   } else {
     let (tauri_dep, tauri_build_dep, tauri_utils_dep, tauri_plugin_dep) =
-      if let Some(tauri_path) = &options.tauri_path {
-        (
-          format!(
-            r#"{{  path = {:?} }}"#,
-            resolve_tauri_path(tauri_path, "crates/tauri")
-          ),
-          format!(
-            "{{  path = {:?} }}",
-            resolve_tauri_path(tauri_path, "crates/tauri-build")
-          ),
-          format!(
-            "{{  path = {:?} }}",
-            resolve_tauri_path(tauri_path, "crates/tauri-utils")
-          ),
-          format!(
-            "{{  path = {:?} }}",
-            resolve_tauri_path(tauri_path, "crates/tauri-plugin")
-          ),
-        )
-      } else {
-        (
-          format!(r#"{{ version = "{}" }}"#, metadata.tauri),
-          format!(r#"{{ version = "{}" }}"#, metadata.tauri_build),
-          r#"{{ version = "2" }}"#.to_string(),
-          r#"{{ version = "2" }}"#.to_string(),
-        )
-      };
+        if let Some(tauri_path) = &options.tauri_path {
+          (
+            format!(
+              r#"{{  path = {:?} }}"#,
+              resolve_tauri_path(tauri_path, "crates/tauri")
+            ),
+            format!(
+              "{{  path = {:?} }}",
+              resolve_tauri_path(tauri_path, "crates/tauri-build")
+            ),
+            format!(
+              "{{  path = {:?} }}",
+              resolve_tauri_path(tauri_path, "crates/tauri-utils")
+            ),
+            format!(
+              "{{  path = {:?} }}",
+              resolve_tauri_path(tauri_path, "crates/tauri-plugin")
+            ),
+          )
+        } else {
+          (
+            format!(r#"{{ version = "{}" }}"#, metadata.tauri),
+            format!(r#"{{ version = "{}" }}"#, metadata.tauri_build),
+            r#"{{ version = "2" }}"#.to_string(),
+            r#"{{ version = "2" }}"#.to_string(),
+          )
+        };
 
     let _ = remove_dir_all(&template_target_path);
     let mut handlebars = Handlebars::new();
@@ -260,12 +284,22 @@ pub fn command(mut options: Options) -> Result<()> {
       to_json(options.before_build_command),
     );
 
-    let mut config = serde_json::from_str(
-      &handlebars
+    // let mut config = serde_json::from_str(
+    //   &handlebars
+    //     .render_template(TAURI_CONF_TEMPLATE, &data)
+    //     .expect("Failed to render tauri.conf.json template"),
+    // )
+    // .unwrap();
+    let mut json_handlebars = Handlebars::new();
+    json_handlebars.register_escape_fn(escape_json_string);
+
+    let rendered = json_handlebars
         .render_template(TAURI_CONF_TEMPLATE, &data)
-        .expect("Failed to render tauri.conf.json template"),
-    )
-    .unwrap();
+        .expect("Failed to render tauri.conf.json template");
+
+    println!("{:#?}", rendered);
+    let mut config: serde_json::Value = serde_json::from_str(&rendered)
+        .with_context(|| format!("failed to parse generated tauri.conf.json:\n{rendered}"))?;
     if option_env!("TARGET") == Some("node") {
       let mut dir = current_dir().expect("failed to read cwd");
       let mut count = 0;
@@ -300,9 +334,9 @@ pub fn command(mut options: Options) -> Result<()> {
           "$schema".into(),
           serde_json::Value::String(
             cli_node_module_path
-              .display()
-              .to_string()
-              .replace('\\', "/"),
+                .display()
+                .to_string()
+                .replace('\\', "/"),
           ),
         );
         let merge_config = serde_json::Value::Object(map);
@@ -312,11 +346,14 @@ pub fn command(mut options: Options) -> Result<()> {
 
     data.insert(
       "tauri_config",
-      to_json(serde_json::to_string_pretty(&config).unwrap()),
+      to_json(
+        serde_json::to_string_pretty(&config)
+            .context("failed to serialize generated tauri.conf.json")?,
+      ),
     );
 
     template::render(&handlebars, &data, &TEMPLATE_DIR, &options.directory)
-      .with_context(|| "failed to render Tauri template")?;
+        .with_context(|| "failed to render Tauri template")?;
   }
 
   Ok(())


### PR DESCRIPTION
Fixes #15635

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
for the fix i reproduice the error localy on my windows 11 machine 
<img width="1814" height="536" alt="Capture d&#39;écran 2026-07-02 162931" src="https://github.com/user-attachments/assets/b9478926-87b6-43fd-ac94-819d08456577" />
the error show me that is en sanitazation the problem the double quote of the name interupted the read of the json because the title was ""title_name"" and in a json is a bad write is you don't echaped the caracter so i propose a correction were i strip the surrounding quotes from every prompt answer before it gets used, and i also escape the user input properly when it's injected into tauri.conf.json, so special characters like quotes, backslashes or newlines can no longer break the generated file. i also added a basic validation for the dev server url, and removed the unwrap() calls that were parsing the generated config, replacing them with proper error handling so a bad value gives a clear error instead of crashing the cli. And is working 
<img width="1837" height="530" alt="Capture d&#39;écran 2026-07-02 232917" src="https://github.com/user-attachments/assets/3b718ece-99c7-45c1-95c7-6198a115f2d2" />

