### PR TITLE
fix(macos-sign): import the signing certificate as an explicit pkcs12 (fix: #15843)

### DIFF
--- a/.changes/keychain-import-pkcs12-format.md
+++ b/.changes/keychain-import-pkcs12-format.md
@@ -1,0 +1,5 @@
+---
+"tauri-macos-sign": patch:bug
+---
+
+Fixed importing a signing certificate failing with `MAC verification failed during PKCS12 import` for p12 files that use modern PBES2/AES encryption.

--- a/crates/tauri-macos-sign/src/keychain.rs
+++ b/crates/tauri-macos-sign/src/keychain.rs
@@ -106,6 +106,7 @@ impl Keychain {
       Command::new("security")
         .arg("import")
         .arg(cert_path)
+        .args(["-f", "pkcs12"])
         .arg("-P")
         .arg(certificate_password)
         .args([


### PR DESCRIPTION
`security import` was left to guess the file format. On macOS 26 that guess goes wrong for p12 files using modern PBES2/AES encryption and the import dies with `MAC verification failed during PKCS12 import (wrong password?)`, even when the password is correct.

I reproduced it on macOS 26.6.1 with a p12 encrypted using AES-256-CBC with a SHA-256 MAC. `Keychain::with_certificate_file` fails on it, and the same file with the same password imports fine as soon as `-f pkcs12` is passed. Older p12s using the legacy RC2/3DES encoding import either way, so nothing changes for those.

One thing worth flagging: naming the format means the import no longer accepts a bare PEM or DER certificate, which inference used to let through. Every caller in the tree passes a p12 and `ENVIRONMENT_VARIABLES.md` documents these variables as p12, so I left it strict rather than adding a fallback, but say the word if you would rather it retried without the flag.

Fixes #15843