### PR TITLE
fix(android): re-create configured windows when resumed without webviews

### DIFF
--- a/.changes/android-resume-recreate-windows.md
+++ b/.changes/android-resume-recreate-windows.md
@@ -1,0 +1,5 @@
+---
+"tauri": "patch:bug"
+---
+
+On Android, re-create the configured windows when the app is resumed with no webviews alive. This fixes a blank screen when the app is relaunched after task removal while a foreground service keeps the process alive.

--- a/.changes/mobile-resumed-run-event.md
+++ b/.changes/mobile-resumed-run-event.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": "patch:bug"
+---
+
+Emit `RunEvent::Resumed` on mobile when the application is resumed. Previously the resume was only dispatched as a per-window event, so it was silently dropped when no windows existed (e.g. on Android after the activity was destroyed while a foreground service kept the process alive).

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -4305,6 +4305,14 @@ fn handle_event_loop<T: UserEvent>(
     }
     #[cfg(mobile)]
     e @ Event::Resumed | e @ Event::Suspended => {
+      // Surface the resume to the app-level callback as well. The per-window
+      // dispatch below never runs when there are no windows (e.g. on Android
+      // when the activity was destroyed while a foreground service kept the
+      // process alive), so the app would otherwise never learn about it.
+      if matches!(e, Event::Resumed) {
+        callback(RunEvent::Resumed);
+      }
+
       let event = match e {
         Event::Resumed => WindowEvent::Resumed,
         Event::Suspended => WindowEvent::Suspended,

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -216,7 +216,9 @@ pub enum RunEvent<T: UserEvent> {
   },
   /// Application ready.
   Ready,
-  /// Sent if the event loop is being resumed.
+  /// Sent when the application has been resumed.
+  ///
+  /// On desktop this is only emitted when the event loop is woken while running in poll mode, which is not used by default.
   Resumed,
   /// Emitted when all of the event loop's input events have been processed and redraw processing is about to begin.
   ///

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -248,7 +248,13 @@ pub enum RunEvent {
   },
   /// Application ready.
   Ready,
-  /// Sent if the event loop is being resumed.
+  /// Emitted when the application has been resumed.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **Android**: This is triggered by `onResume` method of the Activity. The first `onResume()` is ignored to match the iOS implementation, since that is called on activity creation.
+  /// - **iOS**: This is triggered by `applicationWillEnterForeground` method of the `UIApplicationDelegate`.
+  /// - **Linux / macOS / Windows**: Only emitted when the event loop is woken while running in poll mode, which is not used by default.
   Resumed,
   /// Emitted when all of the event loop's input events have been processed and redraw processing is about to begin.
   ///
@@ -2578,7 +2584,25 @@ fn on_event_loop_event<R: Runtime>(
       }
       RunEvent::Ready
     }
-    RuntimeRunEvent::Resumed => RunEvent::Resumed,
+    RuntimeRunEvent::Resumed => {
+      // On Android a foreground service can keep the process alive after the
+      // activity is destroyed, so a relaunch resumes with no webviews and the
+      // activity would stay blank. Re-create the configured windows so the
+      // relaunch behaves like a cold start.
+      #[cfg(target_os = "android")]
+      if manager.window.windows_lock().is_empty() && manager.webview.webviews_lock().is_empty() {
+        for window_config in app_handle.config().app.windows.iter().filter(|w| w.create) {
+          let result = WebviewWindowBuilder::from_config(app_handle, window_config)
+            .and_then(|builder| builder.build());
+
+          if let Err(e) = result {
+            let label = &window_config.label;
+            panic!("Failed to re-create window `{label}` on resume: {e}");
+          }
+        }
+      }
+      RunEvent::Resumed
+    }
     RuntimeRunEvent::MainEventsCleared => RunEvent::MainEventsCleared,
     RuntimeRunEvent::UserEvent(t) => {
       match t {


### PR DESCRIPTION
This PR resolves #15671

On Android, a foreground service can keep the process alive after the activity is destroyed by task removal. When the app is relaunched, the tao event loop resumes but no webviews exist anymore, so the activity stays blank. Reproduction instructions are in the issue.

This PR fixes that in two steps:

- `tauri-runtime-wry` now emits `RunEvent::Resumed` to the app-level callback on mobile. The resume was previously only dispatched as a per-window event, which is dropped when no windows exist.
- On Android, `tauri` re-creates the windows from the config (those with `create: true`) when the app is resumed without any windows or webviews alive, so the relaunch behaves like a cold start. Creation failures panic, matching the `setup()` behavior for the same operation.

Notes:

- iOS apps now also receive the app-level `RunEvent::Resumed`, which was previously never emitted on mobile.
- Windows the user closed before the app was backgrounded reappear on such a relaunch, consistent with cold start semantics.
- The `RunEvent::Resumed` docs were updated to describe the mobile lifecycle triggers.