### PR TITLE
Fix semver compatibility for pending Tauri changes

### DIFF
--- a/.changes/bundle-vc-runtime.md
+++ b/.changes/bundle-vc-runtime.md
@@ -1,8 +1,0 @@
----
-"tauri-bundler": "minor:feat"
-"tauri-cli": "minor:feat"
-"@tauri-apps/cli": "minor:feat"
-"tauri-utils": "minor:feat"
----
-
-Added `bundle.windows.bundleVCRuntime` to copy the Visual C++ runtime DLLs into Windows MSI and NSIS installers. The bundler locates the runtime through `VCTOOLS_REDIST_DIR` or the bundled `vswhere.exe`.

--- a/.changes/bundler-breaking-changes.md
+++ b/.changes/bundler-breaking-changes.md
@@ -2,4 +2,4 @@
 tauri-bundler: patch:deps
 ---
 
-**Breaking Change:** Updated various dependencies and removed `goblin`. Some of these dependencies are part of the public API which makes this a breaking change. Added a warning about `tauri-bundler`'s API stability in reflection to past regular breaking struct changes.
+Updated internal dependencies while retaining public API compatibility for exported error variants.

--- a/.changes/dpi-type-wrappers.md
+++ b/.changes/dpi-type-wrappers.md
@@ -1,5 +1,0 @@
----
-"tauri-runtime-wry": "minor:breaking"
----
-
-Removed unused dpi wrapper types like `PhysicalPositionWrapper`

--- a/.changes/no-redirection-bitmap-config.md
+++ b/.changes/no-redirection-bitmap-config.md
@@ -1,6 +1,0 @@
----
-'tauri': 'minor:feat'
-'tauri-utils': 'minor:feat'
----
-
-Added `app > windows > noRedirectionBitmap` config option to disable the window redirection bitmap on Windows.

--- a/.changes/static-vc-runtime.md
+++ b/.changes/static-vc-runtime.md
@@ -1,7 +1,0 @@
----
-"tauri-cli": "minor:feat"
-"@tauri-apps/cli": "minor:feat"
-"tauri-utils": "minor:feat"
----
-
-Added `build.windows.staticVCRuntime` to control MSVC static runtime linking. The `STATIC_VCRUNTIME` environment variable is now deprecated and emits a migration warning when used.

--- a/.changes/tauri-build-static-vc-runtime.md
+++ b/.changes/tauri-build-static-vc-runtime.md
@@ -2,4 +2,4 @@
 "tauri-build": "minor:feat"
 ---
 
