### PR TITLE
fix: restore CEF macOS app menu after launch

### DIFF
--- a/crates/tauri-runtime-cef/src/runtime.rs
+++ b/crates/tauri-runtime-cef/src/runtime.rs
@@ -54,8 +54,6 @@ use crate::{
   },
   window_handle::SendRawDisplayHandle,
 };
-#[cfg(target_os = "macos")]
-use winit::platform::macos::EventLoopBuilderExtMacOS;
 #[cfg(windows)]
 use winit::platform::windows::EventLoopBuilderExtWindows;
 #[cfg(any(
@@ -1308,9 +1306,6 @@ impl<T: UserEvent> CefRuntime<T> {
       use winit::platform::windows::EventLoopBuilderExtWindows;
       event_loop_builder.with_msg_hook(hook);
     }
-
-    #[cfg(target_os = "macos")]
-    event_loop_builder.with_default_menu(false);
 
     let event_loop = event_loop_builder
       .build()

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -2688,6 +2688,15 @@ fn on_event_loop_event<R: Runtime>(
           unsafe { app.setApplicationIconImage(Some(&app_icon)) };
         }
       }
+
+      #[cfg(all(target_os = "macos", feature = "cef"))]
+      if let Some(menu) = app_handle.manager.menu.menu_lock().clone() {
+        // winit installs a minimal app menu when the macOS event loop starts.
+        // Re-apply Tauri's menu after launch so the Edit submenu and standard
+        // copy/paste accelerators remain available.
+        let _ = init_app_menu(&menu);
+      }
+
       RunEvent::Ready
     }
     RuntimeRunEvent::Resumed => RunEvent::Resumed,


### PR DESCRIPTION
## Summary

- Removes the CEF runtime `with_default_menu(false)` macOS override that regressed startup stability.
- Re-applies Tauri's app menu on macOS CEF after the event loop reports `Ready`, so winit's minimal menu does not leave the app without the standard Edit menu.

## Root Cause

The CEF runtime change in `a06db3aab` disabled winit's default macOS menu creation before building the event loop. In downstream testing this made startup crash with a native malloc abort while the app was also initializing AppKit/CEF and resolving Tauri runtime authority ACLs.

Reverting that suppression restored startup stability, but winit can still install its minimal menu after Tauri has already configured the real app menu. This keeps the stable startup path and restores Tauri's menu after launch so the Edit submenu and standard copy/paste accelerators remain available.

## Validation

- `cargo fmt --package tauri --package tauri-runtime-cef`
- `cargo check -p tauri --no-default-features --features cef`
- Downstream TAP app no longer crashes when pinned before `a06db3aab`; this patch preserves that startup path while restoring the menu after launch.
