### PR TITLE
enhance(android): use `Theme.Material3.DayNight.NoActionBar`

### DIFF
--- a/.changes/android-material3.md
+++ b/.changes/android-material3.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Use `Theme.Material3.DayNight.NoActionBar` instead of `Theme.MaterialComponents.DayNight.NoActionBar` when running `tauri android init`

--- a/crates/tauri-cli/templates/mobile/android/app/src/main/res/values-night/themes.xml
+++ b/crates/tauri-cli/templates/mobile/android/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.{{snake-case app.name}}" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.{{snake-case app.name}}" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/themes.xml
+++ b/crates/tauri-cli/templates/mobile/android/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.{{snake-case app.name}}" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+    <style name="Theme.{{snake-case app.name}}" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
     </style>
 </resources>

--- a/examples/api/src/App.svelte
+++ b/examples/api/src/App.svelte
@@ -250,7 +250,7 @@
 </div>
 
 <div
-  class="flex h-screen w-screen overflow-hidden children-pt4 children-pb-2 text-primaryText dark:text-darkPrimaryText"
+  class="flex h-screen w-screen overflow-hidden text-primaryText dark:text-darkPrimaryText"
 >
   <aside
     id="sidebar"

--- a/examples/api/src/App.svelte
+++ b/examples/api/src/App.svelte
@@ -256,7 +256,7 @@
     id="sidebar"
     bind:this={sidebar}
     class="lt-sm:h-screen lt-sm:shadow-lg lt-sm:shadow lt-sm:transition-transform lt-sm:absolute lt-sm:z-1999
-      bg-darkPrimaryLighter transition-colors-250 overflow-hidden grid grid-rows-[min-content_auto] select-none px-2"
+      bg-darkPrimaryLighter transition-colors-250 overflow-hidden grid grid-rows-[min-content_auto] content-start select-none px-2"
   >
     <img
       class="self-center p-7 cursor-pointer"

--- a/examples/api/src/App.svelte
+++ b/examples/api/src/App.svelte
@@ -239,7 +239,7 @@
 <div
   id="sidebarToggle"
   bind:this={sidebarToggle}
-  class="z-2000 hidden lt-sm:flex justify-center items-center absolute top-2 left-2 w-8 h-8 rd-8
+  class="z-2000 hidden lt-sm:flex justify-center absolute items-center w-8 h-8 rd-8
             bg-accent dark:bg-darkAccent active:bg-accentDark dark:active:bg-darkAccentDark"
 >
   {#if isSideBarOpen}

--- a/examples/api/src/app.css
+++ b/examples/api/src/app.css
@@ -63,7 +63,7 @@ main {
 }
 
 #sidebarToggle {
-  margin-top: calc(env(safe-area-inset-top) + 1rem);
+  margin-top: calc(env(safe-area-inset-top) + 0.5rem);
   margin-left: calc(env(safe-area-inset-left) + 0.5rem);
 }
 

--- a/examples/api/src/app.css
+++ b/examples/api/src/app.css
@@ -42,9 +42,32 @@ code.code-block {
   width: 18.75rem;
 }
 
-@media screen and (max-width: 640px) {
+@media screen and (width < 640px) {
   #sidebar {
     --translate-x: -18.75rem;
     transform: translateX(var(--translate-x));
   }
+}
+
+#sidebar,
+main {
+  padding-top: calc(env(safe-area-inset-top) + 1rem);
+}
+
+#sidebar {
+  padding-left: calc(env(safe-area-inset-left) + 0.5rem);
+}
+
+main {
+  padding-right: env(safe-area-inset-right);
+}
+
+#sidebarToggle {
+  margin-top: calc(env(safe-area-inset-top) + 1rem);
+  margin-left: calc(env(safe-area-inset-left) + 0.5rem);
+}
+
+#sidebar,
+#console {
+  padding-bottom: calc(env(safe-area-inset-bottom) + 1.5rem);
 }


### PR DESCRIPTION
Use `Theme.Material3.DayNight.NoActionBar` instead of `Theme.MaterialComponents.DayNight.NoActionBar` when running `tauri android init`

Also fixed the API example insets:

<img width="651" height="1376" alt="image" src="https://github.com/user-attachments/assets/ac7b0e91-ba5c-4fde-afd8-620583e3e899" />