### PR TITLE
fix(runtime-wry): clamp window size dimensions to i32::MAX

### DIFF
--- a/.changes/clamp-window-size-dimensions.md
+++ b/.changes/clamp-window-size-dimensions.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": "patch:bug"
+---
+
+Fixed the app crashing with a non-unwinding panic during window creation when `width`, `height`, `minWidth`, `minHeight`, `maxWidth` or `maxHeight` was set to a value greater than `i32::MAX` (e.g. on macOS this surfaced as an `NSWindow` frame assertion). These dimensions are now clamped to `i32::MAX` instead of being passed through unchecked.

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -730,6 +730,13 @@ impl From<ProgressBarState> for ProgressBarStateWrapper {
   }
 }
 
+// Values beyond `i32::MAX` have been observed to crash native window creation
+// (e.g. an AppKit `NSWindow` frame assertion on macOS), so clamp instead of
+// passing them through unchecked. See https://github.com/tauri-apps/tauri/issues/15648
+fn clamp_window_dimension(value: f64) -> f64 {
+  value.min(i32::MAX as f64)
+}
+
 #[derive(Clone, Default)]
 pub struct WindowBuilderWrapper {
   inner: TaoWindowBuilder,
@@ -880,16 +887,20 @@ impl WindowBuilder for WindowBuilderWrapper {
     let mut constraints = WindowSizeConstraints::default();
 
     if let Some(min_width) = config.min_width {
-      constraints.min_width = Some(tao::dpi::LogicalUnit::new(min_width).into());
+      constraints.min_width =
+        Some(tao::dpi::LogicalUnit::new(clamp_window_dimension(min_width)).into());
     }
     if let Some(min_height) = config.min_height {
-      constraints.min_height = Some(tao::dpi::LogicalUnit::new(min_height).into());
+      constraints.min_height =
+        Some(tao::dpi::LogicalUnit::new(clamp_window_dimension(min_height)).into());
     }
     if let Some(max_width) = config.max_width {
-      constraints.max_width = Some(tao::dpi::LogicalUnit::new(max_width).into());
+      constraints.max_width =
+        Some(tao::dpi::LogicalUnit::new(clamp_window_dimension(max_width)).into());
     }
     if let Some(max_height) = config.max_height {
-      constraints.max_height = Some(tao::dpi::LogicalUnit::new(max_height).into());
+      constraints.max_height =
+        Some(tao::dpi::LogicalUnit::new(clamp_window_dimension(max_height)).into());
     }
     if let Some(color) = config.background_color {
       window = window.background_color(color);
@@ -932,21 +943,26 @@ impl WindowBuilder for WindowBuilderWrapper {
   }
 
   fn inner_size(mut self, width: f64, height: f64) -> Self {
-    self.inner = self.inner.with_inner_size(LogicalSize::new(width, height));
+    self.inner = self.inner.with_inner_size(LogicalSize::new(
+      clamp_window_dimension(width),
+      clamp_window_dimension(height),
+    ));
     self
   }
 
   fn min_inner_size(mut self, min_width: f64, min_height: f64) -> Self {
-    self.inner = self
-      .inner
-      .with_min_inner_size(LogicalSize::new(min_width, min_height));
+    self.inner = self.inner.with_min_inner_size(LogicalSize::new(
+      clamp_window_dimension(min_width),
+      clamp_window_dimension(min_height),
+    ));
     self
   }
 
   fn max_inner_size(mut self, max_width: f64, max_height: f64) -> Self {
-    self.inner = self
-      .inner
-      .with_max_inner_size(LogicalSize::new(max_width, max_height));
+    self.inner = self.inner.with_max_inner_size(LogicalSize::new(
+      clamp_window_dimension(max_width),
+      clamp_window_dimension(max_height),
+    ));
     self
   }
 


### PR DESCRIPTION
## Summary

Fixes #15648.

Setting a window's `width`/`height` (or `minWidth`/`minHeight`/`maxWidth`/`maxHeight`) above `i32::MAX` (e.g. `2147483648`) in `tauri.conf.json` crashes the whole app on startup instead of failing gracefully.

I reproduced this locally on macOS using the `helloworld` example with `width` set to `2147483648`. The failure is a non-unwinding panic:

```
thread 'main' panicked at core/src/panicking.rs:225:5:
panic in a function that cannot unwind
thread caused non-unwinding panic. aborting.
```

Running under `lldb`, the console shows the actual native failure right before the abort:

```
*** Assertion failure in void _NSWindowSetFrameIvar(NSWindow *, NSRect)(), NSWindow.m:1070
```

So the oversized width reaches AppKit's `NSWindow` frame validation and fails there, and because this all happens inside the `applicationDidFinishLaunching:` → `tao::...::did_finish_launching` callback boundary, the resulting panic can't unwind across the FFI boundary and Rust aborts the process (which is also why the compiler discards the real panic message and reports the generic "cannot unwind" text instead of the original panic).

Nothing in `tauri-runtime-wry` clamps or validates these dimensions before handing them to tao/AppKit — an out-of-range config value goes straight through unchecked.

## Fix

Clamp `width`/`height` and the min/max size constraints to `i32::MAX` in `WindowBuilderWrapper` (`crates/tauri-runtime-wry/src/lib.rs`) before they're handed to tao, in both the `inner_size`/`min_inner_size`/`max_inner_size` builder methods and the `with_config` constraints setup. This covers both the `tauri.conf.json` path and direct use of the Rust builder APIs.

## Test plan

- [x] Reproduced the crash with the `helloworld` example (`width: 2147483648`) before the fix
- [x] Confirmed the same config no longer crashes after the fix (window creates successfully)
- [x] `cargo check -p tauri-runtime-wry`
- [x] `cargo clippy -p tauri-runtime-wry` — no new warnings