### PR TITLE
fix(android): Migrate Gradle scripts to `compilerOptions` DSL

### DIFF
--- a/.changes/android-compileroptions-dsl.md
+++ b/.changes/android-compileroptions-dsl.md
@@ -1,0 +1,7 @@
+---
+"tauri": patch:enhance
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Migrate the Android Gradle scripts from the deprecated `kotlinOptions` DSL to `compilerOptions`, which is accepted by both Kotlin Gradle Plugin 1.9.x and 2.x. This lets projects move to Kotlin 2.x without hitting the hard error that 2.3+ raises on the old DSL.

--- a/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
 plugins {
@@ -50,11 +51,14 @@ android {
             )
         }
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
     buildFeatures {
         buildConfig = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
     }
 }
 

--- a/crates/tauri-cli/templates/plugin/android/build.gradle.kts
+++ b/crates/tauri-cli/templates/plugin/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -27,8 +29,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
     }
 }
 

--- a/crates/tauri/mobile/android/build.gradle.kts
+++ b/crates/tauri/mobile/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -27,11 +29,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
     buildFeatures {
         buildConfig = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
     }
 }
 

--- a/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
+++ b/examples/api/src-tauri/tauri-plugin-sample/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
@@ -27,8 +29,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
     }
 }
 


### PR DESCRIPTION
Kotlin Gradle Plugin deprecated the string-based `kotlinOptions` DSL and 2.3+ rejects it with a hard error. This PR changes the code to use the `compilerOptions` DSL with `JvmTarget.JVM_1_8` instead, which is accepted on both 1.9.x and 2.x, so projects can move to Kotlin 2.x without editing the vendored `:tauri-android` scripts.

This has a bit of overlap with #15335, but is a more focused non-breaking change, since this new syntax is supported by both major versions of the Gradle plugin.