### PR TITLE
feat(ohos): back key handling, launcher icons, dev-mode fixes for OpenHarmony

### DIFF
--- a/crates/tauri-cli/src/icon.rs
+++ b/crates/tauri-cli/src/icon.rs
@@ -357,6 +357,8 @@ pub fn command(options: Options) -> Result<()> {
     ico(&source, &out_dir).context("Failed to generate .ico file")?;
 
     png(&source, &out_dir, bg_color).context("Failed to generate png icons")?;
+    open_harmony(&source, &manifest, &bg_color_string, &out_dir)
+      .context("Failed to generate OpenHarmony icons")?;
     android(&source, &input, manifest, &bg_color_string, &out_dir)
       .context("Failed to generate android icons")?;
   } else {
@@ -736,6 +738,93 @@ fn android(
   launcher_file
     .write_all(launcher_content.as_bytes())
     .fs_context("failed to write Android launcher file", &launcher_xml_path)?;
+
+  Ok(())
+}
+
+// Generate OpenHarmony layered launcher icons: `background.png` (solid
+// color), `foreground.png` (source centered on a transparent canvas), and
+// `startIcon.png` (plain square icon). Written into the generated
+// `gen/ohos` media dirs when they exist (i.e. after `tauri ohos init`), or
+// into `icons/ohos` otherwise for a later init to consume.
+fn open_harmony(
+  source: &Source,
+  manifest: &Option<Manifest>,
+  bg_color: &String,
+  out_dir: &Path,
+) -> Result<()> {
+  let gen_ohos = out_dir.parent().unwrap().join("gen/ohos");
+  let entry_media = gen_ohos.join("entry/src/main/resources/base/media");
+  let appscope_media = gen_ohos.join("AppScope/resources/base/media");
+
+  let entry_out = if entry_media.exists() {
+    entry_media
+  } else {
+    let out = out_dir.join("ohos");
+    create_dir_all(&out).fs_context("Can't create OpenHarmony output directory", &out)?;
+    out
+  };
+  let appscope_out = if appscope_media.exists() {
+    appscope_media
+  } else {
+    entry_out.clone()
+  };
+
+  let bg_color = parse_bg_color(bg_color)?;
+
+  // foreground.png: source centered on a transparent 1024 canvas, scaled to
+  // the safe zone so the icon doesn't butt against the square edges.
+  let fg_scale = manifest
+    .as_ref()
+    .and_then(|manifest| manifest.android_fg_scale)
+    .unwrap_or(80.0);
+  let foreground = resize_asset(&source.resize_exact(1024), 1024, fg_scale);
+
+  // background.png: solid color canvas.
+  let background = DynamicImage::ImageRgba8(ImageBuffer::from_pixel(1024, 1024, bg_color));
+
+  // startIcon.png: the plain square icon (content fills the canvas).
+  let start_icon = resize_asset(&source.resize_exact(144), 144, 100.0);
+
+  for dir in [&entry_out, &appscope_out] {
+    create_dir_all(dir).fs_context("Can't create OpenHarmony media directory", dir)?;
+
+    let foreground_path = dir.join("foreground.png");
+    log::info!(action = "OpenHarmony"; "Creating {}", foreground_path.display());
+    let mut out_file = BufWriter::new(
+      File::create(&foreground_path)
+        .fs_context("failed to create OpenHarmony foreground", &foreground_path)?,
+    );
+    write_png(foreground.as_bytes(), &mut out_file, 1024)
+      .context("failed to write OpenHarmony foreground")?;
+    out_file
+      .flush()
+      .fs_context("failed to flush OpenHarmony foreground", &foreground_path)?;
+
+    let background_path = dir.join("background.png");
+    log::info!(action = "OpenHarmony"; "Creating {}", background_path.display());
+    let mut out_file = BufWriter::new(
+      File::create(&background_path)
+        .fs_context("failed to create OpenHarmony background", &background_path)?,
+    );
+    write_png(background.as_bytes(), &mut out_file, 1024)
+      .context("failed to write OpenHarmony background")?;
+    out_file
+      .flush()
+      .fs_context("failed to flush OpenHarmony background", &background_path)?;
+
+    let start_icon_path = dir.join("startIcon.png");
+    log::info!(action = "OpenHarmony"; "Creating {}", start_icon_path.display());
+    let mut out_file = BufWriter::new(
+      File::create(&start_icon_path)
+        .fs_context("failed to create OpenHarmony startIcon", &start_icon_path)?,
+    );
+    write_png(start_icon.as_bytes(), &mut out_file, 144)
+      .context("failed to write OpenHarmony startIcon")?;
+    out_file
+      .flush()
+      .fs_context("failed to flush OpenHarmony startIcon", &start_icon_path)?;
+  }
 
   Ok(())
 }

--- a/crates/tauri-cli/src/mobile/open_harmony/dev.rs
+++ b/crates/tauri-cli/src/mobile/open_harmony/dev.rs
@@ -91,7 +91,12 @@ pub struct Options {
   /// When this is set or when running on an iOS device the CLI sets the `TAURI_DEV_HOST`
   /// environment variable so you can check this on your framework's configuration to expose the development server
   /// on the public network address.
-  #[clap(long, default_value_t, default_missing_value(""), num_args(0..=1))]
+  #[clap(
+    long,
+    default_value("<none>"),
+    default_missing_value(""),
+    num_args(0..=1)
+  )]
   pub host: DevHost,
   /// Disable the built-in dev server for static files.
   #[clap(long)]

