### PR TITLE
docs(bundler): document runtime resource paths

### DIFF
--- a/crates/tauri-bundler/README.md
+++ b/crates/tauri-bundler/README.md
@@ -12,14 +12,15 @@ As it's intended to be used primarily in `tauri-cli`, the public API does not st
 
 ## Configuration
 
-Tauri automatically loads configurations from the `tauri.conf.json > bundle` object, but this library doesn't rely on it and can be used by non-Tauri apps.
+The Tauri CLI maps configuration from `tauri.conf.json` into this library's settings, but the
+library does not rely on that file and can be used by non-Tauri apps.
 
 ### General settings
 
 These settings apply to bundles for all (or most) OSes.
 
-- `name`: The name of the built application. If this is not present, then it will use the `name` value from
-  your `Cargo.toml` file.
+- `product_name`: The name of the built application. The Tauri CLI maps the `productName` configuration
+  value to this field and falls back to the `name` value from your `Cargo.toml` file.
 - `identifier`: [REQUIRED] A string that uniquely identifies your application,
   in reverse-DNS form (for example, `"com.example.appname"` or
   `"io.github.username.project"`). For OS X and iOS, this is used as the
@@ -113,6 +114,82 @@ These settings are used only when bundling `app` and `dmg` packages.
   }
 }
 ```
+
+## Runtime paths
+
+`tauri-bundler` creates the platform package and copies configured resources into it. It does not
+provide a runtime context or automatically resolve paths for the packaged application.
+
+### Bundled resources
+
+Applications that do not use the Tauri runtime can use
+[`tauri_utils::platform::resource_dir`](https://docs.rs/tauri-utils/latest/tauri_utils/platform/fn.resource_dir.html)
+to locate the resource root. Pass the same product name used in
+[`PackageSettings::product_name`](https://docs.rs/tauri-bundler/latest/tauri_bundler/bundle/struct.PackageSettings.html#structfield.product_name)
+(the `productName` value in a Tauri configuration), because Linux uses it as the resource directory
+name.
+
+Add the path helpers as direct dependencies:
+
+```toml
+[dependencies]
+dirs = "6"
+tauri-utils = "2"
+```
+
+Then resolve resources at runtime and append the target path from `resources` or `resources_map`:
+
+```rust
+use std::path::{Path, PathBuf};
+use tauri_utils::{platform::resource_dir, Env, PackageInfo};
+
+fn bundled_resource(path: impl AsRef<Path>) -> tauri_utils::Result<PathBuf> {
+  let package_info = PackageInfo {
+    // Must match the product name passed to tauri-bundler.
+    name: "Your Awesome App".into(),
+    version: env!("CARGO_PKG_VERSION").parse().unwrap(),
+    authors: env!("CARGO_PKG_AUTHORS"),
+    description: env!("CARGO_PKG_DESCRIPTION"),
+    crate_name: env!("CARGO_PKG_NAME"),
+  };
+
+  resource_dir(&package_info, &Env::default()).map(|dir| dir.join(path))
+}
+```
+
+The helper currently resolves the desktop bundle layouts as follows:
+
+| Platform               | Resource root                                     |
+| ---------------------- | ------------------------------------------------- |
+| Windows                | The directory containing the installed executable |
+| Linux (`deb` or `rpm`) | `/usr/lib/<product-name>`                         |
+| Linux (AppImage)       | `${APPDIR}/usr/lib/<product-name>`                |
+| macOS                  | `<app>.app/Contents/Resources`                    |
+
+These locations describe the current package layout, not a path contract. Use the helper instead of
+hardcoding them.
+
+### Other base directories
+
+The bundle identifier does not determine the resource root. `tauri-bundler` uses it for
+platform-specific package metadata where applicable, but the application is responsible for
+choosing and creating its runtime data directories.
+
+Tauri's generic desktop base directories are provided by the
+[`dirs`](https://docs.rs/dirs/latest/dirs/) crate. Its `config_dir`, `data_dir`,
+`data_local_dir`, and `cache_dir` functions return OS-level user directories and do not append an
+application name or identifier.
+
+Tauri's app-specific desktop directories append the bundle identifier to those generic bases:
+
+| Purpose                      | Equivalent path without the Tauri runtime                 |
+| ---------------------------- | --------------------------------------------------------- |
+| App config                   | `dirs::config_dir()?.join(identifier)`                    |
+| App data                     | `dirs::data_dir()?.join(identifier)`                      |
+| App local data               | `dirs::data_local_dir()?.join(identifier)`                |
+| App cache                    | `dirs::cache_dir()?.join(identifier)`                     |
+| App logs (Linux and Windows) | `dirs::data_local_dir()?.join(identifier).join("logs")`   |
+| App logs (macOS)             | `dirs::home_dir()?.join("Library/Logs").join(identifier)` |
 
 ## License
 

--- a/crates/tauri-utils/src/platform.rs
+++ b/crates/tauri-utils/src/platform.rs
@@ -251,16 +251,36 @@ fn is_cargo_output_directory(path: &std::path::Path) -> bool {
 /// ## Platform-specific
 ///
 /// - **Windows:** Resolves to the directory that contains the main executable.
-/// - **Linux:** When running in an AppImage, the `APPDIR` variable will be set to
-///   the mounted location of the app, and the resource dir will be `${APPDIR}/usr/lib/${exe_name}`.
-///   If not running in an AppImage, the path is `/usr/lib/${exe_name}`.
-///   When running the app from `src-tauri/target/(debug|release)/`, the path is `${exe_dir}/../lib/${exe_name}`.
+/// - **Linux:** When running from a Cargo output directory, resolves to the directory containing the
+///   executable. Otherwise, resolves to `${exe_dir}/../lib/${package_info.name}` when that directory
+///   exists, `${APPDIR}/usr/lib/${package_info.name}` inside an AppImage, or
+///   `/usr/lib/${package_info.name}` for an installed package.
 /// - **macOS:** Resolves to `${exe_dir}/../Resources` (inside .app).
 /// - **iOS:** Resolves to `${exe_dir}/assets`.
 /// - **Android:** Currently the resources are stored in the APK as assets so it's not a normal file system path,
 ///   we return a special URI prefix `asset://localhost/` here that can be used with the [file system plugin](https://tauri.app/plugin/file-system/),
 ///   with that, you can read the files through [`FsExt::fs`](https://docs.rs/tauri-plugin-fs/latest/tauri_plugin_fs/trait.FsExt.html#tymethod.fs)
 ///   like this: `app.fs().read_to_string(app.path().resource_dir().unwrap().join("resource"));`
