### PR TITLE
fix(ipc): do not re-invoke in-flight command on webview reload (#14154)

### DIFF
--- a/.changes/fix-ipc-reload-reinvoke.md
+++ b/.changes/fix-ipc-reload-reinvoke.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixes an issue where an in-flight asynchronous command was invoked a second time when the webview was reloaded (or navigated away) while the command was still running. The custom protocol `fetch` request cancelled by the reload is no longer treated as a custom protocol failure, so it no longer falls back to the `postMessage` interface and re-sends the message.

--- a/crates/tauri/scripts/ipc-protocol.js
+++ b/crates/tauri/scripts/ipc-protocol.js
@@ -16,6 +16,23 @@
   const fetchChannelDataCommand = __TEMPLATE_fetch_channel_data_command__
   let customProtocolIpcFailed = false
 
+  // Tracks whether the document is being torn down (a reload or navigation).
+  // When that happens, any in-flight custom protocol `fetch` is aborted by the
+  // webview and its promise rejects. We must not treat that as a custom
+  // protocol failure and re-send the message over the postMessage fallback,
+  // because the command may already be running on the backend and would be
+  // invoked a second time. See https://github.com/tauri-apps/tauri/issues/14154
+  let documentIsUnloading = false
+  const markUnloading = () => {
+    documentIsUnloading = true
+  }
+  // `pagehide` covers reloads/navigations across all supported webviews;
+  // `beforeunload` fires earlier on Chromium (WebView2) so the flag is set
+  // before the aborted fetch's rejection handler runs. Both are passive (they
+  // never call `preventDefault`/set `returnValue`), so no unload prompt shows.
+  window.addEventListener('pagehide', markUnloading)
+  window.addEventListener('beforeunload', markUnloading)
+
   // on Android we never use it because Android does not have support to reading the request body
   const canUseCustomProtocol = osName !== 'android'
 
@@ -57,6 +74,13 @@
             window.__TAURI_INTERNALS__.runCallback(callbackId, data)
           },
           (e) => {
+            // the document is unloading (reload/navigation), so the fetch was
+            // aborted rather than blocked. Re-sending over postMessage would
+            // re-invoke a command that may already be running on the backend,
+            // so bail out. See https://github.com/tauri-apps/tauri/issues/14154
+            if (documentIsUnloading) {
+              return
+            }
             console.warn(
               'IPC custom protocol failed, Tauri will now use the postMessage interface instead',
               e


### PR DESCRIPTION
Fixes #14154

## Summary

When a webview is reloaded (or navigated away) while an asynchronous command is in-flight, the custom-protocol `fetch` in `crates/tauri/scripts/ipc-protocol.js` is aborted by the browser and its promise rejects. The rejection handler treated this like a custom-protocol failure (CSP restriction / unsupported webview), flipped `customProtocolIpcFailed = true`, and re-sent the message over the `postMessage` fallback — invoking the command a **second time** on the still-alive backend.

## Fix

Track document teardown via `pagehide`/`beforeunload` and skip the `postMessage` fallback when the page is unloading. An aborted-by-navigation fetch is no longer mistaken for a blocked protocol, so the in-flight command is not re-invoked.

- `pagehide` covers reloads/navigations across all supported webviews.
- `beforeunload` fires earlier on Chromium (WebView2), setting the flag before the aborted fetch's rejection handler runs.
- Both listeners are passive (they never call `preventDefault` / set `returnValue`), so no unload prompt is shown.
- The flag resets on every page load, since the init script is re-injected per navigation.

## Notes

Unlike #15775 (labeled `ai-slop`), this does not rely on a prior IPC request having succeeded, so it also covers the reported reproduction where the cancelled command is the first invoke of the session.

## Test plan

Using the reproduction from the issue (https://github.com/kanatapple/tauri-app-command):

1. Run the app and open Dev Tools.
2. Click the greet button (a long-running async command).
3. While it is running, execute `location.reload()` in the console.
4. Confirm the command is **not** invoked a second time after reload.