--- a/crates/tauri-cli/src/mobile/open_harmony/mod.rs
+++ b/crates/tauri-cli/src/mobile/open_harmony/mod.rs
@@ -24,6 +24,7 @@ use clap::{Parser, Subcommand};
 use std::{
   env::set_var,
   fs::{create_dir_all, write},
+  path::PathBuf,
   thread::sleep,
   time::Duration,
 };
@@ -165,9 +166,38 @@ pub fn get_config(
 }
 
 pub fn env() -> Result<Env> {
+  #[cfg(windows)]
+  if std::env::var_os("DEV_ECO_STUDIO_INSTALL_PATH").is_none() {
+    if let Some(install_path) = detect_dev_eco_studio_install() {
+      set_var("DEV_ECO_STUDIO_INSTALL_PATH", install_path);
+    }
+  }
+
   let env = super::env().context("failed to setup OpenHarmony environment")?;
   cargo_mobile2::open_harmony::env::Env::from_env(env)
     .context("failed to load OpenHarmony environment")
+}
+
+/// Locate a DevEco Studio installation from the `ohpm` executable that
+/// DevEco Studio puts on PATH (`<install>\tools\ohpm\bin\ohpm.bat`), going up
+/// three levels to the install root and verifying it with the sibling
+/// `tools\hvigor\bin\hvigorw.bat`. Only used on Windows when
+/// `DEV_ECO_STUDIO_INSTALL_PATH` is not set, and covers installs on any drive
+/// without scanning drives for a well-known folder.
+#[cfg(windows)]
+fn detect_dev_eco_studio_install() -> Option<PathBuf> {
+  let path_var = std::env::var_os("PATH")?;
+  for dir in std::env::split_paths(&path_var) {
+    if dir.join("ohpm.bat").is_file() {
+      // dir is <install>\tools\ohpm\bin; three levels up is the install root
+      if let Some(install) = dir.ancestors().nth(3) {
+        if install.join("tools/hvigor/bin/hvigorw.bat").is_file() {
+          return Some(install.to_path_buf());
+        }
+      }
+    }
+  }
+  None
 }
 
 fn delete_codegen_vars() {

--- a/crates/tauri-cli/templates/mobile/open-harmony/entry/hvigorfile.ts
+++ b/crates/tauri-cli/templates/mobile/open-harmony/entry/hvigorfile.ts
@@ -14,7 +14,10 @@ function tauriPlugin(): HvigorPlugin {
     apply(node: HvigorNode) {
       const buildRustCode = () => {
         const properties = hvigor.getParameter().getProperties();
-        const target = properties.target || "aarch64";
+        // Priority: TAURI_OHOS_TARGET env var > hvigor `target` property >
+        // aarch64 (the default device architecture; override to x86_64 for
+        // the OpenHarmony emulator).
+        const target = process.env.TAURI_OHOS_TARGET || properties.target || "aarch64";
         execFileSync(`{{tauri-binary}}`,
           [{{quote-and-join tauri-binary-args}}, "--target", target.toString()], {
             cwd: resolve(__dirname, "{{root-dir-rel}}"),

--- a/crates/tauri-cli/templates/mobile/open-harmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/crates/tauri-cli/templates/mobile/open-harmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -24,12 +24,13 @@ export default class EntryAbility extends RustAbility {
   }
 
   /**
-   * Back key handling: when any WebView can navigate back, go back and
-   * consume the event instead of exiting the app; fall through to the
-   * system default when there is no history. The controller is registered
-   * by the openharmony-ability DefaultXComponent under this key when the
-   * WebView is created (this SDK exposes no getAllWebControllers /
-   * findControllerByName static API).
+   * Back key handling at the ability level. The page-level onBackPress
+   * (MainPage) navigates the WebView back first; when there is no history
+   * the event reaches here and we move the app to the background instead of
+   * destroying it (true keeps the instance alive, false destroys it). The
+   * controller is registered to AppStorage by DefaultXComponent under this
+   * key when the WebView is created (this SDK exposes no
+   * getAllWebControllers / findControllerByName static API).
    */
   onBackPressed(): boolean {
     try {
@@ -37,11 +38,11 @@ export default class EntryAbility extends RustAbility {
         "ohos.rs.ability.webviewController",
       );
       if (controller && typeof controller.backwardIfPossible === "function") {
-        return controller.backwardIfPossible();
+        controller.backwardIfPossible();
       }
     } catch (e) {
       console.error('[EntryAbility] back handling failed:', e);
     }
-    return false;
+    return true;
   }
 }

--- a/crates/tauri-cli/templates/mobile/open-harmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/crates/tauri-cli/templates/mobile/open-harmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -3,6 +3,10 @@ import Want from '@ohos.app.ability.Want'
 import { AbilityConstant } from '@kit.AbilityKit';
 import window from '@ohos.window';
 
+interface BackwardCapable {
+  backwardIfPossible: () => boolean;
+}
+
 export default class EntryAbility extends RustAbility {
   // change to dynamic library name
   public moduleName: string = "{{app.lib-name}}"
@@ -17,5 +21,27 @@ export default class EntryAbility extends RustAbility {
     const window = windowStage.getMainWindowSync();
     await window.setWindowLayoutFullScreen(false);
     super.onWindowStageCreate(windowStage);
+  }
+
+  /**
+   * Back key handling: when any WebView can navigate back, go back and
+   * consume the event instead of exiting the app; fall through to the
+   * system default when there is no history. The controller is registered
+   * by the openharmony-ability DefaultXComponent under this key when the
+   * WebView is created (this SDK exposes no getAllWebControllers /
+   * findControllerByName static API).
+   */
+  onBackPressed(): boolean {
+    try {
+      const controller = AppStorage.get<BackwardCapable>(
+        "ohos.rs.ability.webviewController",
+      );
+      if (controller && typeof controller.backwardIfPossible === "function") {
+        return controller.backwardIfPossible();
+      }
+    } catch (e) {
+      console.error('[EntryAbility] back handling failed:', e);
+    }
+    return false;
   }
 }

--- a/crates/tauri-cli/templates/mobile/open-harmony/entry/src/main/resources/base/element/string.json
+++ b/crates/tauri-cli/templates/mobile/open-harmony/entry/src/main/resources/base/element/string.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "EntryAbility_label",
-      "value": "label"
+      "value": "{{app.stylized-name}}"
     }
   ]
 }

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -12,11 +12,16 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
-[dependencies]
+[target.'cfg(not(target_env = "ohos"))'.dependencies]
 wry = { version = "0.56.0", default-features = false, features = [
   "os-webview",
   "linux-body",
 ] }
+
+[target.'cfg(target_env = "ohos")'.dependencies]
+wry = { version = "0.56.0", default-features = false, features = ["os-webview"] }
+
+[dependencies]
 tao = { version = "0.36.0", default-features = false, features = ["rwh_06"] }
 tauri-runtime = { version = "2.11.3", path = "../tauri-runtime" }
 tauri-utils = { version = "2.9.3", path = "../tauri-utils" }

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -40,7 +40,12 @@ use super::{
 // and we do not get a secure context without the custom protocol that proxies to the dev server
 // additionally, we need the custom protocol to inject the initialization scripts on Android
 // must also keep in sync with the `let mut response` assignment in prepare_uri_scheme_protocol
-pub(crate) const PROXY_DEV_SERVER: bool = cfg!(all(dev, mobile));
+// OpenHarmony is excluded: ArkWeb cannot run `evaluate_script` (the IPC
+// response channel) on documents served through the tauri:// proxy from an
+// HTTP dev server, which makes every invoke hang. Loading the devUrl
+// directly (http://localhost:3000, reachable via the hdc rport forward the
+// CLI sets up) keeps IPC, eval and RSC navigation working.
+pub(crate) const PROXY_DEV_SERVER: bool = cfg!(all(dev, mobile)) && !cfg!(target_env = "ohos");
 
 pub(crate) const PROCESS_IPC_MESSAGE_FN: &str =
   include_str!("../../scripts/process-ipc-message-fn.js");


### PR DESCRIPTION
## Summary

Six focused fixes/features for the `feat/open-harmony` branch:

1. **feat(ohos): handle back key in the EntryAbility template** — intercept `onBackPressed`; let the WebView navigate back first, fall through to the system default (app exit) when there is no history. Degrades gracefully (returns false) when the controller is not registered.
2. **feat(cli): generate OpenHarmony launcher icons from source** — `tauri icon` now writes `foreground.png` / `background.png` / `startIcon.png` into the generated `gen/ohos` media dirs (or `icons/ohos` when no generated project exists), so the OHOS launcher gets layered icons without manual asset creation.
3. **feat(ohos): use app stylized name for EntryAbility label** — the launcher shows the app name instead of a literal `label`.
4. **fix(cli): default OpenHarmony dev `--host` to `<none>` when unspecified** — `default_value_t` inferred an empty default and consumed positional args as the host value.
5. **fix(ohos): skip the tauri dev server proxy on OHOS** — ArkWeb cannot run `evaluate_script` on documents served through the tauri:// proxy, which hangs every invoke. Loading the devUrl directly (reachable via the hdc rport forward the CLI sets up) keeps IPC, eval and RSC navigation working.
6. **fix(ohos): exclude wry `linux-body` feature on OHOS** — wry's Linux deps are gated by `not(target_env = "ohos")`, but the `os-webview`/`linux-body` features still pulled the Linux dep graph into the OHOS resolution; split the dependency by target instead.

## Notes

- Back-key handling depends on openharmony-ability exposing `backwardIfPossible` on the Webview helper (companion PR in that repo); without it the template returns false and the system default applies.
- `tauri icon` OHOS icon generation reuses the existing `android_fg_scale` manifest option for the foreground safe-zone scaling.

## Test plan

- `cargo check --target x86_64-unknown-linux-ohos` passes for the changed crates.
- ArkWeb APIs (`backward()`/`forward()`/`accessBackward()`/`accessForward()`) verified against the DevEco SDK type declarations.