### PR TITLE
feat(cli): warn when productName is left as the default (fix #14968)

### DIFF
--- a/.changes/default-product-name-warning.md
+++ b/.changes/default-product-name-warning.md
@@ -1,6 +1,7 @@
 ---
 "tauri-cli": patch:enhance
+"@tauri-apps/cli": patch:enhance
 "tauri-utils": patch:enhance
 ---
 
-`tauri build` now warns when `productName` is still set to the default `tauri-app`, since it is used to derive the default Windows installer (WiX) upgrade code, which must be unique across applications. The config documentation for `productName` and `identifier` was updated accordingly.
+`tauri build` now warns when `productName` is still set to the default `tauri-app`, since it names the generated bundles and is written into install paths and metadata that are expected to be unique to your application. The config documentation for `productName` now lists what the field controls on each platform, and `identifier`'s documentation notes that the default value is rejected.

--- a/.changes/default-product-name-warning.md
+++ b/.changes/default-product-name-warning.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:enhance
+"tauri-utils": patch:enhance
+---
+
+`tauri build` now warns when `productName` is still set to the default `tauri-app`, since it is used to derive the default Windows installer (WiX) upgrade code, which must be unique across applications. The config documentation for `productName` and `identifier` was updated accordingly.

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -16,7 +16,7 @@
       ]
     },
     "productName": {
-      "description": "App name.\n\n Make sure to change this from the default `tauri-app` before publishing your app.\n On Windows it is used to derive the default WiX installer upgrade code,\n which must be unique across applications and can be set explicitly with the\n [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code) setting.",
+      "description": "App name.\n\n This is the name your app is known by on the user's system, so it must be changed from the\n default before publishing. Besides naming the generated bundles, it is written into platform\n metadata and install paths that are expected to be unique to your application.\n\n ## Platform-specific\n\n - **macOS**: Names the `.app` bundle and the `.dmg`, and sets the bundle's\n    `CFBundleDisplayName` and `CFBundleName` properties. `CFBundleName` can be overridden with\n    [`bundle > macOS > bundleName`](MacConfig::bundle_name).\n - **Linux**: Kebab-cased for the Debian and RPM package names, used as the `Name` entry of\n    the desktop file and as the resource directory name under `/usr/lib`.\n - **Windows**: Names the installers, the installation directory, the Start Menu folder and\n    the `HKCU\\Software\\<publisher>\\<product name>` registry key. It also derives the default\n    WiX upgrade code, which must be unique across applications and can be set explicitly with\n    [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code).",
       "type": [
         "string",
         "null"

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -16,7 +16,7 @@
       ]
     },
     "productName": {
-      "description": "App name.",
+      "description": "App name.\n\n Make sure to change this from the default `tauri-app` before publishing your app.\n On Windows it is used to derive the default WiX installer upgrade code,\n which must be unique across applications and can be set explicitly with the\n [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code) setting.",
       "type": [
         "string",
         "null"
@@ -38,7 +38,7 @@
       ]
     },
     "identifier": {
-      "description": "The application identifier in reverse domain name notation (e.g. `com.tauri.example`).\n This string must be unique across applications since it is used in system configurations like\n the bundle ID and path to the webview data directory.\n This string must contain only alphanumeric characters (A-Z, a-z, and 0-9), hyphens (-),\n and periods (.).",
+      "description": "The application identifier in reverse domain name notation (e.g. `com.tauri.example`).\n This string must be unique across applications since it is used in system configurations like\n the bundle ID and path to the webview data directory.\n This string must contain only alphanumeric characters (A-Z, a-z, and 0-9), hyphens (-),\n and periods (.).\n The default value `com.tauri.dev` is rejected by `tauri build` and must be changed before\n building your application.",
       "type": "string"
     },
     "app": {

--- a/crates/tauri-cli/src/build.rs
+++ b/crates/tauri-cli/src/build.rs
@@ -193,6 +193,12 @@ pub fn setup(
     );
   }
 
