### PR TITLE
fix(core): correct asset protocol multi-range responses (fix: #15837)

### DIFF
--- a/.changes/asset-protocol-multi-range.md
+++ b/.changes/asset-protocol-multi-range.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+Fixed the `asset://` protocol returning malformed multi-range responses: the multipart body ended with an opening boundary instead of the closing one, the response carried both the file mime type and the `multipart/byteranges` type in two `Content-Type` headers, and the status was `200 OK` instead of `206 Partial Content`.

--- a/.changes/asset-protocol-multi-range.md
+++ b/.changes/asset-protocol-multi-range.md
@@ -2,4 +2,4 @@
 tauri: patch:bug
 ---
 
-Fixed the `asset://` protocol returning malformed multi-range responses: the multipart body ended with an opening boundary instead of the closing one, the response carried both the file mime type and the `multipart/byteranges` type in two `Content-Type` headers, and the status was `200 OK` instead of `206 Partial Content`.
+Fix malformed `asset://` multi-range responses: the multipart body now ends with the closing boundary, `Content-Type` is only `multipart/byteranges`, and the status is `206 Partial Content`.

--- a/crates/tauri/src/protocol/asset.rs
+++ b/crates/tauri/src/protocol/asset.rs
@@ -169,7 +169,7 @@ fn get_response(
       let boundary_sep = format!("\r\n--{boundary}\r\n");
       let boundary_closer = format!("\r\n--{boundary}--\r\n");
 
-      // replace the sniffed file mime type set earlier, `Builder::header` would append instead
+      // `Builder::header` appends, so replace the file mime type set earlier
       if let Some(headers) = resp.headers_mut() {
         headers.insert(
           CONTENT_TYPE,
@@ -205,6 +205,7 @@ fn get_response(
 
         buf
       };
+
       resp = resp.status(StatusCode::PARTIAL_CONTENT);
       resp.body(buf.into())
     }
@@ -252,7 +253,10 @@ mod tests {
   fn multi_range_request() {
     let app = crate::test::mock_app();
 
-    let path = std::env::temp_dir().join("tauri-asset-protocol-multi-range.bin");
+    let path = std::env::temp_dir().join(format!(
+      "tauri-asset-protocol-multi-range-{}.bin",
+      std::process::id()
+    ));
     std::fs::write(&path, vec![b'a'; 1000]).unwrap();
 
     let scope = Scope::new(&app, &FsScope::default()).unwrap();
@@ -271,6 +275,7 @@ mod tests {
       .unwrap();
 
     let response = get_response(request, &scope, "http://tauri.localhost").unwrap();
+    std::fs::remove_file(&path).unwrap();
 
     assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
 

--- a/crates/tauri/src/protocol/asset.rs
+++ b/crates/tauri/src/protocol/asset.rs
@@ -167,12 +167,15 @@ fn get_response(
 
       let boundary = random_boundary();
       let boundary_sep = format!("\r\n--{boundary}\r\n");
-      let boundary_closer = format!("\r\n--{boundary}\r\n");
+      let boundary_closer = format!("\r\n--{boundary}--\r\n");
 
-      resp = resp.header(
-        CONTENT_TYPE,
-        format!("multipart/byteranges; boundary={boundary}"),
-      );
+      // replace the sniffed file mime type set earlier, `Builder::header` would append instead
+      if let Some(headers) = resp.headers_mut() {
+        headers.insert(
+          CONTENT_TYPE,
+          HeaderValue::from_str(&format!("multipart/byteranges; boundary={boundary}"))?,
+        );
+      }
 
       let buf = {
         // multi-part range header
@@ -202,6 +205,7 @@ fn get_response(
 
         buf
       };
+      resp = resp.status(StatusCode::PARTIAL_CONTENT);
       resp.body(buf.into())
     }
   } else if request.method() == http::Method::HEAD {
@@ -235,4 +239,54 @@ fn random_boundary() -> String {
       a.push_str(x.as_str());
       a
     })
+}
+
+#[cfg(test)]
+mod tests {
+  use super::get_response;
+  use crate::scope::fs::Scope;
+  use http::{header::CONTENT_TYPE, status::StatusCode, Request};
+  use tauri_utils::config::FsScope;
+
+  #[test]
+  fn multi_range_request() {
+    let app = crate::test::mock_app();
+
+    let path = std::env::temp_dir().join("tauri-asset-protocol-multi-range.bin");
+    std::fs::write(&path, vec![b'a'; 1000]).unwrap();
+
+    let scope = Scope::new(&app, &FsScope::default()).unwrap();
+    scope.allow_file(&path).unwrap();
+
+    let encoded_path = percent_encoding::percent_encode(
+      path.to_string_lossy().as_bytes(),
+      percent_encoding::NON_ALPHANUMERIC,
+    )
+    .to_string();
+
+    let request = Request::builder()
+      .uri(format!("asset://localhost/{encoded_path}"))
+      .header("range", "bytes=0-9, 20-29")
+      .body(Vec::new())
+      .unwrap();
+
+    let response = get_response(request, &scope, "http://tauri.localhost").unwrap();
+
+    assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+
+    let content_types = response
+      .headers()
+      .get_all(CONTENT_TYPE)
+      .iter()
+      .map(|v| v.to_str().unwrap().to_string())
+      .collect::<Vec<_>>();
+    assert_eq!(content_types.len(), 1);
+
+    let boundary = content_types[0]
+      .strip_prefix("multipart/byteranges; boundary=")
+      .unwrap();
+    assert!(response
+      .body()
+      .ends_with(format!("\r\n--{boundary}--\r\n").as_bytes()));
+  }
 }

--- a/crates/tauri/src/protocol/asset.rs
+++ b/crates/tauri/src/protocol/asset.rs
@@ -169,7 +169,7 @@ fn get_response(
       let boundary_sep = format!("\r\n--{boundary}\r\n");
       let boundary_closer = format!("\r\n--{boundary}--\r\n");
 
-      // `Builder::header` appends, so replace the file mime type set earlier
+      // `Builder::header` appends, we want to replace the file mime type set earlier
       if let Some(headers) = resp.headers_mut() {
         headers.insert(
           CONTENT_TYPE,

--- a/examples/streaming/main.rs
+++ b/examples/streaming/main.rs
@@ -109,12 +109,15 @@ fn get_stream_response(
 
       let boundary = random_boundary();
       let boundary_sep = format!("\r\n--{boundary}\r\n");
-      let boundary_closer = format!("\r\n--{boundary}\r\n");
+      let boundary_closer = format!("\r\n--{boundary}--\r\n");
 
-      resp = resp.header(
-        CONTENT_TYPE,
-        format!("multipart/byteranges; boundary={boundary}"),
-      );
+      // `Builder::header` appends, we want to replace the file mime type set earlier
+      if let Some(headers) = resp.headers_mut() {
+        headers.insert(
+          CONTENT_TYPE,
+          HeaderValue::from_str(&format!("multipart/byteranges; boundary={boundary}"))?,
+        );
+      }
 
       for (start, end) in ranges {
         // a new range is being written, write the range boundary
@@ -138,6 +141,7 @@ fn get_stream_response(
       // all ranges have been written, write the closing boundary
       buf.write_all(boundary_closer.as_bytes())?;
 
+      resp = resp.status(StatusCode::PARTIAL_CONTENT);
       resp.body(buf)
     }
   } else {


### PR DESCRIPTION
Multi-range `asset://` responses had three problems. The multipart body was terminated with an opening boundary (`--boundary`) instead of the close-delimiter RFC 2046 asks for (`--boundary--`). The sniffed file mime type set before the range branch stayed on the response alongside `multipart/byteranges`, because `Builder::header` appends rather than replaces, so clients reading the first `Content-Type` parsed the envelope as the file itself. And the status stayed `200 OK` while the body was partial.

Single-range requests, which is what `<video>` and `<audio>` normally send, were never affected, so this only shows up on clients asking for more than one range. Added a unit test covering all three.

Closes #15837.