### PR TITLE
fix(core): guard event unlisten script when listener entry is missing

### DIFF
--- a/.changes/fix-unlisten-guard-missing-entry.md
+++ b/.changes/fix-unlisten-guard-missing-entry.md
@@ -1,0 +1,5 @@
+---
+'tauri': 'patch:bug'
+---
+
+Guard the handler lookup in the generated unlisten script. When the unlisten function ran before its listener registration eval reached the webview, the entry was still missing and reading its `handlerId` threw, which aborted `_unlisten` before it sent the backend `plugin:event|unlisten` and left the listener registered.

--- a/crates/tauri/src/event/mod.rs
+++ b/crates/tauri/src/event/mod.rs
@@ -214,7 +214,10 @@ pub(crate) fn unlisten_js_script(
     "(function () {{
         const listeners = (window['{listeners_object_name}'] || {{}})[{event_arg}]
         if (listeners) {{
-          window.__TAURI_INTERNALS__.unregisterCallback(listeners[{event_id_arg}].handlerId)
+          const listener = listeners[{event_id_arg}]
+          if (listener) {{
+            window.__TAURI_INTERNALS__.unregisterCallback(listener.handlerId)
+          }}
         }}
       }})()
     ",
@@ -248,5 +251,13 @@ mod tests {
       .unwrap_err()
       .to_string();
     assert_eq!("only alphanumeric, '-', '/', ':', '_' permitted for event names: \"some\\r illegal event name\"", s);
+  }
+
+  #[test]
+  fn unlisten_script_guards_missing_entry() {
+    let script = unlisten_js_script("__listeners__", "event", "eventId");
+    assert!(!script.contains("listeners[eventId].handlerId"));
+    assert!(script.contains("const listener = listeners[eventId]"));
+    assert!(script.contains("if (listener) {"));
   }
 }

--- a/crates/tauri/src/event/mod.rs
+++ b/crates/tauri/src/event/mod.rs
@@ -252,12 +252,4 @@ mod tests {
       .to_string();
     assert_eq!("only alphanumeric, '-', '/', ':', '_' permitted for event names: \"some\\r illegal event name\"", s);
   }
-
-  #[test]
-  fn unlisten_script_guards_missing_entry() {
-    let script = unlisten_js_script("__listeners__", "event", "eventId");
-    assert!(!script.contains("listeners[eventId].handlerId"));
-    assert!(script.contains("const listener = listeners[eventId]"));
-    assert!(script.contains("if (listener) {"));
-  }
 }


### PR DESCRIPTION
`listen()` resolves once Rust answers its invoke, but the webview registry entry is written by a separate, later eval, so the returned unlisten function can run before that entry exists. In that window the generated unlisten script read `handlerId` off an undefined entry and threw, and because that throw happens before `_unlisten` sends the backend `plugin:event|unlisten`, the listener stayed registered and kept firing. This checks the entry is present before reading it, the same guard the event delivery script already uses.

Fixes #15799