+  if config.product_name.as_deref() == Some("tauri-app") {
+    log::warn!(
+      "The `productName` is still set to the default value `tauri-app`. You should change it before publishing your app since it is used to derive the default Windows installer (WiX) upgrade code, which must be unique across applications."
+    );
+  }
+
   if let Some(before_build) = config.build.before_build_command.clone() {
     helpers::run_hook(
       "beforeBuildCommand",

--- a/crates/tauri-cli/src/build.rs
+++ b/crates/tauri-cli/src/build.rs
@@ -195,7 +195,7 @@ pub fn setup(
 
   if config.product_name.as_deref() == Some("tauri-app") {
     log::warn!(
-      "The `productName` is still set to the default value `tauri-app`. You should change it before publishing your app since it is used to derive the default Windows installer (WiX) upgrade code, which must be unique across applications."
+      "The `productName` is still set to the default value `tauri-app`. You should change it before publishing your app since it names the generated bundles and is written into install paths and platform metadata that are expected to be unique to your application, like the Windows installer upgrade code."
     );
   }
 

--- a/crates/tauri-cli/src/build.rs
+++ b/crates/tauri-cli/src/build.rs
@@ -195,7 +195,7 @@ pub fn setup(
 
   if config.product_name.as_deref() == Some("tauri-app") {
     log::warn!(
-      "The `productName` is still set to the default value `tauri-app`. You should change it before publishing your app since it names the generated bundles and is written into install paths and platform metadata that are expected to be unique to your application, like the Windows installer upgrade code."
+      "The `productName` is still set to the default value `tauri-app`, it must be unique across applications since it is written into install paths and platform metadata that are expected to be unique to your application, like the Windows installer upgrade code."
     );
   }
 

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -16,7 +16,7 @@
       ]
     },
     "productName": {
-      "description": "App name.\n\n Make sure to change this from the default `tauri-app` before publishing your app.\n On Windows it is used to derive the default WiX installer upgrade code,\n which must be unique across applications and can be set explicitly with the\n [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code) setting.",
+      "description": "App name.\n\n This is the name your app is known by on the user's system, so it must be changed from the\n default before publishing. Besides naming the generated bundles, it is written into platform\n metadata and install paths that are expected to be unique to your application.\n\n ## Platform-specific\n\n - **macOS**: Names the `.app` bundle and the `.dmg`, and sets the bundle's\n    `CFBundleDisplayName` and `CFBundleName` properties. `CFBundleName` can be overridden with\n    [`bundle > macOS > bundleName`](MacConfig::bundle_name).\n - **Linux**: Kebab-cased for the Debian and RPM package names, used as the `Name` entry of\n    the desktop file and as the resource directory name under `/usr/lib`.\n - **Windows**: Names the installers, the installation directory, the Start Menu folder and\n    the `HKCU\\Software\\<publisher>\\<product name>` registry key. It also derives the default\n    WiX upgrade code, which must be unique across applications and can be set explicitly with\n    [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code).",
       "type": [
         "string",
         "null"

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -16,7 +16,7 @@
       ]
     },
     "productName": {
-      "description": "App name.",
+      "description": "App name.\n\n Make sure to change this from the default `tauri-app` before publishing your app.\n On Windows it is used to derive the default WiX installer upgrade code,\n which must be unique across applications and can be set explicitly with the\n [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code) setting.",
       "type": [
         "string",
         "null"
@@ -38,7 +38,7 @@
       ]
     },
     "identifier": {
-      "description": "The application identifier in reverse domain name notation (e.g. `com.tauri.example`).\n This string must be unique across applications since it is used in system configurations like\n the bundle ID and path to the webview data directory.\n This string must contain only alphanumeric characters (A-Z, a-z, and 0-9), hyphens (-),\n and periods (.).",
+      "description": "The application identifier in reverse domain name notation (e.g. `com.tauri.example`).\n This string must be unique across applications since it is used in system configurations like\n the bundle ID and path to the webview data directory.\n This string must contain only alphanumeric characters (A-Z, a-z, and 0-9), hyphens (-),\n and periods (.).\n The default value `com.tauri.dev` is rejected by `tauri build` and must be changed before\n building your application.",
       "type": "string"
     },
     "app": {

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -3745,10 +3745,21 @@ pub struct Config {
   pub schema: Option<String>,
   /// App name.
   ///
-  /// Make sure to change this from the default `tauri-app` before publishing your app.
-  /// On Windows it is used to derive the default WiX installer upgrade code,
-  /// which must be unique across applications and can be set explicitly with the
-  /// [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code) setting.
+  /// This is the name your app is known by on the user's system, so it must be changed from the
+  /// default before publishing. Besides naming the generated bundles, it is written into platform
+  /// metadata and install paths that are expected to be unique to your application.
+  ///
+  /// ## Platform-specific
+  ///
+  /// - **macOS**: Names the `.app` bundle and the `.dmg`, and sets the bundle's
+  ///    `CFBundleDisplayName` and `CFBundleName` properties. `CFBundleName` can be overridden with
+  ///    [`bundle > macOS > bundleName`](MacConfig::bundle_name).
+  /// - **Linux**: Kebab-cased for the Debian and RPM package names, used as the `Name` entry of
+  ///    the desktop file and as the resource directory name under `/usr/lib`.
+  /// - **Windows**: Names the installers, the installation directory, the Start Menu folder and
+  ///    the `HKCU\Software\<publisher>\<product name>` registry key. It also derives the default
+  ///    WiX upgrade code, which must be unique across applications and can be set explicitly with
+  ///    [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code).
   #[serde(alias = "product-name")]
   #[cfg_attr(feature = "schema", validate(regex(pattern = "^[^/\\:*?\"<>|]+$")))]
   pub product_name: Option<String>,

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -3744,6 +3744,11 @@ pub struct Config {
   #[serde(rename = "$schema")]
   pub schema: Option<String>,
   /// App name.
+  ///
+  /// Make sure to change this from the default `tauri-app` before publishing your app.
+  /// On Windows it is used to derive the default WiX installer upgrade code,
+  /// which must be unique across applications and can be set explicitly with the
+  /// [`bundle > windows > wix > upgradeCode`](WixConfig::upgrade_code) setting.
   #[serde(alias = "product-name")]
   #[cfg_attr(feature = "schema", validate(regex(pattern = "^[^/\\:*?\"<>|]+$")))]
   pub product_name: Option<String>,
@@ -3784,6 +3789,8 @@ pub struct Config {
   /// the bundle ID and path to the webview data directory.
   /// This string must contain only alphanumeric characters (A-Z, a-z, and 0-9), hyphens (-),
   /// and periods (.).
+  /// The default value `com.tauri.dev` is rejected by `tauri build` and must be changed before
+  /// building your application.
   pub identifier: String,
   /// The App configuration.
   #[serde(default)]


### PR DESCRIPTION
Adds a warning to `tauri build` when `productName` is still the default `tauri-app`. Apps published with the default name all derive the same WiX upgrade code, which is how the winget collision in the issue happens. The check sits next to the existing identifier checks in `setup()`, so it also covers `tauri android build` and `tauri ios build`, and stays quiet on `tauri dev`. The `productName` and `identifier` config docs now say what has to change before publishing, and the generated schemas were rebuilt. The upgrade code derivation itself is untouched since changing it would break updates for already shipped apps.

Output with the default name:

```
Warn The `productName` is still set to the default value `tauri-app`. You should change it before publishing your app since it is used to derive the default Windows installer (WiX) upgrade code, which must be unique across applications.
```

Closes #14968
