### PR TITLE
fix(cli): clarify init frontend command prompts (fix: #13820)

### DIFF
--- a/.changes/clarify-init-frontend-command-prompts.md
+++ b/.changes/clarify-init-frontend-command-prompts.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": "patch:enhance"
+"@tauri-apps/cli": "patch:enhance"
+---
+
+Clarify that the `tauri init` frontend commands run before `tauri dev` and `tauri build`, and can be left empty when they are not needed.

--- a/crates/tauri-cli/src/init.rs
+++ b/crates/tauri-cli/src/init.rs
@@ -142,7 +142,7 @@ impl Options {
       .map(|s| Ok(Some(s)))
       .unwrap_or_else(|| {
         prompts::input(
-          "What is your frontend dev command?",
+          "What command should Tauri run before `tauri dev` to start your frontend? (leave empty if not needed)",
           Some(default_dev_command(detected_package_manager).into()),
           self.ci,
           true,
@@ -154,7 +154,7 @@ impl Options {
       .map(|s| Ok(Some(s)))
       .unwrap_or_else(|| {
         prompts::input(
-          "What is your frontend build command?",
+          "What command should Tauri run before `tauri build` to build your frontend? (leave empty if not needed)",
           Some(default_build_command(detected_package_manager).into()),
           self.ci,
           true,


### PR DESCRIPTION
### Summary

- clarify that the `tauri init` frontend commands run before `tauri dev` and `tauri build`
- explain that either hook can be left empty when it is not needed

Closes #13820.

### Testing

- `cargo fmt --manifest-path crates/tauri-cli/Cargo.toml -- --check`
- `cargo test --manifest-path crates/tauri-cli/Cargo.toml` (56 passed)
- `cargo clippy --manifest-path crates/tauri-cli/Cargo.toml --all-targets -- -D warnings`
- `node ./.scripts/ci/check-change-tags.js .changes/clarify-init-frontend-command-prompts.md`
- Windows interactive smoke test in an empty project without `package.json`; clearing both suggested commands omitted `beforeDevCommand` and `beforeBuildCommand` from the generated configuration