### PR TITLE
fix(core): carry filter through pending emit queue

### DIFF
--- a/.changes/emit-filter-pending.md
+++ b/.changes/emit-filter-pending.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fix `emit_filter`/`emit_str_filter` emitting to every target when the emit is deferred onto the pending queue (which happens when it runs while the handlers lock is held, e.g. emitting from inside an event handler). The filter is now carried through the pending queue instead of degrading into a broadcast. The filter closure now requires `Send + 'static`, matching the bound already required by `Listeners::listen`.

--- a/crates/tauri/src/event/listener.rs
+++ b/crates/tauri/src/event/listener.rs
@@ -16,6 +16,12 @@ use std::{
   },
 };
 
+/// A boxed event target filter that can be stored in the pending queue.
+///
+/// Requires `Send` because the queue may be flushed from a different thread than
+/// the one that deferred the emit.
+type BoxedFilter = Box<dyn Fn(&EventTarget) -> bool + Send>;
+
 /// What to do with the pending handler when resolving it?
 enum Pending {
   Unlisten(EventId),
@@ -24,7 +30,10 @@ enum Pending {
     event: crate::EventName,
     handler: Handler,
   },
-  Emit(EmitArgs),
+  Emit {
+    args: EmitArgs,
+    filter: Option<BoxedFilter>,
+  },
   RemoveForTarget(EventTarget),
 }
 
@@ -128,7 +137,7 @@ impl Listeners {
       match action {
         Pending::Unlisten(id) => self.unlisten(id),
         Pending::Listen { id, event, handler } => self.listen_with_id(id, event, handler),
-        Pending::Emit(args) => self.emit(args)?,
+        Pending::Emit { args, filter } => self.emit_filter(args, filter)?,
         Pending::RemoveForTarget(target) => self.remove_listeners_for_target(target),
       }
     }
