### PR TITLE
fix(runtime-wry): report window focus from the foreground window on Windows (fix #15903)

### DIFF
--- a/.changes/windows-is-focused-webview.md
+++ b/.changes/windows-is-focused-webview.md
@@ -1,0 +1,6 @@
+---
+"tauri": patch:bug
+"tauri-runtime-wry": patch:bug
+---
+
+Fix `Window::is_focused` always returning `false` on Windows when the window hosts a webview, which also made `Manager::get_focused_window` return `None`.

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -3348,7 +3348,7 @@ fn handle_user_message<T: UserEvent>(
           WindowMessage::IsFullscreen(tx) => tx.send(window.fullscreen().is_some()).unwrap(),
           WindowMessage::IsMinimized(tx) => tx.send(window.is_minimized()).unwrap(),
           WindowMessage::IsMaximized(tx) => tx.send(window.is_maximized()).unwrap(),
-          WindowMessage::IsFocused(tx) => tx.send(window.is_focused()).unwrap(),
+          WindowMessage::IsFocused(tx) => tx.send(is_focused(&window)).unwrap(),
           WindowMessage::IsDecorated(tx) => tx.send(window.is_decorated()).unwrap(),
           WindowMessage::IsResizable(tx) => tx.send(window.is_resizable()).unwrap(),
           WindowMessage::IsMaximizable(tx) => tx.send(window.is_maximizable()).unwrap(),
@@ -5322,6 +5322,18 @@ fn inner_size(
   has_children: bool,
 ) -> PhysicalSize<u32> {
   window.inner_size()
+}
+
+#[cfg(windows)]
+fn is_focused(window: &Window) -> bool {
+  use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+  // the webview child window owns the keyboard focus, so the window itself never reports it
+  HWND(window.hwnd() as _) == unsafe { GetForegroundWindow() }
+}
+
+#[cfg(not(windows))]
+fn is_focused(window: &Window) -> bool {
+  window.is_focused()
 }
 
 fn to_tao_theme(theme: Option<Theme>) -> Option<TaoTheme> {


### PR DESCRIPTION
On Windows the webview is a child window and it owns the keyboard focus, so tao's `Window::is_focused` answers `false` for every window that hosts one. That is why `Manager::get_focused_window` never finds a window, and why filtering `windows()` by `is_focused()` gives useless answers too.

The runtime now compares the window against `GetForegroundWindow`, which names exactly one top level window at a time no matter which child holds the focus.

Closes #15903