-Added `tauri_build::WindowsAttributes::static_vc_runtime` to control MSVC static runtime linking from build scripts.
+Added `tauri_build::WindowsAttributes::static_vc_runtime` to control MSVC static runtime linking from build scripts. The `STATIC_VCRUNTIME` environment variable is now deprecated and emits a migration warning when used.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8939,6 +8939,7 @@ dependencies = [
  "dunce",
  "flate2",
  "glob",
+ "goblin",
  "handlebars",
  "heck 0.5.0",
  "hex",

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -288,7 +288,7 @@ impl WindowsAttributes {
 
   /// Sets whether to statically link the Visual C++ runtime into the application binary on Windows MSVC targets.
   ///
-  /// If unset, this is read from `build > windows > staticVCRuntime` in the Tauri configuration.
+  /// If unset, this defaults to `true`.
   #[must_use]
   pub fn static_vc_runtime(mut self, static_vc_runtime: bool) -> Self {
     self.static_vc_runtime.replace(static_vc_runtime);
@@ -740,17 +740,17 @@ fn to_winres_version(v: &semver::Version) -> u64 {
   (v.major << 48) | (v.minor << 32) | (v.patch << 16) | build
 }
 
-fn should_static_link_vc_runtime(config: &Config, attributes: &Attributes) -> bool {
+fn should_static_link_vc_runtime(_config: &Config, attributes: &Attributes) -> bool {
   if let Some(value) = env::var_os("STATIC_VCRUNTIME") {
     println!(
-      "cargo:warning=STATIC_VCRUNTIME is deprecated; use build.windows.staticVCRuntime in tauri.conf.json or tauri_build::WindowsAttributes::static_vc_runtime instead."
+      "cargo:warning=STATIC_VCRUNTIME is deprecated; use tauri_build::WindowsAttributes::static_vc_runtime instead."
     );
     value != "false"
   } else {
     attributes
       .windows_attributes
       .static_vc_runtime
-      .unwrap_or(config.build.windows.static_vc_runtime)
+      .unwrap_or(true)
   }
 }
 
@@ -831,47 +831,13 @@ mod tests {
       .windows_attributes(crate::WindowsAttributes::new().static_vc_runtime(false));
     assert!(!crate::should_static_link_vc_runtime(&config, &attributes));
 
-    // 6. Set to true in config, should be true
-    let config = tauri_utils::config::Config {
-      build: tauri_utils::config::BuildConfig {
-        windows: tauri_utils::config::WindowsBuildConfig {
-          static_vc_runtime: true,
-        },
-        ..Default::default()
-      },
-      ..Default::default()
-    };
-    let attributes = crate::Attributes::new();
-    assert!(crate::should_static_link_vc_runtime(&config, &attributes));
-
-    // 7. Set to false in config, should be false
-    let config = tauri_utils::config::Config {
-      build: tauri_utils::config::BuildConfig {
-        windows: tauri_utils::config::WindowsBuildConfig {
-          static_vc_runtime: false,
-        },
-        ..Default::default()
-      },
-      ..Default::default()
-    };
-    let attributes = crate::Attributes::new();
-    assert!(!crate::should_static_link_vc_runtime(&config, &attributes));
-
-    // 8. Set to true in config and false in attributes, should be false because attributes takes precedence over config
-    let config = tauri_utils::config::Config {
-      build: tauri_utils::config::BuildConfig {
-        windows: tauri_utils::config::WindowsBuildConfig {
-          static_vc_runtime: true,
-        },
-        ..Default::default()
-      },
-      ..Default::default()
-    };
+    // 6. Set false in attributes, should be false
+    let config = tauri_utils::config::Config::default();
     let attributes = crate::Attributes::new()
       .windows_attributes(crate::WindowsAttributes::new().static_vc_runtime(false));
     assert!(!crate::should_static_link_vc_runtime(&config, &attributes));
 
-    // 9. Set to false in env and true in attributes, should be false because env takes precedence over attributes
+    // 7. Set to false in env and true in attributes, should be false because env takes precedence over attributes
     std::env::set_var("STATIC_VCRUNTIME", "false");
     let config = tauri_utils::config::Config::default();
     let attributes = crate::Attributes::new()

--- a/crates/tauri-bundler/Cargo.toml
+++ b/crates/tauri-bundler/Cargo.toml
@@ -45,6 +45,7 @@ uuid = { version = "1", features = ["v4", "v5"] }
 regex = "1"
 plist = "1"
 glob = "0.3"
+goblin = "0.9"
 
 [target."cfg(target_os = \"windows\")".dependencies]
 bitness = "0.4"

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -603,13 +603,6 @@ pub struct WindowsSettings {
   /// if the user's WebView2 is older than this version,
   /// the installer will try to trigger a WebView2 update.
   pub minimum_webview2_version: Option<String>,
-  /// Whether to bundle the Visual C++ runtime DLLs alongside the application.
-  ///
-  /// This can be particularly useful when the application includes sidecars or DLLs that do not
-  /// statically link the Visual C++ runtime and require the runtime DLLs at runtime, and users
-  /// should not be required to install the Visual C++ Redistributable. This can also be useful
-  /// when `static_vc_runtime` is set to `false`.
-  pub bundle_vc_runtime: bool,
 }
 
 impl WindowsSettings {
@@ -636,7 +629,6 @@ mod _default {
         allow_downgrades: true,
         sign_command: None,
         minimum_webview2_version: None,
-        bundle_vc_runtime: false,
       }
     }
   }

--- a/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/msi/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     windows::{
       sign::{should_sign, try_sign},
       util::{
-        download_webview2_bootstrapper, download_webview2_offline_installer, vc_runtime_dlls,
+        download_webview2_bootstrapper, download_webview2_offline_installer,
         WIX_OUTPUT_FOLDER_NAME, WIX_UPDATER_OUTPUT_FOLDER_NAME,
       },
     },
@@ -1078,21 +1078,6 @@ fn generate_resource_data(settings: &Settings) -> crate::Result<ResourceMap> {
   }
 
   let mut dlls = Vec::new();
-
-  if settings.windows().bundle_vc_runtime {
-    for dll in vc_runtime_dlls(settings.binary_arch())? {
-      let resource_path = dunce::simplified(&dll);
-      if added_resources.contains(&resource_path.to_path_buf()) {
-        continue;
-      }
-      added_resources.push(resource_path.to_path_buf());
-      dlls.push(ResourceFile {
-        id: format!("I{}", Uuid::new_v4().as_simple()),
-        guid: Uuid::new_v4().to_string(),
-        path: resource_path.to_path_buf(),
-      });
-    }
-  }
 
   // TODO: The bundler should not include all DLLs it finds. Instead it should only include WebView2Loader.dll if present and leave the rest to the resources config.
   let out_dir = settings.project_out_directory();

--- a/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
+++ b/crates/tauri-bundler/src/bundle/windows/nsis/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     windows::{
       sign::{should_sign, sign_command, try_sign},
       util::{
-        download_webview2_bootstrapper, download_webview2_offline_installer, vc_runtime_dlls,
+        download_webview2_bootstrapper, download_webview2_offline_installer,
         NSIS_OUTPUT_FOLDER_NAME, NSIS_UPDATER_OUTPUT_FOLDER_NAME,
       },
     },
@@ -799,22 +799,6 @@ fn generate_resource_data(settings: &Settings) -> crate::Result<ResourcesMap> {
         loader_path,
         (PathBuf::new(), PathBuf::from("WebView2Loader.dll")),
       );
-    }
-  }
-
-  if settings.windows().bundle_vc_runtime {
-    for dll in vc_runtime_dlls(settings.binary_arch())? {
-      let dll = dunce::simplified(&dll).to_path_buf();
-      if added_resources.contains(&dll) {
-        continue;
-      }
-      let target = PathBuf::from(
-        dll
-          .file_name()
-          .expect("failed to extract Visual C++ runtime DLL filename"),
-      );
-      added_resources.push(dll.clone());
-      resources.insert(dll, (PathBuf::new(), target));
     }
   }
 

--- a/crates/tauri-bundler/src/bundle/windows/util.rs
+++ b/crates/tauri-bundler/src/bundle/windows/util.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-#[cfg(windows)]
-use std::process::Command;
 use std::{
   fs,
   io::Write,
@@ -11,7 +9,6 @@ use std::{
 };
 use ureq::ResponseExt;
 
-use crate::bundle::settings::Arch;
 use crate::utils::http_utils::{base_ureq_agent, download};
 
 pub const WEBVIEW2_BOOTSTRAPPER_URL: &str = "https://go.microsoft.com/fwlink/p/?LinkId=2124703";
@@ -27,9 +24,6 @@ pub const WIX_OUTPUT_FOLDER_NAME: &str = "msi";
 pub const WIX_UPDATER_OUTPUT_FOLDER_NAME: &str = "msi-updater";
 
 const VSWHERE: &[u8] = include_bytes!("vswhere.exe");
-const VCTOOLS_REDIST_DIR_ENV_VAR: &str = "VCTOOLS_REDIST_DIR";
-#[cfg(windows)]
-const VC_REDIST_COMPONENT: &str = "Microsoft.VisualStudio.Component.VC.Redist.14.Latest";
 
 pub fn webview2_guid_path(url: &str) -> crate::Result<(String, String)> {
   let agent = base_ureq_agent();
@@ -70,146 +64,6 @@ pub fn download_webview2_offline_installer(base_path: &Path, arch: &str) -> crat
     std::fs::write(&file_path, download(url)?)?;
   }
   Ok(file_path)
-}
-
-/// Finds the Visual C++ runtime DLLs for the given architecture.
-pub fn vc_runtime_dlls(arch: Arch) -> crate::Result<Vec<PathBuf>> {
-  let arch = vc_runtime_arch(arch)?;
-  let redist_dir = vc_redist_dir()?;
-  let runtime_dir = vc_runtime_dir(&redist_dir, arch)?;
-
-  let dlls = glob::glob(&glob_path(&runtime_dir, "*.dll"))?.collect::<Result<Vec<_>, _>>()?;
-  if dlls.is_empty() {
-    return Err(crate::Error::GenericError(format!(
-      "no Visual C++ runtime DLLs found in `{}`",
-      runtime_dir.display()
-    )));
-  }
-
-  Ok(dlls)
-}
-
-#[inline(always)]
-fn vc_runtime_arch(arch: Arch) -> crate::Result<&'static str> {
-  match arch {
-    Arch::X86_64 => Ok("x64"),
-    Arch::X86 => Ok("x86"),
-    Arch::AArch64 => Ok("arm64"),
-    _ => Err(crate::Error::GenericError(
-      "bundling the Visual C++ runtime is only supported for Windows x86, x64 and arm64 targets"
-        .into(),
-    )),
-  }
-}
-
-#[cfg(windows)]
-fn visual_studio_dir() -> crate::Result<PathBuf> {
-  let Some(vswhere) = vswhere_path() else {
-    return Err(crate::Error::GenericError(
-      "failed to prepare bundled vswhere.exe".into(),
-    ));
-  };
-
-  let output = Command::new(vswhere)
-    .args([
-      "-latest",
-      "-prerelease",
-      "-products",
-      "*",
-      "-requires",
-      VC_REDIST_COMPONENT,
-      "-property",
-      "installationPath",
-      "-format",
-      "value",
-      "-utf8",
-    ])
-    .output()?;
-
-  if !output.status.success() {
-    return Err(crate::Error::GenericError(format!(
-      "failed to locate Visual Studio with the {VC_REDIST_COMPONENT} component"
-    )));
-  }
-
-  let stdout = String::from_utf8_lossy(&output.stdout);
-  let Some(vs_dir) = stdout.lines().map(str::trim).find(|line| !line.is_empty()) else {
-    return Err(crate::Error::GenericError(format!(
-      "failed to locate Visual Studio with the {VC_REDIST_COMPONENT} component"
-    )));
-  };
-
-  Ok(PathBuf::from(vs_dir))
-}
-
-fn vc_redist_dir() -> crate::Result<PathBuf> {
-  if let Ok(redist_dir) = std::env::var(VCTOOLS_REDIST_DIR_ENV_VAR) {
-    return Ok(PathBuf::from(redist_dir));
-  }
-
-  #[cfg(windows)]
-  {
-    let vs_dir = visual_studio_dir()?;
-    Ok(vs_dir.join("VC/Redist/MSVC"))
-  }
-
-  #[cfg(not(windows))]
-  {
-    Err(crate::Error::GenericError(format!(
-      "failed to find Visual C++ runtime redist directory; set {VCTOOLS_REDIST_DIR_ENV_VAR} when bundling the Visual C++ runtime from non-Windows hosts"
-    )))
-  }
-}
-
-fn vc_runtime_dir(redist_dir: &Path, arch: &str) -> crate::Result<PathBuf> {
-  let Some(latest_version_dir) = latest_vc_redist_version_dir(redist_dir)? else {
-    return Err(crate::Error::GenericError(format!(
-      "failed to find Visual C++ runtime versions in `{}`",
-      redist_dir.display()
-    )));
-  };
-
-  let arch_dir = latest_version_dir.join(arch);
-  let Some(runtime_dir) = glob::glob(&glob_path(&arch_dir, "Microsoft.VC*.CRT"))?
-    .filter_map(Result::ok)
-    .find(|path| path.is_dir())
-  else {
-    return Err(crate::Error::GenericError(format!(
-      "failed to find Visual C++ runtime directory for `{arch}` in `{}`",
-      arch_dir.display()
-    )));
-  };
-
-  Ok(runtime_dir)
-}
-
-fn latest_vc_redist_version_dir(redist_dir: &Path) -> crate::Result<Option<PathBuf>> {
-  let dir = fs::read_dir(redist_dir)?
-    .flatten()
-    .map(|entry| entry.path())
-    .filter(|path| path.is_dir())
-    .filter_map(|path| {
-      let version = path
-        .file_name()?
-        .to_str()?
-        .parse::<semver::Version>()
-        .ok()?;
-      Some((version, path))
-    })
-    .max_by(|(a, _), (b, _)| a.cmp(b))
-    .map(|(_, path)| path);
-  Ok(dir)
-}
-
-/// Builds a glob pattern from a literal base path and an unescaped glob suffix.
-///
-/// The base path is escaped so Visual Studio paths containing glob metacharacters are treated as
-/// literal directories, while `pattern` remains active glob syntax.
-fn glob_path(path: &Path, pattern: &str) -> String {
-  PathBuf::from(glob::Pattern::escape(&path.to_string_lossy()))
-    .join(pattern)
-    .to_string_lossy()
-    .into_owned()
 }
 
 /// Returns the bundled `vswhere.exe` path.

--- a/crates/tauri-bundler/src/error.rs
+++ b/crates/tauri-bundler/src/error.rs
@@ -93,6 +93,9 @@ pub enum Error {
   /// Failed to validate downloaded file hash.
   #[error("hash mismatch of downloaded file")]
   HashError,
+  /// Failed to parse binary
+  #[error("Binary parse error: `{0}`")]
+  BinaryParseError(#[from] goblin::error::Error),
   /// Package type is not supported by target platform
   #[error("Wrong package type {0} for platform {1}")]
   InvalidPackageType(String, String),

--- a/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
+++ b/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
@@ -24,8 +24,7 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `TAURI_SIGNING_RPM_KEY` — The private GPG key used to sign the RPM bundle, exported to its ASCII-armored format.
 - `TAURI_SIGNING_RPM_KEY_PASSPHRASE` — The GPG key passphrase for `TAURI_SIGNING_RPM_KEY`, if needed.
 - `TAURI_WINDOWS_SIGNTOOL_PATH` — Specify a path to `signtool.exe` used for code signing the application on Windows.
-- `STATIC_VCRUNTIME` — Deprecated. Set `build > windows > staticVCRuntime` in `tauri.conf.json` instead.
-- `VCTOOLS_REDIST_DIR` — Override the Visual C++ redistributable root directory used when `bundle > windows > bundleVCRuntime` is enabled. If unset, Tauri uses its bundled `vswhere.exe` to locate Visual Studio and derive this directory.
+- `STATIC_VCRUNTIME` — Deprecated. Use `tauri_build::WindowsAttributes::static_vc_runtime` in `build.rs` instead.
 - `APPLE_CERTIFICATE` — Base64 encoded of the `.p12` certificate for code signing. To get this value, run `openssl base64 -in MyCertificate.p12 -out MyCertificate-base64.txt`.
 - `APPLE_CERTIFICATE_PASSWORD` — The password you used to export the certificate.
 - `APPLE_ID` — The Apple ID used to notarize the application. If this environment variable is provided, `APPLE_PASSWORD` and `APPLE_TEAM_ID` must also be set. Alternatively, `APPLE_API_KEY` and `APPLE_API_ISSUER` can be used to authenticate.

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -71,10 +71,7 @@
       "description": "The build configuration.",
       "default": {
         "additionalWatchFolders": [],
-        "removeUnusedCommands": false,
-        "windows": {
-          "staticVCRuntime": true
-        }
+        "removeUnusedCommands": false
       },
       "allOf": [
         {
@@ -132,7 +129,6 @@
         "useLocalToolsDir": false,
         "windows": {
           "allowDowngrades": true,
-          "bundleVCRuntime": false,
           "certificateThumbprint": null,
           "digestAlgorithm": null,
           "minimumWebview2Version": null,
@@ -378,7 +374,7 @@
           "type": "boolean"
         },
         "transparent": {
-          "description": "Whether the window is transparent or not.\n\n Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.\n WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.\n\n On Windows, using `noRedirectionBitmap` can help avoid a white flash when creating a transparent window.",
+          "description": "Whether the window is transparent or not.\n\n Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.\n WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.",
           "default": false,
           "type": "boolean"
         },
@@ -428,11 +424,6 @@
             "string",
             "null"
           ]
-        },
-        "noRedirectionBitmap": {
-          "description": "This sets `WS_EX_NOREDIRECTIONBITMAP`.\n\n This can avoid the white flash that may appear before the webview content is rendered\n when using a transparent window. **Windows only**.",
-          "default": false,
-          "type": "boolean"
         },
         "theme": {
           "description": "The initial window theme. Defaults to the system theme. Only implemented on Windows and macOS 10.14+.",
@@ -1980,17 +1971,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "windows": {
-          "description": "Windows-specific build configuration.",
-          "default": {
-            "staticVCRuntime": true
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/WindowsBuildConfig"
-            }
-          ]
         }
       },
       "additionalProperties": false
@@ -2117,18 +2097,6 @@
           }
         }
       ]
