### PR TITLE
WIP: special case state management of required plugins

### DIFF
--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -5,8 +5,7 @@
 use crate::{
   image::Image,
   ipc::{
-    channel::ChannelDataIpcQueue, CallbackFn, CommandArg, CommandItem, Invoke, InvokeError,
-    InvokeHandler, InvokeResponseBody,
+    CallbackFn, CommandArg, CommandItem, Invoke, InvokeError, InvokeHandler, InvokeResponseBody,
   },
   manager::{webview::UriSchemeProtocol, AppManager, Asset},
   plugin::{Plugin, PluginStore},
@@ -2450,7 +2449,6 @@ tauri::Builder::default()
       )?,
     });
 
-    app.manage(ChannelDataIpcQueue::default());
     app.handle.plugin(crate::ipc::channel::plugin())?;
 
     let handle = app.handle();

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -16,7 +16,7 @@ use crate::{
     ExitRequestedEventAction, RunEvent as RuntimeRunEvent,
   },
   sealed::{ManagerBase, RuntimeOrDispatch},
-  utils::{config::Config, Env},
+  utils::config::Config,
   webview::PageLoadPayload,
   Context, DeviceEventFilter, Emitter, EventLoopMessage, EventName, Listener, Manager, Monitor,
   Runtime, Scopes, StateManager, Theme, Webview, WebviewWindowBuilder, Window,
@@ -2441,9 +2441,6 @@ tauri::Builder::default()
 
       app.manager.menu.menu_lock().replace(menu);
     }
