### PR TITLE
fix(tauri-utils): strip a leading UTF-8 BOM from the config file (fix #15922)

### DIFF
--- a/.changes/config-strip-utf8-bom.md
+++ b/.changes/config-strip-utf8-bom.md
@@ -2,4 +2,4 @@
 "tauri-utils": "patch:bug"
 ---
 
-Strip a leading UTF-8 BOM when reading the Tauri config file. `std::fs::read_to_string` keeps `U+FEFF`, and none of the JSON, JSON5 or TOML parsers accept it, so a BOM-prefixed config previously failed with an opaque `expected value at line 1 column 1` on a file that looks valid in an editor. This is easy to hit on Windows, where several common ways of writing the file (for instance PowerShell's `Set-Content -Encoding UTF8`) add a BOM.
+Fixed an issue that caused reading the Tauri config file to fail when it starts with a UTF-8 BOM sequence.

--- a/.changes/config-strip-utf8-bom.md
+++ b/.changes/config-strip-utf8-bom.md
@@ -1,0 +1,5 @@
+---
+"tauri-utils": "patch:bug"
+---
+
+Strip a leading UTF-8 BOM when reading the Tauri config file. `std::fs::read_to_string` keeps `U+FEFF`, and none of the JSON, JSON5 or TOML parsers accept it, so a BOM-prefixed config previously failed with an opaque `expected value at line 1 column 1` on a file that looks valid in an editor. This is easy to hit on Windows, where several common ways of writing the file (for instance PowerShell's `Set-Content -Encoding UTF8`) add a BOM.

--- a/crates/tauri-utils/src/config/parse.rs
+++ b/crates/tauri-utils/src/config/parse.rs
@@ -391,12 +391,7 @@ fn do_parse_toml<D: DeserializeOwned>(raw: &str, path: &Path) -> Result<D, Confi
 
 /// Helper function to wrap IO errors from [`std::fs::read_to_string`] into a [`ConfigError`].
 ///
-/// A leading UTF-8 BOM is stripped before the contents are handed to a parser.
-/// [`std::fs::read_to_string`] validates UTF-8 but keeps `U+FEFF` in the returned string, and
-/// none of the parsers used above accept it. Windows tooling writes BOM-prefixed files in
-/// several common cases (for instance PowerShell's `Set-Content -Encoding UTF8`), which would
-/// otherwise fail with an opaque `expected value at line 1 column 1` on a file that looks
-/// perfectly valid in an editor.
+/// A leading UTF-8 BOM is stripped before the contents are handed to the parser.
 fn read_to_string(path: &Path) -> Result<String, ConfigError> {
   let mut content = std::fs::read_to_string(path).map_err(|error| ConfigError::Io {
     path: path.into(),
@@ -414,40 +409,14 @@ fn read_to_string(path: &Path) -> Result<String, ConfigError> {
 mod tests {
   use super::*;
 
-  fn write_temp(name: &str, contents: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join("tauri-utils-parse-tests");
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join(name);
-    std::fs::write(&path, contents).unwrap();
-    path
-  }
-
   #[test]
   fn read_to_string_strips_a_leading_utf8_bom() {
-    let path = write_temp("with-bom.json", "\u{feff}{\"productName\":\"test\"}");
+    let path = std::env::temp_dir().join("tauri-utils-bom.json");
+    std::fs::write(&path, "\u{feff}{\"productName\":\"test\"}").unwrap();
 
     let raw = read_to_string(&path).unwrap();
 
-    assert!(
-      !raw.starts_with('\u{feff}'),
-      "the BOM must be stripped, otherwise every parser below rejects the file"
-    );
-    assert!(
-      do_parse_json::<serde_json::Value>(&raw, &path).is_ok(),
-      "a BOM-prefixed config must parse once the BOM is stripped"
-    );
-
-    std::fs::remove_file(&path).unwrap();
-  }
-
-  #[test]
-  fn read_to_string_leaves_a_file_without_a_bom_untouched() {
-    let contents = "{\"productName\":\"test\"}";
-    let path = write_temp("without-bom.json", contents);
-
-    let raw = read_to_string(&path).unwrap();
-
-    assert_eq!(raw, contents);
+    assert!(do_parse_json::<serde_json::Value>(&raw, &path).is_ok());
 
     std::fs::remove_file(&path).unwrap();
   }

--- a/crates/tauri-utils/src/config/parse.rs
+++ b/crates/tauri-utils/src/config/parse.rs
@@ -390,9 +390,65 @@ fn do_parse_toml<D: DeserializeOwned>(raw: &str, path: &Path) -> Result<D, Confi
 }
 
 /// Helper function to wrap IO errors from [`std::fs::read_to_string`] into a [`ConfigError`].
+///
+/// A leading UTF-8 BOM is stripped before the contents are handed to a parser.
+/// [`std::fs::read_to_string`] validates UTF-8 but keeps `U+FEFF` in the returned string, and
+/// none of the parsers used above accept it. Windows tooling writes BOM-prefixed files in
+/// several common cases (for instance PowerShell's `Set-Content -Encoding UTF8`), which would
+/// otherwise fail with an opaque `expected value at line 1 column 1` on a file that looks
+/// perfectly valid in an editor.
 fn read_to_string(path: &Path) -> Result<String, ConfigError> {
-  std::fs::read_to_string(path).map_err(|error| ConfigError::Io {
+  let mut content = std::fs::read_to_string(path).map_err(|error| ConfigError::Io {
     path: path.into(),
     error,
-  })
+  })?;
+
+  if content.starts_with('\u{feff}') {
+    content.remove(0);
+  }
+
+  Ok(content)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn write_temp(name: &str, contents: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join("tauri-utils-parse-tests");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, contents).unwrap();
+    path
+  }
+
+  #[test]
+  fn read_to_string_strips_a_leading_utf8_bom() {
+    let path = write_temp("with-bom.json", "\u{feff}{\"productName\":\"test\"}");
+
+    let raw = read_to_string(&path).unwrap();
+
+    assert!(
+      !raw.starts_with('\u{feff}'),
+      "the BOM must be stripped, otherwise every parser below rejects the file"
+    );
+    assert!(
+      do_parse_json::<serde_json::Value>(&raw, &path).is_ok(),
+      "a BOM-prefixed config must parse once the BOM is stripped"
+    );
+
+    std::fs::remove_file(&path).unwrap();
+  }
+
+  #[test]
+  fn read_to_string_leaves_a_file_without_a_bom_untouched() {
+    let contents = "{\"productName\":\"test\"}";
+    let path = write_temp("without-bom.json", contents);
+
+    let raw = read_to_string(&path).unwrap();
+
+    assert_eq!(raw, contents);
+
+    std::fs::remove_file(&path).unwrap();
+  }
 }


### PR DESCRIPTION
Fixes #15922.

### What

`tauri.conf.json` fails to parse when the file starts with a UTF-8 BOM. The error surfaced is
a generic `expected value at line 1 column 1`, on a file that looks perfectly valid in an
editor — the leading byte is invisible, so the actual cause is not discoverable from the
message.

This is easy to hit on Windows: several common ways of writing the file add a BOM, including
PowerShell's `Set-Content -Encoding UTF8`.

### Why it happens

`read_to_string` (`crates/tauri-utils/src/config/parse.rs`) wraps `std::fs::read_to_string`,
which validates UTF-8 but does **not** strip a BOM — `U+FEFF` is valid UTF-8 and stays in the
returned `String`. The contents are then handed straight to `serde_json::from_str`, which
rejects it.

### The change

Strip a single leading `U+FEFF` in the shared `read_to_string` helper. That helper is the one
read boundary for all three config formats — JSON (`:282`), JSON5 (`:306`) and TOML (`:318`) —
so one place covers every branch, and no parser call site needs to change.

### Tests

Two tests are added next to the helper:

- `read_to_string_strips_a_leading_utf8_bom` — a BOM-prefixed config is read without the BOM
  and parses.
- `read_to_string_leaves_a_file_without_a_bom_untouched` — contents without a BOM are returned
  byte-for-byte, so the change is a no-op on existing files.

Both pass, and I checked they actually fail without the fix rather than passing vacuously:
removing the two stripping lines makes `read_to_string_strips_a_leading_utf8_bom` fail with
`the BOM must be stripped, otherwise every parser below rejects the file`, while the non-BOM
test stays green.

```
$ cargo test -p tauri-utils --lib config::parse
running 2 tests
test config::parse::tests::read_to_string_leaves_a_file_without_a_bom_untouched ... ok
test config::parse::tests::read_to_string_strips_a_leading_utf8_bom ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 34 filtered out
```

### Note on tooling

This was written with AI assistance. Per the AI Tool Policy I'm responsible for what's here,
so rather than just asserting it works: the change is two lines, the tests are in the diff, and
the mutation check described above is the evidence that they fail without the fix instead of
passing vacuously. Happy to adjust anything — placement, wording, or test shape.
