### PR TITLE
fix: menu related commands can panic

### DIFF
--- a/.changes/menu-command-panic-on-wrong-input.md
+++ b/.changes/menu-command-panic-on-wrong-input.md
@@ -3,4 +3,7 @@ tauri: minor:bug
 tauri-macros: minor:bug
 ---
 
-Fix menu related commands can panic if called with invalid menu types through `invoke` directly. The internal `do_menu_item!` macro now returns `Err(crate::Error::UnexpectedMenuKind)` instead of `unreachable!()`
+Fix menu related commands can panic if called with invalid menu types through `invoke` directly.
+
+- The internal `do_menu_item!` macro now returns `Err(crate::Error::UnexpectedMenuKind)` instead of `unreachable!()`
+- Added a new error type `tauri::Error::UnexpectedMenuKind`

--- a/.changes/menu-command-panic-on-wrong-input.md
+++ b/.changes/menu-command-panic-on-wrong-input.md
@@ -1,0 +1,6 @@
+---
+tauri: minor:bug
+tauri-macros: minor:bug
+---
+
+Fix menu related commands can panic if called with invalid menu types through `invoke` directly. The internal `do_menu_item!` macro now returns `Err(crate::Error::UnexpectedMenuKind)` instead of `unreachable!()`

--- a/crates/tauri-macros/src/lib.rs
+++ b/crates/tauri-macros/src/lib.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: MIT
 
 //! Create macros for `tauri::Context`, invoke handler and commands leveraging the `tauri-codegen` crate.
+//!
+//! Don't depend on this crate directly, use the re-exported types from tauri instead.
 
 #![doc(
   html_logo_url = "https://github.com/tauri-apps/tauri/raw/dev/.github/icon.png",
@@ -117,7 +119,7 @@ pub fn default_runtime(attributes: TokenStream, input: TokenStream) -> TokenStre
 /// do_menu_item!(resources_table, rid, kind, |i| i.set_text(text), !Check | Submenu);
 /// ```
 ///
-/// #### Example
+/// ## Examples
 ///
 /// ```ignore
 ///  let rid = 23;
@@ -151,9 +153,10 @@ pub fn default_runtime(attributes: TokenStream, input: TokenStream) -> TokenStre
 ///      let i = resources_table.get::<IconMenuItem<R>>(rid)?;
 ///      i.set_text(text)
 ///    }
-///    _ => unreachable!(),
+///    _ => return Err(crate::Error::UnexpectedMenuKind),
 ///  }
 /// ```
+#[doc(hidden)]
 #[proc_macro]
 pub fn do_menu_item(input: TokenStream) -> TokenStream {
   let tokens = parse_macro_input!(input as menu::DoMenuItemInput);

--- a/crates/tauri-macros/src/menu.rs
+++ b/crates/tauri-macros/src/menu.rs
@@ -130,7 +130,7 @@ pub fn do_menu_item(input: DoMenuItemInput) -> TokenStream {
         #expr
       }
       )*
-      _ => unreachable!(),
+      _ => return Err(crate::Error::UnexpectedMenuKind),
     }
   }
 }

--- a/crates/tauri/src/error.rs
+++ b/crates/tauri/src/error.rs
@@ -166,6 +166,9 @@ pub enum Error {
   /// tokio oneshot channel failed to receive message
   #[error(transparent)]
   TokioOneshotRecv(#[from] tokio::sync::oneshot::error::RecvError),
+  /// Unexpected menu kind passed to menu/tray plugin command
+  #[error("Unexpected menu kind")]
+  UnexpectedMenuKind,
 }
 
 impl From<getrandom::Error> for Error {

--- a/crates/tauri/src/menu/plugin.rs
+++ b/crates/tauri/src/menu/plugin.rs
@@ -486,7 +486,7 @@ fn append<R: Runtime>(
         item.with_item(&webview, &resources_table, |i| submenu.append(i))?;
       }
     }
-    _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+    _ => return Err(crate::Error::UnexpectedMenuKind),
   };
 
   Ok(())
@@ -513,7 +513,7 @@ fn prepend<R: Runtime>(
         item.with_item(&webview, &resources_table, |i| submenu.prepend(i))?;
       }
     }
-    _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+    _ => return Err(crate::Error::UnexpectedMenuKind),
   };
 
   Ok(())
@@ -543,7 +543,7 @@ fn insert<R: Runtime>(
         position += 1
       }
     }
-    _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+    _ => return Err(crate::Error::UnexpectedMenuKind),
   };
 
   Ok(())
@@ -568,7 +568,7 @@ fn remove<R: Runtime>(
       do_menu_item!(resources_table, item_rid, item_kind, |i| submenu
         .remove(&*i))?;
     }
-    _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+    _ => return Err(crate::Error::UnexpectedMenuKind),
   };
 
   Ok(())
@@ -609,7 +609,7 @@ fn remove_at<R: Runtime>(
         return Ok(Some(make_item_resource!(resources_table, item)));
       }
     }
-    _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+    _ => return Err(crate::Error::UnexpectedMenuKind),
   };
 
   Ok(None)
@@ -625,7 +625,7 @@ fn items<R: Runtime>(
   let items = match kind {
     ItemKind::Menu => resources_table.get::<Menu<R>>(rid)?.items()?,
     ItemKind::Submenu => resources_table.get::<Submenu<R>>(rid)?.items()?,
-    _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+    _ => return Err(crate::Error::UnexpectedMenuKind),
   };
 
   Ok(
@@ -657,7 +657,7 @@ fn get<R: Runtime>(
         return Ok(Some(make_item_resource!(resources_table, item)));
       }
     }
-    _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+    _ => return Err(crate::Error::UnexpectedMenuKind),
   };
 
   Ok(None)
@@ -687,7 +687,7 @@ async fn popup<R: Runtime>(
         let submenu = resources_table.get::<Submenu<R>>(rid)?;
         submenu.popup_inner(window, at)?;
       }
-      _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+      _ => return Err(crate::Error::UnexpectedMenuKind),
     };
   }
 

--- a/crates/tauri/src/tray/plugin.rs
+++ b/crates/tauri/src/tray/plugin.rs
@@ -62,7 +62,7 @@ fn new<R: Runtime>(
         let submenu = resources_table.get::<Submenu<R>>(rid)?;
         builder = builder.menu(&*submenu);
       }
-      _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+      _ => return Err(crate::Error::UnexpectedMenuKind),
     };
   }
   if let Some(icon) = options.icon {
@@ -144,7 +144,7 @@ fn set_menu<R: Runtime>(
         let submenu = webview_resources_table.get::<Submenu<R>>(rid)?;
         tray.set_menu(Some((*submenu).clone()))?;
       }
-      _ => return Err(anyhow::anyhow!("unexpected menu item kind").into()),
+      _ => return Err(crate::Error::UnexpectedMenuKind),
     };
   } else {
     tray.set_menu(None::<Menu<R>>)?;


### PR DESCRIPTION
Fix #15686
Closes #15691

The `do_menu_item` relies on tauri menu plugin internals so that it doesn't work on user land unless you try really hard, so I marked it as hidden properly.