### PR TITLE
ci: fix and run acl-tests

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -103,6 +103,10 @@ jobs:
         # Using --lib --bins --tests to skip doc tests
         run: ${{ matrix.platform.cargo }} ${{ matrix.platform.command }} --target ${{ matrix.platform.target }} ${{ matrix.features.args }} --lib --bins --tests --manifest-path crates/tauri-utils/Cargo.toml
 
+      - name: run acl-tests
+        if: ${{ matrix.features.key != 'no-default' && matrix.platform.command == 'test' }}
+        run: ${{ matrix.platform.cargo }} test --target ${{ matrix.platform.target }} ${{ matrix.features.args }} --manifest-path crates/tests/acl/Cargo.toml
+
       - name: test tauri
         run: ${{ matrix.platform.cargo }} ${{ matrix.features.key == 'no-default' && 'check' || matrix.platform.command }} --target ${{ matrix.platform.target }} ${{ matrix.features.args }} --manifest-path crates/tauri/Cargo.toml
 

--- a/crates/tauri-utils/src/acl/resolved.rs
+++ b/crates/tauri-utils/src/acl/resolved.rs
@@ -152,7 +152,7 @@ impl Resolved {
          }| {
           if commands.allow.is_empty() && commands.deny.is_empty() {
             // global scope
-            global_scope.entry(key.to_string()).or_default().push(scope);
+            global_scope.entry(key).or_default().push(scope);
           } else {
             let scope_id = if scope.allow.is_some() || scope.deny.is_some() {
               current_scope_id += 1;
@@ -181,7 +181,7 @@ impl Resolved {
                 capability,
                 scope_id,
                 #[cfg(debug_assertions)]
-                permission_name.to_string(),
+                permission_name,
               )?;
             }
 
@@ -198,7 +198,7 @@ impl Resolved {
                 capability,
                 scope_id,
                 #[cfg(debug_assertions)]
-                permission_name.to_string(),
+                permission_name,
               )?;
             }
           }
@@ -255,7 +255,7 @@ fn resolve_command(
   command: String,
   capability: &Capability,
   scope_id: Option<ScopeKey>,
-  #[cfg(debug_assertions)] referenced_by_permission_identifier: String,
+  #[cfg(debug_assertions)] referenced_by_permission_identifier: &str,
 ) -> Result<(), Error> {
   let mut contexts = Vec::new();
   if capability.local {
@@ -279,7 +279,7 @@ fn resolve_command(
       #[cfg(debug_assertions)]
       referenced_by: ResolvedCommandReference {
         capability: capability.identifier.clone(),
-        permission: referenced_by_permission_identifier.clone(),
+        permission: referenced_by_permission_identifier.to_owned(),
       },
       windows: parse_glob_patterns(capability.windows.clone())?,
       webviews: parse_glob_patterns(capability.webviews.clone())?,
@@ -291,7 +291,7 @@ fn resolve_command(
 }
 
 struct ResolvedPermission<'a> {
-  key: &'a str,
+  key: String,
   permission_name: &'a str,
   commands: Commands,
   scope: Scopes,
@@ -357,7 +357,7 @@ fn with_resolved_permissions<F: FnMut(ResolvedPermission<'_>) -> Result<(), Erro
       commands.deny.extend(permission.commands.deny.clone());
 
       f(ResolvedPermission {
-        key: &key,
+        key,
         permission_name: &permission_name,
         commands,
         scope: resolved_scope,

--- a/crates/tauri/src/ipc/authority.rs
+++ b/crates/tauri/src/ipc/authority.rs
@@ -609,13 +609,11 @@ impl<T: ScopeObjectMatch> CommandScope<T> {
 impl<'a, R: Runtime, T: ScopeObject> CommandArg<'a, R> for CommandScope<T> {
   /// Grabs the [`ResolvedScope`] from the [`CommandItem`] and returns the associated [`CommandScope`].
   fn from_command(command: CommandItem<'a, R>) -> Result<Self, InvokeError> {
-    let scope_ids = command.acl.as_ref().map(|resolved| {
-      resolved
+    if let Some(resolved) = &command.acl {
+      let scope_ids = resolved
         .iter()
         .filter_map(|cmd| cmd.scope_id)
-        .collect::<Vec<_>>()
-    });
-    if let Some(scope_ids) = scope_ids {
+        .collect::<Vec<_>>();
       CommandScope::resolve(&command.message.webview, scope_ids).map_err(Into::into)
     } else {
       Ok(CommandScope {

--- a/crates/tests/acl/fixtures/snapshots/acl_tests__tests__file-explorer-remote.snap
+++ b/crates/tests/acl/fixtures/snapshots/acl_tests__tests__file-explorer-remote.snap
@@ -14,7 +14,7 @@ Resolved {
                                 pattern_string: "https",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^https$",
+                                        "^https$",
                                     ),
                                 ),
                                 group_name_list: [],
@@ -32,7 +32,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -53,7 +53,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -74,7 +74,7 @@ Resolved {
                                 pattern_string: "tauri.app",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^tauri\\.app$",
+                                        "^tauri\\.app$",
                                     ),
                                 ),
                                 group_name_list: [],
@@ -92,7 +92,7 @@ Resolved {
                                 pattern_string: "",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^$",
+                                        "^$",
                                     ),
                                 ),
                                 group_name_list: [],
@@ -110,7 +110,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -131,7 +131,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -152,7 +152,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -206,7 +206,7 @@ Resolved {
                                 pattern_string: "https",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^https$",
+                                        "^https$",
                                     ),
                                 ),
                                 group_name_list: [],
@@ -224,7 +224,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -245,7 +245,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -266,7 +266,7 @@ Resolved {
                                 pattern_string: "tauri.app",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^tauri\\.app$",
+                                        "^tauri\\.app$",
                                     ),
                                 ),
                                 group_name_list: [],
@@ -284,7 +284,7 @@ Resolved {
                                 pattern_string: "",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^$",
+                                        "^$",
                                     ),
                                 ),
                                 group_name_list: [],
@@ -302,7 +302,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -323,7 +323,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [
@@ -344,7 +344,7 @@ Resolved {
                                 pattern_string: "*",
                                 regexp: Ok(
                                     Regex(
-                                        "(?u)^(.*)$",
+                                        "^(.*)$",
                                     ),
                                 ),
                                 group_name_list: [


### PR DESCRIPTION
The `regexp` field changed in one of the urlpatern updates