### PR TITLE
fix(bundler): notarize and staple the DMG after signing it

### DIFF
--- a/.changes/notarize-dmg.md
+++ b/.changes/notarize-dmg.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": patch
+---
+
+Notarize and staple the signed DMG after signing it, mirroring the existing app-bundle notarization path. A build previously reported success while the downloaded DMG carried no notarization ticket, so Gatekeeper rejected it. The new path respects the `skip_stapling` opt-out and keeps the missing-team-id hard error, matching the app behavior.

--- a/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
+++ b/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs
@@ -3,10 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use super::{app, icon::create_icns_file};
+use super::{
+  app,
+  icon::create_icns_file,
+  sign::{keychain, notarize, notarize_auth, notarize_without_stapling, sign, SignTarget},
+};
 use crate::{
   bundle::{settings::Arch, Bundle},
-  error::{Context, ErrorExt},
+  error::{Context, ErrorExt, NotarizeAuthError},
   utils::CommandExt,
   PackageType, Settings,
 };
@@ -194,15 +198,39 @@ pub fn bundle_project(settings: &Settings, bundles: &[Bundle]) -> crate::Result<
   // skipping self-signing DMGs https://github.com/tauri-apps/tauri/issues/12288
   let identity = settings.macos().signing_identity.as_deref();
   if !settings.no_sign() && identity != Some("-") {
-    if let Some(keychain) = super::sign::keychain(identity)? {
-      super::sign::sign(
+    if let Some(keychain) = keychain(identity)? {
+      sign(
         &keychain,
-        vec![super::sign::SignTarget {
+        vec![SignTarget {
           path: dmg_path.clone(),
           is_an_executable: false,
         }],
         settings,
       )?;
+
+      // Notarize the signed DMG. The .app bundle inside was notarized before
+      // the DMG was created (app.rs), but the DMG itself is the artifact a
+      // user downloads: without its own notarized and stapled ticket, a
+      // gatekeeper check on the DMG fails and the build reports success for a
+      // file Apple will not open without bypassing Gatekeeper. Mirror the app
+      // notarization path exactly, including the skip_stapling opt-out and the
+      // missing-team-id hard error. See https://github.com/tauri-apps/tauri/issues/15822
+      match notarize_auth() {
+        Ok(auth) => {
+          if settings.macos().skip_stapling {
+            notarize_without_stapling(&keychain, dmg_path.clone(), &auth)?;
+          } else {
+            notarize(&keychain, dmg_path.clone(), &auth)?;
+          }
+        }
+        Err(e) => {
+          if matches!(e, NotarizeAuthError::MissingTeamId) {
+            return Err(e.into());
+          } else {
+            log::warn!("skipping dmg notarization, {e}");
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Closes #15822

## The bug

The `.app` bundle is notarized before the DMG is created (app.rs), but the DMG itself is only signed — never submitted to Apple for notarization and never stapled (dmg/mod.rs). The build reports success, so a developer ships a DMG that Gatekeeper rejects on first open while believing the distribution is fully notarized. The issue's reproduction confirms: `xcrun stapler validate App.dmg` exits 65 while the inner `.app` validates.

## The fix

After signing the DMG, submit it for notarization and staple the ticket — mirroring the app path in `app.rs` exactly:

- `notarize_auth()` gates the whole block, same as the app path.
- `settings.macos().skip_stapling` is honored: `notarize_without_stapling` when set, full `notarize` (submit + staple) otherwise.
- A missing team ID is a hard error (same as the app path); any other auth error logs `skipping dmg notarization, {e}` and continues, so builds without notarization credentials keep working with a visible warning.

This does not double-notarize the `.app`: it notarizes the outer container, which is the artifact users actually download.

## Verification

- `cargo check` on tauri-bundler: clean.
- `cargo test` on tauri-bundler: 20/20 pass.
- `cargo clippy`: no new warnings (the one warning in this file pre-exists on the base branch).
- `cargo fmt --check`: clean.
- Notarization itself requires Apple credentials and a Developer ID, so the runtime path is verified by code parity with the tested `app.rs` flow.