### PR TITLE
docs: document browser argument data directory requirement

### DIFF
--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -483,7 +483,7 @@
           ]
         },
         "additionalBrowserArgs": {
-          "description": "Defines additional browser arguments on Windows. By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`\n so if you use this method, you also need to disable these components by yourself if you want.",
+          "description": "Defines additional browser arguments on Windows.\n\n ## Warning\n\n Webview instances with different browser arguments must also have different [data directories](Self::data_directory).\n\n By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`\n so if you set this, you also need to disable these components by yourself if you want.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -483,7 +483,7 @@
           ]
         },
         "additionalBrowserArgs": {
-          "description": "Defines additional browser arguments on Windows. By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`\n so if you use this method, you also need to disable these components by yourself if you want.",
+          "description": "Defines additional browser arguments on Windows.\n\n ## Warning\n\n Webview instances with different browser arguments must also have different [data directories](Self::data_directory).\n\n By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`\n so if you set this, you also need to disable these components by yourself if you want.",
           "type": [
             "string",
             "null"

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -2104,8 +2104,14 @@ pub struct WindowConfig {
   /// [tabbing identifier]: <https://developer.apple.com/documentation/appkit/nswindow/1644704-tabbingidentifier>
   #[serde(default, alias = "tabbing-identifier")]
   pub tabbing_identifier: Option<String>,
-  /// Defines additional browser arguments on Windows. By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
-  /// so if you use this method, you also need to disable these components by yourself if you want.
+  /// Defines additional browser arguments on Windows.
+  ///
+  /// ## Warning
+  ///
+  /// Webview instances with different browser arguments must also have different [data directories](Self::data_directory).
+  ///
+  /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
+  /// so if you set this, you also need to disable these components by yourself if you want.
   #[serde(default, alias = "additional-browser-args")]
   pub additional_browser_args: Option<String>,
   /// Whether or not the window has shadow.

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -950,6 +950,10 @@ fn main() {
   ///
   /// ## Warning
   ///
+  /// On Windows, webviews that use the same data directory must use the same browser arguments.
+  /// To use different browser arguments, set a distinct data directory for each argument set with
+  /// [`WebviewBuilder::data_directory`].
+  ///
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// so if you use this method, you also need to disable these components by yourself if you want.
   #[must_use]

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -950,9 +950,7 @@ fn main() {
   ///
   /// ## Warning
   ///
-  /// On Windows, webviews that use the same data directory must use the same browser arguments.
-  /// To use different browser arguments, set a distinct data directory for each argument set with
-  /// [`WebviewBuilder::data_directory`].
+  /// Webview instances with different browser arguments must also have different [data directories](Self::data_directory).
   ///
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// so if you use this method, you also need to disable these components by yourself if you want.

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -1021,9 +1021,7 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   ///
   /// ## Warning
   ///
-  /// On Windows, webviews that use the same data directory must use the same browser arguments.
-  /// To use different browser arguments, set a distinct data directory for each argument set with
-  /// [`WebviewWindowBuilder::data_directory`].
+  /// Webview instances with different browser arguments must also have different [data directories](Self::data_directory).
   ///
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// so if you use this method, you also need to disable these components by yourself if you want.

--- a/crates/tauri/src/webview/webview_window.rs
+++ b/crates/tauri/src/webview/webview_window.rs
@@ -1021,6 +1021,10 @@ impl<R: Runtime, M: Manager<R>> WebviewWindowBuilder<'_, R, M> {
   ///
   /// ## Warning
   ///
+  /// On Windows, webviews that use the same data directory must use the same browser arguments.
+  /// To use different browser arguments, set a distinct data directory for each argument set with
+  /// [`WebviewWindowBuilder::data_directory`].
+  ///
   /// By default wry passes `--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection`
   /// so if you use this method, you also need to disable these components by yourself if you want.
   #[must_use]


### PR DESCRIPTION
## Summary

- document that webviews sharing a data directory must use the same browser arguments on Windows
- link both public `additional_browser_args` builders to their corresponding `data_directory` method

## Validation

- `cargo fmt --all -- --check`
- `cargo doc --manifest-path crates/tauri/Cargo.toml --all-features --no-deps` (completed with pre-existing warnings outside the changed lines)
- `cargo test --manifest-path crates/tauri/Cargo.toml --all-features` (60 unit tests and 115 doctests passed)
- `cargo clippy --manifest-path crates/tauri/Cargo.toml --all-targets --all-features -- -D warnings`

## Notes

- documentation-only; no runtime behavior or public API changes
- no change file or generated-file updates required
- screenshots are not applicable

Closes #11144