### PR TITLE
feat(resources): resolve resources at runtime in development

### DIFF
--- a/.changes/dev-resources-runtime-resolution.md
+++ b/.changes/dev-resources-runtime-resolution.md
@@ -1,0 +1,15 @@
+---
+"tauri": "minor:feat"
+"tauri-build": "minor:breaking"
+"tauri-utils": "minor:feat"
+"tauri-codegen": "minor:feat"
+---
+
+`tauri-build` no longer copies the configured resources to the cargo target directory; on desktop, unbundled apps (`tauri dev` / `cargo run`) now resolve resources at runtime from their source paths instead. This means editing a resource file no longer triggers a full application rebuild, and changes to plain relative resources are picked up live by the running app.
+
+- When all configured resources are plain relative paths (e.g. `"assets/*"`), the resource directory resolves to the directory containing `tauri.conf.json` and files are read directly from the sources.
+- When resources are remapped (map notation, `../` or absolute paths), the bundle layout is mirrored next to the executable on the first resource directory access of each run.
+
+The `bundle > resources` configuration is now part of the config embedded by `generate_context!`, where it was previously stripped.
+
+`tauri` and `tauri-build` must be updated together: an older `tauri` with a newer `tauri-build` will not find resources when running unbundled. Note that missing resources are now reported at runtime instead of failing the development build, executables produced by `tauri build` only have access to resources when bundled, and apps constructing a `Context` manually (without `generate_context!`) keep the previous exe-directory resolution.

--- a/.changes/dev-resources-runtime-resolution.md
+++ b/.changes/dev-resources-runtime-resolution.md
@@ -1,6 +1,6 @@
 ---
 "tauri": "minor:feat"
-"tauri-build": "minor:breaking"
+"tauri-build": "minor:feat"
 "tauri-utils": "minor:feat"
 "tauri-codegen": "minor:feat"
 ---
@@ -12,4 +12,3 @@
 
 The `bundle > resources` configuration is now part of the config embedded by `generate_context!`, where it was previously stripped.
 
-`tauri` and `tauri-build` must be updated together: an older `tauri` with a newer `tauri-build` will not find resources when running unbundled. Note that missing resources are now reported at runtime instead of failing the development build, executables produced by `tauri build` only have access to resources when bundled, and apps constructing a `Context` manually (without `generate_context!`) keep the previous exe-directory resolution.

--- a/crates/tauri-build/src/lib.rs
+++ b/crates/tauri-build/src/lib.rs
@@ -15,7 +15,7 @@ pub use anyhow::Result;
 use cargo_toml::Manifest;
 
 use tauri_utils::{
-  config::{BundleResources, Config, WebviewInstallMode},
+  config::Config,
   resources::{ResourcePaths, external_binaries},
 };
 
@@ -80,24 +80,6 @@ fn copy_binaries(
       fs::remove_file(&dest).unwrap();
     }
     copy_file(&src, &dest)?;
-  }
-  Ok(())
-}
-
-/// Copies resources to a path.
-fn copy_resources(resources: ResourcePaths<'_>, path: &Path) -> Result<()> {
-  let path = path.canonicalize()?;
-  for resource in resources.iter() {
-    let resource = resource?;
-
-    println!("cargo:rerun-if-changed={}", resource.path().display());
-
-    // avoid copying the resource if target is the same as source
-    let src = resource.path().canonicalize()?;
-    let target = path.join(resource.target());
-    if src != target {
-      copy_file(src, target)?;
-    }
   }
   Ok(())
 }
@@ -576,27 +558,6 @@ pub fn try_build(attributes: Attributes) -> Result<()> {
       target_dir,
       manifest.package.as_ref().map(|p| p.name.as_ref()),
     )?;
