### PR TITLE
fix(ci): restore ndk symlinks on macos

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -59,8 +59,10 @@ jobs:
       # TODO check after https://github.com/nttld/setup-ndk/issues/518 is fixed
       - name: Restore Android Symlinks
         if: matrix.platform == 'ubuntu-latest' || matrix.platform == 'macos-latest'
+        env:
+          NDK_HOST: ${{ matrix.platform == 'ubuntu-latest' && 'linux-x86_64' || 'darwin-x86_64' }}
         run: |
-          directory="${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          directory="${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/$NDK_HOST/bin"
           find "$directory" -type l | while read link; do
               current_target=$(readlink "$link")
               new_target="$directory/$(basename "$current_target")"


### PR DESCRIPTION
#8738 copied the code as is but runs it on both mac and linux which was not correct

Mirror https://github.com/tauri-apps/plugins-workspace/pull/3531/commits/1a88e8238962c8b537248bb3508d044be50aa49b