### PR TITLE
feat(bundler): add AppImage library exclusion config

### DIFF
--- a/.changes/appimage-exclude-libraries.md
+++ b/.changes/appimage-exclude-libraries.md
@@ -1,0 +1,7 @@
+---
+'tauri-utils': 'minor:feat'
+'tauri-bundler': 'minor:feat'
+'tauri-cli': 'minor:feat'
+---
+
+Add `bundle.linux.appimage.excludeLibraries` to pass linuxdeploy library exclusion patterns when building AppImage bundles.

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -201,6 +201,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   if settings.appimage().bundle_media_framework {
     cmd.args(["--plugin", "gstreamer"]);
   }
+  append_exclude_library_args(&mut cmd, &settings.appimage().exclude_libraries);
   cmd.args(["--output", "appimage"]);
 
   // Linuxdeploy logs everything into stderr so we have to ignore the output ourselves here
@@ -217,6 +218,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
 
   fs::remove_dir_all(&package_dir)?;
   Ok(vec![appimage_path])
+}
+
+fn append_exclude_library_args(cmd: &mut Command, exclude_libraries: &[String]) {
+  for pattern in exclude_libraries {
+    cmd.arg("--exclude-library").arg(pattern);
+  }
 }
 
 // returns the linuxdeploy path to keep linuxdeploy_arch contained
