### PR TITLE
fix(acl): improve error handling for non-finite floats

### DIFF
--- a/.changes/acl-nonfinite-float-null-instead-of-panic.md
+++ b/.changes/acl-nonfinite-float-null-instead-of-panic.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": "patch:bug"
+---
+
+Improve error handling for non-finite floats (`NaN`, `±Infinity`) in ACL values. TOML config parsing now rejects these values early with a clear message, and the JSON conversion panics with a descriptive error instead of a bare `unwrap()` failure.

--- a/crates/tauri-utils/src/acl/value.rs
+++ b/crates/tauri-utils/src/acl/value.rs
@@ -66,7 +66,9 @@ impl From<Value> for serde_json::Value {
       Value::Null => serde_json::Value::Null,
       Value::Bool(b) => serde_json::Value::Bool(b),
       Value::Number(Number::Float(f)) => {
-        serde_json::Value::Number(serde_json::Number::from_f64(f).unwrap())
+        serde_json::Value::Number(
+          serde_json::Number::from_f64(f).expect("acl::Value contains non-finite float (NaN or Infinity) which is not representable in JSON"),
+        )
       }
       Value::Number(Number::Int(i)) => serde_json::Value::Number(i.into()),
       Value::String(s) => serde_json::Value::String(s),
@@ -136,7 +138,13 @@ impl From<toml::Value> for Value {
     match value {
       Toml::String(s) => s.into(),
       Toml::Integer(i) => i.into(),
-      Toml::Float(f) => f.into(),
+      Toml::Float(f) => {
+        assert!(
+          f.is_finite(),
+          "TOML config contains non-finite float value ({f}) which is not supported in ACL values"
+        );
+        f.into()
+      }
       Toml::Boolean(b) => b.into(),
       Toml::Datetime(d) => d.to_string().into(),
       Toml::Array(a) => Value::List(a.into_iter().map(Value::from).collect()),


### PR DESCRIPTION
Fixes #15477. `acl::Value` to `serde_json::Value` was calling `.unwrap()` on `from_f64()` which gives a bare panic for NaN and ±Infinity. This adds an early reject at the TOML entry point with a clear assert message, and a descriptive expect message on the JSON conversion so the panic is understandable. Previous attempt in #15482 mapped these to null but that was closed because silently dropping values can mask bugs.