### PR TITLE
fix(event): guard unlisten when listener entry not yet registered

### DIFF
--- a/crates/tauri/src/event/mod.rs
+++ b/crates/tauri/src/event/mod.rs
@@ -214,7 +214,10 @@ pub(crate) fn unlisten_js_script(
     "(function () {{
         const listeners = (window['{listeners_object_name}'] || {{}})[{event_arg}]
         if (listeners) {{
-          window.__TAURI_INTERNALS__.unregisterCallback(listeners[{event_id_arg}].handlerId)
+          const listener = listeners[{event_id_arg}]
+          if (listener) {{
+            window.__TAURI_INTERNALS__.unregisterCallback(listener.handlerId)
+          }}
         }}
       }})()
     ",


### PR DESCRIPTION
Fixes #15799

## What
The webview-side registry entry for a listener is written by a separate eval after listen() resolves. If \unlisten\ is called before that eval lands, \listeners[eventId]\ is undefined and the generated unlisten script throws on the first line, so the \plugin:event|unlisten\ invoke never runs and the backend listener leaks.

## Why
Calling \listen().then(unlisten)\ (or unlisten shortly after listen) currently leaks the backend listener because the JS-side guard throws before the invoke is sent.

## How
Guard the entry lookup the same way event delivery does, and skip \unregisterCallback\ when the entry is absent while still letting the invoke run.