### PR TITLE
fix(path): return "." from path.normalize("")

### DIFF
--- a/.changes/path-normalize-empty.md
+++ b/.changes/path-normalize-empty.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+Fix `path.normalize("")` returning an empty string instead of `"."`, matching Node.js and the existing `path.join("")` behavior.

--- a/crates/tauri/src/path/plugin.rs
+++ b/crates/tauri/src/path/plugin.rs
@@ -120,7 +120,7 @@ pub fn normalize(path: String) -> String {
   // and `"."` for `normalize("")` or `normalize(".")`
   if p.is_empty() && path == ".." {
     "..".into()
-  } else if p.is_empty() && path == "." {
+  } else if p.is_empty() && (path.is_empty() || path == ".") {
     ".".into()
   } else {
     // Add a trailing separator if the path passed to this functions had a trailing separator. That's how Node.js behaves.
@@ -309,5 +309,22 @@ mod tests {
     check(vec!["a", "/b", "c"], "a/b/c", r"a\b\c");
     check(vec!["a", "b/c", "d"], "a/b/c/d", r"a\b\c\d");
     check(vec!["a/", "b"], "a/b", r"a\b");
+  }
+
+  #[test]
+  fn normalize() {
+    fn check(path: &str, expected_unix: &str, expected_windows: &str) {
+      let expected = if cfg!(windows) {
+        expected_windows
+      } else {
+        expected_unix
+      };
+      assert_eq!(super::normalize(path.into()), expected);
+    }
+
+    // Same Node contract as `join(vec![""])` / the comment on `normalize`.
+    check("", ".", ".");
+    check(".", ".", ".");
+    check("..", "..", "..");
   }
 }

--- a/crates/tauri/src/path/plugin.rs
+++ b/crates/tauri/src/path/plugin.rs
@@ -313,18 +313,8 @@ mod tests {
 
   #[test]
   fn normalize() {
-    fn check(path: &str, expected_unix: &str, expected_windows: &str) {
-      let expected = if cfg!(windows) {
-        expected_windows
-      } else {
-        expected_unix
-      };
-      assert_eq!(super::normalize(path.into()), expected);
-    }
-
-    // Same Node contract as `join(vec![""])` / the comment on `normalize`.
-    check("", ".", ".");
-    check(".", ".", ".");
-    check("..", "..", "..");
+    assert_eq!(super::normalize("".into()), ".");
+    assert_eq!(super::normalize(".".into()), ".");
+    assert_eq!(super::normalize("..".into()), "..");
   }
 }


### PR DESCRIPTION
`path.normalize("")` returned an empty string.

The comment in `crates/tauri/src/path/plugin.rs` already states Node.js returns `"."` for `normalize("")` and `normalize(".")`. The same module's `join` already maps empty segments to `"."` (covered by `path::plugin::tests::join`).

This change uses that existing contract:

- `normalize("")` -> `"."`
- existing `normalize(".")` / `normalize("..")` behavior unchanged

Verify:

```
cargo test -p tauri --lib path::plugin::tests
```
