### PR TITLE
chore(example): set `color-scheme`

### DIFF
--- a/examples/api/index.html
+++ b/examples/api/index.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="en" theme="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
     <title>API Example App</title>
   </head>
 

--- a/examples/api/src/App.svelte
+++ b/examples/api/src/App.svelte
@@ -102,9 +102,13 @@
 
   function applyTheme() {
     const isDark = theme === 'auto' ? preferDark.current : theme === 'dark'
-    isDark
-      ? document.documentElement.classList.add('dark')
-      : document.documentElement.classList.remove('dark')
+    if (isDark) {
+      document.documentElement.classList.add('dark')
+      document.documentElement.classList.remove('light')
+    } else {
+      document.documentElement.classList.remove('dark')
+      document.documentElement.classList.add('light')
+    }
     setTheme(theme === 'auto' ? null : theme)
     localStorage.setItem('theme', theme)
   }
@@ -240,7 +244,7 @@
   id="sidebarToggle"
   bind:this={sidebarToggle}
   class="z-2000 hidden lt-sm:flex justify-center absolute items-center w-8 h-8 rd-8
-            bg-accent dark:bg-darkAccent active:bg-accentDark dark:active:bg-darkAccentDark"
+            bg-accent dark:bg-darkAccent active:bg-accentDark dark:active:bg-darkAccentDark text-accentText dark:text-darkAccentText"
 >
   {#if isSideBarOpen}
     <span class="i-codicon-close animate-duration-300ms animate-fade-in"></span>

--- a/examples/api/src/app.css
+++ b/examples/api/src/app.css
@@ -2,6 +2,13 @@
   line-height: 1.5;
 }
 
+:root.dark {
+  color-scheme: dark;
+}
+:root.light {
+  color-scheme: light;
+}
+
 input,
 select {
   min-width: 0;


### PR DESCRIPTION
This allows the unstyled user agent elements (like the checkbox) match the selected theme colors