-
-    let env = Env::default();
-    app.manage(env);
 
     app.manage(Scopes {
       #[cfg(feature = "protocol-asset")]

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -17,7 +17,7 @@ use crate::{
   command,
   ipc::{CommandArg, CommandItem},
   plugin::{Builder as PluginBuilder, TauriPlugin},
-  Manager, Runtime, State, Webview,
+  Runtime, State, Webview,
 };
 
 use super::{
@@ -44,6 +44,12 @@ static CHANNEL_DATA_COUNTER: AtomicU32 = AtomicU32::new(0);
 /// Maps a channel id to a pending data that must be send to the JavaScript side via the IPC.
 #[derive(Default)]
 pub struct ChannelDataIpcQueue(HashMap<u32, InvokeResponseBody>);
+
+impl ChannelDataIpcQueue {
+  fn insert(&mut self, data_id: u32, body: InvokeResponseBody) -> Option<InvokeResponseBody> {
+    self.0.insert(data_id, body)
+  }
+}
 
 /// An IPC channel.
 pub struct Channel<TSend = InvokeResponseBody> {
@@ -169,10 +175,10 @@ impl JavaScriptChannelId {
             let data_id = CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed);
 
             webview
-              .state::<Mutex<ChannelDataIpcQueue>>()
+              .manager
+              .data_ipc_queue()
               .lock()
               .unwrap()
-              .0
               .insert(data_id, body);
 
             webview.eval(format!(
@@ -265,10 +271,10 @@ impl<TSend> Channel<TSend> {
             let data_id = CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed);
 
             webview
-              .state::<Mutex<ChannelDataIpcQueue>>()
+              .manager
+              .data_ipc_queue()
               .lock()
               .unwrap()
-              .0
               .insert(data_id, body);
 
             webview.eval(format!(

--- a/crates/tauri/src/ipc/channel.rs
+++ b/crates/tauri/src/ipc/channel.rs
@@ -42,8 +42,8 @@ static CHANNEL_COUNTER: AtomicU32 = AtomicU32::new(0);
 static CHANNEL_DATA_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// Maps a channel id to a pending data that must be send to the JavaScript side via the IPC.
-#[derive(Default, Clone)]
-pub struct ChannelDataIpcQueue(Arc<Mutex<HashMap<u32, InvokeResponseBody>>>);
+#[derive(Default)]
+pub struct ChannelDataIpcQueue(HashMap<u32, InvokeResponseBody>);
 
 /// An IPC channel.
 pub struct Channel<TSend = InvokeResponseBody> {
@@ -169,10 +169,10 @@ impl JavaScriptChannelId {
             let data_id = CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed);
 
             webview
-              .state::<ChannelDataIpcQueue>()
-              .0
+              .state::<Mutex<ChannelDataIpcQueue>>()
               .lock()
               .unwrap()
+              .0
               .insert(data_id, body);
 
             webview.eval(format!(
@@ -265,10 +265,10 @@ impl<TSend> Channel<TSend> {
             let data_id = CHANNEL_DATA_COUNTER.fetch_add(1, Ordering::Relaxed);
 
             webview
-              .state::<ChannelDataIpcQueue>()
-              .0
+              .state::<Mutex<ChannelDataIpcQueue>>()
               .lock()
               .unwrap()
+              .0
               .insert(data_id, body);
 
             webview.eval(format!(
@@ -318,7 +318,7 @@ impl<'de, R: Runtime, TSend> CommandArg<'de, R> for Channel<TSend> {
 #[command(root = "crate")]
 fn fetch(
   request: Request<'_>,
-  cache: State<'_, ChannelDataIpcQueue>,
+  cache: State<'_, Mutex<ChannelDataIpcQueue>>,
 ) -> Result<Response, &'static str> {
   if let Some(id) = request
     .headers()
@@ -326,7 +326,7 @@ fn fetch(
     .and_then(|v| v.to_str().ok())
     .and_then(|id| id.parse().ok())
   {
-    if let Some(data) = cache.0.lock().unwrap().remove(&id) {
+    if let Some(data) = cache.lock().unwrap().0.remove(&id) {
       Ok(Response::new(data))
     } else {
       Err("data not found")

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -753,8 +753,7 @@ pub trait Manager<R: Runtime>: sealed::ManagerBase<R> {
 
   /// Gets the managed [`Env`].
   fn env(&self) -> Env {
-    use std::ops::Deref;
-    self.state::<Env>().deref().clone()
+    self.manager().env().clone()
   }
 
   /// Gets the scope for the asset protocol.

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     OnPageLoad,
   },
   event::{EmitArgs, Event, EventId, EventTarget, Listeners},
-  ipc::{Invoke, InvokeHandler, RuntimeAuthority},
+  ipc::{channel::ChannelDataIpcQueue, Invoke, InvokeHandler, RuntimeAuthority},
   menu::plugin::MenuChannels,
   plugin::PluginStore,
   resources::ResourceTable,
@@ -702,6 +702,10 @@ impl<R: Runtime> AppManager<R> {
 
   pub(crate) fn env(&self) -> &crate::Env {
     self.state.env()
+  }
+
+  pub(crate) fn data_ipc_queue(&self) -> &Mutex<ChannelDataIpcQueue> {
+    self.state.data_ipc_queue()
   }
 }
 

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -699,6 +699,10 @@ impl<R: Runtime> AppManager<R> {
   pub(crate) fn menu_channels(&self) -> &Mutex<MenuChannels> {
     self.state.menu_channels()
   }
+
+  pub(crate) fn env(&self) -> &crate::Env {
+    self.state.env()
+  }
 }
 
 #[cfg(desktop)]

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -25,6 +25,7 @@ use crate::{
   },
   event::{EmitArgs, Event, EventId, EventTarget, Listeners},
   ipc::{Invoke, InvokeHandler, RuntimeAuthority},
+  menu::plugin::MenuChannels,
   plugin::PluginStore,
   resources::ResourceTable,
   utils::{config::Config, PackageInfo},
@@ -693,6 +694,10 @@ impl<R: Runtime> AppManager<R> {
 
   pub(crate) fn invoke_key(&self) -> &str {
     &self.invoke_key
+  }
+
+  pub(crate) fn menu_channels(&self) -> &Mutex<MenuChannels> {
+    self.state.menu_channels()
   }
 }
 

--- a/crates/tauri/src/menu/mod.rs
+++ b/crates/tauri/src/menu/mod.rs
@@ -19,11 +19,8 @@ pub use builders::*;
 pub use menu::{HELP_SUBMENU_ID, WINDOW_SUBMENU_ID};
 use serde::{Deserialize, Serialize};
 
-use crate::menu::plugin::MenuChannels;
-use crate::Manager;
 use crate::{image::Image, AppHandle, Runtime};
 pub use muda::MenuId;
-use std::sync::Mutex;
 
 macro_rules! run_item_main_thread {
   ($self:ident, $ex:expr) => {{
@@ -97,7 +94,7 @@ macro_rules! gen_wrappers {
 
       impl<R: Runtime> Drop for $inner<R> {
         fn drop(&mut self) {
-          self.app_handle.state::<Mutex<MenuChannels>>().lock().unwrap().remove(self.inner.id());
+          self.app_handle.manager.menu_channels().lock().unwrap().remove(self.inner.id());
           // SAFETY: we will not access `self.inner` after this
           let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
           // SAFETY: inner was created on main thread and is being dropped on main thread

--- a/crates/tauri/src/menu/mod.rs
+++ b/crates/tauri/src/menu/mod.rs
@@ -19,9 +19,11 @@ pub use builders::*;
 pub use menu::{HELP_SUBMENU_ID, WINDOW_SUBMENU_ID};
 use serde::{Deserialize, Serialize};
 
-use crate::menu::plugin::remove_menu_channel;
+use crate::menu::plugin::MenuChannels;
+use crate::Manager;
 use crate::{image::Image, AppHandle, Runtime};
 pub use muda::MenuId;
+use std::sync::Mutex;
 
 macro_rules! run_item_main_thread {
   ($self:ident, $ex:expr) => {{
@@ -95,7 +97,7 @@ macro_rules! gen_wrappers {
 
       impl<R: Runtime> Drop for $inner<R> {
         fn drop(&mut self) {
-          remove_menu_channel(&self.app_handle, self.inner.id());
+          self.app_handle.state::<Mutex<MenuChannels>>().lock().unwrap().remove(self.inner.id());
           // SAFETY: we will not access `self.inner` after this
           let inner = unsafe { ManuallyDrop::take(&mut self.inner) };
           // SAFETY: inner was created on main thread and is being dropped on main thread

--- a/crates/tauri/src/menu/plugin.rs
+++ b/crates/tauri/src/menu/plugin.rs
@@ -162,8 +162,7 @@ impl CheckMenuItemPayload {
     if let Some(handler) = self.handler {
       let handler = handler.channel_on(webview.clone());
       webview
-        .state::<MenuChannels>()
-        .0
+        .state::<Mutex<MenuChannels>>()
         .lock()
         .unwrap()
         .insert(item.id().clone(), handler);
@@ -218,8 +217,7 @@ impl IconMenuItemPayload {
     if let Some(handler) = self.handler {
       let handler = handler.channel_on(webview.clone());
       webview
-        .state::<MenuChannels>()
-        .0
+        .state::<Mutex<MenuChannels>>()
         .lock()
         .unwrap()
         .insert(item.id().clone(), handler);
@@ -257,8 +255,7 @@ impl MenuItemPayload {
     if let Some(handler) = self.handler {
       let handler = handler.channel_on(webview.clone());
       webview
-        .state::<MenuChannels>()
-        .0
+        .state::<Mutex<MenuChannels>>()
         .lock()
         .unwrap()
         .insert(item.id().clone(), handler);
@@ -362,7 +359,7 @@ fn new<R: Runtime>(
   webview: Webview<R>,
   kind: ItemKind,
   options: Option<NewOptions>,
-  channels: State<'_, MenuChannels>,
+  channels: State<'_, Mutex<MenuChannels>>,
   handler: Channel<MenuId>,
 ) -> crate::Result<(ResourceId, MenuId)> {
   let options = options.unwrap_or_default();
@@ -460,7 +457,7 @@ fn new<R: Runtime>(
     }
   };
 
-  channels.0.lock().unwrap().insert(id.clone(), handler);
+  channels.lock().unwrap().insert(id.clone(), handler);
 
   Ok((rid, id))
 }
@@ -885,32 +882,34 @@ fn set_icon<R: Runtime>(
   )
 }
 
-struct MenuChannels(Mutex<HashMap<MenuId, Channel<MenuId>>>);
+#[derive(Default)]
+pub(crate) struct MenuChannels(HashMap<MenuId, Channel<MenuId>>);
 
-// Called in `Menu`'s `Drop` to clean up the event handlers
-pub(crate) fn remove_menu_channel<R: Runtime>(app: &AppHandle<R>, id: &MenuId) {
-  app.state::<MenuChannels>().0.lock().unwrap().remove(id);
+impl MenuChannels {
+  fn insert(&mut self, id: MenuId, channel: Channel<MenuId>) -> Option<Channel<MenuId>> {
+    self.0.insert(id, channel)
+  }
+  fn get(&self, id: &MenuId) -> Option<&Channel<MenuId>> {
+    self.0.get(id)
+  }
+  pub(crate) fn remove(&mut self, id: &MenuId) -> Option<Channel<MenuId>> {
+    self.0.remove(id)
+  }
 }
 
 pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
   Builder::new("menu")
     .setup(|app, _api| {
-      app.manage(MenuChannels(Mutex::default()));
+      app.manage(Mutex::new(MenuChannels::default()));
       Ok(())
     })
     .on_event(|app, e| {
       if let RunEvent::MenuEvent(e) = e {
+        let menu_channels = app.state::<Mutex<MenuChannels>>();
         // Cloning the channel out in case the menu gets dropped during the channel send through `channel_interceptor`
-        let channel = app
-          .state::<MenuChannels>()
-          .0
-          .lock()
-          .unwrap()
-          .get(&e.id)
-          .cloned();
-        if let Some(channel) = channel {
+        if let Some(channel) = menu_channels.lock().unwrap().get(&e.id).cloned() {
           let _ = channel.send(e.id.clone());
-        }
+        };
       }
     })
     .invoke_handler(crate::generate_handler![

--- a/crates/tauri/src/menu/plugin.rs
+++ b/crates/tauri/src/menu/plugin.rs
@@ -162,7 +162,8 @@ impl CheckMenuItemPayload {
     if let Some(handler) = self.handler {
       let handler = handler.channel_on(webview.clone());
       webview
-        .state::<Mutex<MenuChannels>>()
+        .manager
+        .menu_channels()
         .lock()
         .unwrap()
         .insert(item.id().clone(), handler);
@@ -217,7 +218,8 @@ impl IconMenuItemPayload {
     if let Some(handler) = self.handler {
       let handler = handler.channel_on(webview.clone());
       webview
-        .state::<Mutex<MenuChannels>>()
+        .manager
+        .menu_channels()
         .lock()
         .unwrap()
         .insert(item.id().clone(), handler);
@@ -255,7 +257,8 @@ impl MenuItemPayload {
     if let Some(handler) = self.handler {
       let handler = handler.channel_on(webview.clone());
       webview
-        .state::<Mutex<MenuChannels>>()
+        .manager
+        .menu_channels()
         .lock()
         .unwrap()
         .insert(item.id().clone(), handler);
@@ -899,13 +902,9 @@ impl MenuChannels {
 
 pub(crate) fn init<R: Runtime>() -> TauriPlugin<R> {
   Builder::new("menu")
-    .setup(|app, _api| {
-      app.manage(Mutex::new(MenuChannels::default()));
-      Ok(())
-    })
     .on_event(|app, e| {
       if let RunEvent::MenuEvent(e) = e {
-        let menu_channels = app.state::<Mutex<MenuChannels>>();
+        let menu_channels = app.manager().menu_channels();
         // Cloning the channel out in case the menu gets dropped during the channel send through `channel_interceptor`
         if let Some(channel) = menu_channels.lock().unwrap().get(&e.id).cloned() {
           let _ = channel.send(e.id.clone());

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -11,6 +11,7 @@ use std::{
 
 use crate::{
   ipc::{CommandArg, CommandItem, InvokeError},
+  menu::plugin::MenuChannels,
   Runtime,
 };
 
@@ -102,15 +103,26 @@ impl std::hash::Hasher for IdentHash {
 type TypeIdMap = HashMap<TypeId, Box<dyn Any + Sync + Send>, BuildHasherDefault<IdentHash>>;
 
 /// The Tauri state manager.
-#[derive(Debug)]
+// TODO: make private in v3, inline state of required plugins into AppManager
 pub struct StateManager {
   map: Mutex<TypeIdMap>,
+  // state of some required plugins
+  menu_channels: Mutex<MenuChannels>,
+}
+
+impl std::fmt::Debug for StateManager {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("StateManager")
+      .field("map", &self.map)
+      .finish()
+  }
 }
 
 impl StateManager {
   pub(crate) fn new() -> Self {
     Self {
       map: Default::default(),
+      menu_channels: Default::default(),
     }
   }
 
@@ -148,6 +160,17 @@ impl StateManager {
   pub fn try_get<T: 'static>(&self) -> Option<State<'_, T>> {
     let map = self.map.lock().unwrap();
     let type_id = TypeId::of::<T>();
+    // special case state of required plugins
+    match type_id {
+      tyid if tyid == TypeId::of::<Mutex<MenuChannels>>() => {
+        return Some(State(
+          (&self.menu_channels as &(dyn Any + Send + Sync))
+            .downcast_ref()
+            .unwrap(),
+        ))
+      }
+      _ => {}
+    }
     let state = map.get(&type_id)?;
     let value = state
       .downcast_ref::<T>()
@@ -155,6 +178,9 @@ impl StateManager {
     // SAFETY: We ensure the lifetime of `value` is the same as [StateManager] and `value` will not be mutated/moved.
     let v_ref = unsafe { &*(value as *const T) };
     Some(State(v_ref))
+  }
+  pub(crate) fn menu_channels(&self) -> &Mutex<MenuChannels> {
+    &self.menu_channels
   }
 }
 

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::{
   ipc::{CommandArg, CommandItem, InvokeError},
   menu::plugin::MenuChannels,
-  Runtime,
+  Env, Runtime,
 };
 
 /// A guard for a state value.
@@ -108,6 +108,7 @@ pub struct StateManager {
   map: Mutex<TypeIdMap>,
   // state of some required plugins
   menu_channels: Mutex<MenuChannels>,
+  env: Env,
 }
 
 impl std::fmt::Debug for StateManager {
@@ -123,6 +124,7 @@ impl StateManager {
     Self {
       map: Default::default(),
       menu_channels: Default::default(),
+      env: Env::default(),
     }
   }
 
@@ -169,6 +171,13 @@ impl StateManager {
             .unwrap(),
         ))
       }
+      tyid if tyid == TypeId::of::<Env>() => {
+        return Some(State(
+          (&self.env as &(dyn Any + Send + Sync))
+            .downcast_ref()
+            .unwrap(),
+        ))
+      }
       _ => {}
     }
     let state = map.get(&type_id)?;
@@ -181,6 +190,9 @@ impl StateManager {
   }
   pub(crate) fn menu_channels(&self) -> &Mutex<MenuChannels> {
     &self.menu_channels
+  }
+  pub(crate) fn env(&self) -> &Env {
+    &self.env
   }
 }
 

--- a/crates/tauri/src/state.rs
+++ b/crates/tauri/src/state.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::{
-  ipc::{CommandArg, CommandItem, InvokeError},
+  ipc::{channel::ChannelDataIpcQueue, CommandArg, CommandItem, InvokeError},
   menu::plugin::MenuChannels,
   Env, Runtime,
 };
@@ -109,6 +109,7 @@ pub struct StateManager {
   // state of some required plugins
   menu_channels: Mutex<MenuChannels>,
   env: Env,
+  data_ipc_queue: Mutex<ChannelDataIpcQueue>,
 }
 
 impl std::fmt::Debug for StateManager {
@@ -125,6 +126,7 @@ impl StateManager {
       map: Default::default(),
       menu_channels: Default::default(),
       env: Env::default(),
+      data_ipc_queue: Default::default(),
     }
   }
 
@@ -178,6 +180,13 @@ impl StateManager {
             .unwrap(),
         ))
       }
+      tyid if tyid == TypeId::of::<Mutex<ChannelDataIpcQueue>>() => {
+        return Some(State(
+          (&self.data_ipc_queue as &(dyn Any + Send + Sync))
+            .downcast_ref()
+            .unwrap(),
+        ))
+      }
       _ => {}
     }
     let state = map.get(&type_id)?;
@@ -193,6 +202,9 @@ impl StateManager {
   }
   pub(crate) fn env(&self) -> &Env {
     &self.env
+  }
+  pub(crate) fn data_ipc_queue(&self) -> &Mutex<ChannelDataIpcQueue> {
+    &self.data_ipc_queue
   }
 }
 


### PR DESCRIPTION
I'm putting this up for discussion how to do some small QoL improvements to the current state management.

There seem to be a number of things leaking out through things I'm not sure should have ever been public, like `StateManager` so the refactor is less clean than anticipated.

If we can inline the state management of the required plugins into `AppManager` I think this would lean stronger into the strengths of Rust's type system: Things that should be initialized will be statically obvious that they are.