### PR TITLE
fix(core): dispatch menu commands asynchronously to avoid main-thread deadlock

### DIFF
--- a/.changes/fix-menu-command-deadlock.md
+++ b/.changes/fix-menu-command-deadlock.md
@@ -1,0 +1,5 @@
+---
+"tauri": patch:bug
+---
+
+Fixed a potential deadlock where synchronous menu commands (e.g. `Menu.new()`) held the plugin store lock while blocking on a main-thread hop, while the main thread itself needed that same lock to process a queued event. The affected `menu` plugin commands are now dispatched asynchronously so the lock is released before they hop to the main thread.

--- a/crates/tauri/src/menu/plugin.rs
+++ b/crates/tauri/src/menu/plugin.rs
@@ -358,7 +358,7 @@ struct NewOptions {
 }
 
 #[command(root = "crate")]
-fn new<R: Runtime>(
+async fn new<R: Runtime>(
   webview: Webview<R>,
   kind: ItemKind,
   options: Option<NewOptions>,
@@ -466,7 +466,7 @@ fn new<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn append<R: Runtime>(
+async fn append<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -493,7 +493,7 @@ fn append<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn prepend<R: Runtime>(
+async fn prepend<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -520,7 +520,7 @@ fn prepend<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn insert<R: Runtime>(
+async fn insert<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -550,7 +550,7 @@ fn insert<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn remove<R: Runtime>(
+async fn remove<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -589,7 +589,7 @@ macro_rules! make_item_resource {
 }
 
 #[command(root = "crate")]
-fn remove_at<R: Runtime>(
+async fn remove_at<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -616,7 +616,7 @@ fn remove_at<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn items<R: Runtime>(
+async fn items<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -637,7 +637,7 @@ fn items<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn get<R: Runtime>(
+async fn get<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -695,7 +695,7 @@ async fn popup<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn create_default<R: Runtime>(
+async fn create_default<R: Runtime>(
   app: AppHandle<R>,
   webview: Webview<R>,
 ) -> crate::Result<(ResourceId, MenuId)> {
@@ -745,13 +745,17 @@ async fn set_as_window_menu<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn text<R: Runtime>(webview: Webview<R>, rid: ResourceId, kind: ItemKind) -> crate::Result<String> {
+async fn text<R: Runtime>(
+  webview: Webview<R>,
+  rid: ResourceId,
+  kind: ItemKind,
+) -> crate::Result<String> {
   let resources_table = webview.resources_table();
   do_menu_item!(resources_table, rid, kind, |i| i.text())
 }
 
 #[command(root = "crate")]
-fn set_text<R: Runtime>(
+async fn set_text<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -762,7 +766,7 @@ fn set_text<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn is_enabled<R: Runtime>(
+async fn is_enabled<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -772,7 +776,7 @@ fn is_enabled<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn set_enabled<R: Runtime>(
+async fn set_enabled<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -789,7 +793,7 @@ fn set_enabled<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn set_accelerator<R: Runtime>(
+async fn set_accelerator<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,
@@ -806,7 +810,7 @@ fn set_accelerator<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn set_as_windows_menu_for_nsapp<R: Runtime>(
+async fn set_as_windows_menu_for_nsapp<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
 ) -> crate::Result<()> {
@@ -823,7 +827,7 @@ fn set_as_windows_menu_for_nsapp<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn set_as_help_menu_for_nsapp<R: Runtime>(
+async fn set_as_help_menu_for_nsapp<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
 ) -> crate::Result<()> {
@@ -841,14 +845,14 @@ fn set_as_help_menu_for_nsapp<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn is_checked<R: Runtime>(webview: Webview<R>, rid: ResourceId) -> crate::Result<bool> {
+async fn is_checked<R: Runtime>(webview: Webview<R>, rid: ResourceId) -> crate::Result<bool> {
   let resources_table = webview.resources_table();
   let check_item = resources_table.get::<CheckMenuItem<R>>(rid)?;
   check_item.is_checked()
 }
 
 #[command(root = "crate")]
-fn set_checked<R: Runtime>(
+async fn set_checked<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   checked: bool,
@@ -859,7 +863,7 @@ fn set_checked<R: Runtime>(
 }
 
 #[command(root = "crate")]
-fn set_icon<R: Runtime>(
+async fn set_icon<R: Runtime>(
   webview: Webview<R>,
   rid: ResourceId,
   kind: ItemKind,


### PR DESCRIPTION
## Summary

Fixes #15888.

`AppManager::extend_api` holds the `Mutex<PluginStore>` lock for the entire synchronous dispatch of a command. Every `menu` plugin command (aside from `popup`, `set_as_app_menu`, `set_as_window_menu`, which were already `async`) hops to the main thread via `run_main_thread!`/`run_item_main_thread!` and blocks on a channel `recv()` while still holding that lock.

If a background thread dispatches a menu command while holding the plugin store lock, and the main thread later needs that same lock to process a queued window/run event before it drains the queued main-thread closure, both sides wait on each other forever — the exact lock cycle described in the issue.

Making these commands `async` moves execution onto `crate::async_runtime::spawn`. This releases the plugin store lock as soon as the command is spawned, *before* it reaches the main-thread hop, which breaks the deadlock cycle. This is transparent to the JS API since `invoke()` already returns a promise regardless of whether the Rust command is sync or async.

I reproduced the underlying lock-ordering issue with a minimal standalone harness that mirrors the real `PluginStore`/`run_main_thread!`/`on_event` call pattern 1:1 — the blocking-dispatch version reliably hangs, and the async-dispatch version completes cleanly.

## Test plan

- [x] `cargo check -p tauri --features wry`
- [x] `cargo clippy -p tauri --features wry` — no new warnings
- [x] Minimal repro harness confirming the lock-ordering deadlock with blocking dispatch, and that it's resolved with async dispatch
- [ ] Manual verification on macOS with `tauri-runtime-cef` (not available in this environment)