### PR TITLE
fix(bundler): suppress verbose code signing output (fix #15687)

### DIFF
--- a/.changes/fix-signing-verbose-output.md
+++ b/.changes/fix-signing-verbose-output.md
@@ -1,0 +1,7 @@
+---
+"tauri-bundler": patch:bug
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix verbose code signing output during `tauri build` by demoting signtool verification and signing command output to the debug log level.

--- a/crates/tauri-bundler/src/bundle/windows/sign.rs
+++ b/crates/tauri-bundler/src/bundle/windows/sign.rs
@@ -129,7 +129,15 @@ pub fn verify(path: &Path) -> crate::Result<bool> {
   cmd.arg("/pa");
   cmd.arg(path);
 
-  Ok(cmd.status()?.success())
+  let output = cmd.output()?;
+
+  let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+  let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+  let verification_output = format!("{}{}", stdout, stderr);
+
+  log::debug!(action = "Signing";"Verification output for {}:\n{}", tauri_utils::display_path(path), verification_output.trim());
+
+  Ok(output.status.success())
 }
 
 pub fn sign_command_custom<P: AsRef<Path>>(
@@ -210,7 +218,7 @@ pub fn sign_custom<P: AsRef<Path>>(
   let output = cmd.output_ok()?;
 
   let stdout = String::from_utf8_lossy(output.stdout.as_slice()).into_owned();
-  log::info!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
+  log::debug!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
 
   Ok(())
 }
@@ -229,7 +237,7 @@ pub fn sign_default<P: AsRef<Path>>(path: P, params: &SignParams) -> crate::Resu
   let output = cmd.output_ok()?;
 
   let stdout = String::from_utf8_lossy(output.stdout.as_slice()).into_owned();
-  log::info!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
+  log::debug!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
 
   Ok(())
 }


### PR DESCRIPTION
## Description

Closes #15687

When running `tauri build` with code signing enabled, the terminal output becomes extremely verbose (>3000 lines for projects with many binaries). The signing process outputs:
- Full verification tables (Index/Algorithm/Timestamp) for every already-signed file
- Complete stdout from custom signing commands (Azure signing details, etc.)
- Detailed signtool output for every file

This makes the build output nearly unreadable and buries important information.

## Root Cause

Three sources of excessive output in `crates/tauri-bundler/src/bundle/windows/sign.rs`:

1. **`verify()` function (line 132):** Used `cmd.status()` which lets signtool's verification output (signature tables, verification messages) flow directly to the terminal. For 300+ already-signed DLLs, this produces thousands of lines.

2. **`sign_custom()` function (line 213):** Logged the full stdout of custom signing commands at `log::info!` level, exposing detailed Azure/certificate signing output.

3. **`sign_default()` function (line 232):** Logged the full stdout of signtool at `log::info!` level, exposing detailed signing operation output.

## Changes

**File:** `crates/tauri-bundler/src/bundle/windows/sign.rs`

| Change | Before | After |
|--------|--------|-------|
| `verify()` | `cmd.status()` — output leaks to terminal | `cmd.output()` — output captured and discarded |
| `sign_custom()` output | `log::info!` | `log::debug!` |
| `sign_default()` output | `log::info!` | `log::debug!` |

## Behavior After Fix

**Default `tauri build` output** (concise):
```
     Signing C:\path\to\Contoso.API.dll
     Signing C:\path\to\Contoso.API.dll with a custom signing command
```

**Verbose `tauri build -v` output** (full details preserved):
```
     Signing C:\path\to\Contoso.API.dll with identity "ABC123"
     Output of signing command:
     [full signing output...]
```

## Testing

- No existing tests for Windows code signing in `tauri-bundler`
- The fix is minimal and targeted: 3 line changes
- `verify()` function semantics unchanged (still returns `bool`)
- Signing output preserved at `log::debug!` level for `-v` flag
- High-level progress messages (`log::info!` with `action = "Signing"`) remain unchanged

## Checklist

- [x] Code follows the project coding style
- [x] No new comments added
- [x] Change file added in `.changes/` directory
- [ ] Commits need to be signed (GPG key not configured)