### PR TITLE
docs(api): clarify convertFileSrc asset protocol setup (fix #10755)

### DIFF
--- a/packages/api/src/core.ts
+++ b/packages/api/src/core.ts
@@ -257,29 +257,43 @@ async function invoke<T>(
 }
 
 /**
- * Convert a device file path to an URL that can be loaded by the webview.
- * Note that `asset:` and `http://asset.localhost` must be added to [`app.security.csp`](https://v2.tauri.app/reference/config/#csp-1) in `tauri.conf.json`.
- * Example CSP value: `"csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost"` to use the asset protocol on image sources.
+ * Convert a device file path to a URL that can be loaded by the webview.
  *
- * Additionally, `"enable" : "true"` must be added to [`app.security.assetProtocol`](https://v2.tauri.app/reference/config/#assetprotocolconfig)
- * in `tauri.conf.json` and its access scope must be defined on the `scope` array on the same `assetProtocol` object.
+ * The asset protocol must be enabled and the files you want to expose must be
+ * included in its scope. The protocol origins must also be allowed by the
+ * relevant [`app.security.csp`](https://v2.tauri.app/reference/config/#csp-1)
+ * directive. For example, this configuration allows images from the user's
+ * downloads directory:
+ *
+ * ```json
+ * {
+ *   "app": {
+ *     "security": {
+ *       "assetProtocol": {
+ *         "enable": true,
+ *         "scope": ["$DOWNLOAD/**"]
+ *       },
+ *       "csp": "default-src 'self'; img-src 'self' asset: http://asset.localhost"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * See [`assetProtocol`](https://v2.tauri.app/reference/config/#assetprotocolconfig)
+ * for the available scope variables and platform-specific protocol details.
  *
  * @param  filePath The file path.
  * @param  protocol The protocol to use. Defaults to `asset`. You only need to set this when using a custom protocol.
  * @example
  * ```typescript
- * import { appDataDir, join } from '@tauri-apps/api/path';
+ * import { downloadDir, join } from '@tauri-apps/api/path';
  * import { convertFileSrc } from '@tauri-apps/api/core';
- * const appDataDirPath = await appDataDir();
- * const filePath = await join(appDataDirPath, 'assets/video.mp4');
+ * const downloads = await downloadDir();
+ * const filePath = await join(downloads, 'photo.png');
  * const assetUrl = convertFileSrc(filePath);
  *
- * const video = document.getElementById('my-video');
- * const source = document.createElement('source');
- * source.type = 'video/mp4';
- * source.src = assetUrl;
- * video.appendChild(source);
- * video.load();
+ * const image = document.getElementById('my-image') as HTMLImageElement;
+ * image.src = assetUrl;
  * ```
  *
  * @return the URL that can be used as source on the webview.


### PR DESCRIPTION
Fixes #10755.

This updates the `convertFileSrc` API documentation with a complete Tauri v2 configuration example. It shows the asset protocol scope and CSP origins together, then uses the same Downloads-directory scope in the TypeScript example.

Validation:

- `pnpm --filter @tauri-apps/api eslint:check`
- `pnpm --filter @tauri-apps/api ts:check`
- `pnpm --filter @tauri-apps/api build`
