### PR TITLE
docs(github): fix relative link in `.github/CONTRIBUTING.md`.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Tauri Contributing Guide
 
-Hi! We, the maintainers, are really excited that you are interested in contributing to Tauri. Before submitting your contribution though, please make sure to take a moment and read through the [Code of Conduct](CODE_OF_CONDUCT.md), as well as the appropriate section for the contribution you intend to make:
+Hi! We, the maintainers, are really excited that you are interested in contributing to Tauri. Before submitting your contribution though, please make sure to take a moment and read through the [Code of Conduct](/.github/CODE_OF_CONDUCT.md), as well as the appropriate section for the contribution you intend to make:
 
 - [Issue Reporting Guidelines](#issue-reporting-guidelines)
 - [Pull Request Guidelines](#pull-request-guidelines)
@@ -64,7 +64,7 @@ pnpm build
 
 ### Overview
 
-See [Architecture](../ARCHITECTURE.md#major-components) for an overview of the packages in this repository.
+See [Architecture](/ARCHITECTURE.md#major-components) for an overview of the packages in this repository.
 
 ### Developing Tauri Core and Related Components (Rust API, Macros, Codegen, and Utils)
 


### PR DESCRIPTION
Change the link to the "CODE OF CONDUCT" and "Architecture" document to use an absolute repository path.

GitHub's Contributing overview tab incorrectly resolves relative links. Updating the path ensures the link to the commit convention works correctly both in the standard repository file view and on the Contributing overview tab.

Reference: https://github.com/orgs/community/discussions/200300