### PR TITLE
docs(core): document path resolver access (fix #10478)

### DIFF
--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -763,7 +763,10 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
     self.state::<Scopes>().asset_protocol.clone()
   }
 
-  /// The path resolver.
+  /// Returns the path resolver.
+  ///
+  /// See the [`path`] module for usage examples and guidance on resolving paths before application
+  /// initialization.
   fn path(&self) -> &crate::path::PathResolver<R> {
     self.state::<crate::path::PathResolver<R>>().inner()
   }

--- a/crates/tauri/src/path/mod.rs
+++ b/crates/tauri/src/path/mod.rs
@@ -2,6 +2,33 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+//! Path resolution APIs.
+//!
+//! Tauri exposes path resolution through [`Manager::path`](crate::Manager::path) so the resolver
+//! can use the running application's configuration and platform integration. Import the
+//! [`Manager`](crate::Manager) trait and call `.path()` on a manager such as an
+//! [`App`](crate::App) or [`AppHandle`](crate::AppHandle).
+//!
+//! # Examples
+//!
+//! Access paths from a command by injecting an [`AppHandle`](crate::AppHandle):
+//!
+//! ```rust,no_run
+//! use std::path::PathBuf;
+//! use tauri::Manager;
+//!
+//! #[tauri::command]
+//! fn home_dir(app: tauri::AppHandle) -> tauri::Result<PathBuf> {
+//!   app.path().home_dir()
+//! }
+//! ```
+//!
+//! Application-specific paths are available after Tauri initializes because they can depend on
+//! application configuration and mobile runtime APIs. Desktop code that only needs a platform
+//! user directory before Tauri initializes can add the [`dirs`](https://docs.rs/dirs/) crate as a
+//! dependency and call the corresponding function directly, such as
+//! [`dirs::home_dir`](https://docs.rs/dirs/latest/dirs/fn.home_dir.html).
+
 use std::{
   path::{Component, Display, Path, PathBuf},
   str::FromStr,


### PR DESCRIPTION
## Summary

- document how to access the path resolver through `Manager::path`
- explain why application and runtime state is required, with a command example
- point desktop callers that need user directories before Tauri initialization to the `dirs` crate

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tauri --doc path`
- `cargo test -p tauri --doc`
- `cargo test --manifest-path crates/tauri/Cargo.toml --all-features`
- `cargo clippy -p tauri --all-targets --all-features -- -D warnings`
- `cargo doc -p tauri --all-features --no-deps`

No change file: documentation-only clarification.

Fixes #10478