### PR TITLE
docs(cli): document TAURI_SIGNING_PRIVATE_KEY_PATH and clarify key vars

### DIFF
--- a/.changes/signing-env-vars.md
+++ b/.changes/signing-env-vars.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Document the `TAURI_SIGNING_PRIVATE_KEY_PATH` environment variable and clarify that `TAURI_SIGNING_PRIVATE_KEY` accepts a string or a path for the `build` and `bundle` command but must be the literal key string for the `signer sign` command, both in `ENVIRONMENT_VARIABLES.md` and in the `signer generate` command output.

--- a/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
+++ b/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
@@ -19,7 +19,8 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `TAURI_BUNDLER_TOOLS_GITHUB_MIRROR_TEMPLATE` - Specify a GitHub mirror template to download files and tools used by tauri bundler, for example: `https://mirror.example.com/<owner>/<repo>/releases/download/<version>/<asset>`.
 - `TAURI_BUNDLER_DMG_IGNORE_CI` - Disable the check for `CI: true` in the `.dmg` bundler.
 - `TAURI_SKIP_SIDECAR_SIGNATURE_CHECK` - Skip signing sidecars.
-- `TAURI_SIGNING_PRIVATE_KEY` — Private key used to sign your app bundles, can be either a string or a path to the file.
+- `TAURI_SIGNING_PRIVATE_KEY` — Private key used to sign your app bundles. For the `build` and `bundle` command, can be either a string or a path to the file. For the `signer sign` command, this must be the literal key string.
+- `TAURI_SIGNING_PRIVATE_KEY_PATH` — Path to the private key file for the `signer sign` command. Mutually exclusive with `TAURI_SIGNING_PRIVATE_KEY` when using the signer command.
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — The signing private key password, see `TAURI_SIGNING_PRIVATE_KEY`.
 - `TAURI_SIGNING_RPM_KEY` — The private GPG key used to sign the RPM bundle, exported to its ASCII-armored format.
 - `TAURI_SIGNING_RPM_KEY_PASSPHRASE` — The GPG key passphrase for `TAURI_SIGNING_RPM_KEY`, if needed.

--- a/crates/tauri-cli/src/signer/generate.rs
+++ b/crates/tauri-cli/src/signer/generate.rs
@@ -57,8 +57,8 @@ pub fn command(mut options: Options) -> Result<()> {
 
   println!();
   println!("Environment variables used to sign:");
-  println!("- `TAURI_SIGNING_PRIVATE_KEY`: String of your private key");
-  println!("- `TAURI_SIGNING_PRIVATE_KEY_PATH`: Path to your private key file");
+  println!("- `TAURI_SIGNING_PRIVATE_KEY`: Your private key. For the `build` and `bundle` command it can be either a string or a path to the file, for the `signer sign` command it must be the literal key string");
+  println!("- `TAURI_SIGNING_PRIVATE_KEY_PATH`: Path to your private key file, used by the `signer sign` command");
   println!("- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`:  Your private key password (optional if key has no password)");
   println!();
   println!("ATTENTION: If you lose your private key OR password, you'll not be able to sign your update package and updates will not work");


### PR DESCRIPTION
`TAURI_SIGNING_PRIVATE_KEY_PATH` was missing from the reference even though `tauri signer sign` reads it. The old wording also glossed over how `build`/`bundle` accept the key as a string or a path, while `signer sign` only takes the literal string. So this adds the var and spells out that difference. #15028
