### PR TITLE
docs: fix Rust capitalization and crate name in tauri-codegen README

### DIFF
--- a/crates/tauri-codegen/README.md
+++ b/crates/tauri-codegen/README.md
@@ -19,7 +19,7 @@
 
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
-Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
+Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from Rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
 
@@ -30,7 +30,7 @@ To learn more about the details of how all of these pieces fit together, please 
 
 ## Semver
 
-**tauri** is following [Semantic Versioning 2.0](https://semver.org/).
+**tauri-codegen** is following [Semantic Versioning 2.0](https://semver.org/).
 
 ## Licenses
 

--- a/crates/tauri/README.md
+++ b/crates/tauri/README.md
@@ -19,7 +19,7 @@
 
 Tauri is a polyglot and generic system that is very composable and allows engineers to make a wide variety of applications. It is used for building applications for Desktop Computers using a combination of Rust tools and HTML rendered in a Webview. Apps built with Tauri can ship with any number of pieces of an optional JS API / Rust API so that webviews can control the system via message passing. In fact, developers can extend the default API with their own functionality and bridge the Webview and Rust-based backend easily.
 
-Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from rust. This makes the reversing of Tauri apps not a trivial task.
+Tauri apps can have custom menus and have tray-type interfaces. They can be updated, and are managed by the user's operating system as expected. They are very small, because they use the system's webview. They do not ship a runtime, since the final binary is compiled from Rust. This makes the reversing of Tauri apps not a trivial task.
 
 ## This module
 


### PR DESCRIPTION
Fixes two issues in the tauri-codegen README:

1. Capitalize 'Rust' consistently (was lowercase 'rust' on line 22)
2. Correct crate name from 'tauri' to 'tauri-codegen' in the Semver section (line 33)

These are documentation-only changes with no impact on functionality.