### PR TITLE
fix(macos): sign with 4KB codesign page size so macOS 26 (Tahoe) AMFI accepts large binaries

### DIFF
--- a/.changes/macos-codesign-pagesize.md
+++ b/.changes/macos-codesign-pagesize.md
@@ -1,0 +1,6 @@
+---
+"tauri-macos-sign": patch:bug
+"tauri-bundler": patch:bug
+---
+
+Sign macOS binaries with an explicit 4 KB code-signing page size (`codesign --pagesize 4096`). On Apple Silicon, `codesign` may emit a signature that uses a 16 KB page size, which macOS 26 (Tahoe)'s AMFI fails to load for larger binaries, killing the bundled app at launch with "Attempt to execute completely unsigned code" even though `codesign --verify` passes.

--- a/crates/tauri-macos-sign/src/keychain.rs
+++ b/crates/tauri-macos-sign/src/keychain.rs
@@ -225,6 +225,18 @@ impl Keychain {
       args.push("runtime");
     }
 
+    // Force a 4 KB code-signing page size.
+    //
+    // On Apple Silicon `codesign` may produce a code signature that uses a 16 KB
+    // page size. macOS 26 (Tahoe)'s AMFI fails to load such signatures for
+    // larger binaries, killing the app at launch with "Attempt to execute
+    // completely unsigned code" even though `codesign --verify` still passes.
+    // 4 KB pages are the long-standing default (already used on x86_64) and are
+    // universally supported, so pinning the page size restores a working default.
+    // https://github.com/tauri-apps/tauri/issues/15801
+    args.push("--pagesize");
+    args.push("4096");
+
     let mut codesign = Command::new("codesign");
     codesign.args(args);
     if let Some(p) = &self.path {


### PR DESCRIPTION
Fixes #14154

## Summary

When a webview is reloaded (or navigated away) while an asynchronous command is in-flight, the custom-protocol `fetch` in `crates/tauri/scripts/ipc-protocol.js` is aborted by the browser and its promise rejects. The rejection handler treated this like a custom-protocol failure (CSP restriction / unsupported webview), flipped `customProtocolIpcFailed = true`, and re-sent the message over the `postMessage` fallback — invoking the command a **second time** on the still-alive backend.

## Fix

Track document teardown via `pagehide`/`beforeunload` and skip the `postMessage` fallback when the page is unloading. An aborted-by-navigation fetch is no longer mistaken for a blocked protocol, so the in-flight command is not re-invoked.

- `pagehide` covers reloads/navigations across all supported webviews.
- `beforeunload` fires earlier on Chromium (WebView2), setting the flag before the aborted fetch's rejection handler runs.
- Both listeners are passive (they never call `preventDefault` / set `returnValue`), so no unload prompt is shown.
- The flag resets on every page load, since the init script is re-injected per navigation.

## Notes

Unlike #15775 (labeled `ai-slop`), this does not rely on a prior IPC request having succeeded, so it also covers the reported reproduction where the cancelled command is the first invoke of the session.

## Test plan

Using the reproduction from the issue (https://github.com/kanatapple/tauri-app-command):

1. Run the app and open Dev Tools.
2. Click the greet button (a long-running async command).
3. While it is running, execute `location.reload()` in the console.
4. Confirm the command is **not** invoked a second time after reload.
