### PR TITLE
process: relaunch macOS app via LaunchServices to avoid inheriting dying stdio

### DIFF
--- a/crates/tauri/src/process.rs
+++ b/crates/tauri/src/process.rs
@@ -108,23 +108,38 @@ fn restart_macos_app(current_binary: &std::path::Path, env: &Env) {
         return;
       }
 
-      if let Ok(info_plist) =
-        plist::from_file::<_, plist::Dictionary>(contents_directory.join("Info.plist"))
-      {
-        if let Some(binary_name) = info_plist
-          .get("CFBundleExecutable")
-          .and_then(|v| v.as_string())
-        {
-          if let Err(e) = Command::new(macos_directory.join(binary_name))
-            .args(env.args_os.iter().skip(1))
-            .spawn()
+      if let Some(bundle_root) = contents_directory.parent() {
+        // Prefer LaunchServices so the new process is reparented to
+        // launchd with clean stdio, instead of inheriting the dying
+        // process's pipe fds.
+        let launched = Command::new("/usr/bin/open")
+          .arg("-n")
+          .arg(bundle_root)
+          .stdout(std::process::Stdio::null())
+          .stderr(std::process::Stdio::null())
+          .stdin(std::process::Stdio::null())
+          .spawn()
+          .is_ok();
+        if !launched {
+          if let Ok(info_plist) =
+            plist::from_file::<_, plist::Dictionary>(contents_directory.join("Info.plist"))
           {
-            log::error!("failed to restart app: {e}");
+            if let Some(binary_name) = info_plist
+              .get("CFBundleExecutable")
+              .and_then(|v| v.as_string())
+            {
+              if let Err(e) = Command::new(macos_directory.join(binary_name))
+                .args(env.args_os.iter().skip(1))
+                .spawn()
+              {
+                log::error!("failed to restart app: {e}");
+              }
+            }
           }
-
-          exit(0);
         }
       }
+
+      exit(0);
     }
   }
 }


### PR DESCRIPTION
On macOS, process::restart forked and exec'd the new instance from
the dying process. The replacement inherited the dying process's stdio
fds, session, and process group, producing a reproducible crash when
the original binary was launched from a terminal, IDE, or login item.

Use LaunchServices (open -n <bundle>) as the primary path so launchd
owns the new process: parent = launchd, stdio = /dev/null, fresh session.
The previous direct-spawn path stays as a fallback when /usr/bin/open
is unreachable.

Fixes #15742

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
