### PR TITLE
Fix doubled word in RELEASING.md

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -15,7 +15,7 @@ It can be configured in [`.changes/config.json`](../.changes/config.json) which 
 
 Some packages can't be published directly using `covector` as it requires to be built on a matrix of platforms
 such as `tauri-cli` prebuilt binaries which is published using [publish-cli-rs.yml](./workflows/publish-cli-rs.yml)
-and `@tauri-apps/cli` native Node.js modules which is published using using [publish-cli-js.yml](./workflows/publish-cli-js.yml)
+and `@tauri-apps/cli` native Node.js modules which is published using [publish-cli-js.yml](./workflows/publish-cli-js.yml)
 both of which are triggered after `covector` has created a github release for both of them, see `Trigger @tauri-apps/cli publishing workflow`
 and `Trigger tauri-cli publishing workflow` steps in [covector-version-or-publish.yml](./workflows/covector-version-or-publish.yml)
 


### PR DESCRIPTION
Small doubled-word fix: "published using using [publish-cli-js.yml]" -> "published using [publish-cli-js.yml]" (the parallel line just above, for `publish-cli-rs.yml`, has the single "using").