@@ -276,4 +283,32 @@ fn prepare_tools(tools_path: &Path, arch: &str, verbose: bool) -> crate::Result<
     .output();
 
   Ok(linuxdeploy)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn append_exclude_library_args_adds_repeated_linuxdeploy_pairs() {
+    let mut cmd = Command::new("linuxdeploy");
+    let exclude_libraries = vec!["libwayland-*.so*".to_string(), "libEGL*.so*".to_string()];
+
+    append_exclude_library_args(&mut cmd, &exclude_libraries);
+
+    let args = cmd
+      .get_args()
+      .map(|arg| arg.to_string_lossy().into_owned())
+      .collect::<Vec<_>>();
+
+    assert_eq!(
+      args,
+      [
+        "--exclude-library",
+        "libwayland-*.so*",
+        "--exclude-library",
+        "libEGL*.so*"
+      ]
+    );
+  }
 }

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -222,6 +222,8 @@ pub struct AppImageSettings {
   pub files: HashMap<PathBuf, PathBuf>,
   /// Whether to include gstreamer plugins for audio/media support.
   pub bundle_media_framework: bool,
+  /// Shared libraries to exclude from the AppImage dependency deployment.
+  pub exclude_libraries: Vec<String>,
   /// Whether to include the `xdg-open` binary.
   pub bundle_xdg_open: bool,
 }

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -98,6 +98,7 @@
         "linux": {
           "appimage": {
             "bundleMediaFramework": false,
+            "excludeLibraries": [],
             "files": {}
           },
           "deb": {
@@ -2286,6 +2287,7 @@
           "default": {
             "appimage": {
               "bundleMediaFramework": false,
+              "excludeLibraries": [],
               "files": {}
             },
             "deb": {
@@ -3255,6 +3257,7 @@
           "description": "Configuration for the AppImage bundle.",
           "default": {
             "bundleMediaFramework": false,
+            "excludeLibraries": [],
             "files": {}
           },
           "allOf": [
@@ -3298,6 +3301,14 @@
           "description": "Include additional gstreamer dependencies needed for audio and video playback.\n This increases the bundle size by ~15-35MB depending on your build system.",
           "default": false,
           "type": "boolean"
+        },
+        "excludeLibraries": {
+          "description": "Shared libraries to exclude from the AppImage dependency deployment.\n\n Each value is passed to linuxdeploy's `--exclude-library` option as a glob pattern.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "files": {
           "description": "The files to include in the Appimage Binary.",

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1584,6 +1584,7 @@ fn tauri_config_to_bundle_settings(
     appimage: AppImageSettings {
       files: appimage_files,
       bundle_media_framework: config.linux.appimage.bundle_media_framework,
+      exclude_libraries: config.linux.appimage.exclude_libraries,
       bundle_xdg_open: false,
     },
     rpm: RpmSettings {

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -98,6 +98,7 @@
         "linux": {
           "appimage": {
             "bundleMediaFramework": false,
+            "excludeLibraries": [],
             "files": {}
           },
           "deb": {
@@ -2286,6 +2287,7 @@
           "default": {
             "appimage": {
               "bundleMediaFramework": false,
+              "excludeLibraries": [],
               "files": {}
             },
             "deb": {
@@ -3255,6 +3257,7 @@
           "description": "Configuration for the AppImage bundle.",
           "default": {
             "bundleMediaFramework": false,
+            "excludeLibraries": [],
             "files": {}
           },
           "allOf": [
@@ -3298,6 +3301,14 @@
           "description": "Include additional gstreamer dependencies needed for audio and video playback.\n This increases the bundle size by ~15-35MB depending on your build system.",
           "default": false,
           "type": "boolean"
+        },
+        "excludeLibraries": {
+          "description": "Shared libraries to exclude from the AppImage dependency deployment.\n\n Each value is passed to linuxdeploy's `--exclude-library` option as a glob pattern.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "files": {
           "description": "The files to include in the Appimage Binary.",

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -323,6 +323,11 @@ pub struct AppImageConfig {
   /// This increases the bundle size by ~15-35MB depending on your build system.
   #[serde(default, alias = "bundle-media-framework")]
   pub bundle_media_framework: bool,
+  /// Shared libraries to exclude from the AppImage dependency deployment.
+  ///
+  /// Each value is passed to linuxdeploy's `--exclude-library` option as a glob pattern.
+  #[serde(default, alias = "exclude-libraries")]
+  pub exclude_libraries: Vec<String>,
   /// The files to include in the Appimage Binary.
   #[serde(default)]
   pub files: HashMap<PathBuf, PathBuf>,


### PR DESCRIPTION
Adds `bundle.linux.appimage.excludeLibraries`, allowing AppImage builds to pass library exclusion patterns through to linuxdeploy's `--exclude-library` option.

This gives projects a supported way to avoid bundling known problematic system libraries, such as graphics or Wayland stack libraries.

## Reference

linuxdeploy's official AppImage documentation describes it as the AppDir packaging tool used to bundle dependencies and produce AppImages:

- https://docs.appimage.org/packaging-guide/from-source/linuxdeploy-user-guide.html

The exact `--exclude-library` flag is not currently listed in that guide; linuxdeploy exposes it in the CLI as a shared-library exclusion glob:

- https://github.com/linuxdeploy/linuxdeploy/blob/a9f929ff0e32d5c4bcb7b5c380adff4802f918ba/src/main.cpp#L33-L34

Example:

```json
{
  "bundle": {
    "linux": {
      "appimage": {
        "excludeLibraries": ["libwayland-*.so*"]
      }
    }
  }
}
```

## Changes

- Adds `excludeLibraries` to the AppImage config.
- Carries the config through `tauri-cli` into `tauri-bundler`.
- Passes each configured pattern to linuxdeploy as repeated `--exclude-library <pattern>` pairs.
- Adds a targeted unit test for the generated linuxdeploy argument pairs.
- Updates generated config schemas.
- Adds a `.changes` entry.

## Validation

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo test --manifest-path ./crates/tauri-bundler/Cargo.toml append_exclude_library_args_adds_repeated_linuxdeploy_pairs`
- `cargo build --manifest-path crates/tauri-schema-generator/Cargo.toml`
- `cargo check --manifest-path crates/tauri-cli/Cargo.toml`
- `node ./.scripts/ci/check-change-tags.js .changes/appimage-exclude-libraries.md`

`cargo clippy --all-targets --all-features -- -D warnings` currently fails on an unrelated existing lint in `crates/tauri-cli/src/mobile/android/mod.rs:920`.

```
error: called `is_none()` after searching an `Iterator` with `find`
   --> crates/tauri-cli/src/mobile/android/mod.rs:920:8
    |
920 |       if devices
    |  ________^
921 | |       .into_iter()
922 | |       .find(|d| d.serial_no() == serial_no)
923 | |       .is_none()
    | |________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#search_is_some
    = note: `-D clippy::search-is-some` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::search_is_some)]`
help: consider using
    |
920 ~     if !devices
921 +       .into_iter().any(|d| d.serial_no() == serial_no)
    |
```