### PR TITLE
fix(event): guard unlisten when listener entry not yet registered

### DIFF
--- a/crates/tauri/src/event/mod.rs
+++ b/crates/tauri/src/event/mod.rs
@@ -214,7 +214,10 @@ pub(crate) fn unlisten_js_script(
     "(function () {{
         const listeners = (window['{listeners_object_name}'] || {{}})[{event_arg}]
         if (listeners) {{
-          window.__TAURI_INTERNALS__.unregisterCallback(listeners[{event_id_arg}].handlerId)
+          const listener = listeners[{event_id_arg}]
+          if (listener) {{
+            window.__TAURI_INTERNALS__.unregisterCallback(listener.handlerId)
+          }}
         }}
       }})()
     ",


### PR DESCRIPTION
### The bug

`listen()` resolves as soon as the Rust side answers `plugin:event|listen`, but the webview-side registry entry is written by a separate eval (`listen_js_script`). If the returned unlisten function is called in that window, the generated unlisten script throws:

```
TypeError: undefined is not an object (evaluating 'listeners[eventId].handlerId')
```

Worse than the crash: the throw is on the first line of the script, so the `invoke('plugin:event|unlisten', …)` on the following line of `_unlisten` in `@tauri-apps/api/event` never runs. The backend listener stays registered and the JS callback stays alive — the "removed" handler keeps firing, and after a remount events are delivered twice. React StrictMode (mount → unmount → mount) hits this on essentially every fast unsubscribe.

### The fix

Guard the entry lookup exactly the way event delivery already does (`event_initialization_script` checks `const listener = listeners[id]; if (listener)`). When the entry is absent, `unregisterCallback` is skipped but the script no longer throws — so `_unlisten` proceeds to `invoke('plugin:event|unlisten', …)` and the backend listener is still cleaned up.

Fixes #15799