-    },
-    "WindowsBuildConfig": {
-      "description": "Windows-specific build configuration.",
-      "type": "object",
-      "properties": {
-        "staticVCRuntime": {
-          "description": "Whether to statically link the Visual C++ runtime into the application binary on Windows MSVC targets.",
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
     },
     "BundleConfig": {
       "description": "Configuration for tauri-bundler.\n\n See more: <https://v2.tauri.app/reference/config/#bundleconfig>",
@@ -2261,7 +2229,6 @@
           "description": "Configuration for the Windows bundles.",
           "default": {
             "allowDowngrades": true,
-            "bundleVCRuntime": false,
             "certificateThumbprint": null,
             "digestAlgorithm": null,
             "minimumWebview2Version": null,
@@ -2782,11 +2749,6 @@
               "type": "null"
             }
           ]
-        },
-        "bundleVCRuntime": {
-          "description": "Whether to bundle the Visual C++ runtime DLLs alongside the application.\n\n This can be particularly useful when your application includes sidecars or DLLs that do\n not statically link the Visual C++ runtime and require the runtime DLLs at runtime, and\n you do not want to require users to install the Visual C++ Redistributable. This can also\n be useful when `build > windows > staticVCRuntime` is set to `false`.",
-          "default": false,
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -1675,7 +1675,6 @@ fn tauri_config_to_bundle_settings(
       allow_downgrades: config.windows.allow_downgrades,
       sign_command: config.windows.sign_command.map(custom_sign_settings),
       minimum_webview2_version: config.windows.minimum_webview2_version,
-      bundle_vc_runtime: config.windows.bundle_vc_runtime,
     },
     license: config.license.or_else(|| {
       settings

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -63,6 +63,11 @@ use wry::WebViewBuilderExtWindows;
 use wry::{WebViewBuilderExtDarwin, WebViewExtDarwin};
 
 use tao::{
+  dpi::{
+    LogicalPosition as TaoLogicalPosition, LogicalSize as TaoLogicalSize,
+    PhysicalPosition as TaoPhysicalPosition, PhysicalSize as TaoPhysicalSize,
+    Position as TaoPosition, Size as TaoSize,
+  },
   event::{Event, StartCause, WindowEvent as TaoWindowEvent},
   event_loop::{
     ControlFlow, DeviceEventFilter as TaoDeviceEventFilter, EventLoop, EventLoopBuilder,
@@ -321,16 +326,24 @@ impl<T: UserEvent> Context<T> {
       Message::CreateWindow(
         window_id,
         Box::new(move |event_loop| {
-          create_window(
+          match create_window(
             window_id,
             webview_id.unwrap_or_default(),
             event_loop,
             &context,
             pending,
             after_window_creation,
-          )
+          ) {
+            Ok(window) => {
+              let _ = tx.send(Ok(()));
+              Ok(window)
+            }
+            Err(e) => {
+              let _ = tx.send(Err(Error::CreateWindow));
+              Err(e)
+            }
+          }
         }),
-        tx,
       ),
     )?;
     rx.recv()
@@ -383,7 +396,7 @@ impl<T: UserEvent> Context<T> {
       Message::CreateWebview(
         window_id,
         Box::new(move |window, options| {
-          create_webview(
+          match create_webview(
             WebviewKind::WindowChild,
             window,
             window_id_wrapper_,
@@ -391,9 +404,20 @@ impl<T: UserEvent> Context<T> {
             &context,
             pending,
             options.focused_webview,
-          )
+          ) {
+            Ok(webview) => {
+              let _ = tx.send(Ok(()));
+              Ok(webview)
+            }
+            Err(e) => {
+              let message = e.to_string();
+              let _ = tx.send(Err(e));
+              Err(Error::CreateWebview(Box::new(std::io::Error::other(
+                message,
+              ))))
+            }
+          }
         }),
-        tx,
       ),
     )?;
     rx.recv()
@@ -435,6 +459,13 @@ pub enum ActiveTracingSpan {
 #[derive(Debug)]
 pub struct WindowsStore(pub RefCell<BTreeMap<WindowId, WindowWrapper>>);
 
+// SAFETY: Kept for public API compatibility. Access to the store is routed
+// through the event loop thread, as in previous releases.
+unsafe impl Send for WindowsStore {}
+
+// SAFETY: See the `Send` impl above.
+unsafe impl Sync for WindowsStore {}
+
 #[derive(Debug, Clone)]
 pub struct DispatcherMainThreadContext<T: UserEvent> {
   pub window_target: EventLoopWindowTarget<Message<T>>,
@@ -444,6 +475,13 @@ pub struct DispatcherMainThreadContext<T: UserEvent> {
   #[cfg(feature = "tracing")]
   pub active_tracing_spans: ActiveTraceSpanStore,
 }
+
+// SAFETY: Kept for public API compatibility. The context is only used to
+// dispatch work back to the main event loop thread.
+unsafe impl<T: UserEvent> Send for DispatcherMainThreadContext<T> {}
+
+// SAFETY: See the `Send` impl above.
+unsafe impl<T: UserEvent> Sync for DispatcherMainThreadContext<T> {}
 
 impl<T: UserEvent> fmt::Debug for Context<T> {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -474,6 +512,90 @@ impl From<tauri_runtime::dpi::Rect> for RectWrapper {
       position: value.position,
       size: value.size,
     })
+  }
+}
+
+pub struct PhysicalPositionWrapper<T>(pub TaoPhysicalPosition<T>);
+
+impl<T> From<PhysicalPositionWrapper<T>> for PhysicalPosition<T> {
+  fn from(position: PhysicalPositionWrapper<T>) -> Self {
+    Self {
+      x: position.0.x,
+      y: position.0.y,
+    }
+  }
+}
+
+impl<T> From<PhysicalPosition<T>> for PhysicalPositionWrapper<T> {
+  fn from(position: PhysicalPosition<T>) -> Self {
+    Self(TaoPhysicalPosition {
+      x: position.x,
+      y: position.y,
+    })
+  }
+}
+
+struct LogicalPositionWrapper<T>(TaoLogicalPosition<T>);
+
+impl<T> From<LogicalPosition<T>> for LogicalPositionWrapper<T> {
+  fn from(position: LogicalPosition<T>) -> Self {
+    Self(TaoLogicalPosition {
+      x: position.x,
+      y: position.y,
+    })
+  }
+}
+
+pub struct PhysicalSizeWrapper<T>(pub TaoPhysicalSize<T>);
+
+impl<T> From<PhysicalSizeWrapper<T>> for PhysicalSize<T> {
+  fn from(size: PhysicalSizeWrapper<T>) -> Self {
+    Self {
+      width: size.0.width,
+      height: size.0.height,
+    }
+  }
+}
+
+impl<T> From<PhysicalSize<T>> for PhysicalSizeWrapper<T> {
+  fn from(size: PhysicalSize<T>) -> Self {
+    Self(TaoPhysicalSize {
+      width: size.width,
+      height: size.height,
+    })
+  }
+}
+
+struct LogicalSizeWrapper<T>(TaoLogicalSize<T>);
+
+impl<T> From<LogicalSize<T>> for LogicalSizeWrapper<T> {
+  fn from(size: LogicalSize<T>) -> Self {
+    Self(TaoLogicalSize {
+      width: size.width,
+      height: size.height,
+    })
+  }
+}
+
+pub struct SizeWrapper(pub TaoSize);
+
+impl From<Size> for SizeWrapper {
+  fn from(size: Size) -> Self {
+    match size {
+      Size::Logical(s) => Self(TaoSize::Logical(LogicalSizeWrapper::from(s).0)),
+      Size::Physical(s) => Self(TaoSize::Physical(PhysicalSizeWrapper::from(s).0)),
+    }
+  }
+}
+
+pub struct PositionWrapper(pub TaoPosition);
+
+impl From<Position> for PositionWrapper {
+  fn from(position: Position) -> Self {
+    match position {
+      Position::Logical(s) => Self(TaoPosition::Logical(LogicalPositionWrapper::from(s).0)),
+      Position::Physical(s) => Self(TaoPosition::Physical(PhysicalPositionWrapper::from(s).0)),
+    }
   }
 }
 
@@ -851,7 +973,6 @@ impl WindowBuilder for WindowBuilderWrapper {
       .content_protected(config.content_protected)
       .skip_taskbar(config.skip_taskbar)
       .theme(config.theme)
-      .no_redirection_bitmap(config.no_redirection_bitmap)
       .closable(config.closable)
       .maximizable(config.maximizable)
       .minimizable(config.minimizable)
@@ -1483,8 +1604,8 @@ pub enum Message<T: 'static> {
   Window(WindowId, WindowMessage),
   Webview(WindowId, WebviewId, WebviewMessage),
   EventLoopWindowTarget(EventLoopWindowTargetMessage),
-  CreateWebview(WindowId, CreateWebviewClosure, Sender<Result<()>>),
-  CreateWindow(WindowId, CreateWindowClosure<T>, Sender<Result<()>>),
+  CreateWebview(WindowId, CreateWebviewClosure),
+  CreateWindow(WindowId, CreateWindowClosure<T>),
   CreateRawWindow(
     WindowId,
     Box<dyn FnOnce() -> (String, TaoWindowBuilder) + Send>,
@@ -3953,7 +4074,7 @@ fn handle_user_message<T: UserEvent>(
         }
       }
     }
-    Message::CreateWebview(window_id, handler, sender) => {
+    Message::CreateWebview(window_id, handler) => {
       let window = windows
         .0
         .borrow()
@@ -3966,25 +4087,19 @@ fn handle_user_message<T: UserEvent>(
               w.webviews.push(webview);
               w.has_children.store(true, Ordering::Relaxed);
             }
-            // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
-            sender.send(Ok(())).unwrap();
           }
           Err(e) => {
-            // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
-            sender.send(Err(e)).unwrap();
+            log::error!("{e}");
           }
         }
       }
     }
-    Message::CreateWindow(window_id, handler, sender) => match handler(event_loop) {
+    Message::CreateWindow(window_id, handler) => match handler(event_loop) {
       Ok(webview) => {
         windows.0.borrow_mut().insert(window_id, webview);
-        // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
-        sender.send(Ok(())).unwrap();
       }
       Err(e) => {
-        // SAFETY: The caller calls blocking `rx.recv()` so the receiver will never be dropped before this
-        sender.send(Err(e)).unwrap();
+        log::error!("{e}");
       }
     },
     Message::CreateRawWindow(window_id, handler, sender) => {

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -71,10 +71,7 @@
       "description": "The build configuration.",
       "default": {
         "additionalWatchFolders": [],
-        "removeUnusedCommands": false,
-        "windows": {
-          "staticVCRuntime": true
-        }
+        "removeUnusedCommands": false
       },
       "allOf": [
         {
@@ -132,7 +129,6 @@
         "useLocalToolsDir": false,
         "windows": {
           "allowDowngrades": true,
-          "bundleVCRuntime": false,
           "certificateThumbprint": null,
           "digestAlgorithm": null,
           "minimumWebview2Version": null,
@@ -378,7 +374,7 @@
           "type": "boolean"
         },
         "transparent": {
-          "description": "Whether the window is transparent or not.\n\n Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.\n WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.\n\n On Windows, using `noRedirectionBitmap` can help avoid a white flash when creating a transparent window.",
+          "description": "Whether the window is transparent or not.\n\n Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.\n WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.",
           "default": false,
           "type": "boolean"
         },
@@ -428,11 +424,6 @@
             "string",
             "null"
           ]
-        },
-        "noRedirectionBitmap": {
-          "description": "This sets `WS_EX_NOREDIRECTIONBITMAP`.\n\n This can avoid the white flash that may appear before the webview content is rendered\n when using a transparent window. **Windows only**.",
-          "default": false,
-          "type": "boolean"
         },
         "theme": {
           "description": "The initial window theme. Defaults to the system theme. Only implemented on Windows and macOS 10.14+.",
@@ -1980,17 +1971,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "windows": {
-          "description": "Windows-specific build configuration.",
-          "default": {
-            "staticVCRuntime": true
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/WindowsBuildConfig"
-            }
-          ]
         }
       },
       "additionalProperties": false
@@ -2117,18 +2097,6 @@
           }
         }
       ]
-    },
-    "WindowsBuildConfig": {
-      "description": "Windows-specific build configuration.",
-      "type": "object",
-      "properties": {
-        "staticVCRuntime": {
-          "description": "Whether to statically link the Visual C++ runtime into the application binary on Windows MSVC targets.",
-          "default": true,
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
     },
     "BundleConfig": {
       "description": "Configuration for tauri-bundler.\n\n See more: <https://v2.tauri.app/reference/config/#bundleconfig>",
@@ -2261,7 +2229,6 @@
           "description": "Configuration for the Windows bundles.",
           "default": {
             "allowDowngrades": true,
-            "bundleVCRuntime": false,
             "certificateThumbprint": null,
             "digestAlgorithm": null,
             "minimumWebview2Version": null,
@@ -2782,11 +2749,6 @@
               "type": "null"
             }
           ]
-        },
-        "bundleVCRuntime": {
-          "description": "Whether to bundle the Visual C++ runtime DLLs alongside the application.\n\n This can be particularly useful when your application includes sidecars or DLLs that do\n not statically link the Visual C++ runtime and require the runtime DLLs at runtime, and\n you do not want to require users to install the Visual C++ Redistributable. This can also\n be useful when `build > windows > staticVCRuntime` is set to `false`.",
-          "default": false,
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -1078,19 +1078,6 @@ pub struct WindowsConfig {
   /// need to use another tool like `osslsigncode`.
   #[serde(alias = "sign-command")]
   pub sign_command: Option<CustomSignCommandConfig>,
-  /// Whether to bundle the Visual C++ runtime DLLs alongside the application.
-  ///
-  /// This can be particularly useful when your application includes sidecars or DLLs that do
-  /// not statically link the Visual C++ runtime and require the runtime DLLs at runtime, and
-  /// you do not want to require users to install the Visual C++ Redistributable. This can also
-  /// be useful when `build > windows > staticVCRuntime` is set to `false`.
-  #[serde(
-    default,
-    rename = "bundleVCRuntime",
-    alias = "bundle-vc-runtime",
-    alias = "bundleVcRuntime"
-  )]
-  pub bundle_vc_runtime: bool,
 }
 
 impl Default for WindowsConfig {
@@ -1106,7 +1093,6 @@ impl Default for WindowsConfig {
       wix: None,
       nsis: None,
       sign_command: None,
-      bundle_vc_runtime: false,
     }
   }
 }
@@ -2035,7 +2021,6 @@ pub struct WindowConfig {
   /// Note that on `macOS` this requires the `macos-private-api` feature flag, enabled under `tauri > macOSPrivateApi`.
   /// WARNING: Using private APIs on `macOS` prevents your application from being accepted to the `App Store`.
   ///
-  /// On Windows, using `noRedirectionBitmap` can help avoid a white flash when creating a transparent window.
   #[serde(default)]
   pub transparent: bool,
   /// Whether the window is maximized or not.
@@ -2068,12 +2053,6 @@ pub struct WindowConfig {
   pub skip_taskbar: bool,
   /// The name of the window class created on Windows to create the window. **Windows only**.
   pub window_classname: Option<String>,
-  /// This sets `WS_EX_NOREDIRECTIONBITMAP`.
-  ///
-  /// This can avoid the white flash that may appear before the webview content is rendered
-  /// when using a transparent window. **Windows only**.
-  #[serde(default, alias = "no-redirection-bitmap")]
-  pub no_redirection_bitmap: bool,
   /// The initial window theme. Defaults to the system theme. Only implemented on Windows and macOS 10.14+.
   pub theme: Option<crate::Theme>,
   /// The style of the macOS title bar.
@@ -2348,7 +2327,6 @@ impl Default for WindowConfig {
       content_protected: false,
       skip_taskbar: false,
       window_classname: None,
-      no_redirection_bitmap: false,
       theme: None,
       title_bar_style: Default::default(),
       traffic_light_position: None,
@@ -3470,9 +3448,6 @@ pub struct BuildConfig {
   /// Additional paths to watch for changes when running `tauri dev`.
   #[serde(alias = "additional-watch-directories", default)]
   pub additional_watch_folders: Vec<PathBuf>,
-  /// Windows-specific build configuration.
-  #[serde(default)]
-  pub windows: WindowsBuildConfig,
 }
 
 /// Windows-specific build configuration.
@@ -3921,7 +3896,6 @@ mod build {
       let content_protected = self.content_protected;
       let skip_taskbar = self.skip_taskbar;
       let window_classname = opt_str_lit(self.window_classname.as_ref());
-      let no_redirection_bitmap = self.no_redirection_bitmap;
       let theme = opt_lit(self.theme.as_ref());
       let title_bar_style = &self.title_bar_style;
       let traffic_light_position = opt_lit(self.traffic_light_position.as_ref());
@@ -3987,7 +3961,6 @@ mod build {
         content_protected,
         skip_taskbar,
         window_classname,
-        no_redirection_bitmap,
         theme,
         title_bar_style,
         traffic_light_position,
@@ -4176,7 +4149,6 @@ mod build {
       let features = quote!(None);
       let remove_unused_commands = quote!(false);
       let additional_watch_folders = quote!(Vec::new());
-      let windows = &self.windows;
 
       literal_struct!(
         tokens,
@@ -4189,8 +4161,7 @@ mod build {
         before_bundle_command,
         features,
         remove_unused_commands,
-        additional_watch_folders,
-        windows
+        additional_watch_folders
       );
     }
   }
@@ -4546,7 +4517,6 @@ mod test {
       features: None,
       remove_unused_commands: false,
       additional_watch_folders: Vec::new(),
-      windows: WindowsBuildConfig::default(),
     };
 
     // create a bundle config


### PR DESCRIPTION
## Summary
- restore patch-safe public API for tauri-bundler by keeping BinaryParseError compatible and removing the new constructible WindowsSettings field
- keep tauri-runtime-wry patch-compatible by restoring dpi wrapper exports, Send/Sync auto traits, and the previous Message variant shapes
- remove config-file fields that made tauri-utils constructible structs breaking, and regenerate the config schemas/changesets accordingly

## Testing
- cargo check -p tauri-runtime-wry -p tauri-utils -p tauri-bundler -p tauri-build --no-default-features
- cargo check -p tauri --no-default-features
- cargo check -p tauri-schema-generator
- cargo-semver-checks tauri-bundler 2.9.3 -> 2.9.4: 223 pass, no semver update required
- cargo-semver-checks tauri-runtime-wry 2.11.3 -> 2.11.4: 223 pass, no semver update required
- cargo-semver-checks tauri-utils 2.9.2 -> 2.9.3: 223 pass, no semver update required
- cargo-semver-checks tauri-build 2.6.2 -> 2.6.3: 223 pass, no semver update required
- cargo-semver-checks tauri-runtime 2.11.2 -> 2.11.3: 223 pass, no semver update required
- cargo-semver-checks tauri 2.11.4 -> 2.11.5: 223 pass, no semver update required