### PR TITLE
fix(macos-sign): pass explicit pkcs12/cert flags to security import

### DIFF
--- a/crates/tauri-macos-sign/src/keychain.rs
+++ b/crates/tauri-macos-sign/src/keychain.rs
@@ -109,6 +109,10 @@ impl Keychain {
         .arg("-P")
         .arg(certificate_password)
         .args([
+          "-f",
+          "pkcs12",
+          "-t",
+          "cert",
           "-T",
           "/usr/bin/codesign",
           "-T",


### PR DESCRIPTION
## What
When importing a signing identity into the keychain, \security import\ receives \-f pkcs12 -t cert\ explicitly instead of relying on file extension inference.

## Why
Importing a PKCS#12 that is not on a \.p12\/\.pfx\ extension (e.g. via \--certificate-password\ + an alternate format) can be silently treated as a non-cert, producing confusing 'no identity found' errors downstream.