### PR TITLE
fix(asset): correct multipart/byteranges response

### DIFF
--- a/crates/tauri/src/protocol/asset.rs
+++ b/crates/tauri/src/protocol/asset.rs
@@ -85,8 +85,6 @@ fn get_response(
     )
   };
 
-  resp = resp.header(CONTENT_TYPE, &mime_type);
-
   // handle 206 (partial range) http requests
   let response = if let Some(range_header) = request
     .headers()
@@ -145,6 +143,7 @@ fn get_response(
 
       resp = resp.header(CONTENT_RANGE, format!("bytes {start}-{end}/{len}"));
       resp = resp.header(CONTENT_LENGTH, end + 1 - start);
+      resp = resp.header(CONTENT_TYPE, &mime_type);
       resp = resp.status(StatusCode::PARTIAL_CONTENT);
       resp.body(buf.into())
     } else {
@@ -167,12 +166,13 @@ fn get_response(
 
       let boundary = random_boundary();
       let boundary_sep = format!("\r\n--{boundary}\r\n");
-      let boundary_closer = format!("\r\n--{boundary}\r\n");
+      let boundary_closer = format!("\r\n--{boundary}--");
 
       resp = resp.header(
         CONTENT_TYPE,
         format!("multipart/byteranges; boundary={boundary}"),
       );
+      resp = resp.status(StatusCode::PARTIAL_CONTENT);
 
       let buf = {
         // multi-part range header
@@ -206,6 +206,7 @@ fn get_response(
     }
   } else if request.method() == http::Method::HEAD {
     // if the HEAD method is used, we should not return a body
+    resp = resp.header(CONTENT_TYPE, &mime_type);
     resp = resp.header(CONTENT_LENGTH, len);
     resp.body(Vec::new().into())
   } else {
@@ -218,6 +219,7 @@ fn get_response(
       file.read_to_end(&mut local_buf)?;
       local_buf
     };
+    resp = resp.header(CONTENT_TYPE, &mime_type);
     resp = resp.header(CONTENT_LENGTH, len);
     resp.body(buf.into())
   };


### PR DESCRIPTION
### The bug

Three defects in the multi-range branch of the `asset://` protocol handler (`crates/tauri/src/protocol/asset.rs`). They only affect requests carrying a `Range` header with more than one range:

1. **No closing delimiter** — `boundary_closer` was identical to `boundary_sep` (`--{boundary}`), but RFC 2046 §5.1.1 requires `--{boundary}--`. A strict parser sees the body as ending mid-part.
2. **Duplicate `Content-Type`** — the sniffed file MIME type was appended before knowing whether the request was multi-range, so the response carried both the file MIME type and `multipart/byteranges; boundary=...`. A client reading the first header parses the multipart envelope as an image.
3. **`200` instead of `206`** — the multi-range branch never set a status, falling through to `200 OK` while returning a partial multipart body. RFC 9110 §15.3.7 requires `206`.

### The fix

- Multi-range branch sets `Content-Type: multipart/byteranges; boundary=...` and `206 Partial Content`, and terminates the body with `\r\n--{boundary}--\r\n`.
- The sniffed file `Content-Type` is now set only where it belongs: single-range, `HEAD`, and full-body responses.

Fixes #15837
