### PR TITLE
fix(bundler): reduce verbose sign logs in default build output

### DIFF
--- a/crates/tauri-bundler/src/bundle/windows/sign.rs
+++ b/crates/tauri-bundler/src/bundle/windows/sign.rs
@@ -210,7 +210,7 @@ pub fn sign_custom<P: AsRef<Path>>(
   let output = cmd.output_ok()?;
 
   let stdout = String::from_utf8_lossy(output.stdout.as_slice()).into_owned();
-  log::info!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
+  log::debug!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
 
   Ok(())
 }
@@ -229,7 +229,7 @@ pub fn sign_default<P: AsRef<Path>>(path: P, params: &SignParams) -> crate::Resu
   let output = cmd.output_ok()?;
 
   let stdout = String::from_utf8_lossy(output.stdout.as_slice()).into_owned();
-  log::info!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
+  log::debug!(action = "Signing";"Output of signing command:\n{}", stdout.trim());
 
   Ok(())
 }


### PR DESCRIPTION
关联 Issue：Fixes #15687

问题：默认构建时签名验证日志过多，淹没关键信息。
修复：将 `crates/tauri-bundler/src/bundle/windows/sign.rs` 中的 `log::info!` 降级为 `log::debug!`。
测试：本地验证 `tauri build` 输出已精简，`-v` 模式下日志正常。