### PR TITLE
fix(tauri-build): emit absolute capabilities rerun-if-changed path

### DIFF
--- a/.changes/fix-capabilities-rerun-absolute-path.md
+++ b/.changes/fix-capabilities-rerun-absolute-path.md
@@ -1,0 +1,5 @@
+---
+'tauri-build': 'patch:bug'
+---
+
+Emit an absolute path for the capabilities directory `cargo:rerun-if-changed`. Cargo resolves a relative watch path against the package owning the build script, while the capabilities glob is resolved against the process working directory, so callers that change the current directory before `try_build`/`try_build_context` ended up watching a non-existent directory — which is always dirty and re-ran the build script (and recompiled everything downstream) on every build.

--- a/crates/tauri-build/src/acl.rs
+++ b/crates/tauri-build/src/acl.rs
@@ -424,7 +424,19 @@ pub fn build(out_dir: &Path, target: Target, attributes: &Attributes) -> super::
   let capabilities = if let Some(pattern) = attributes.capabilities_path_pattern {
     tauri_utils::acl::build::parse_capabilities(pattern)?
   } else {
-    println!("cargo:rerun-if-changed=capabilities");
+    // Emit an absolute watch path: cargo resolves a relative
+    // `rerun-if-changed` against the package that owns the build script, while
+    // the glob below is resolved against the process working directory.
+    // Callers that `set_current_dir` before `try_build[_context]` (for example
+    // a crate generating a context byte-identical to the app's) would
+    // otherwise watch a `<caller-manifest-dir>/capabilities` that usually does
+    // not exist — and a missing watched path is dirty on every fingerprint
+    // check, re-running the build script and recompiling the whole downstream
+    // chain on every build.
+    let capabilities_dir = std::env::current_dir()
+      .context("resolve current dir for capabilities watch path")?
+      .join("capabilities");
+    println!("cargo:rerun-if-changed={}", capabilities_dir.display());
     tauri_utils::acl::build::parse_capabilities("./capabilities/**/*")?
   };
   validate_capabilities(&acl_manifests, &capabilities)?;


### PR DESCRIPTION
## Summary

`tauri-build` emits a relative `cargo:rerun-if-changed=capabilities` in the default capabilities branch of `acl::build`. Cargo resolves a relative watch path against the **package that owns the build script**, while the glob right below it (`./capabilities/**/*`) is resolved against the **process working directory**.

Those two are the same directory for a normal app crate, so the bug is invisible there. But any caller that `set_current_dir`s before `try_build`/`try_build_context` — for example a separate crate that generates a context byte-identical to the app's, or a workspace layout where the build script runs from a different directory — ends up watching `<caller-manifest-dir>/capabilities`, which usually does not exist.

A missing watched path is **dirty on every fingerprint check**. The build script then re-runs on every build, which recompiles the crate and everything downstream of it. Measured in a 1.9k-unit workspace app: a zero-change `cargo build` took **~140s**; with the watched directory present it takes **~1s**.

## Fix

Anchor the emitted watch path to the same base the glob already uses (`std::env::current_dir()`), so the watch and the parse can never disagree about which `capabilities/` they mean.

## Testing

- `rustfmt --check` on the modified file: clean.
- Behavior verified downstream: pointing the consumer crate at a patched tauri-build eliminates the spurious re-run (the consumer-side workaround is a committed empty `capabilities/` dir with an explanatory marker, which this PR makes removable).