### PR TITLE
chore: notice increased gradle version requirement

### DIFF
--- a/.changes/android-compileroptions-dsl.md
+++ b/.changes/android-compileroptions-dsl.md
@@ -5,3 +5,5 @@
 ---
 
 Migrate the Android Gradle scripts from the deprecated `kotlinOptions` DSL to `compilerOptions`, which is accepted by both Kotlin Gradle Plugin 1.9.x and 2.x. This lets projects move to Kotlin 2.x without hitting the hard error that 2.3+ raises on the old DSL.
+
+This increased the minimum supported Gradle version to 8.13, if your `gradle` is on an earlier version, delete `src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties` and re-run `tauri android init` to update it.


### PR DESCRIPTION
Reference #15694

(this is technically breaking but we can't adopt/support newer Android versions (a must have or the app can't go on the Google Play Store) without those bumps, we have done this in the past to support Android 16 #13759)

Since this was mainly for supporting Kotlin Gradle Plugin 2.3+, which we can also just don't to avoid the break...