### PR TITLE
fix: do not close parent window when a child webview is closed

### DIFF
--- a/crates/tauri-runtime-cef/src/cef_impl/client/life_span.rs
+++ b/crates/tauri-runtime-cef/src/cef_impl/client/life_span.rs
@@ -125,6 +125,40 @@ wrap_life_span_handler! {
       }
     }
 
+    /// Take over the browser close so it does not take the window down with it.
+    ///
+    /// Returning 0 runs CEF's default, which sends the standard close
+    /// notification to the browser's *top-level parent window* (`performClose:`
+    /// on macOS, `WM_CLOSE` on Windows). Every Tauri webview is a child browser
+    /// parented to a shared window, so that default turns "close this webview"
+    /// into "close the window and every sibling webview" — and with the last
+    /// window gone, the app exits.
+    ///
+    /// Returning 1 leaves the parent window alone and makes us responsible for
+    /// completing the close, which means destroying this browser's own child
+    /// view/window on the event loop. That destruction is what drives CEF's
+    /// `WindowDestroyed` -> `on_before_close` sequence.
+    ///
+    /// On Linux the default only closes the browser's own X11 child window (and
+    /// calls `WindowDestroyed` itself), so the default is already correct there.
+    fn do_close(&self, browser: Option<&mut Browser>) -> std::os::raw::c_int {
+      if browser.is_none() {
+        return 0;
+      }
+
+      #[cfg(any(target_os = "macos", windows))]
+      {
+        let _ = self
+          .sender
+          .send(Message::DestroyWebviewHostWindow(self.webview_id));
+        self.proxy.wake_up();
+        return 1;
+      }
+
+      #[cfg(not(any(target_os = "macos", windows)))]
+      0
+    }
+
     fn on_before_close(&self, browser: Option<&mut Browser>) {
       if browser.is_none() {
         return;

--- a/crates/tauri-runtime-cef/src/platform/macos/webview.rs
+++ b/crates/tauri-runtime-cef/src/platform/macos/webview.rs
@@ -72,6 +72,16 @@ impl AppWebview {
     nsview.setHidden(!visible);
   }
 
+  /// Destroys CEF's own view for this browser, completing a close that
+  /// `do_close` took over.
+  ///
+  /// The superview holds the only strong reference to that view, so dropping it
+  /// deallocates the view — and its `dealloc` is what reports `WindowDestroyed`
+  /// back to CEF.
+  pub(crate) fn destroy_host_window(&self) {
+    self.nsview().removeFromSuperview();
+  }
+
   pub(crate) fn apply_physical_bounds(&self, scale: f64, x: i32, y: i32, width: i32, height: i32) {
     let nsview = self.nsview();
     let Some(parent) = (unsafe { nsview.superview() }) else {

--- a/crates/tauri-runtime-cef/src/platform/windows/webview.rs
+++ b/crates/tauri-runtime-cef/src/platform/windows/webview.rs
@@ -10,8 +10,9 @@ use windows::Win32::{
   Graphics::Gdi::MapWindowPoints,
   UI::Shell::{DefSubclassProc, SetWindowSubclass},
   UI::WindowsAndMessaging::{
-    GetParent, GetWindowRect, HWND_TOP, SW_HIDE, SW_SHOW, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE,
-    SWP_NOZORDER, SetParent, SetWindowPos, ShowWindow, WINDOWPOS, WM_WINDOWPOSCHANGING,
+    DestroyWindow, GetParent, GetWindowRect, HWND_TOP, SW_HIDE, SW_SHOW, SWP_NOACTIVATE,
+    SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SetParent, SetWindowPos, ShowWindow, WINDOWPOS,
+    WM_WINDOWPOSCHANGING,
   },
 };
 
@@ -71,6 +72,13 @@ impl AppWebview {
 
   pub(crate) fn apply_visible(&self, visible: bool) {
     let _ = unsafe { ShowWindow(self.hwnd(), if visible { SW_SHOW } else { SW_HIDE }) };
+  }
+
+  /// Destroys CEF's own window for this browser, completing a close that
+  /// `do_close` took over. CEF's browser window procedure reports
+  /// `WindowDestroyed` back to CEF on `WM_NCDESTROY`.
+  pub(crate) fn destroy_host_window(&self) {
+    let _ = unsafe { DestroyWindow(self.hwnd()) };
   }
 
   const PIN_Z_ORDER_SUBCLASS_ID: usize = 124;

--- a/crates/tauri-runtime-cef/src/platform/windows/window.rs
+++ b/crates/tauri-runtime-cef/src/platform/windows/window.rs
@@ -98,12 +98,18 @@ impl AppWindow {
     self.window.request_redraw();
   }
 
+  /// Paints the window's own background over everything its webviews do not
+  /// cover — the window is `WS_CLIPCHILDREN`, so live webviews clip themselves
+  /// out of this paint.
+  ///
+  /// This is the only thing that ever paints the window itself: winit registers
+  /// its window class without a background brush, and Windows leaves the pixels
+  /// a destroyed child window drew last sitting in the parent's client area. A
+  /// closed webview would otherwise keep showing its final frame — visible, and
+  /// backed by no window at all — for as long as the window lived. Destroying
+  /// the webview's window invalidates the area it covered, so painting on every
+  /// redraw is what clears it.
   pub(crate) fn draw_background_surface(&mut self) {
-    if !self.attrs.inner.transparent && self.attrs.background_color.is_none() {
-      self.background_surface = None;
-      return;
-    }
-
     let size = self.window.surface_size();
     let (Some(width), Some(height)) = (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
     else {
@@ -127,11 +133,13 @@ impl AppWindow {
       return;
     };
 
-    let color = self
-      .attrs
-      .background_color
-      .map(|Color(r, g, b, _)| (b as u32) | ((g as u32) << 8) | ((r as u32) << 16))
-      .unwrap_or(0);
+    let color = match self.attrs.background_color {
+      Some(Color(r, g, b, _)) => (b as u32) | ((g as u32) << 8) | ((r as u32) << 16),
+      // A transparent window paints nothing so the desktop shows through, while
+      // an ordinary one falls back to the opaque white a blank browser shows.
+      None if self.attrs.inner.transparent => 0,
+      None => 0x00ff_ffff,
+    };
 
     if surface.resize(width, height).is_ok()
       && let Ok(mut buffer) = surface.buffer_mut()

--- a/crates/tauri-runtime-cef/src/runtime.rs
+++ b/crates/tauri-runtime-cef/src/runtime.rs
@@ -309,6 +309,10 @@ pub(crate) type AfterWindowCreationCallback = Box<dyn for<'a> Fn(RawWindow<'a>) 
 pub(crate) enum Message<T: UserEvent> {
   EventLoop(EventLoopMessage),
   BrowserClosed(WindowId, u32),
+  /// CEF handed us the teardown of a webview's browser, keyed by the webview's
+  /// process-unique id. See `TauriCefChildLifeSpanHandler::do_close`.
+  #[cfg(any(target_os = "macos", windows))]
+  DestroyWebviewHostWindow(u32),
   Opened(Vec<url::Url>),
   #[cfg(target_os = "macos")]
   Reopen {
@@ -512,19 +516,55 @@ impl<T: UserEvent> WinitCefApp<T> {
         // window rather than trusting the message's window_id — otherwise a
         // reparented webview's scheme-handler entries would leak and its
         // AppWebview would linger in the target window forever.
-        let child = self.state.windows.values_mut().find_map(|appwindow| {
+        let closed = self.state.windows.iter_mut().find_map(|(id, appwindow)| {
           appwindow
             .children
             .iter()
             .position(|child| child.webview_id == webview_id)
-            .map(|index| appwindow.children.remove(index))
+            .map(|index| {
+              let child = appwindow.children.remove(index);
+              (*id, child, appwindow.children.is_empty())
+            })
         });
-        if let Some(child) = child {
+
+        let mut emptied_window = None;
+        if let Some((window_id, child, was_last)) = closed {
           self.remove_scheme_handler_entries(&child);
+          if was_last {
+            emptied_window = Some(window_id);
+          }
         }
 
         self.state.live_browsers = self.state.live_browsers.saturating_sub(1);
-        self.exit_if_done(event_loop);
+
+        // A window that just lost its last webview has nothing left to show, so
+        // it follows the webview out through the regular close path — listeners
+        // still get `CloseRequested` and can keep the empty window around.
+        // `close_window` runs the exit check itself.
+        if let Some(window_id) = emptied_window {
+          self.request_window_close(window_id, event_loop);
+        } else {
+          self.exit_if_done(event_loop);
+        }
+      }
+      #[cfg(any(target_os = "macos", windows))]
+      Message::DestroyWebviewHostWindow(webview_id) => {
+        // Destroying the browser's own child view/window is what completes the
+        // close CEF handed over in `do_close`; CEF acknowledges it with
+        // `BrowserClosed`, which is where the bookkeeping is dropped. Same
+        // reasoning as there for searching every window by webview id.
+        //
+        // A webview that is already gone from state means its window is being
+        // torn down, and that teardown destroys the child view anyway.
+        if let Some(child) = self
+          .state
+          .windows
+          .values()
+          .flat_map(|appwindow| appwindow.children.iter())
+          .find(|child| child.webview_id == webview_id)
+        {
+          child.destroy_host_window();
+        }
       }
       Message::CreateWindow {
         window_id,

--- a/crates/tauri-runtime-cef/src/window.rs
+++ b/crates/tauri-runtime-cef/src/window.rs
@@ -467,9 +467,7 @@ impl<T: UserEvent> WinitCefApp<T> {
     }
 
     #[cfg(windows)]
-    if appwindow.attrs.inner.transparent || appwindow.attrs.background_color.is_some() {
-      appwindow.draw_background_surface();
-    }
+    appwindow.draw_background_surface();
 
     #[cfg(not(windows))]
     if appwindow.attrs.background_color.is_some() {

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -79,9 +79,10 @@ tracing = { version = "0.1", optional = true }
 heck = "0.5"
 log = "0.4.21"
 dunce = "1"
-specta = { version = "^2.0.0-rc.16", optional = true, default-features = false, features = [
+specta = { version = "^2.0.0-rc.25", optional = true, default-features = false, features = [
   "function",
   "derive",
+  "std",
 ] }
 # WARNING: cookie::Cookie is re-exported so bumping this is a breaking change, documented to be done as a minor bump
 cookie = "0.18"

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -1139,34 +1139,34 @@ pub mod test;
 
 #[cfg(feature = "specta")]
 const _: () = {
-  use specta::{TypeMap, datatype::DataType, function::FunctionArg};
+  use specta::{Types, datatype::DataType, function::FunctionArg};
 
   impl<T: Send + Sync + 'static> FunctionArg for crate::State<'_, T> {
-    fn to_datatype(_: &mut TypeMap) -> Option<DataType> {
+    fn to_datatype(_: &mut Types) -> Option<DataType> {
       None
     }
   }
 
   impl<R: crate::Runtime> FunctionArg for crate::AppHandle<R> {
-    fn to_datatype(_: &mut TypeMap) -> Option<DataType> {
+    fn to_datatype(_: &mut Types) -> Option<DataType> {
       None
     }
   }
 
   impl<R: crate::Runtime> FunctionArg for crate::Window<R> {
-    fn to_datatype(_: &mut TypeMap) -> Option<DataType> {
+    fn to_datatype(_: &mut Types) -> Option<DataType> {
       None
     }
   }
 
   impl<R: crate::Runtime> FunctionArg for crate::Webview<R> {
-    fn to_datatype(_: &mut TypeMap) -> Option<DataType> {
+    fn to_datatype(_: &mut Types) -> Option<DataType> {
       None
     }
   }
 
   impl<R: crate::Runtime> FunctionArg for crate::WebviewWindow<R> {
-    fn to_datatype(_: &mut TypeMap) -> Option<DataType> {
+    fn to_datatype(_: &mut Types) -> Option<DataType> {
       None
     }
   }

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -811,6 +811,8 @@ mod test {
       PluginStore::default(),
       Box::new(|_| false),
       None,
+      #[cfg(any(target_os = "macos", target_os = "ios"))]
+      None,
       Default::default(),
       StateManager::new(),
       Default::default(),

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -501,7 +501,7 @@ impl<R: Runtime> WebviewManager<R> {
       let html = String::from_utf8_lossy(&body).into_owned();
       // naive way to check if it's an html
       if html.contains('<') && html.contains('>') {
-        let document = tauri_utils::html2::parse(html);
+        let document = tauri_utils::html2::parse_doc(html);
         tauri_utils::html2::inject_csp(&document, &csp.to_string());
         url.set_path(&format!("{},{document}", mime::TEXT_HTML));
       }

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -503,7 +503,11 @@ impl<R: Runtime> WebviewManager<R> {
       if html.contains('<') && html.contains('>') {
         let document = tauri_utils::html2::parse_doc(html);
         tauri_utils::html2::inject_csp(&document, &csp.to_string());
-        url.set_path(&format!("{},{document}", mime::TEXT_HTML));
+        url.set_path(&format!(
+          "{},{}",
+          mime::TEXT_HTML,
+          String::from_utf8_lossy(&tauri_utils::html2::serialize_doc(&document))
+        ));
       }
     }
 


### PR DESCRIPTION
only let the parent window be destroyed when ALL child webviews are closed