### PR TITLE
fix(build): resolve target dir from OUT_DIR on new nightly

### DIFF
--- a/.changes/target-dir-nightly-out-dir.md
+++ b/.changes/target-dir-nightly-out-dir.md
@@ -1,0 +1,5 @@
+---
+'tauri-build': 'patch:bug'
+---
+
+Resolve the target directory by walking up from `OUT_DIR` to the `build` directory instead of assuming it is exactly three levels up. Recent nightly toolchains add another level to `OUT_DIR`, which made sidecars and resources land in `target/debug/build` instead of `target/debug`.

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -21,7 +21,9 @@ use tauri_utils::{
 
 use std::{
   collections::HashMap,
-  env, fs,
+  env,
+  ffi::OsStr,
+  fs,
   path::{Path, PathBuf},
 };
 
@@ -203,6 +205,15 @@ fn copy_frameworks(dest_dir: &Path, frameworks: &[String]) -> Result<()> {
     }
   }
   Ok(())
+}
+
+// resolves the target dir from `OUT_DIR`, which is
+// `<target-dir>/build/<crate dir>/out` - one crate dir on stable, two on nightly.
+fn target_dir_from_out_dir(out_dir: &Path) -> Option<&Path> {
+  out_dir
+    .ancestors()
+    .find(|path| path.file_name() == Some(OsStr::new("build")))
+    .and_then(|build_dir| build_dir.parent())
 }
 
 // creates a cfg alias if `has_feature` is true.
@@ -574,13 +585,8 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
   env::set_var("TAURI_ENV_TARGET_TRIPLE", &target_triple);
 
   // TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/5457>
-  let target_dir = out_dir
-    .parent()
-    .unwrap()
-    .parent()
-    .unwrap()
-    .parent()
-    .unwrap();
+  let target_dir = target_dir_from_out_dir(&out_dir)
+    .with_context(|| format!("failed to resolve the target directory from {out_dir:?}"))?;
 
   if let Some(paths) = &config.bundle.external_bin {
     copy_binaries(
@@ -785,6 +791,37 @@ fn should_static_link_vc_runtime(config: &Config, attributes: &Attributes) -> bo
 #[cfg(test)]
 mod tests {
   use semver::Version;
+  use std::path::Path;
+
+  #[test]
+  fn target_dir_from_stable_out_dir() {
+    assert_eq!(
+      crate::target_dir_from_out_dir(Path::new(
+        "/app/target/debug/build/app-63ba68eead531e35/out"
+      )),
+      Some(Path::new("/app/target/debug"))
+    );
+  }
+
+  #[test]
+  fn target_dir_from_nightly_out_dir() {
+    assert_eq!(
+      crate::target_dir_from_out_dir(Path::new(
+        "/app/target/debug/build/app/63ba68eead531e35/out"
+      )),
+      Some(Path::new("/app/target/debug"))
+    );
+  }
+
+  #[test]
+  fn target_dir_from_out_dir_with_triple() {
+    assert_eq!(
+      crate::target_dir_from_out_dir(Path::new(
+        "/app/target/aarch64-apple-darwin/release/build/app/63ba68eead531e35/out"
+      )),
+      Some(Path::new("/app/target/aarch64-apple-darwin/release"))
+    );
+  }
 
   #[test]
   fn version_uses_numeric_build_metadata() {

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -207,8 +207,8 @@ fn copy_frameworks(dest_dir: &Path, frameworks: &[String]) -> Result<()> {
   Ok(())
 }
 
-// resolves the target dir from `OUT_DIR`, which is
-// `<target-dir>/build/<crate dir>/out` - one crate dir on stable, two on nightly.
+// resolves the target dir from `OUT_DIR`, which is `<target dir>/build/<crate dirs>/out`.
+// there is a single crate dir on stable and two of them on the new nightly layout.
 fn target_dir_from_out_dir(out_dir: &Path) -> Option<&Path> {
   out_dir
     .ancestors()
@@ -795,30 +795,31 @@ mod tests {
 
   #[test]
   fn target_dir_from_stable_out_dir() {
+    let out_dir = Path::new("/app/target/debug/build/app-63ba68eead531e35/out");
+
     assert_eq!(
-      crate::target_dir_from_out_dir(Path::new(
-        "/app/target/debug/build/app-63ba68eead531e35/out"
-      )),
+      crate::target_dir_from_out_dir(out_dir),
       Some(Path::new("/app/target/debug"))
     );
   }
 
   #[test]
   fn target_dir_from_nightly_out_dir() {
+    let out_dir = Path::new("/app/target/debug/build/app/63ba68eead531e35/out");
+
     assert_eq!(
-      crate::target_dir_from_out_dir(Path::new(
-        "/app/target/debug/build/app/63ba68eead531e35/out"
-      )),
+      crate::target_dir_from_out_dir(out_dir),
       Some(Path::new("/app/target/debug"))
     );
   }
 
   #[test]
   fn target_dir_from_out_dir_with_triple() {
+    let out_dir =
+      Path::new("/app/target/aarch64-apple-darwin/release/build/app/63ba68eead531e35/out");
+
     assert_eq!(
-      crate::target_dir_from_out_dir(Path::new(
-        "/app/target/aarch64-apple-darwin/release/build/app/63ba68eead531e35/out"
-      )),
+      crate::target_dir_from_out_dir(out_dir),
       Some(Path::new("/app/target/aarch64-apple-darwin/release"))
     );
   }

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -207,8 +207,10 @@ fn copy_frameworks(dest_dir: &Path, frameworks: &[String]) -> Result<()> {
   Ok(())
 }
 
-// resolves the target dir from `OUT_DIR`, which is `<target dir>/build/<crate dirs>/out`.
-// there is a single crate dir on stable and two of them on the new nightly layout.
+// TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/5457>
+// resolves the target dir from `OUT_DIR`, which is `<target dir>/build/<pkg>-<hash>/out` on stable
+// and `<target dir>/build/<pkg>/<hash>/out` on recent nightlies, so we walk up to the `build` dir
+// and take its parent instead of assuming a fixed depth.
 fn target_dir_from_out_dir(out_dir: &Path) -> Option<&Path> {
   out_dir
     .ancestors()
@@ -584,7 +586,6 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
   // when running codegen in this build script, we need to access the env var directly
   env::set_var("TAURI_ENV_TARGET_TRIPLE", &target_triple);
 
-  // TODO: far from ideal, but there's no other way to get the target dir, see <https://github.com/rust-lang/cargo/issues/5457>
   let target_dir = target_dir_from_out_dir(&out_dir)
     .with_context(|| format!("failed to resolve the target directory from {out_dir:?}"))?;
 


### PR DESCRIPTION
`tauri-build` assumed the target dir sits exactly three levels above `OUT_DIR`. Recent nightly toolchains changed the build script output layout from `build/<pkg>-<hash>/out` to `build/<pkg>/<hash>/out`, so that assumption pointed one level too deep and sidecars and resources were copied into `target/debug/build` instead of `target/debug`.

It now walks up from `OUT_DIR` to the `build` directory and takes its parent, which works on both layouts.

Verified with the reproduction from the issue: on nightly the sidecar now lands in `target/debug/hello` again, and stable is unaffected.

Closes #15830