### PR TITLE
ci: upgrade setup-java to v6

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -43,7 +43,7 @@ jobs:
           node-version: lts/*
           cache: 'pnpm'
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25


### PR DESCRIPTION
Upgrades the Android test workflow from `actions/setup-java@v5` to `actions/setup-java@v6`.

The workflow diff was reviewed and all active `setup-java` references were checked. No runtime tests were needed for this workflow-only change.
