### PR TITLE
refactor: rename `extend_api` to `run_invoke_handler`

### DIFF
--- a/crates/tauri/src/ipc/protocol.rs
+++ b/crates/tauri/src/ipc/protocol.rs
@@ -328,12 +328,10 @@ fn handle_ipc_message<R: Runtime>(request: Request<String>, manager: &AppManager
             js: crate::Result<String>,
             error: CallbackFn,
           ) {
-            let eval_js = match js {
-              Ok(js) => js,
-              Err(e) => crate::ipc::format_callback::format(error, &e.to_string())
-                .expect("unable to serialize response error string to json"),
-            };
-
+            let eval_js = js.unwrap_or_else(|e| {
+              crate::ipc::format_callback::format(error, &e.to_string())
+                .expect("unable to serialize response error string to json")
+            });
             let _ = webview.eval(eval_js);
           }
 

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -472,12 +472,12 @@ impl<R: Runtime> AppManager<R> {
     (self.webview.invoke_handler)(invoke)
   }
 
-  pub fn extend_api(&self, plugin: &str, invoke: Invoke<R>) -> bool {
+  pub fn run_plugin_invoke_handler(&self, plugin: &str, invoke: Invoke<R>) -> bool {
     self
       .plugins
       .lock()
       .expect("poisoned plugin store")
-      .extend_api(plugin, invoke)
+      .run_invoke_handler(plugin, invoke)
   }
 
   pub fn initialize_plugins(&self, app: &AppHandle<R>) -> crate::Result<()> {

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -472,6 +472,9 @@ impl<R: Runtime> AppManager<R> {
     (self.webview.invoke_handler)(invoke)
   }
 
+  /// Runs the plugin [`crate::plugin::Plugin::extend_api`] hook if it exists. Returns whether the invoke message was handled or not.
+  ///
+  /// The message is not handled when the plugin exists **and** the command does not.
   pub fn run_plugin_invoke_handler(&self, plugin: &str, invoke: Invoke<R>) -> bool {
     self
       .plugins

--- a/crates/tauri/src/plugin.rs
+++ b/crates/tauri/src/plugin.rs
@@ -980,7 +980,7 @@ impl<R: Runtime> PluginStore<R> {
       .for_each(|plugin| plugin.on_event(app, event))
   }
 
-  /// Runs the plugin `extend_api` hook if it exists. Returns whether the invoke message was handled or not.
+  /// Runs the plugin [`Plugin::extend_api`] hook if it exists. Returns whether the invoke message was handled or not.
   ///
   /// The message is not handled when the plugin exists **and** the command does not.
   pub(crate) fn run_invoke_handler(&mut self, plugin: &str, invoke: Invoke<R>) -> bool {

--- a/crates/tauri/src/plugin.rs
+++ b/crates/tauri/src/plugin.rs
@@ -104,6 +104,7 @@ pub trait Plugin<R: Runtime>: Send {
   #[allow(unused_variables)]
   fn on_event(&mut self, app: &AppHandle<R>, event: &RunEvent) {}
 
+  // TODO: Change this to `run_invoke_handler` in v3
   /// Extend commands to [`crate::Builder::invoke_handler`].
   #[allow(unused_variables)]
   fn extend_api(&mut self, invoke: Invoke<R>) -> bool {
@@ -982,7 +983,7 @@ impl<R: Runtime> PluginStore<R> {
   /// Runs the plugin `extend_api` hook if it exists. Returns whether the invoke message was handled or not.
   ///
   /// The message is not handled when the plugin exists **and** the command does not.
-  pub(crate) fn extend_api(&mut self, plugin: &str, invoke: Invoke<R>) -> bool {
+  pub(crate) fn run_invoke_handler(&mut self, plugin: &str, invoke: Invoke<R>) -> bool {
     for p in self.store.iter_mut() {
       if p.name() == plugin {
         #[cfg(feature = "tracing")]

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1862,7 +1862,7 @@ tauri::Builder::default()
       let message = invoke.message.clone();
 
       #[allow(unused_mut)]
-      let mut handled = manager.extend_api(plugin, invoke);
+      let mut handled = manager.run_plugin_invoke_handler(plugin, invoke);
 
       #[cfg(mobile)]
       {


### PR DESCRIPTION
I'm not sure why is it called `extend_api` but if it's job is to call `invoke_handler`, why not `run_invoke_handler`?