### PR TITLE
fix(cli): respect CARGO_BUILD_TARGET when resolving build target

### DIFF
--- a/.changes/cargo-build-target-env.md
+++ b/.changes/cargo-build-target-env.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Respect the `CARGO_BUILD_TARGET` environment variable when resolving the build target, matching Cargo's precedence over `build.target` in `.cargo/config.toml`.

--- a/crates/tauri-cli/src/interface/rust/cargo_config.rs
+++ b/crates/tauri-cli/src/interface/rust/cargo_config.rs
@@ -60,6 +60,13 @@ impl Config {
   pub fn load(path: &Path) -> Result<Self> {
     let mut config = Self::default();
 
+    if let Ok(target) = std::env::var("CARGO_BUILD_TARGET")
+      && !target.is_empty()
+    {
+      config.build.target = Some(target);
+      return Ok(config);
+    }
+
     let get_config = |path: PathBuf| -> Result<ConfigSchema> {
       let contents =
         fs::read_to_string(&path).fs_context("failed to read configuration file", path.clone())?;


### PR DESCRIPTION
`cargo tauri dev` compiles for the target Cargo resolves from `CARGO_BUILD_TARGET`, but the CEF dev assembly read the target from `.cargo/config.toml`'s `build.target` only. When the config file points at a different target, the app builds for the env target while CEF bundling fails on the config one, e.g. `invalid CEF target x86_64-unknown-linux-musl`.

Cargo gives `CARGO_BUILD_TARGET` precedence over `build.target` in the config file, so `CargoConfig::load` now does the same.

Closes #15768