+///
+/// For applications packaged with `tauri-bundler`, `package_info.name` must match
+/// [`tauri_bundler::PackageSettings::product_name`](https://docs.rs/tauri-bundler/latest/tauri_bundler/struct.PackageSettings.html#structfield.product_name).
+///
+/// ## Example
+///
+/// ```no_run
+/// use tauri_utils::{platform::resource_dir, Env, PackageInfo};
+///
+/// let package_info = PackageInfo {
+///   name: "Your Awesome App".into(),
+///   version: "1.0.0".parse().unwrap(),
+///   authors: "",
+///   description: "",
+///   crate_name: "your-awesome-app",
+/// };
+///
+/// let _index_html = resource_dir(&package_info, &Env::default())?.join("assets/index.html");
+/// # Ok::<(), tauri_utils::Error>(())
+/// ```
 pub fn resource_dir(package_info: &PackageInfo, env: &Env) -> crate::Result<PathBuf> {
   #[cfg(target_os = "android")]
   return resource_dir_android(package_info, env);

--- a/crates/tauri/src/path/desktop.rs
+++ b/crates/tauri/src/path/desktop.rs
@@ -217,10 +217,10 @@ impl<R: Runtime> PathResolver<R> {
   /// this is not a contract and things might change in the future
   ///
   /// - **Windows:** Resolves to the directory that contains the main executable.
-  /// - **Linux:** When running in an AppImage, the `APPDIR` variable will be set to
-  ///   the mounted location of the app, and the resource dir will be `${APPDIR}/usr/lib/${exe_name}`.
-  ///   If not running in an AppImage, the path is `/usr/lib/${exe_name}`.
-  ///   When running the app from `src-tauri/target/(debug|release)/`, the path is `${exe_dir}/../lib/${exe_name}`.
+  /// - **Linux:** When running from a Cargo output directory, resolves to the directory containing the
+  ///   executable. Otherwise, resolves to `${exe_dir}/../lib/${product_name}` when that directory
+  ///   exists, `${APPDIR}/usr/lib/${product_name}` inside an AppImage, or
+  ///   `/usr/lib/${product_name}` for an installed package.
   /// - **macOS:** Resolves to `${exe_dir}/../Resources` (inside .app).
   /// - **iOS:** Resolves to `${exe_dir}/assets`.
   /// - **Android:** Currently the resources are stored in the APK as assets so it's not a normal file system path,


### PR DESCRIPTION
## Summary

- clarify that `tauri-bundler` packages resources but does not resolve their paths at runtime
- document `tauri_utils::platform::resource_dir` as the public helper for applications that use the bundler without the Tauri runtime
- explain platform-specific resource locations and distinguish generic OS directories from bundle-identifier-specific application directories
- align the Tauri runtime path documentation with the shared resource-directory helper

## Testing

- `cargo fmt --check -- crates/tauri-utils/src/platform.rs crates/tauri/src/path/desktop.rs`
- `cargo test -p tauri-utils --doc platform::resource_dir`
- `cargo test -p tauri-utils platform::tests::resolve_resource_dir`
- compiled the exact README example as Rust metadata
- `cargo doc -p tauri-utils --no-deps`
- `cargo doc -p tauri --no-deps`
- `git diff --check`

The documentation builds emitted only pre-existing warnings outside the changed lines. Full-workspace tests and Clippy were not run because this change only updates documentation and examples. No `.changes` entry is included because the change does not require a version bump.

Fixes #15738