### PR TITLE
fix(macos-sign): pass explicit pkcs12/cert flags to security import

### DIFF
--- a/crates/tauri-macos-sign/src/keychain.rs
+++ b/crates/tauri-macos-sign/src/keychain.rs
@@ -109,6 +109,10 @@ impl Keychain {
         .arg("-P")
         .arg(certificate_password)
         .args([
+          "-f",
+          "pkcs12",
+          "-t",
+          "cert",
           "-T",
           "/usr/bin/codesign",
           "-T",


### PR DESCRIPTION
### The bug

`tauri ios build` with `IOS_CERTIFICATE` / `IOS_CERTIFICATE_PASSWORD` fails while importing a valid Apple Distribution PKCS#12 on a GitHub-hosted `macos-26` runner (Xcode 26.6). The identical decoded P12 and password import successfully immediately beforehand when `security import` is given explicit `-f pkcs12 -t cert` flags.

The import in `Keychain::with_certificate_file` (`crates/tauri-macos-sign/src/keychain.rs`) relies on implicit format inference, which macOS 26 regressed — the resulting error even reports the password may be wrong, though an explicit import with that password just succeeded.

### The fix

Pass `-f pkcs12 -t cert` to `security import`, matching the explicit-import command that deterministically succeeds on the affected P12 files.

Fixes #15843
