### PR TITLE
fix(core): resolve asset protocol requests off the webview thread (fix #7434)

### DIFF
--- a/.changes/asset-protocol-non-blocking.md
+++ b/.changes/asset-protocol-non-blocking.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+Read `asset://` files on the blocking thread pool instead of on the thread the webview invokes the protocol handler on, so a slow or unreachable path no longer freezes the whole application.

--- a/crates/tauri/src/protocol/asset.rs
+++ b/crates/tauri/src/protocol/asset.rs
@@ -11,19 +11,25 @@ use std::{borrow::Cow, io::SeekFrom};
 use tauri_utils::mime_type::MimeType;
 
 pub fn get(scope: scope::fs::Scope, window_origin: String) -> UriSchemeProtocolHandler {
-  Box::new(
-    move |_, request, responder| match get_response(request, &scope, &window_origin) {
-      Ok(response) => responder.respond(response),
-      Err(e) => responder.respond(
-        http::Response::builder()
-          .status(http::StatusCode::INTERNAL_SERVER_ERROR)
-          .header(CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
-          .header("Access-Control-Allow-Origin", &window_origin)
-          .body(e.to_string().into_bytes())
-          .unwrap(),
-      ),
-    },
-  )
+  Box::new(move |_, request, responder| {
+    let scope = scope.clone();
+    let window_origin = window_origin.clone();
+    // `get_response` performs blocking filesystem I/O, so it must not run on the
+    // thread the webview calls us on, otherwise the whole event loop stalls.
+    crate::async_runtime::spawn_blocking(move || {
+      match get_response(request, &scope, &window_origin) {
+        Ok(response) => responder.respond(response),
+        Err(e) => responder.respond(
+          http::Response::builder()
+            .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+            .header(CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
+            .header("Access-Control-Allow-Origin", &window_origin)
+            .body(e.to_string().into_bytes())
+            .unwrap(),
+        ),
+      }
+    });
+  })
 }
 
 fn get_response(
@@ -235,4 +241,77 @@ fn random_boundary() -> String {
       a.push_str(x.as_str());
       a
     })
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+  use crate::app::UriSchemeResponder;
+  use crate::Manager;
+  use std::sync::mpsc::{channel, TryRecvError};
+  use std::time::Duration;
+
+  /// The handler must hand the request off and return, rather than reading the
+  /// file on the thread the webview called it on.
+  ///
+  /// A FIFO stands in for a slow or unreachable path: opening one for reading
+  /// blocks until a writer appears, which is the same shape as the unreachable
+  /// network share in #7434 without needing one. If the read happened inline,
+  /// `handler(..)` below would not return until the writer thread runs.
+  #[test]
+  fn does_not_block_the_calling_thread() {
+    let dir = std::env::temp_dir().join(format!("tauri-asset-protocol-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("blocking-asset");
+    let _ = std::fs::remove_file(&path);
+    assert!(std::process::Command::new("mkfifo")
+      .arg(&path)
+      .status()
+      .unwrap()
+      .success());
+
+    let app = crate::test::mock_app();
+    let scope = app.asset_protocol_scope();
+    scope.allow_file(&path).unwrap();
+
+    let handler = super::get(scope, "tauri://localhost".into());
+
+    let (tx, rx) = channel();
+    let responder = UriSchemeResponder(Box::new(move |response| {
+      let _ = tx.send(response);
+    }));
+
+    let encoded = percent_encoding::percent_encode(
+      path.to_str().unwrap().as_bytes(),
+      percent_encoding::NON_ALPHANUMERIC,
+    );
+    let request = http::Request::builder()
+      .uri(format!("asset://localhost/{encoded}"))
+      .body(Vec::new())
+      .unwrap();
+
+    // call the handler off the test thread so a regression fails the test instead
+    // of hanging it
+    let (returned_tx, returned_rx) = channel();
+    std::thread::spawn(move || {
+      handler("main", request, responder);
+      let _ = returned_tx.send(());
+    });
+    returned_rx
+      .recv_timeout(Duration::from_secs(30))
+      .expect("asset protocol handler did not return before reading the file");
+
+    // it cannot have read the file yet, because nothing has opened the write end
+    // of the FIFO
+    assert_eq!(rx.try_recv().unwrap_err(), TryRecvError::Empty);
+
+    // unblock the read so the request resolves instead of leaking a blocked thread
+    std::thread::spawn(move || {
+      let _ = std::fs::write(&path, b"tauri");
+    });
+
+    rx.recv_timeout(Duration::from_secs(30))
+      .expect("asset protocol never responded");
+
+    let _ = std::fs::remove_dir_all(&dir);
+  }
 }


### PR DESCRIPTION
# Summary

Closes #7434.

`asset://` requests are served by a handler registered through wry's `with_asynchronous_custom_protocol` (`crates/tauri-runtime-wry/src/lib.rs`), an API whose point is that the handler may return immediately and respond later from another thread. The asset handler did not do that — it called `get_response`, which is synchronous `std::fs` I/O, inline and only then responded, so the whole read ran on the thread the webview invoked it on.

That is the thread running the event loop, so a read that blocks stalls every window driven by that event loop, not just the one that asked. This matches #7434, where an image on an unreachable SMB path freezes the entire app, and the reporter's own guess that "the rust-end was blocked".

This wraps the existing handler body in `crate::async_runtime::spawn_blocking` and changes nothing else. `get_response` is untouched, so the range/206 path, the `HEAD` path, the `SafePathBuf` and scope checks, the CORS header and the Android external-storage branch all keep their current behaviour — every one of them is reached through that single call, and both `responder.respond` arms moved with it, so there is no route that still responds from the calling thread.

### Why `spawn_blocking` rather than `spawn`

#15220 did this for the sibling `tauri://` protocol and used `crate::async_runtime::spawn`, because that `get_response` is `async`. This one is not: since #15117 (`refactor(tauri): use blocking apis where it makes sense`) the asset body is plain `std::fs`, which is what a blocking pool is for, and `spawn` would park an async worker on a blocking read. Happy to switch to `spawn` if you would rather the two protocols read the same way.

`scope` is `Arc`-backed so cloning it is a refcount bump, and `window_origin` is a short `String`. I kept it to those two clones rather than introducing an `Arc<Context>` as #15220 did, to hold the diff to the handler.

# Testing

On macOS (aarch64):

- `cargo test -p tauri --all-features` — 61 unit tests and 122 doc tests, all passing
- `cargo clippy -p tauri --all-targets --all-features` — clean
- `cargo fmt --all -- --check` — clean

I added one test, `does_not_block_the_calling_thread`. It uses a FIFO as a stand-in for a path that never answers — opening one for reading blocks until a writer appears — and asserts that the handler has returned while nothing has been read yet. I checked that it actually exercises the defect: with this change reverted and the test kept, it blocks indefinitely instead of passing. It is `#[cfg(all(test, unix))]` and calls the handler on a spawned thread, so a regression fails the test rather than hanging CI.

I separately checked, with a throwaway test I have not included, that the range path behaves identically through the new call: full `GET`, `bytes=10-19`, `bytes=0-`, `bytes=-100`, an unsatisfiable range, `HEAD`, a missing file and a scope denial all produce the same status, the same `content-range` / `content-length` / `accept-ranges` headers and the same bodies as before. I left it out to keep the diff to the fix; glad to add it if you want the coverage.

### What I could not verify

I have no SMB share or other unreachable network path available, so I have **not** reproduced #7434 itself, and I have not confirmed the fix against the reporter's scenario. The case that this fixes it rests on the code and on the FIFO test, not on the original repro.

### One behaviour change worth flagging

On Android, wry blocks `shouldInterceptRequest` waiting on the responder with `MAIN_PIPE_TIMEOUT * 3` — 30s, `src/android/mod.rs` in wry 0.56. Today the asset handler responds inline, so that deadline is never reached; after this change a read taking longer than 30s would time out and the request would fall through to Android's network stack instead of eventually succeeding. #15220 already put `tauri://` in the same position. That seemed the right trade against freezing the app for those same 30s, but I am happy to handle it differently if you disagree.
