### PR TITLE
fix(build): clear error when sidecar collides with a directory

### DIFF
--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -78,6 +78,17 @@ fn copy_binaries(
     }
 
     let dest = path.join(file_name);
+    if dest.is_dir() {
+      // The destination path is a directory. This most likely means a Cargo
+      // dependency (or its build script output) with the same name as the
+      // sidecar occupies that path, so the sidecar binary cannot be placed
+      // there. Surface a clear error instead of a confusing
+      // PermissionDenied/IsADirectory panic from remove_file.
+      return Err(anyhow::anyhow!(
+        "Cannot copy sidecar `{file_name}` to `{}`: a directory already exists at that path. A Cargo dependency likely has the same name as the sidecar; rename either the sidecar binary or the dependency crate.",
+        dest.display()
+      ));
+    }
     if dest.exists() {
       fs::remove_file(&dest).unwrap();
     }


### PR DESCRIPTION
### The bug

When a sidecar binary has the same name as a Cargo dependency crate (or its build output), the destination path in the target directory can be a directory rather than a file. `copy_binaries` then calls `fs::remove_file(&dest).unwrap()`, which panics with a confusing `Permission denied` / `Is a directory` error — as in `cargo tauri dev` failing to copy a sidecar whose name matched a direct dependency.

### The fix

Before attempting to remove the destination, check whether it is a directory. If so, return a clear error explaining the likely name collision and how to resolve it (rename the sidecar binary or the dependency crate), matching the existing package-name collision check in the same function.

Fixes #15849
