### PR TITLE
fix(bundler): respect configured GDK backend (fix: #15781)

### DIFF
--- a/.changes/appimage-respect-gdk-backend.md
+++ b/.changes/appimage-respect-gdk-backend.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": "patch:bug"
+---
+
+Respect an explicitly configured `GDK_BACKEND` in AppImage GTK hooks while retaining `x11` as the default.

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy-plugin-gtk.sh
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy-plugin-gtk.sh
@@ -184,7 +184,7 @@ APPIMAGE_GTK_THEME="${APPIMAGE_GTK_THEME:-"Adwaita:$GTK_THEME_VARIANT"}" # Allow
 export APPDIR="${APPDIR:-"$(dirname "$(realpath "$0")")"}" # Workaround to run extracted AppImage
 export GTK_DATA_PREFIX="$APPDIR"
 export GTK_THEME="$APPIMAGE_GTK_THEME" # Custom themes are broken
-export GDK_BACKEND=x11 # Crash with Wayland backend on Wayland - We tested it without it and ended up with this: https://github.com/tauri-apps/tauri/issues/8541
+export GDK_BACKEND="${GDK_BACKEND:-x11}" # Crash with Wayland backend on Wayland - We tested it without it and ended up with this: https://github.com/tauri-apps/tauri/issues/8541
 export XDG_DATA_DIRS="$APPDIR/usr/share:/usr/share:$XDG_DATA_DIRS" # g_get_system_data_dirs() from GLib
 EOF
 
@@ -324,4 +324,3 @@ EOF
 
 #binary patch absolute paths in libwebkit files
 find "$APPDIR"/usr/lib* -name 'libwebkit*' -exec sed -i -e "s|/usr|././|g" '{}' \;
-


### PR DESCRIPTION
## Summary

- preserve an explicitly configured `GDK_BACKEND` in the AppImage GTK hook
- retain `x11` as the safe default when the variable is unset
- add a patch release note for `tauri-bundler`

Fixes #15781.

OpenJobs task: https://openjobs.bot/jobs/6cbdfdad-d49f-4eed-a0b9-04df4a7e2b12

## Testing

- `bash -n crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy-plugin-gtk.sh`
- explicit `GDK_BACKEND=wayland` preservation check
- unset `GDK_BACKEND` fallback-to-`x11` check
- `cargo fmt --check`
- `cargo test -p tauri-bundler`