### PR TITLE
fix(cef): preserve mapped custom protocol authorities

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl/mapped_scheme.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl/mapped_scheme.rs
@@ -1,0 +1,254 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+//! Host-preserving mapped custom-protocol routing for CEF.
+//!
+//! CEF — like WebView2 and Android WebView — cannot expose a non-standard
+//! custom scheme to `fetch`/storage/etc. without registering that scheme in
+//! every process. Tauri instead maps a logical custom-protocol URL onto the
+//! built-in `https` (or `http`) scheme, exactly like Wry's WebView2/Android
+//! workaround (`wry::custom_protocol_workaround`):
+//!
+//! ```text
+//! logical   scheme://authority/path
+//! mapped    https://scheme.authority/path
+//! ```
+//!
+//! The `scheme.` label is prepended to the authority, so the *logical authority
+//! is preserved* as a browser-visible subdomain rather than collapsed to a
+//! single fixed host. That is what lets distinct logical authorities on one
+//! scheme (`app://a.localhost/…`, `app://b.localhost/…`) become distinct
+//! browser origins (`https://app.a.localhost/…`, `https://app.b.localhost/…`),
+//! each with its own same-origin storage.
+//!
+//! Unlike Wry — whose per-protocol interception filter is scoped by the host
+//! runtime — the CEF factory is registered against the whole built-in scheme
+//! (see [`crate::cef_impl::request_context`]). Routing therefore has to do two
+//! extra jobs here:
+//!
+//! 1. [`split_mapped_host`] restricts interception to the reserved
+//!    `<scheme>.….localhost` namespace, so unrelated HTTPS is never claimed.
+//! 2. [`to_logical_url`] normalizes an intercepted mapped URL back to the
+//!    logical custom-protocol request before it reaches the Tauri handler, so
+//!    the handler always receives one logical URL shape across every runtime.
+
+use url::Url;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct MappedRequest {
+  pub(crate) custom_scheme: String,
+  pub(crate) logical_url: String,
+}
+
+/// Splits a mapped work-around host `<scheme>.<authority>` into its logical
+/// scheme label and logical authority, but only for the reserved
+/// `*.localhost` namespace.
+///
+/// Returns `None` for any host that is not `<non-empty-label>.….localhost`, so
+/// a factory registered against the whole `https`/`http` scheme leaves
+/// unrelated origins untouched.
+///
+/// ```text
+/// app.localhost                -> ("app", "localhost")
+/// app.a.localhost              -> ("app", "a.localhost")
+/// localhost | example.com      -> None
+/// app.a.localhost.example.com  -> None  (does not end in .localhost)
+/// ```
+pub(crate) fn split_mapped_host(host: &str) -> Option<(&str, &str)> {
+  // A bare `localhost` is not part of the reserved namespace: the scheme label
+  // is mandatory, so the host must have at least `<label>.localhost`.
+  if !host.ends_with(".localhost") {
+    return None;
+  }
+
+  let (label, authority) = host.split_once('.')?;
+  if label.is_empty()
+    || authority.is_empty()
+    || label.split('.').any(str::is_empty)
+    || authority.split('.').any(str::is_empty)
+  {
+    return None;
+  }
+
+  Some((label, authority))
+}
+
+/// Reverts a mapped browser URL back to its logical custom-protocol form,
+/// mirroring `wry::custom_protocol_workaround::revert_uri_work_around`.
+///
+/// `mapped_scheme` is the built-in scheme the logical scheme was mapped onto
+/// (`https` or `http`); `scheme` is the logical custom scheme. Returns `None`
+/// when `url` is not a mapped URL for `scheme`. Only the scheme + first host
+/// label are rewritten, so the logical authority (and everything after it) is
+/// preserved verbatim.
+///
+/// ```text
+/// https://app.a.localhost/index.html -> app://a.localhost/index.html
+/// https://app.localhost/x            -> app://localhost/x
+/// ```
+pub(crate) fn to_logical_url(url: &str, mapped_scheme: &str, scheme: &str) -> Option<String> {
+  let prefix = format!("{mapped_scheme}://{scheme}.");
+  let authority_and_rest = url.strip_prefix(&prefix)?;
+  Some(format!("{scheme}://{authority_and_rest}"))
+}
+
+/// Classifies one built-in-scheme request for the CEF scheme-handler factory.
+///
+/// A request is routed only when it uses HTTP(S), its host is in the reserved
+/// mapped namespace, and the extracted custom scheme is registered for this
+/// browser. Returning `None` deliberately hands the request back to CEF's
+/// built-in network stack.
+pub(crate) fn route_mapped_request(
+  request_url: &str,
+  mut is_registered: impl FnMut(&str) -> bool,
+) -> Option<MappedRequest> {
+  let parsed = Url::parse(request_url).ok()?;
+  if !matches!(parsed.scheme(), "http" | "https") {
+    return None;
+  }
+
+  let (custom_scheme, _authority) = split_mapped_host(parsed.host_str()?)?;
+  if !is_registered(custom_scheme) {
+    return None;
+  }
+
+  Some(MappedRequest {
+    custom_scheme: custom_scheme.to_string(),
+    // Use url's canonical serialization so scheme/host casing cannot make the
+    // prefix reversal disagree with the parsed routing decision.
+    logical_url: to_logical_url(parsed.as_str(), parsed.scheme(), custom_scheme)?,
+  })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn splits_reserved_hosts_and_preserves_authority() {
+    assert_eq!(
+      split_mapped_host("app.localhost"),
+      Some(("app", "localhost"))
+    );
+    assert_eq!(
+      split_mapped_host("my-scheme.localhost"),
+      Some(("my-scheme", "localhost"))
+    );
+    // A multi-label authority (the host-preserving case) keeps everything after
+    // the scheme label intact.
+    assert_eq!(
+      split_mapped_host("app.a1b2c3.localhost"),
+      Some(("app", "a1b2c3.localhost"))
+    );
+  }
+
+  #[test]
+  fn rejects_hosts_outside_the_reserved_namespace() {
+    // A factory registered on the whole scheme must ignore these so they fall
+    // through to CEF's normal network path.
+    assert_eq!(split_mapped_host("localhost"), None);
+    assert_eq!(split_mapped_host("example.com"), None);
+    assert_eq!(split_mapped_host("app.localhost.example.com"), None);
+    assert_eq!(split_mapped_host("app.a.localhost.example.com"), None);
+    assert_eq!(split_mapped_host(".localhost"), None);
+    assert_eq!(split_mapped_host("app..localhost"), None);
+    assert_eq!(split_mapped_host("app.a..localhost"), None);
+  }
+
+  #[test]
+  fn distinct_authorities_stay_distinct_on_one_scheme() {
+    let a = split_mapped_host("app.a.localhost").unwrap();
+    let b = split_mapped_host("app.b.localhost").unwrap();
+    assert_eq!(a.0, b.0, "same logical scheme");
+    assert_ne!(a.1, b.1, "distinct logical authorities / origins");
+  }
+
+  #[test]
+  fn reverts_mapped_url_to_logical_preserving_authority() {
+    assert_eq!(
+      to_logical_url("https://app.a.localhost/index.html", "https", "app").as_deref(),
+      Some("app://a.localhost/index.html")
+    );
+    assert_eq!(
+      to_logical_url("https://app.localhost/x", "https", "app").as_deref(),
+      Some("app://localhost/x")
+    );
+    // The mapping also works for the `http` variant used when `use_https_scheme`
+    // is disabled.
+    assert_eq!(
+      to_logical_url("http://app.a.localhost/", "http", "app").as_deref(),
+      Some("app://a.localhost/")
+    );
+  }
+
+  #[test]
+  fn revert_is_none_for_urls_outside_this_scheme() {
+    assert_eq!(
+      to_logical_url("https://example.com/x", "https", "app"),
+      None
+    );
+    // A different logical scheme's mapped host is not this scheme's business.
+    assert_eq!(
+      to_logical_url("https://other.localhost/x", "https", "app"),
+      None
+    );
+  }
+
+  #[test]
+  fn entrypoints_under_one_authority_revert_to_one_origin() {
+    for path in ["/index.html", "/headless-runtime.html"] {
+      let mapped = format!("https://app.a1b2c3.localhost{path}");
+      let logical = to_logical_url(&mapped, "https", "app").unwrap();
+      assert_eq!(logical, format!("app://a1b2c3.localhost{path}"));
+    }
+  }
+
+  #[test]
+  fn routes_two_authorities_for_the_registered_handler_and_normalizes_both() {
+    for authority in ["profile-one.localhost", "profile-two.localhost"] {
+      let mapped = format!("https://app.{authority}/index.html");
+      assert_eq!(
+        route_mapped_request(&mapped, |scheme| scheme == "app"),
+        Some(MappedRequest {
+          custom_scheme: "app".into(),
+          logical_url: format!("app://{authority}/index.html"),
+        })
+      );
+    }
+  }
+
+  #[test]
+  fn routing_rejects_malformed_unknown_and_unrelated_urls() {
+    let registered = |scheme: &str| scheme == "app";
+
+    assert_eq!(
+      route_mapped_request("https://app..localhost/index.html", registered),
+      None
+    );
+    assert_eq!(
+      route_mapped_request("https://unknown.a.localhost/index.html", registered),
+      None
+    );
+    assert_eq!(
+      route_mapped_request("https://example.com/index.html", registered),
+      None
+    );
+    assert_eq!(
+      route_mapped_request("file://app.a.localhost/index.html", registered),
+      None
+    );
+  }
+
+  #[test]
+  fn routing_normalizes_scheme_and_host_casing_before_reversal() {
+    assert_eq!(
+      route_mapped_request("HTTPS://APP.A.LOCALHOST/index.html", |scheme| scheme
+        == "app"),
+      Some(MappedRequest {
+        custom_scheme: "app".into(),
+        logical_url: "app://a.localhost/index.html".into(),
+      })
+    );
+  }
+}