@@ -207,12 +216,15 @@ impl Listeners {
   /// Emits the given event with its payload based on a filter.
   pub(crate) fn emit_filter<F>(&self, emit_args: EmitArgs, filter: Option<F>) -> crate::Result<()>
   where
-    F: Fn(&EventTarget) -> bool,
+    F: Fn(&EventTarget) -> bool + Send + 'static,
   {
     let mut maybe_pending = false;
 
     match self.inner.handlers.try_lock() {
-      Err(_) => self.insert_pending(Pending::Emit(emit_args)),
+      Err(_) => self.insert_pending(Pending::Emit {
+        args: emit_args,
+        filter: filter.map(|f| Box::new(f) as BoxedFilter),
+      }),
       Ok(lock) => {
         if let Some(handlers) = lock.get(&emit_args.event) {
           let handlers = handlers.iter();
@@ -234,7 +246,7 @@ impl Listeners {
 
   /// Emits the given event with its payload.
   pub(crate) fn emit(&self, emit_args: EmitArgs) -> crate::Result<()> {
-    self.emit_filter(emit_args, None::<&dyn Fn(&EventTarget) -> bool>)
+    self.emit_filter(emit_args, None::<fn(&EventTarget) -> bool>)
   }
 
   pub(crate) fn listen_js(
@@ -437,6 +449,49 @@ mod test {
     listeners
       .emit(EmitArgs::new(event.as_str_event(), &()).unwrap())
       .unwrap();
+  }
+
+  #[test]
+  fn pending_emit_keeps_filter() {
+    let listeners = Listeners::default();
+    let listeners_clone = listeners.clone();
+
+    let outer = crate::EventName::new("outer".to_owned()).unwrap();
+    let inner = crate::EventName::new("inner".to_owned()).unwrap();
+    let inner_clone = inner.clone();
+
+    let a_hits = Arc::new(AtomicU32::new(0));
+    let b_hits = Arc::new(AtomicU32::new(0));
+
+    let a_hits_cb = a_hits.clone();
+    listeners.listen(inner.clone(), EventTarget::webview("a"), move |_| {
+      a_hits_cb.fetch_add(1, Ordering::SeqCst);
+    });
+    let b_hits_cb = b_hits.clone();
+    listeners.listen(inner.clone(), EventTarget::webview("b"), move |_| {
+      b_hits_cb.fetch_add(1, Ordering::SeqCst);
+    });
+
+    // Emitting `inner` from within the `outer` handler runs while the handlers
+    // lock is held, so the emit is deferred onto the pending queue. The filter
+    // must survive that round-trip instead of degrading into a broadcast.
+    listeners.listen(outer.clone(), EventTarget::Any, move |_| {
+      listeners_clone
+        .emit_filter(
+          EmitArgs::new(inner_clone.as_str_event(), &()).unwrap(),
+          Some(
+            |target: &EventTarget| matches!(target, EventTarget::Webview { label } if label == "a"),
+          ),
+        )
+        .unwrap();
+    });
+
+    listeners
+      .emit(EmitArgs::new(outer.as_str_event(), &()).unwrap())
+      .unwrap();
+
+    assert_eq!(a_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(b_hits.load(Ordering::SeqCst), 0);
   }
 
   #[test]

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -1020,7 +1020,7 @@ pub trait Emitter<R: Runtime>: sealed::ManagerBase<R> {
   fn emit_filter<S, F>(&self, event: &str, payload: S, filter: F) -> Result<()>
   where
     S: Serialize + Clone,
-    F: Fn(&EventTarget) -> bool,
+    F: Fn(&EventTarget) -> bool + Send + 'static,
   {
     let event = EventName::new(event)?;
     let payload = EmitPayload::Serialize(&payload);
@@ -1030,7 +1030,7 @@ pub trait Emitter<R: Runtime>: sealed::ManagerBase<R> {
   /// Similar to [`Emitter::emit_filter`] but the payload is json serialized.
   fn emit_str_filter<F>(&self, event: &str, payload: String, filter: F) -> Result<()>
   where
-    F: Fn(&EventTarget) -> bool,
+    F: Fn(&EventTarget) -> bool + Send + 'static,
   {
     let event = EventName::new(event)?;
     let payload = EmitPayload::<()>::Str(payload);

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -566,7 +566,7 @@ impl<R: Runtime> AppManager<R> {
   ) -> crate::Result<()>
   where
     S: Serialize,
-    F: Fn(&EventTarget) -> bool,
+    F: Fn(&EventTarget) -> bool + Send + 'static,
   {
     #[cfg(feature = "tracing")]
     let _span = tracing::debug_span!("emit::run").entered();
@@ -636,7 +636,7 @@ impl<R: Runtime> AppManager<R> {
     match target {
       // if targeting all, emit to all using emit without filter
       EventTarget::Any => self.emit(event, payload),
-      target => self.emit_filter(event, payload, |t| filter_target(&target, t)),
+      target => self.emit_filter(event, payload, move |t| filter_target(&target, t)),
     }
   }
 

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -688,13 +688,13 @@ impl<R: Runtime> Webview<R> {
     event: crate::EventName<&str>,
     payload: &S,
   ) -> crate::Result<()> {
-    let window_label = self.label();
+    let window_label = self.label().to_string();
     let payload = EmitPayload::Serialize(payload);
     self
       .manager()
-      .emit_filter(event, payload, |target| match target {
+      .emit_filter(event, payload, move |target| match target {
         EventTarget::Webview { label } | EventTarget::WebviewWindow { label } => {
-          label == window_label
+          *label == window_label
         }
         _ => false,
       })

--- a/crates/tauri/src/manager/window.rs
+++ b/crates/tauri/src/manager/window.rs
@@ -133,13 +133,13 @@ impl<R: Runtime> WindowManager<R> {
 impl<R: Runtime> Window<R> {
   /// Emits event to [`EventTarget::Window`] and [`EventTarget::WebviewWindow`]
   fn emit_to_window<S: Serialize>(&self, event: EventName<&str>, payload: &S) -> crate::Result<()> {
-    let window_label = self.label();
+    let window_label = self.label().to_string();
     let payload = EmitPayload::Serialize(payload);
     self
       .manager()
-      .emit_filter(event, payload, |target| match target {
+      .emit_filter(event, payload, move |target| match target {
         EventTarget::Window { label } | EventTarget::WebviewWindow { label } => {
-          label == window_label
+          *label == window_label
         }
         _ => false,
       })


### PR DESCRIPTION
Closes #15759

`emit_filter`/`emit_str_filter` broadcast to every target when the emit gets deferred onto the pending queue. That deferral happens whenever an emit runs while the handlers lock is held — most commonly emitting from inside an event handler. The queued `Pending::Emit` only stored the payload, so on flush it replayed as a plain unfiltered `emit()`.

Fix: store the filter on `Pending::Emit` and replay it through `emit_filter` on flush.

Because the queue can be flushed from a different thread than the one that deferred the emit, the stored filter has to be `Send`, and boxing it into the queue requires `'static`. So the filter closure now requires `Send + 'static`, threaded through `Emitter::emit_filter`/`emit_str_filter` and the internal manager/listener paths. This matches the bound `Listeners::listen` already places on its callback. Internal callers were updated to own their captured labels; if you'd rather keep the public bound unchanged I can rework, but this mirrors the existing listener API.

Added a regression test (`pending_emit_keeps_filter`) that emits a filtered event from within a handler (forcing the pending path) and asserts only the targeted listener fires.
