### PR TITLE
fix: `referenced_by` compilation on different debug profiles

### DIFF
--- a/.changes/resolved-command-reference-debug-assertion.md
+++ b/.changes/resolved-command-reference-debug-assertion.md
@@ -1,0 +1,8 @@
+---
+tauri: minor:enhance
+tauri-macros: minor:enhance
+tauri-utils: minor:enhance
+tauri-build: minor:enhance
+---
+
+Fix different build and runtime debug assertion profiles on the tauri-utils crate can resulting in compilation errors.

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -33,6 +33,23 @@ pub struct ResolvedCommandReference {
   pub permission: String,
 }
 
+impl ResolvedCommandReference {
+  /// Internal helper for tauri-macros to avoid compilation errors on different `debug_assertions` settings,
+  /// see https://github.com/tauri-apps/tauri/issues/13865
+  #[doc(hidden)]
+  pub fn new(
+    #[cfg_attr(not(debug_assertions), allow(unused))] capability: String,
+    #[cfg_attr(not(debug_assertions), allow(unused))] permission: String,
+  ) -> Self {
+    Self {
+      #[cfg(debug_assertions)]
+      capability,
+      #[cfg(debug_assertions)]
+      permission,
+    }
+  }
+}
+
 /// A resolved command permission.
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct ResolvedCommand {
@@ -478,12 +495,9 @@ mod build {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let capability = str_lit(&self.capability);
       let permission = str_lit(&self.permission);
-      literal_struct!(
-        tokens,
-        ::tauri::utils::acl::resolved::ResolvedCommandReference,
-        capability,
-        permission
-      )
+      tokens.append_all(quote! {
+        ::tauri::utils::acl::resolved::ResolvedCommandReference::new(#capability, #permission)
+      });
     }
   }
 

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -48,7 +48,7 @@ impl ResolvedCommand {
   /// Internal helper for tauri-macros to avoid compile errors on different `debug_assertions` settings,
   /// see https://github.com/tauri-apps/tauri/issues/13865
   #[doc(hidden)]
-  pub const fn new(
+  pub fn new(
     context: ExecutionContext,
     #[cfg_attr(not(debug_assertions), allow(unused))] referenced_by: ResolvedCommandReference,
     windows: Vec<glob::Pattern>,

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -468,7 +468,6 @@ mod build {
   use super::*;
   use crate::{literal_struct, tokens::*};
 
-  #[cfg(debug_assertions)]
   impl ToTokens for ResolvedCommandReference {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let capability = str_lit(&self.capability);

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -45,6 +45,28 @@ pub struct ResolvedCommand {
   pub scope_id: Option<ScopeKey>,
 }
 
+impl ResolvedCommand {
+  /// Internal helper for tauri-macros to avoid compile errors on different `debug_assertions` settings,
+  /// see https://github.com/tauri-apps/tauri/issues/13865
+  #[doc(hidden)]
+  pub const fn new(
+    context: ExecutionContext,
+    #[cfg_attr(not(debug_assertions), allow(unused))] referenced_by: ResolvedCommandReference,
+    windows: Vec<glob::Pattern>,
+    webviews: Vec<glob::Pattern>,
+    scope_id: Option<ScopeKey>,
+  ) -> Self {
+    Self {
+      context,
+      #[cfg(debug_assertions)]
+      referenced_by,
+      windows,
+      webviews,
+      scope_id,
+    }
+  }
+}
+
 impl fmt::Debug for ResolvedCommand {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("ResolvedCommand")
@@ -465,6 +487,8 @@ mod build {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       #[cfg(debug_assertions)]
       let referenced_by = &self.referenced_by;
+      #[cfg(not(debug_assertions))]
+      let referenced_by = &ResolvedCommandReference::default();
 
       let context = &self.context;
 
@@ -478,27 +502,15 @@ mod build {
       });
       let scope_id = opt_lit(self.scope_id.as_ref());
 
-      #[cfg(debug_assertions)]
-      {
-        literal_struct!(
-          tokens,
-          ::tauri::utils::acl::resolved::ResolvedCommand,
-          context,
-          referenced_by,
-          windows,
-          webviews,
-          scope_id
+      tokens.append_all(quote! {
+        ::tauri::utils::acl::resolved::ResolvedCommand::new(
+          #context,
+          #referenced_by,
+          #windows,
+          #webviews,
+          #scope_id
         )
-      }
-      #[cfg(not(debug_assertions))]
-      literal_struct!(
-        tokens,
-        ::tauri::utils::acl::resolved::ResolvedCommand,
-        context,
-        windows,
-        webviews,
-        scope_id
-      )
+      })
     }
   }
 

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -20,7 +20,6 @@ use super::{
 pub type ScopeKey = u64;
 
 /// Metadata for what referenced a [`ResolvedCommand`].
-#[cfg(debug_assertions)]
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct ResolvedCommandReference {
   /// Identifier of the capability.

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -19,12 +19,17 @@ use super::{
 /// A key for a scope, used to link a [`ResolvedCommand#structfield.scope`] to the store [`Resolved#structfield.scopes`].
 pub type ScopeKey = u64;
 
+// All the fields are marked with `#[cfg(debug_assertions)]` but not the struct itself is because
+// we want to avoid compilation errors on different `debug_assertions` settings,
+// see https://github.com/tauri-apps/tauri/issues/13865
 /// Metadata for what referenced a [`ResolvedCommand`].
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct ResolvedCommandReference {
   /// Identifier of the capability.
+  #[cfg(debug_assertions)]
   pub capability: String,
   /// Identifier of the permission.
+  #[cfg(debug_assertions)]
   pub permission: String,
 }
 
@@ -45,7 +50,7 @@ pub struct ResolvedCommand {
 }
 
 impl ResolvedCommand {
-  /// Internal helper for tauri-macros to avoid compile errors on different `debug_assertions` settings,
+  /// Internal helper for tauri-macros to avoid compilation errors on different `debug_assertions` settings,
   /// see https://github.com/tauri-apps/tauri/issues/13865
   #[doc(hidden)]
   pub fn new(
@@ -468,6 +473,7 @@ mod build {
   use super::*;
   use crate::{literal_struct, tokens::*};
 
+  #[cfg(debug_assertions)]
   impl ToTokens for ResolvedCommandReference {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let capability = str_lit(&self.capability);
@@ -486,7 +492,8 @@ mod build {
       #[cfg(debug_assertions)]
       let referenced_by = &self.referenced_by;
       #[cfg(not(debug_assertions))]
-      let referenced_by = &ResolvedCommandReference::default();
+      let referenced_by =
+        quote!(::tauri::utils::acl::resolved::ResolvedCommandReference::default());
 
       let context = &self.context;
 


### PR DESCRIPTION
Closes #13865
Closes #15406

Closes #15603

I don't even know how I thought of this to be honest 🤯