--- a/crates/tauri-runtime-cef/src/cef_impl/mod.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl/mod.rs
@@ -5,5 +5,6 @@
 pub(crate) mod client;
 pub(crate) mod cookie;
 pub(crate) mod ipc;
+pub(crate) mod mapped_scheme;
 pub(crate) mod request_context;
 pub(crate) mod request_handler;

--- a/crates/tauri-runtime-cef/src/cef_impl/request_context.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl/request_context.rs
@@ -357,13 +357,26 @@ pub(crate) fn request_context_from_webview_attributes<'a>(
   *rc_holder.lock().unwrap() = request_context.clone();
 
   if let Some(request_context) = request_context.as_ref() {
-    for scheme in custom_schemes {
+    // Logical custom-protocol URLs (`scheme://authority/…`) are mapped onto the
+    // built-in `https`/`http` scheme as `https://scheme.authority/…`, mirroring
+    // Wry's WebView2/Android workaround while preserving the logical authority
+    // as a browser-visible subdomain.
+    //
+    // CEF cannot match the reserved `<scheme>.*.localhost` namespace with a
+    // fixed domain, and registering one entry per authority is impractical when
+    // authorities are created dynamically. So a single factory is registered
+    // against the whole mapped scheme with a NULL domain — which for a standard
+    // scheme matches every host. The factory then routes only the reserved
+    // namespace to a registered handler and returns `None` for everything else;
+    // because `https`/`http` is a built-in scheme, that `None` falls through to
+    // CEF's normal network handler, so unrelated HTTPS is never intercepted.
+    // See [`super::mapped_scheme`].
+    if custom_schemes.into_iter().next().is_some() {
       request_context.register_scheme_handler_factory(
         Some(&custom_protocol_scheme.into()),
-        Some(&format!("{scheme}.localhost").as_str().into()),
+        None,
         Some(&mut request_handler::UriSchemeHandlerFactory::new(
           scheme_registry.clone(),
-          scheme.clone(),
         )),
       );
     }

--- a/crates/tauri-runtime-cef/src/cef_impl/request_handler.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl/request_handler.rs
@@ -29,6 +29,7 @@ use url::Url;
 
 use crate::{
   cef_impl::client::{DragDropEventTarget, DragDropState, WebDragDropResourceRequestHandler},
+  cef_impl::mapped_scheme,
   runtime::RuntimeContext,
   webview::{CefInitScript, INITIAL_LOAD_URL},
 };
@@ -205,6 +206,10 @@ wrap_resource_handler! {
     webview_label: String,
     handler: Arc<Box<UriSchemeProtocolHandler>>,
     initialization_scripts: Arc<Vec<CefInitScript>>,
+    // Logical URL selected by the mapped-namespace router (for example
+    // `app://<authority>/…`). The Tauri callback therefore sees the same request
+    // shape on CEF as it does on the other mapped-protocol runtimes.
+    logical_url: String,
     // Serialized origin of the main frame that initiated this request, captured
     // browser-side in the scheme handler factory. The renderer can issue an IPC
     // request before its execution context is fully wired to the loader; in
@@ -226,10 +231,8 @@ wrap_resource_handler! {
       let Some(request) = request else { return 0 };
       let Some(callback) = callback else { return 0 };
 
-      let url = CefString::from(&request.url()).to_string();
-      let url = Url::parse(&url).ok();
-
-      if let Some(url) = url {
+      if Url::parse(&CefString::from(&request.url()).to_string()).is_ok() {
+        let logical_url = self.logical_url.clone();
         let callback = ThreadSafe(callback.clone());
         let response_store = ThreadSafe(self.response.clone());
         let initialization_scripts = self.initialization_scripts.clone();
@@ -296,7 +299,7 @@ wrap_resource_handler! {
         std::thread::spawn(move || {
           let mut http_request = http::Request::builder()
             .method(method)
-            .uri(url.as_str())
+            .uri(logical_url.as_str())
             .body(data)
             .unwrap();
           *http_request.headers_mut() = headers;
@@ -387,7 +390,6 @@ wrap_resource_handler! {
 wrap_scheme_handler_factory! {
   pub struct UriSchemeHandlerFactory {
     registry: SchemeRegistry,
-    scheme: String,
   }
 
   impl SchemeHandlerFactory {
@@ -396,17 +398,27 @@ wrap_scheme_handler_factory! {
       browser: Option<&mut Browser>,
       frame: Option<&mut Frame>,
       _scheme_name: Option<&CefString>,
-      _request: Option<&mut Request>,
+      request: Option<&mut Request>,
     ) -> Option<ResourceHandler> {
       let browser = browser?;
       let id = browser.identifier();
 
-      // get handler from our regsitry based on browser ID and scheme
-      let (webview_label, handler, initialization_scripts) = self
-        .registry
-        .lock()
-        .unwrap()
-        .get(&(id, self.scheme.clone()))
+      // This factory is registered against the whole mapped scheme, so it is
+      // consulted for every `https`/`http` request. Route only the reserved
+      // `<scheme>.….localhost` namespace whose scheme label is a registered
+      // custom protocol for this browser; return `None` (which for a built-in
+      // scheme falls through to CEF's normal network path) for anything else,
+      // so unrelated origins are never intercepted.
+      let request = request?;
+      let request_url = CefString::from(&request.url()).to_string();
+      let registry = self.registry.lock().unwrap();
+      let route = mapped_scheme::route_mapped_request(&request_url, |scheme| {
+        registry.contains_key(&(id, scheme.to_string()))
+      })?;
+
+      // get handler from our registry based on browser ID and scheme
+      let (webview_label, handler, initialization_scripts) = registry
+        .get(&(id, route.custom_scheme.clone()))
         .cloned()?;
 
       // Capture the initiating main frame's origin so `process_request` can
@@ -424,6 +436,7 @@ wrap_scheme_handler_factory! {
         webview_label,
         handler,
         initialization_scripts,
+        route.logical_url,
         initiator_origin,
         Arc::new(RefCell::new(None)),
       ))

--- a/crates/tauri-runtime-cef/src/webview.rs
+++ b/crates/tauri-runtime-cef/src/webview.rs
@@ -424,10 +424,7 @@ impl<T: UserEvent> WinitCefApp<T> {
       "http"
     }
     .to_string();
-    let custom_scheme_domain_names: Vec<String> = uri_scheme_protocols
-      .keys()
-      .map(|scheme| format!("{scheme}.localhost"))
-      .collect();
+    let custom_scheme_names: Vec<String> = uri_scheme_protocols.keys().cloned().collect();
     let real_initial_url = pending.url.as_str().to_string();
     let (browser_tx, browser_rx) = mpsc::channel();
     let (init_done, on_initialized) = request_context::deferred_init_continuation({
@@ -435,7 +432,7 @@ impl<T: UserEvent> WinitCefApp<T> {
       let uri_scheme_protocols = uri_scheme_protocols.clone();
       let initialization_scripts = initialization_scripts.clone();
       let custom_protocol_scheme = custom_protocol_scheme.clone();
-      let custom_scheme_domain_names = custom_scheme_domain_names.clone();
+      let custom_scheme_names = custom_scheme_names.clone();
       let label = pending.label.clone();
       move |mut request_context| {
         request_context::apply_theme_scheme(request_context.as_ref(), theme);
@@ -485,7 +482,7 @@ impl<T: UserEvent> WinitCefApp<T> {
           &browser,
           &initialization_scripts,
           &custom_protocol_scheme,
-          &custom_scheme_domain_names,
+          &custom_scheme_names,
           &real_initial_url,
           &pending_initial_loads,
         );
@@ -1453,21 +1450,31 @@ pub(crate) fn add_dev_tools_observer(
 fn devtools_initialization_script_source(
   initialization_scripts: &[CefInitScript],
   custom_protocol_scheme: &str,
-  custom_scheme_domain_names: &[String],
+  custom_scheme_names: &[String],
 ) -> Option<String> {
   if initialization_scripts.is_empty() {
     return None;
   }
 
   let custom_protocol = serde_json::to_string(&format!("{custom_protocol_scheme}:")).ok()?;
-  let custom_domains = serde_json::to_string(custom_scheme_domain_names).ok()?;
+  let custom_schemes = serde_json::to_string(custom_scheme_names).ok()?;
+  // A mapped custom-protocol document lives at `https://<scheme>.<authority>`
+  // where the whole host ends in `.localhost` (for example `app.localhost` or
+  // `app.<authority>.localhost`). Recognize the reserved namespace by matching
+  // any registered scheme label rather than a fixed host, so per-authority
+  // origins are also detected. These documents receive the initialization
+  // scripts injected into their HTML directly, so the CDP document-start copy
+  // below is guarded off for them to avoid double injection.
   let mut source = format!(
     r#"{{
   const __TAURI_CEF_INIT_CUSTOM_PROTOCOL__ = {custom_protocol};
-  const __TAURI_CEF_INIT_CUSTOM_DOMAINS__ = new Set({custom_domains});
+  const __TAURI_CEF_INIT_CUSTOM_SCHEMES__ = {custom_schemes};
   const __TAURI_CEF_INIT_IS_CUSTOM_PROTOCOL__ =
     location.protocol === __TAURI_CEF_INIT_CUSTOM_PROTOCOL__
-    && __TAURI_CEF_INIT_CUSTOM_DOMAINS__.has(location.hostname);
+    && location.hostname.endsWith(".localhost")
+    && __TAURI_CEF_INIT_CUSTOM_SCHEMES__.some(
+      (scheme) => location.hostname.startsWith(scheme + ".")
+    );
   const __TAURI_CEF_INIT_IS_MAIN_FRAME__ = (() => {{
     try {{
       return window.top === window;
@@ -1496,14 +1503,14 @@ fn register_initialization_scripts(
   browser: &Browser,
   initialization_scripts: &[CefInitScript],
   custom_protocol_scheme: &str,
-  custom_scheme_domain_names: &[String],
+  custom_scheme_names: &[String],
   initial_url: String,
   pending_initial_loads: &PendingInitialLoads,
 ) -> bool {
   let Some(source) = devtools_initialization_script_source(
     initialization_scripts,
     custom_protocol_scheme,
-    custom_scheme_domain_names,
+    custom_scheme_names,
   ) else {
     return false;
   };
@@ -1572,7 +1579,7 @@ pub(crate) fn load_initial_url_after_registering_initialization_scripts(
   browser: &Browser,
   initialization_scripts: &[CefInitScript],
   custom_protocol_scheme: &str,
-  custom_scheme_domain_names: &[String],
+  custom_scheme_names: &[String],
   initial_url: &str,
   pending_initial_loads: &PendingInitialLoads,
 ) {
@@ -1582,7 +1589,7 @@ pub(crate) fn load_initial_url_after_registering_initialization_scripts(
     browser,
     initialization_scripts,
     custom_protocol_scheme,
-    custom_scheme_domain_names,
+    custom_scheme_names,
     initial_url.clone(),
     pending_initial_loads,
   );


### PR DESCRIPTION
Closes #15748

Brings the CEF mapped custom protocol in line with what Wry already does for WebView2 and Android. The mapping onto `https` was already there, but the factory was registered against the fixed domain `<scheme>.localhost`, so mapped URLs with any other authority were never intercepted, and there was no revert step, so the Tauri protocol callback got the mapped `https` URL instead of the logical `scheme://` one.

Changes:

- Register a single factory per mapped scheme with a NULL domain, which for a standard scheme matches every host. CEF cannot match a wildcard domain, and one registration per authority is not workable when authorities are created at runtime.
- Add `cef_impl/mapped_scheme.rs`, which decides what that factory claims. It routes only hosts of the form `<scheme>.*.localhost` where the leading label is a registered custom scheme for that browser, and returns `None` for everything else. Because `https`/`http` is a built-in scheme, `None` falls through to CEF's normal network handler, so unrelated origins are untouched.
- Normalize the intercepted URL back to `scheme://authority/path` before calling the handler, mirroring `revert_uri_work_around` in WebView2's `prepare_request` and the `request.uri_mut()` rewrite on Android, so handlers see the same request shape on every runtime.
- Update the devtools init script guard to match the scheme label plus a `.localhost` suffix rather than a fixed host set, so per-authority origins are detected too.

Net effect: distinct logical authorities on one scheme become distinct browser origins with their own storage, which is already how WebView2 and Android behave.

Note this is deliberately stricter than Wry: `is_work_around_uri` matches any host beginning with `<scheme>.`, and WebView2's filter is `https://<scheme>.*`. The CEF factory has no per-protocol filter to sit behind, so it is consulted for every http(s) request, and claiming everything under `<scheme>.` felt too broad. Restricting to `.localhost` keeps the intercepted namespace reserved. Happy to widen it to match Wry exactly if you'd rather the two be identical.

### Testing

`cargo test -p tauri-runtime-cef`, 9 tests covering namespace matching, rejection of unrelated and malformed hosts, URL reversal, and case normalization.

Also verified live over CDP: origin and storage isolation across authorities, non-mapped HTTPS falling through to the network, and separate renderer processes per origin.

First time contributing here, so happy to adjust the approach or the naming. This has been running in an unreleased app of mine that relies on per-authority origins on CEF, so it has had real use, but nothing public yet.