### PR TITLE
fix(bundler): stop bundling xdg-open and xdg-utils

### DIFF
--- a/.changes/fix-appimage-xdg-utils.md
+++ b/.changes/fix-appimage-xdg-utils.md
@@ -1,0 +1,7 @@
+---
+tauri-bundler: patch:bug
+tauri-cli: patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+On Linux, do not bundle xdg-open and xdg-utils in the AppImage anymore. This rarely worked and usually requires host system support anyway.

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -118,21 +118,6 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   fs::create_dir_all(&app_dir_usr_bin)?;
   fs::create_dir_all(app_dir_usr_lib)?;
 
-  // Copy bins and libs that linuxdeploy doesn't know about
-
-  // we also check if the user may have provided their own copy already
-  // xdg-open will be handled by the `files` config instead
-  if settings.deep_link_protocols().is_some() && !app_dir_usr_bin.join("xdg-open").exists() {
-    fs::copy("/usr/bin/xdg-mime", app_dir_usr_bin.join("xdg-mime"))
-      .fs_context("xdg-mime binary not found", "/usr/bin/xdg-mime".to_string())?;
-  }
-
-  // we also check if the user may have provided their own copy already
-  if settings.appimage().bundle_xdg_open && !app_dir_usr_bin.join("xdg-open").exists() {
-    fs::copy("/usr/bin/xdg-open", app_dir_usr_bin.join("xdg-open"))
-      .fs_context("xdg-open binary not found", "/usr/bin/xdg-open".to_string())?;
-  }
-
   let search_dirs = [
     match settings.binary_arch() {
       Arch::X86_64 => "/usr/lib/x86_64-linux-gnu/",

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -6,7 +6,7 @@
 use super::{super::debian, write_and_make_executable};
 use crate::{
   bundle::settings::Arch,
-  error::{Context, ErrorExt},
+  error::Context,
   utils::{fs_utils, http_utils::download, CommandExt},
   Settings,
 };

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -223,6 +223,10 @@ pub struct AppImageSettings {
   /// Whether to include gstreamer plugins for audio/media support.
   pub bundle_media_framework: bool,
   /// Whether to include the `xdg-open` binary.
+  #[deprecated(
+    since = "2.12.0",
+    note = "Bundling xdg-open in an AppImage does not work and therefore was disabled."
+  )]
   pub bundle_xdg_open: bool,
 }
 

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -899,26 +899,6 @@ impl AppSettings for RustAppSettings {
       });
     }
 
-    if let Some(open) = config.plugins.0.get("shell").and_then(|v| v.get("open")) {
-      if open.as_bool().is_some_and(|x| x) || open.is_string() {
-        settings.appimage.bundle_xdg_open = true;
-      }
-    }
-
-    if let Some(deps) = self
-      .manifest
-      .lock()
-      .unwrap()
-      .inner
-      .as_table()
-      .get("dependencies")
-      .and_then(|f| f.as_table())
-    {
-      if deps.contains_key("tauri-plugin-opener") {
-        settings.appimage.bundle_xdg_open = true;
-      };
-    }
-
     Ok(settings)
   }
 


### PR DESCRIPTION
This rarely actually worked. xdg-open had a bunch of problems (see list below) but xdg-mime especially requires the host system to have xdg-mime / update-desktop-database or rather support for mime handling for this to properly work. In other words: there's no value in bundling them.

fixes #15430
fixes #10617
fixes #10078 
fixes #6172 (or maybe not, that's too generic)

And yes this means that if the host system does not have these the relevant functionality breaks but this is not our problem to fix (though we could have a popup warning or something idk)