-  }
-
-  #[allow(unused_mut, clippy::redundant_clone)]
-  let mut resources = config
-    .bundle
-    .resources
-    .clone()
-    .unwrap_or_else(|| BundleResources::List(Vec::new()));
-  if target_triple.contains("windows")
-    && let Some(fixed_webview2_runtime_path) = match &config.bundle.windows.webview_install_mode {
-      WebviewInstallMode::FixedRuntime { path } => Some(path),
-      _ => None,
-    }
-  {
-    resources.push(fixed_webview2_runtime_path.display().to_string());
-  }
-  match resources {
-    BundleResources::List(res) => {
-      copy_resources(ResourcePaths::new(res.as_slice(), true), target_dir)?
-    }
-    BundleResources::Map(map) => copy_resources(ResourcePaths::from_map(&map, true), target_dir)?,
   }
 
   if target_triple.contains("darwin") {

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -4019,6 +4019,28 @@ mod build {
     }
   }
 
+  impl ToTokens for BundleResources {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+      let prefix = quote! { ::tauri::utils::config::BundleResources };
+
+      tokens.append_all(match self {
+        Self::List(paths) => {
+          let paths = vec_lit(paths, str_lit);
+          quote! { #prefix::List(#paths) }
+        }
+        Self::Map(map) => {
+          let map = map_lit(
+            quote! { ::std::collections::HashMap },
+            map,
+            str_lit,
+            str_lit,
+          );
+          quote! { #prefix::Map(#map) }
+        }
+      })
+    }
+  }
+
   impl ToTokens for BundleConfig {
     fn to_tokens(&self, tokens: &mut TokenStream) {
       let publisher = quote!(None);
@@ -4027,7 +4049,7 @@ mod build {
       let active = self.active;
       let targets = quote!(Default::default());
       let create_updater_artifacts = quote!(Default::default());
-      let resources = quote!(None);
+      let resources = opt_lit(self.resources.as_ref());
       let copyright = quote!(None);
       let category = quote!(None);
       let file_associations = quote!(None);

--- a/crates/tauri-utils/src/resources.rs
+++ b/crates/tauri-utils/src/resources.rs
@@ -97,6 +97,7 @@ impl<'a> ResourcePaths<'a> {
       iter: ResourcePathsIter {
         pattern_iter: PatternIter::Slice(patterns.iter()),
         allow_walk,
+        base_dir: None,
         current_dest: None,
         current_iter: None,
       },
@@ -109,10 +110,23 @@ impl<'a> ResourcePaths<'a> {
       iter: ResourcePathsIter {
         pattern_iter: PatternIter::Map(patterns.iter()),
         allow_walk,
+        base_dir: None,
         current_dest: None,
         current_iter: None,
       },
     }
+  }
+
+  /// Resolves the resource patterns against the given base directory
+  /// instead of the current working directory.
+  ///
+  /// [`Resource::target`] is still computed from the pattern as written
+  /// (as if the iterator ran with `base_dir` as the working directory),
+  /// but [`Resource::path`] yields the pattern joined with `base_dir`.
+  #[must_use]
+  pub fn with_base_dir(mut self, base_dir: impl Into<PathBuf>) -> Self {
+    self.iter.base_dir = Some(base_dir.into());
+    self
   }
 
   /// Returns the resource iterator that yields the source and target paths.
@@ -129,6 +143,8 @@ pub struct ResourcePathsIter<'a> {
   pattern_iter: PatternIter<'a>,
   /// whether the resource paths allows directories or not.
   allow_walk: bool,
+  /// the directory patterns are resolved against instead of the current working directory.
+  base_dir: Option<PathBuf>,
 
   /// The value of map when [`Self::pattern_iter`] is a [`PatternIter::Map`],
   /// used for determining [`Resource::target`]
@@ -178,7 +194,14 @@ impl ResourcePathsIter<'_> {
         if entry.is_dir() {
           self.next_current_iter()?
         } else {
-          self.resource_from_path(normalize(&entry))
+          // with a base dir, entries are already full paths; normalizing would
+          // strip Windows path prefixes
+          let entry = if self.base_dir.is_some() {
+            entry
+          } else {
+            normalize(&entry)
+          };
+          self.resource_from_path(entry)
         }
       }
       Err(error) => Err(error),
@@ -190,47 +213,53 @@ impl ResourcePathsIter<'_> {
       return Err(crate::Error::ResourcePathNotFound(path));
     }
 
-    Ok(Resource {
-      target: if let Some(dest) = &self.current_dest {
-        match &self.current_iter {
-          Some(current_iter) => match current_iter {
-            // if processing a directory, preserve directory structure under current_dest
-            ResourcePathsInnerIter::Walk {
-              current_pattern, ..
-            } => {
-              if let Some(pattern) = current_pattern {
-                dest.join(path.strip_prefix(pattern).unwrap_or(&path))
-              } else {
-                dest.join(&path)
-              }
-            }
-            // if processing a glob and current_dest is not empty
-            // we put all globbed paths under current_dest
-            // preserving the file name as it is
-            ResourcePathsInnerIter::Glob { .. } => dest.join(path.file_name().unwrap()),
-          },
-          None => {
-            if dest.components().count() == 0 {
-              // if current_dest is empty while processing a file pattern
-              // we preserve the file name as it is
-              //
-              // e.g. `{ "README.md": "" }` is `README.md` -> `$RESOURCE/README.md`
-              //
-              // TODO: This behavior is a confusing special case,
-              // remove this in v3 or make other cases like this work
-              // > `{ "README.md": "./folder/" }` is `README.md` -> `$RESOURCE/folder/README.md` (this gives `$RESOURCE/folder` today)
-              PathBuf::from(path.file_name().unwrap())
+    // the path as written in the pattern (relative to the base dir, if any),
+    // which determines the resource target
+    let relative_path: &Path = match &self.base_dir {
+      Some(base_dir) => path.strip_prefix(base_dir).unwrap_or(&path),
+      None => &path,
+    };
+
+    let target = if let Some(dest) = &self.current_dest {
+      match &self.current_iter {
+        Some(current_iter) => match current_iter {
+          // if processing a directory, preserve directory structure under current_dest
+          ResourcePathsInnerIter::Walk {
+            current_pattern, ..
+          } => {
+            if let Some(pattern) = current_pattern {
+              dest.join(path.strip_prefix(pattern).unwrap_or(&path))
             } else {
-              dest.clone()
+              dest.join(relative_path)
             }
           }
+          // if processing a glob and current_dest is not empty
+          // we put all globbed paths under current_dest
+          // preserving the file name as it is
+          ResourcePathsInnerIter::Glob { .. } => dest.join(path.file_name().unwrap()),
+        },
+        None => {
+          if dest.components().count() == 0 {
+            // if current_dest is empty while processing a file pattern
+            // we preserve the file name as it is
+            //
+            // e.g. `{ "README.md": "" }` is `README.md` -> `$RESOURCE/README.md`
+            //
+            // TODO: This behavior is a confusing special case,
+            // remove this in v3 or make other cases like this work
+            // > `{ "README.md": "./folder/" }` is `README.md` -> `$RESOURCE/folder/README.md` (this gives `$RESOURCE/folder` today)
+            PathBuf::from(path.file_name().unwrap())
+          } else {
+            dest.clone()
+          }
         }
-      } else {
-        // If [`ResourcePathsIter::pattern_iter`] is a [`PatternIter::Slice`]
-        resource_relpath(&path)
-      },
-      path,
-    })
+      }
+    } else {
+      // If [`ResourcePathsIter::pattern_iter`] is a [`PatternIter::Slice`]
+      resource_relpath(relative_path)
+    };
+
+    Ok(Resource { target, path })
   }
 
   fn next_pattern(&mut self) -> Option<crate::Result<Resource>> {
@@ -247,7 +276,16 @@ impl ResourcePathsIter<'_> {
     };
 
     if pattern.contains('*') {
-      self.current_iter = match glob::glob(pattern) {
+      let glob_pattern = match &self.base_dir {
+        // escape the base dir so path components with glob special characters
+        // (e.g. `[`) are matched literally
+        Some(base_dir) => Path::new(&glob::Pattern::escape(&base_dir.to_string_lossy()))
+          .join(pattern)
+          .to_string_lossy()
+          .into_owned(),
+        None => pattern.clone(),
+      };
+      self.current_iter = match glob::glob(&glob_pattern) {
         Ok(glob) => Some(ResourcePathsInnerIter::Glob { iter: glob }),
         Err(error) => return Some(Err(error.into())),
       };
@@ -260,6 +298,10 @@ impl ResourcePathsIter<'_> {
       }
     } else {
       let path = normalize(Path::new(pattern));
+      let path = match &self.base_dir {
+        Some(base_dir) => base_dir.join(path),
+        None => path,
+      };
       if path.is_dir() {
         if !self.allow_walk {
           return Some(Err(crate::Error::NotAllowedToWalkDir(path)));
@@ -583,6 +625,128 @@ mod tests {
       ("Tauri.toml", "Tauri.toml"),
       ("tauri.conf.json", "json/tauri.conf.json"),
     ]);
+
+    assert_eq!(resources.len(), expected.len());
+    for resource in expected {
+      if !resources.contains(&resource) {
+        panic!("{resource:?} was expected but not found in {resources:?}");
+      }
+    }
+  }
+
+  #[test]
+  #[serial_test::serial(resources)]
+  fn resource_paths_iter_slice_with_base_dir() {
+    setup_test_dirs();
+
+    // the current dir is the temp dir, NOT the base dir:
+    // resolution must not depend on the current working directory
+    let base_dir = std::env::current_dir().unwrap().join("src-tauri");
+
+    let resources = ResourcePaths::new(
+      &[
+        "../src/script.js".into(),
+        "../src/assets".into(),
+        "../src/textures/**/*".into(),
+        "*.toml".into(),
+        "some-folder".into(),
+      ],
+      true,
+    )
+    .with_base_dir(&base_dir)
+    .iter()
+    .flatten()
+    .collect::<Vec<_>>();
+
+    let expected: Vec<Resource> = [
+      ("../src/script.js", "_up_/src/script.js"),
+      (
+        "../src/assets/javascript.svg",
+        "_up_/src/assets/javascript.svg",
+      ),
+      ("../src/assets/tauri.svg", "_up_/src/assets/tauri.svg"),
+      ("../src/assets/rust.svg", "_up_/src/assets/rust.svg"),
+      ("../src/assets/lang/en.json", "_up_/src/assets/lang/en.json"),
+      ("../src/assets/lang/ar.json", "_up_/src/assets/lang/ar.json"),
+      (
+        "../src/textures/ground/earth.tex",
+        "_up_/src/textures/ground/earth.tex",
+      ),
+      (
+        "../src/textures/ground/sand.tex",
+        "_up_/src/textures/ground/sand.tex",
+      ),
+      ("../src/textures/water.tex", "_up_/src/textures/water.tex"),
+      ("../src/textures/fire.tex", "_up_/src/textures/fire.tex"),
+      ("Cargo.toml", "Cargo.toml"),
+      ("Tauri.toml", "Tauri.toml"),
+      ("some-folder/some-file.txt", "some-folder/some-file.txt"),
+    ]
+    .iter()
+    .map(|(path, target)| Resource {
+      path: base_dir.join(path),
+      target: Path::new(target).components().collect(),
+    })
+    .collect();
+
+    assert_eq!(resources.len(), expected.len());
+    for resource in expected {
+      if !resources.contains(&resource) {
+        panic!("{resource:?} was expected but not found in {resources:?}");
+      }
+    }
+  }
+
+  #[test]
+  #[serial_test::serial(resources)]
+  fn resource_paths_iter_map_with_base_dir() {
+    setup_test_dirs();
+
+    // the current dir is the temp dir, NOT the base dir:
+    // resolution must not depend on the current working directory
+    let base_dir = std::env::current_dir().unwrap().join("src-tauri");
+
+    let resources = ResourcePaths::from_map(
+      &resources_map(&[
+        ("../src/script.js", "main.js"),
+        ("../src/assets", ""),
+        ("../src/sounds", "voices"),
+        ("../src/textures/*", "textures"),
+        ("*.conf.json", "json"),
+        ("some-folder", "some-target-folder"),
+        ("Cargo.toml", ""),
+      ]),
+      true,
+    )
+    .with_base_dir(&base_dir)
+    .iter()
+    .flatten()
+    .collect::<Vec<_>>();
+
+    let expected: Vec<Resource> = [
+      ("../src/script.js", "main.js"),
+      ("../src/assets/javascript.svg", "javascript.svg"),
+      ("../src/assets/tauri.svg", "tauri.svg"),
+      ("../src/assets/rust.svg", "rust.svg"),
+      ("../src/assets/lang/en.json", "lang/en.json"),
+      ("../src/assets/lang/ar.json", "lang/ar.json"),
+      ("../src/sounds/lang/es.wav", "voices/lang/es.wav"),
+      ("../src/sounds/lang/fr.wav", "voices/lang/fr.wav"),
+      ("../src/textures/water.tex", "textures/water.tex"),
+      ("../src/textures/fire.tex", "textures/fire.tex"),
+      ("tauri.conf.json", "json/tauri.conf.json"),
+      (
+        "some-folder/some-file.txt",
+        "some-target-folder/some-file.txt",
+      ),
+      ("Cargo.toml", "Cargo.toml"),
+    ]
+    .iter()
+    .map(|(path, target)| Resource {
+      path: base_dir.join(path),
+      target: Path::new(target).components().collect(),
+    })
+    .collect();
 
     assert_eq!(resources.len(), expected.len());
     for resource in expected {

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -2428,12 +2428,22 @@ tauri::Builder::<tauri::Wry>::new()
       if let crate::utils::config::WebviewInstallMode::FixedRuntime { path } =
         &manager.config.bundle.windows.webview_install_mode
       {
-        if let Some(exe_dir) = crate::utils::platform::current_exe()
-          .ok()
-          .and_then(|p| p.parent().map(|p| p.to_path_buf()))
-        {
+        // In development the runtime is not copied next to the executable,
+        // so resolve it from the directory the configured path is relative to.
+        #[cfg(dev)]
+        let base_dir = manager.config_parent().cloned();
+        #[cfg(not(dev))]
+        let base_dir: Option<std::path::PathBuf> = None;
+
+        let base_dir = base_dir.or_else(|| {
+          crate::utils::platform::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+        });
+
+        if let Some(base_dir) = base_dir {
           unsafe {
-            std::env::set_var("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER", exe_dir.join(path));
+            std::env::set_var("WEBVIEW2_BROWSER_EXECUTABLE_FOLDER", base_dir.join(path));
           }
         } else {
           #[cfg(debug_assertions)]

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -196,6 +196,11 @@ pub struct AppManager<R: Runtime> {
   pub config: Config,
   #[cfg(dev)]
   pub config_parent: Option<std::path::PathBuf>,
+  /// Directory where remapped resources have been mirrored for this run,
+  /// so joined resource paths keep working in development.
+  /// See [`crate::path::PathResolver::resource_dir`].
+  #[cfg(all(dev, desktop))]
+  pub(crate) dev_resources_dir: Mutex<Option<std::path::PathBuf>>,
   pub assets: Box<dyn Assets<R>>,
 
   pub app_icon: Option<Vec<u8>>,
@@ -316,6 +321,8 @@ impl<R: Runtime> AppManager<R> {
       config: context.config,
       #[cfg(dev)]
       config_parent: context.config_parent,
+      #[cfg(all(dev, desktop))]
+      dev_resources_dir: Mutex::default(),
       assets: context.assets,
       app_icon: context.app_icon,
       package_info: context.package_info,

--- a/crates/tauri/src/path/desktop.rs
+++ b/crates/tauri/src/path/desktop.rs
@@ -227,9 +227,61 @@ impl<R: Runtime> PathResolver<R> {
   ///   we return a special URI prefix `asset://localhost/` here that can be used with the [file system plugin](https://tauri.app/plugin/file-system/),
   ///   with that, you can read the files through [`FsExt::fs`](https://docs.rs/tauri-plugin-fs/latest/tauri_plugin_fs/trait.FsExt.html#tymethod.fs)
   ///   like this: `app.fs().read_to_string(app.path().resource_dir().unwrap().join("resource"));`
+  ///
+  /// ## Development
+  ///
+  /// On desktop, when running with `tauri dev` or `cargo run`, resources are read from their
+  /// source location instead of being copied next to the executable by the build script:
+  ///
+  /// - If all configured resources are plain relative paths, their bundle layout mirrors the
+  ///   source layout, so this resolves to the directory containing `tauri.conf.json` and
+  ///   resource files are read directly from the sources.
+  /// - If resources are remapped (map notation, or paths outside the app directory), they are
+  ///   mirrored to the directory containing the executable on the first call, so joined paths
+  ///   keep working, and refreshed on each run.
   pub fn resource_dir(&self) -> Result<PathBuf> {
+    #[cfg(all(dev, desktop))]
+    if let Some(dir) = self.dev_resource_dir()? {
+      return Ok(dir);
+    }
+
     crate::utils::platform::resource_dir(self.0.package_info(), &self.0.env())
       .map_err(|_| Error::UnknownPath)
+  }
+
+  #[cfg(all(dev, desktop))]
+  fn dev_resource_dir(&self) -> Result<Option<PathBuf>> {
+    use tauri_utils::config::BundleResources;
+
+    let manager = &self.0.manager;
+    let Some(app_dir) = manager.config_parent() else {
+      return Ok(None);
+    };
+    let Some(resources) = manager.config().bundle.resources.as_ref() else {
+      return Ok(None);
+    };
+
+    match resources {
+      BundleResources::List(patterns) if patterns.is_empty() => Ok(None),
+      // the bundle layout mirrors the source layout, so the app directory
+      // acts as the resource directory and files are read directly from the sources
+      resources if resources_mirror_source_layout(resources) => Ok(Some(app_dir.clone())),
+      // remapped resources: mirror the bundle layout next to the executable
+      resources => {
+        let mut dev_resources_dir = manager.dev_resources_dir.lock().unwrap();
+        if let Some(dir) = dev_resources_dir.as_ref() {
+          return Ok(Some(dir.clone()));
+        }
+
+        let exe_dir = crate::utils::platform::current_exe()?
+          .parent()
+          .ok_or(Error::UnknownPath)?
+          .to_path_buf();
+        mirror_resources(resources, app_dir, &exe_dir)?;
+        dev_resources_dir.replace(exe_dir.clone());
+        Ok(Some(exe_dir))
+      }
+    }
   }
 
   /// Returns the path to the suggested directory for your app's config files.
@@ -292,5 +344,208 @@ impl<R: Runtime> PathResolver<R> {
   /// A temporary directory. Resolves to [`std::env::temp_dir`].
   pub fn temp_dir(&self) -> Result<PathBuf> {
     Ok(std::env::temp_dir())
+  }
+}
+
+/// Whether the bundle target path of every configured resource matches its source path,
+/// meaning the directory the resource patterns are relative to can be used
+/// as the resource directory directly.
+///
+/// This is only the case for list notation with plain relative patterns:
+/// map notation remaps targets, and patterns reaching outside the base directory
+/// get their target rewritten (`..` -> `_up_`).
+#[cfg(all(dev, desktop))]
+fn resources_mirror_source_layout(resources: &tauri_utils::config::BundleResources) -> bool {
+  match resources {
+    tauri_utils::config::BundleResources::List(patterns) => patterns.iter().all(|pattern| {
+      let path = Path::new(pattern);
+      path.is_relative()
+        && !path
+          .components()
+          .any(|c| matches!(c, std::path::Component::ParentDir))
+    }),
+    tauri_utils::config::BundleResources::Map(_) => false,
+  }
+}
+
+/// Copies the configured resources, laid out as in the bundle, into `out_dir`.
+///
+/// Copies are skipped when the destination is already up to date, so this stays
+/// cheap when called once per run.
+#[cfg(all(dev, desktop))]
+fn mirror_resources(
+  resources: &tauri_utils::config::BundleResources,
+  base_dir: &Path,
+  out_dir: &Path,
+) -> Result<()> {
+  use tauri_utils::{config::BundleResources, resources::ResourcePaths};
+
+  let resources = match resources {
+    BundleResources::List(patterns) => ResourcePaths::new(patterns.as_slice(), true),
+    BundleResources::Map(map) => ResourcePaths::from_map(map, true),
+  };
+
+  for resource in resources.with_base_dir(base_dir).iter() {
+    let resource = resource.map_err(std::io::Error::other)?;
+    let dest = out_dir.join(resource.target());
+    if !up_to_date(resource.path(), &dest) {
+      if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+      }
+      std::fs::copy(resource.path(), &dest)?;
+    }
+  }
+
+  Ok(())
+}
+
+#[cfg(all(dev, desktop))]
+fn up_to_date(src: &Path, dest: &Path) -> bool {
+  let (Ok(src), Ok(dest)) = (src.metadata(), dest.metadata()) else {
+    return false;
+  };
+  src.len() == dest.len()
+    && matches!(
+      (src.modified(), dest.modified()),
+      (Ok(src), Ok(dest)) if dest >= src
+    )
+}
+
+#[cfg(all(test, dev, desktop))]
+mod tests {
+  use std::{collections::HashMap, fs};
+
+  use tauri_utils::config::BundleResources;
+
+  use super::{mirror_resources, resources_mirror_source_layout};
+
+  fn list(patterns: &[&str]) -> BundleResources {
+    BundleResources::List(patterns.iter().map(ToString::to_string).collect())
+  }
+
+  #[test]
+  fn source_layout_mirror_detection() {
+    assert!(resources_mirror_source_layout(&list(&[
+      "assets/*",
+      "lang/en.json",
+      "./data",
+      "files/**/*"
+    ])));
+
+    assert!(!resources_mirror_source_layout(&list(&["../assets/*"])));
+    assert!(!resources_mirror_source_layout(&list(&[
+      "assets/*",
+      "dir/../../escape.txt"
+    ])));
+    #[cfg(windows)]
+    assert!(!resources_mirror_source_layout(&list(&["C:\\abs\\file"])));
+    #[cfg(not(windows))]
+    assert!(!resources_mirror_source_layout(&list(&["/abs/file"])));
+
+    assert!(!resources_mirror_source_layout(&BundleResources::Map(
+      HashMap::from([("assets".into(), "assets".into())])
+    )));
+  }
+
+  #[test]
+  fn resource_dir_resolves_to_sources_in_dev() {
+    use crate::Manager;
+
+    let mut context = crate::test::mock_context(crate::test::noop_assets());
+    context.config.bundle.resources = Some(list(&["assets/*", "lang/en.json"]));
+    context.with_config_parent("/app/src-tauri");
+
+    let app = crate::test::mock_builder().build(context).unwrap();
+    assert_eq!(
+      app.path().resource_dir().unwrap(),
+      std::path::PathBuf::from("/app/src-tauri")
+    );
+    assert_eq!(
+      app
+        .path()
+        .resolve("assets/logo.png", crate::path::BaseDirectory::Resource)
+        .unwrap(),
+      std::path::PathBuf::from("/app/src-tauri/assets/logo.png")
+    );
+
+    // without configured resources, the default resolution is used
+    let context = crate::test::mock_context(crate::test::noop_assets());
+    let app = crate::test::mock_builder().build(context).unwrap();
+    assert_ne!(
+      app.path().resource_dir().unwrap(),
+      std::path::PathBuf::from("/app/src-tauri")
+    );
+  }
+
+  #[test]
+  fn mirrors_remapped_resources() {
+    let mut random = [0; 8];
+    getrandom::fill(&mut random).unwrap();
+    let root = std::env::temp_dir().join(format!(
+      "tauri_dev_resources_test_{}",
+      random.map(|b| b.to_string()).join("")
+    ));
+    let _ = fs::remove_dir_all(&root);
+
+    let app_dir = root.join("app/src-tauri");
+    for (path, content) in [
+      ("app/assets/logo.png", "logo"),
+      ("app/assets/nested/deep.txt", "deep"),
+      ("app/src-tauri/lang/en.json", "en"),
+      ("app/src-tauri/data.bin", "data"),
+    ] {
+      let path = root.join(path);
+      fs::create_dir_all(path.parent().unwrap()).unwrap();
+      fs::write(path, content).unwrap();
+    }
+
+    let resources = BundleResources::Map(HashMap::from([
+      ("../assets".to_string(), "assets".to_string()),
+      ("lang/en.json".to_string(), "locales/en.json".to_string()),
+      ("data.bin".to_string(), String::new()),
+    ]));
+
+    let out_dir = root.join("out");
+    fs::create_dir_all(&out_dir).unwrap();
+    mirror_resources(&resources, &app_dir, &out_dir).unwrap();
+
+    for (path, content) in [
+      ("assets/logo.png", "logo"),
+      ("assets/nested/deep.txt", "deep"),
+      ("locales/en.json", "en"),
+      ("data.bin", "data"),
+    ] {
+      assert_eq!(
+        fs::read_to_string(out_dir.join(path)).unwrap(),
+        content,
+        "unexpected content for {path}"
+      );
+    }
+
+    // a second run refreshes modified sources and keeps up-to-date copies
+    let dest_modified = |p: &str| out_dir.join(p).metadata().unwrap().modified().unwrap();
+    let untouched_before = dest_modified("data.bin");
+    fs::write(app_dir.join("lang/en.json"), "en-updated").unwrap();
+    mirror_resources(&resources, &app_dir, &out_dir).unwrap();
+    assert_eq!(
+      fs::read_to_string(out_dir.join("locales/en.json")).unwrap(),
+      "en-updated"
+    );
+    assert_eq!(dest_modified("data.bin"), untouched_before);
+
+    // resources reaching outside the app dir via list notation get `_up_` targets
+    let out_dir = root.join("out-list");
+    fs::create_dir_all(&out_dir).unwrap();
+    mirror_resources(&list(&["../assets/*.png", "data.bin"]), &app_dir, &out_dir).unwrap();
+    assert_eq!(
+      fs::read_to_string(out_dir.join("_up_/assets/logo.png")).unwrap(),
+      "logo"
+    );
+    assert_eq!(
+      fs::read_to_string(out_dir.join("data.bin")).unwrap(),
+      "data"
+    );
+
+    let _ = fs::remove_dir_all(&root);
   }
 }


### PR DESCRIPTION
tauri-build currently copies every configured resource into the cargo target directory and emits a rerun-if-changed instruction for each one, so editing any resource file invalidated the crate fingerprint and foces a full rebuild.

this PR drops the copy entirely and resolve resources from their source paths at runtime instead, on desktop in development builds:

- when every configured resource is a plain relative path, the resource directory resolves to the app directory and files are read live from the sources, so edits need no rebuild at all
- when resources are remapped (map notation, `../` or absolute paths), the bundle layout is mirrored next to the executable on the first resource directory access of each run, so joined paths keep working

The embedded config strips `bundle.resources` to keep production binaries small, so codegen restores it for development builds through a new hidden Context setter. The fixed WebView2 runtime path is resolved from the app directory in development as well, since it is no longer staged next to the executable.

Production builds are unchanged: the bundlers copy resources from their configured source paths and never read the staged copies. `tauri` and `tauri-build` must be updated together.
