### PR TITLE
chore(renovate): group napi-rs packages take 2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
     {
       "description": "Group napi-rs packages",
       "groupName": "napi-rs packages",
-      "matchSourceUrls": ["https://github.com/napi-rs/napi-rs"]
+      "matchPackageNames": ["napi", "napi-build", "napi-derive", "@napi-rs/cli"]
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"]


### PR DESCRIPTION
Reference #15600, guess it didn't work looking at #15724, let's try manually adding all the packages.