### PR TITLE
fix(linux): use GtkFixed for child webviews to enable absolute positioning

### DIFF
--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -5135,9 +5135,33 @@ You may have it installed on another user account, but it is not available for t
       target_os = "android"
     )))]
     WebviewKind::WindowChild => {
-      // only way to account for menu bar height, and also works for multiwebviews :)
+      // Use GtkFixed instead of GtkBox for child webviews so that
+      // position and size from add_child() are respected on Linux.
+      // GtkBox stacks children vertically, ignoring position.
+      // GtkFixed allows absolute positioning which wry already supports.
+      use gtk::prelude::*;
       let vbox = window.default_vbox().unwrap();
-      webview_builder.build_gtk(vbox)
+
+      // Find or create a GtkFixed inside the vbox
+      let fixed = {
+        let mut found: Option<gtk::Fixed> = None;
+        for child in vbox.children() {
+          if let Some(f) = child.downcast_ref::<gtk::Fixed>() {
+            found = Some(f.clone());
+            break;
+          }
+        }
+        if let Some(f) = found {
+          f
+        } else {
+          let f = gtk::Fixed::new();
+          vbox.pack_start(&f, true, true, 0);
+          f.show();
+          f
+        }
+      };
+
+      webview_builder.build_gtk(&fixed)
     }
     #[cfg(any(
       target_os = "windows",


### PR DESCRIPTION
## Summary

On Linux, `Window::add_child()` ignores the position parameter because child webviews are added to the window's default `GtkBox` container, which stacks children vertically regardless of the position specified.

This PR creates a `GtkFixed` container inside the vbox and adds child webviews there instead. `GtkFixed` supports absolute positioning, which wry already handles via `add_to_container()` (checking for `"GtkFixed"` container type and using `fixed.put(webview, x, y)`).

## What this enables

Multi-webview layouts (e.g. side-by-side split views) on Linux, matching the behavior on Windows and macOS where `build_as_child(&window)` is used.

## Implementation

- On first `WindowChild` webview creation, a `GtkFixed` is created inside the existing vbox
- Subsequent child webviews reuse the same `GtkFixed`
- The `WindowContent` webview path (single webview) is unchanged
- wry already supports `GtkFixed` containers — this just makes Tauri use one

## Testing

Tested on Fedora 40 with GTK 4.14.5 / WebKitGTK 2.48.1:
- Two webviews side by side in one window (350px + 850px)
- Position and size correctly applied
- Previously both webviews were stacked vertically