### PR TITLE
feat(android): update template to use targetSdk 37

### DIFF
--- a/.changes/android-target-sdk-37.md
+++ b/.changes/android-target-sdk-37.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
+---
+
+Update template to use `targetSdk = 37`

--- a/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
+++ b/crates/tauri-cli/templates/mobile/android/app/build.gradle.kts
@@ -17,13 +17,13 @@ val tauriProperties = Properties().apply {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
     namespace = "{{app.identifier}}"
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "{{app.identifier}}"
         minSdk = {{android.min-sdk-version}}
-        targetSdk = 36
+        targetSdk = 37
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }


### PR DESCRIPTION
Since we have bumped AGP to v9, we can upgrade the `targetSdk` as well now