### PR TITLE
fix(runtime): resolve macOS parent window content view

### DIFF
--- a/crates/tauri-runtime-cef/src/window.rs
+++ b/crates/tauri-runtime-cef/src/window.rs
@@ -33,10 +33,18 @@ use winit::{
 #[cfg(target_os = "macos")]
 use crate::platform::macos::AppkitState;
 use crate::platform::{EventLoopExt, MonitorExt};
+#[cfg(target_os = "macos")]
+use objc2::MainThreadMarker;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::NSWindow;
+#[cfg(target_os = "macos")]
+use raw_window_handle::{AppKitWindowHandle, RawWindowHandle};
 #[cfg(any(windows, target_os = "macos"))]
 use std::marker::PhantomData;
 #[cfg(target_os = "macos")]
 use std::sync::RwLock;
+#[cfg(target_os = "macos")]
+use std::{ffi::c_void, ptr::NonNull};
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowExtMacOS;
 #[cfg(windows)]
@@ -336,6 +344,8 @@ pub(crate) struct AppWindow {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct AppWindowAttrs {
   pub(crate) inner: WindowAttributes,
+  #[cfg(target_os = "macos")]
+  pub(crate) parent_ns_window: Option<NonNull<c_void>>,
   pub(crate) center: bool,
   pub(crate) background_color: Option<Color>,
   pub(crate) prevent_overflow: Option<Size>,
@@ -358,6 +368,29 @@ pub(crate) struct AppWindowAttrs {
     target_os = "openbsd"
   ))]
   pub(crate) skip_taskbar: bool,
+}
+
+#[cfg(target_os = "macos")]
+fn install_macos_parent_view(
+  attrs: WindowAttributes,
+  parent_ns_window: NonNull<c_void>,
+) -> Result<WindowAttributes> {
+  // Window creation is handled by winit's main-thread event loop. Refuse to
+  // message AppKit if that invariant is ever broken.
+  let Some(_main_thread_marker) = MainThreadMarker::new() else {
+    return Err(Error::CreateWindow);
+  };
+
+  // SAFETY: Tauri passes a live NSWindow owned by the application for the
+  // duration of child-window creation.
+  let parent_window = unsafe { parent_ns_window.cast::<NSWindow>().as_ref() };
+  let parent_view = parent_window.contentView().ok_or(Error::CreateWindow)?;
+  let parent_view_ptr = NonNull::from(&*parent_view).cast::<c_void>();
+  let parent_handle = RawWindowHandle::AppKit(AppKitWindowHandle::new(parent_view_ptr));
+
+  // SAFETY: parent_view is installed in the live parent NSWindow, and winit
+  // retains the view while establishing the native child-window relationship.
+  Ok(unsafe { attrs.with_parent_window(Some(parent_handle)) })
 }
 
 impl AppWindow {
@@ -426,6 +459,11 @@ impl<T: UserEvent> WinitCefApp<T> {
         tauri_theme_to_winit_theme(*self.context.app_wide_theme.lock().unwrap());
     }
     prepare_window_attributes(event_loop, &mut attrs);
+
+    #[cfg(target_os = "macos")]
+    if let Some(parent_ns_window) = attrs.parent_ns_window {
+      attrs.inner = install_macos_parent_view(attrs.inner, parent_ns_window)?;
+    }
 
     let window = event_loop
       .create_window(attrs.inner.clone())

--- a/crates/tauri-runtime-cef/src/window_builder.rs
+++ b/crates/tauri-runtime-cef/src/window_builder.rs
@@ -21,7 +21,7 @@ use crate::window::{
   AppWindowAttrs, paired_size_constraint, tauri_theme_to_winit_theme, winit_theme_to_tauri_theme,
 };
 
-#[cfg(any(windows, target_os = "macos"))]
+#[cfg(windows)]
 use winit::raw_window_handle::RawWindowHandle;
 
 #[cfg(target_os = "macos")]
@@ -407,12 +407,10 @@ impl WindowBuilder for WindowBuilderWrapper {
 
   #[cfg(target_os = "macos")]
   fn parent(mut self, parent: *mut std::ffi::c_void) -> Self {
-    if let Some(ns_view) = NonNull::new(parent) {
-      let handle =
-        RawWindowHandle::AppKit(winit::raw_window_handle::AppKitWindowHandle::new(ns_view));
-      // SAFETY: Tauri passes a live parent NSView owned by the application.
-      self.attrs.inner = unsafe { self.attrs.inner.with_parent_window(Some(handle)) };
-    }
+    // Tauri's macOS WindowBuilder contract passes an NSWindow pointer. Keep it
+    // separate from winit's AppKitWindowHandle until create_window runs on the
+    // AppKit thread and can resolve the window's content NSView safely.
+    self.attrs.parent_ns_window = NonNull::new(parent);
     self
   }
 


### PR DESCRIPTION
## Summary

- preserve Tauri's macOS parent pointer as an `NSWindow` until native window creation
- resolve the parent's content `NSView` on the AppKit main thread before constructing winit's `AppKitWindowHandle`
- return `CreateWindow` instead of messaging AppKit if window creation is ever attempted off the main thread

## Why

Tauri's macOS `WindowBuilder::parent` contract passes an `NSWindow *`, while raw-window-handle's `AppKitWindowHandle` requires an `NSView *`. The CEF runtime currently stores the `NSWindow *` directly as an `NSView *`. During child-window creation, winit sends `window` to that object and objc2 aborts because the object is actually an `_NSKVONotifying_WinitWindow`.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p tauri-runtime-cef --all-features`
- `cargo test -p tauri-runtime-cef --all-features --lib`
- verified the branch merges cleanly onto `feat/cef`
- patched The AI Platform desktop app, opened its Code CEF miniapp with a parented native watermark window, and confirmed both the miniapp and watermark render without the Objective-C panic
