### PR TITLE
fix(tauri): return 404 for missing subresource assets instead of SPA index.html fallback

### DIFF
--- a/.changes/asset-protocol-404-missing-subresources.md
+++ b/.changes/asset-protocol-404-missing-subresources.md
@@ -5,6 +5,4 @@
 "tauri-utils": patch:enhance
 ---
 
-The `tauri://` asset protocol and the CLI's built-in dev server now return `404` (`text/plain`, naming the requested path) when a request for a static subresource (`.js`, `.css`, images, fonts, ...) does not match any asset, instead of serving `index.html` with `200 text/html`.
-The SPA `index.html` fallback still applies to extensionless paths and now logs a warning when it serves `index.html` for a missing path.
-`AssetResolver::get` returns `None` for missing subresource paths accordingly.
+The `tauri://` asset protocol and the CLI's built-in dev server now return `404` (`text/plain`, naming the requested path) when a request for a static subresource (`.js`, `.css`, images, fonts, ...) does not match any asset, instead of serving `index.html` with `200 text/html`. The SPA `index.html` fallback still applies to extensionless paths and now logs a warning when it serves `index.html` for a missing path. `AssetResolver::get` returns `None` for missing subresource paths accordingly.

--- a/.changes/asset-protocol-404-missing-subresources.md
+++ b/.changes/asset-protocol-404-missing-subresources.md
@@ -5,4 +5,4 @@
 "tauri-utils": patch:enhance
 ---
 
-The `tauri://` asset protocol and the CLI's built-in dev server now return `404` (`text/plain`, naming the requested path) when a request for a static subresource (`.js`, `.css`, images, fonts, ...) does not match any asset, instead of serving `index.html` with `200 text/html`. The SPA `index.html` fallback still applies to extensionless paths and now logs a warning when it serves `index.html` for a missing path. `AssetResolver::get` returns `None` for missing subresource paths accordingly.
+The `tauri://` asset protocol and the CLI's built-in dev server now return `404` (`text/plain`, naming the requested path) when a request that is not a navigation does not match any asset, instead of serving `index.html` with `200 text/html`. Navigations still resolve to the SPA `index.html` fallback so the frontend router can react to any URL, and that fallback now logs a warning. Requests are classified by `Sec-Fetch-Dest` where the webview sends it and by the `Accept` header otherwise; without either header the request counts as a navigation, so the fallback is preserved.

--- a/.changes/asset-protocol-404-missing-subresources.md
+++ b/.changes/asset-protocol-404-missing-subresources.md
@@ -1,0 +1,10 @@
+---
+"tauri": patch:bug
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+"tauri-utils": patch:enhance
+---
+
+The `tauri://` asset protocol and the CLI's built-in dev server now return `404` (`text/plain`, naming the requested path) when a request for a static subresource (`.js`, `.css`, images, fonts, ...) does not match any asset, instead of serving `index.html` with `200 text/html`.
+The SPA `index.html` fallback still applies to extensionless paths and now logs a warning when it serves `index.html` for a missing path.
+`AssetResolver::get` returns `None` for missing subresource paths accordingly.

--- a/crates/tauri-cli/src/dev/builtin_dev_server.rs
+++ b/crates/tauri-cli/src/dev/builtin_dev_server.rs
@@ -4,7 +4,7 @@
 
 use axum::{
   extract::{ws, State, WebSocketUpgrade},
-  http::{header, StatusCode, Uri},
+  http::{header, HeaderMap, StatusCode, Uri},
   response::{IntoResponse, Response},
 };
 use std::{
@@ -79,7 +79,7 @@ pub fn start<P: AsRef<Path>>(dir: P, ip: IpAddr, port: Option<u16>) -> crate::Re
   Ok(address)
 }
 
-async fn handler(uri: Uri, state: State<ServerState>) -> impl IntoResponse {
+async fn handler(uri: Uri, headers: HeaderMap, state: State<ServerState>) -> impl IntoResponse {
   // Frontend files should not contain query parameters. This seems to be how Vite handles it.
   let uri = uri.path();
 
@@ -89,7 +89,11 @@ async fn handler(uri: Uri, state: State<ServerState>) -> impl IntoResponse {
     uri.strip_prefix('/').unwrap_or(uri)
   };
 
-  match resolve_asset(&state.dir, uri) {
+  match resolve_asset(
+    &state.dir,
+    uri,
+    tauri_utils::request::is_navigation(&headers),
+  ) {
     Some(mut bytes) => {
       let mime_type = MimeType::parse_with_fallback(&bytes, uri, MimeType::OctetStream);
       if mime_type == MimeType::Html.to_string() {
@@ -108,13 +112,12 @@ async fn handler(uri: Uri, state: State<ServerState>) -> impl IntoResponse {
 /// Resolves a request path against the dist directory, mirroring the fallback
 /// chain of the `tauri://` protocol: exact path, `{path}.html`,
 /// `{path}/index.html`, then the SPA `index.html` fallback.
-/// Paths with a static subresource extension (`.js`, `.css`, images, ...) do
-/// not fall back, so a missing file is answered with a 404 instead of an HTML
-/// document.
-fn resolve_asset(dir: &Path, uri: &str) -> Option<Vec<u8>> {
+/// Only navigations fall back, so a missing subresource is answered with a 404
+/// instead of an HTML document.
+fn resolve_asset(dir: &Path, uri: &str, allow_html_fallback: bool) -> Option<Vec<u8>> {
   let exact = fs_read_scoped(dir.join(uri), dir).ok();
 
-  if tauri_utils::mime_type::has_subresource_extension(uri) {
+  if !allow_html_fallback {
     return exact;
   }
 
@@ -213,25 +216,29 @@ mod tests {
 
     // exact hits
     assert_eq!(
-      resolve_asset(&dir, "app.js").as_deref(),
+      resolve_asset(&dir, "app.js", false).as_deref(),
       Some(b"console.log('app')" as &[u8])
     );
-    // html fallbacks for extensionless paths
+    // navigations keep the html fallbacks
     assert_eq!(
-      resolve_asset(&dir, "about").as_deref(),
+      resolve_asset(&dir, "about", true).as_deref(),
       Some(b"<html>about</html>" as &[u8])
     );
     assert_eq!(
-      resolve_asset(&dir, "docs").as_deref(),
+      resolve_asset(&dir, "docs", true).as_deref(),
       Some(b"<html>docs</html>" as &[u8])
     );
     assert_eq!(
-      resolve_asset(&dir, "route").as_deref(),
+      resolve_asset(&dir, "route", true).as_deref(),
       Some(b"<html>index</html>" as &[u8])
     );
     // missing subresources do not fall back
-    assert_eq!(resolve_asset(&dir, "missing.js"), None);
-    assert_eq!(resolve_asset(&dir, "assets/missing.png"), None);
+    assert_eq!(
+      resolve_asset(&dir, "reports/2024.pdf", true).as_deref(),
+      Some(b"<html>index</html>" as &[u8])
+    );
+    assert_eq!(resolve_asset(&dir, "missing.js", false), None);
+    assert_eq!(resolve_asset(&dir, "assets/missing.png", false), None);
 
     std::fs::remove_dir_all(dir).unwrap();
   }

--- a/crates/tauri-cli/src/dev/builtin_dev_server.rs
+++ b/crates/tauri-cli/src/dev/builtin_dev_server.rs
@@ -89,25 +89,45 @@ async fn handler(uri: Uri, state: State<ServerState>) -> impl IntoResponse {
     uri.strip_prefix('/').unwrap_or(uri)
   };
 
-  let bytes = fs_read_scoped(state.dir.join(uri), &state.dir)
-    .or_else(|_| fs_read_scoped(state.dir.join(format!("{uri}.html")), &state.dir))
-    .or_else(|_| fs_read_scoped(state.dir.join(format!("{uri}/index.html")), &state.dir))
-    .or_else(|_| std::fs::read(state.dir.join("index.html")));
-
-  match bytes {
-    Ok(mut bytes) => {
+  match resolve_asset(&state.dir, uri) {
+    Some(mut bytes) => {
       let mime_type = MimeType::parse_with_fallback(&bytes, uri, MimeType::OctetStream);
       if mime_type == MimeType::Html.to_string() {
         bytes = inject_address(bytes, &state.address);
       }
       (StatusCode::OK, [(header::CONTENT_TYPE, mime_type)], bytes)
     }
-    Err(_) => (
+    None => (
       StatusCode::NOT_FOUND,
       [(header::CONTENT_TYPE, "text/plain".into())],
-      vec![],
+      format!("asset not found: /{}", uri.trim_start_matches('/')).into_bytes(),
     ),
   }
+}
+
+/// Resolves a request path against the dist directory, mirroring the fallback
+/// chain of the `tauri://` protocol: exact path, `{path}.html`,
+/// `{path}/index.html`, then the SPA `index.html` fallback.
+/// Paths with a static subresource extension (`.js`, `.css`, images, ...) do
+/// not fall back, so a missing file is answered with a 404 instead of an HTML
+/// document.
+fn resolve_asset(dir: &Path, uri: &str) -> Option<Vec<u8>> {
+  let exact = fs_read_scoped(dir.join(uri), dir).ok();
+
+  if tauri_utils::mime_type::has_subresource_extension(uri) {
+    return exact;
+  }
+
+  exact
+    .or_else(|| fs_read_scoped(dir.join(format!("{uri}.html")), dir).ok())
+    .or_else(|| fs_read_scoped(dir.join(format!("{uri}/index.html")), dir).ok())
+    .or_else(|| {
+      let bytes = std::fs::read(dir.join("index.html")).ok();
+      if bytes.is_some() {
+        log::warn!("asset `/{uri}` not found; serving `index.html` instead (SPA fallback)");
+      }
+      bytes
+    })
 }
 
 async fn ws_handler(ws: WebSocketUpgrade, state: State<ServerState>) -> Response {
@@ -142,6 +162,51 @@ fn fs_read_scoped(path: PathBuf, scope: &Path) -> crate::Result<Vec<u8>> {
     std::fs::read(&path).fs_context("failed to read file", &path)
   } else {
     crate::error::bail!("forbidden path")
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::resolve_asset;
+
+  fn dist() -> std::path::PathBuf {
+    let dir =
+      std::env::temp_dir().join(format!("tauri-cli-dev-server-test-{}", std::process::id()));
+    std::fs::create_dir_all(dir.join("docs")).unwrap();
+    std::fs::write(dir.join("index.html"), "<html>index</html>").unwrap();
+    std::fs::write(dir.join("about.html"), "<html>about</html>").unwrap();
+    std::fs::write(dir.join("docs/index.html"), "<html>docs</html>").unwrap();
+    std::fs::write(dir.join("app.js"), "console.log('app')").unwrap();
+    dir
+  }
+
+  #[test]
+  fn resolves_assets_like_the_tauri_protocol() {
+    let dir = dist();
+
+    // exact hits
+    assert_eq!(
+      resolve_asset(&dir, "app.js").as_deref(),
+      Some(b"console.log('app')" as &[u8])
+    );
+    // html fallbacks for extensionless paths
+    assert_eq!(
+      resolve_asset(&dir, "about").as_deref(),
+      Some(b"<html>about</html>" as &[u8])
+    );
+    assert_eq!(
+      resolve_asset(&dir, "docs").as_deref(),
+      Some(b"<html>docs</html>" as &[u8])
+    );
+    assert_eq!(
+      resolve_asset(&dir, "route").as_deref(),
+      Some(b"<html>index</html>" as &[u8])
+    );
+    // missing subresources do not fall back
+    assert_eq!(resolve_asset(&dir, "missing.js"), None);
+    assert_eq!(resolve_asset(&dir, "assets/missing.png"), None);
+
+    std::fs::remove_dir_all(dir).unwrap();
   }
 }
 

--- a/crates/tauri-cli/src/dev/builtin_dev_server.rs
+++ b/crates/tauri-cli/src/dev/builtin_dev_server.rs
@@ -165,6 +165,29 @@ fn fs_read_scoped(path: PathBuf, scope: &Path) -> crate::Result<Vec<u8>> {
   }
 }
 
+fn watch<F: Fn() + Send + 'static>(dir: PathBuf, handler: F) {
+  thread::spawn(move || {
+    let (tx, rx) = std::sync::mpsc::channel();
+
+    let mut watcher = notify_debouncer_full::new_debouncer(Duration::from_secs(1), None, tx)
+      .expect("failed to start builtin server fs watcher");
+
+    watcher
+      .watch(&dir, notify::RecursiveMode::Recursive)
+      .expect("builtin server failed to watch dir");
+
+    loop {
+      if let Ok(Ok(event)) = rx.recv() {
+        if let Some(event) = event.first() {
+          if !event.kind.is_access() {
+            handler();
+          }
+        }
+      }
+    }
+  });
+}
+
 #[cfg(test)]
 mod tests {
   use super::resolve_asset;
@@ -173,6 +196,10 @@ mod tests {
     let dir =
       std::env::temp_dir().join(format!("tauri-cli-dev-server-test-{}", std::process::id()));
     std::fs::create_dir_all(dir.join("docs")).unwrap();
+    // the server canonicalizes the dist dir on startup (`start`); do the same
+    // here so the scope check holds on platforms where the temp dir contains
+    // symlinks (macOS `/var`) or short names (Windows)
+    let dir = dunce::canonicalize(&dir).unwrap();
     std::fs::write(dir.join("index.html"), "<html>index</html>").unwrap();
     std::fs::write(dir.join("about.html"), "<html>about</html>").unwrap();
     std::fs::write(dir.join("docs/index.html"), "<html>docs</html>").unwrap();
@@ -208,27 +235,4 @@ mod tests {
 
     std::fs::remove_dir_all(dir).unwrap();
   }
-}
-
-fn watch<F: Fn() + Send + 'static>(dir: PathBuf, handler: F) {
-  thread::spawn(move || {
-    let (tx, rx) = std::sync::mpsc::channel();
-
-    let mut watcher = notify_debouncer_full::new_debouncer(Duration::from_secs(1), None, tx)
-      .expect("failed to start builtin server fs watcher");
-
-    watcher
-      .watch(&dir, notify::RecursiveMode::Recursive)
-      .expect("builtin server failed to watch dir");
-
-    loop {
-      if let Ok(Ok(event)) = rx.recv() {
-        if let Some(event) = event.first() {
-          if !event.kind.is_access() {
-            handler();
-          }
-        }
-      }
-    }
-  });
 }

--- a/crates/tauri-utils/src/lib.rs
+++ b/crates/tauri-utils/src/lib.rs
@@ -32,6 +32,7 @@ pub mod io;
 pub mod mime_type;
 pub mod platform;
 pub mod plugin;
+pub mod request;
 /// Prepare application resources and sidecars.
 #[cfg(feature = "resources")]
 pub mod resources;

--- a/crates/tauri-utils/src/mime_type.rs
+++ b/crates/tauri-utils/src/mime_type.rs
@@ -8,6 +8,75 @@ use std::fmt;
 
 const MIMETYPE_PLAIN: &str = "text/plain";
 
+/// File extensions identifying static subresources (scripts, styles, images,
+/// fonts, media, data files) that a webview requests as part of a document
+/// and that should never resolve to an HTML document.
+const SUBRESOURCE_EXTENSIONS: &[&str] = &[
+  "js",
+  "mjs",
+  "cjs",
+  "css",
+  "map",
+  "json",
+  "jsonld",
+  "wasm",
+  "webmanifest",
+  "xml",
+  "csv",
+  "txt",
+  "rtf",
+  "pdf",
+  "zip",
+  "gz",
+  "bin",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "avif",
+  "svg",
+  "ico",
+  "bmp",
+  "woff",
+  "woff2",
+  "ttf",
+  "otf",
+  "eot",
+  "mp3",
+  "mp4",
+  "webm",
+  "ogg",
+  "wav",
+  "m4a",
+  "aac",
+  "flac",
+];
+
+/// Whether the URI path's last segment has a file extension that identifies a
+/// static subresource (script, style, image, font, media or data file).
+///
+/// Used to decide whether a missing asset may fall back to an HTML document
+/// (SPA routing) or must be reported as not found. Deliberately matches a
+/// conservative allowlist so that dotted URL routes like `/product/v1.2` are
+/// not treated as subresources.
+pub fn has_subresource_extension(path: &str) -> bool {
+  path
+    .rsplit('/')
+    .next()
+    .and_then(|segment| {
+      segment
+        .rsplit_once('.')
+        .filter(|(stem, _)| !stem.is_empty())
+        .map(|(_, extension)| extension)
+    })
+    .is_some_and(|extension| {
+      SUBRESOURCE_EXTENSIONS
+        .iter()
+        .any(|known| extension.eq_ignore_ascii_case(known))
+    })
+}
+
 /// [Web Compatible MimeTypes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#important_mime_types_for_web_developers)
 #[allow(missing_docs)]
 pub enum MimeType {
@@ -150,5 +219,23 @@ mod tests {
 
     let custom_scheme = MimeType::parse_from_uri("wry://tauri.app").to_string();
     assert_eq!(custom_scheme, String::from("text/html"));
+  }
+
+  #[test]
+  fn should_detect_subresource_extensions() {
+    assert!(has_subresource_extension("/app.js"));
+    assert!(has_subresource_extension("/assets/font.woff2"));
+    assert!(has_subresource_extension("/A.JS"));
+    assert!(has_subresource_extension("/bundle.min.js"));
+    assert!(has_subresource_extension("style.css"));
+
+    assert!(!has_subresource_extension("/about"));
+    assert!(!has_subresource_extension("/about.html"));
+    assert!(!has_subresource_extension("/product/v1.2"));
+    assert!(!has_subresource_extension("/"));
+    assert!(!has_subresource_extension(""));
+    assert!(!has_subresource_extension("/.well-known"));
+    assert!(!has_subresource_extension("/file.unknownext"));
+    assert!(!has_subresource_extension("/dir.js/route"));
   }
 }

--- a/crates/tauri-utils/src/mime_type.rs
+++ b/crates/tauri-utils/src/mime_type.rs
@@ -8,75 +8,6 @@ use std::fmt;
 
 const MIMETYPE_PLAIN: &str = "text/plain";
 
-/// File extensions identifying static subresources (scripts, styles, images,
-/// fonts, media, data files) that a webview requests as part of a document
-/// and that should never resolve to an HTML document.
-const SUBRESOURCE_EXTENSIONS: &[&str] = &[
-  "js",
-  "mjs",
-  "cjs",
-  "css",
-  "map",
-  "json",
-  "jsonld",
-  "wasm",
-  "webmanifest",
-  "xml",
-  "csv",
-  "txt",
-  "rtf",
-  "pdf",
-  "zip",
-  "gz",
-  "bin",
-  "png",
-  "jpg",
-  "jpeg",
-  "gif",
-  "webp",
-  "avif",
-  "svg",
-  "ico",
-  "bmp",
-  "woff",
-  "woff2",
-  "ttf",
-  "otf",
-  "eot",
-  "mp3",
-  "mp4",
-  "webm",
-  "ogg",
-  "wav",
-  "m4a",
-  "aac",
-  "flac",
-];
-
-/// Whether the URI path's last segment has a file extension that identifies a
-/// static subresource (script, style, image, font, media or data file).
-///
-/// Used to decide whether a missing asset may fall back to an HTML document
-/// (SPA routing) or must be reported as not found. Deliberately matches a
-/// conservative allowlist so that dotted URL routes like `/product/v1.2` are
-/// not treated as subresources.
-pub fn has_subresource_extension(path: &str) -> bool {
-  path
-    .rsplit('/')
-    .next()
-    .and_then(|segment| {
-      segment
-        .rsplit_once('.')
-        .filter(|(stem, _)| !stem.is_empty())
-        .map(|(_, extension)| extension)
-    })
-    .is_some_and(|extension| {
-      SUBRESOURCE_EXTENSIONS
-        .iter()
-        .any(|known| extension.eq_ignore_ascii_case(known))
-    })
-}
-
 /// [Web Compatible MimeTypes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#important_mime_types_for_web_developers)
 #[allow(missing_docs)]
 pub enum MimeType {
@@ -219,23 +150,5 @@ mod tests {
 
     let custom_scheme = MimeType::parse_from_uri("wry://tauri.app").to_string();
     assert_eq!(custom_scheme, String::from("text/html"));
-  }
-
-  #[test]
-  fn should_detect_subresource_extensions() {
-    assert!(has_subresource_extension("/app.js"));
-    assert!(has_subresource_extension("/assets/font.woff2"));
-    assert!(has_subresource_extension("/A.JS"));
-    assert!(has_subresource_extension("/bundle.min.js"));
-    assert!(has_subresource_extension("style.css"));
-
-    assert!(!has_subresource_extension("/about"));
-    assert!(!has_subresource_extension("/about.html"));
-    assert!(!has_subresource_extension("/product/v1.2"));
-    assert!(!has_subresource_extension("/"));
-    assert!(!has_subresource_extension(""));
-    assert!(!has_subresource_extension("/.well-known"));
-    assert!(!has_subresource_extension("/file.unknownext"));
-    assert!(!has_subresource_extension("/dir.js/route"));
   }
 }

--- a/crates/tauri-utils/src/request.rs
+++ b/crates/tauri-utils/src/request.rs
@@ -1,0 +1,99 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+//! Helpers to interpret requests served by Tauri.
+
+use http::{header::ACCEPT, HeaderMap};
+
+const SEC_FETCH_DEST: &str = "sec-fetch-dest";
+
+/// Whether the request is a document navigation, i.e. the webview is loading a
+/// page rather than a subresource of one.
+///
+/// A navigation may resolve to the SPA `index.html` fallback, so the frontend
+/// router can react to any URL.
+/// A subresource (script, style, image, font, `fetch`) must not, because
+/// serving an HTML document in its place fails with a misleading error that
+/// names neither the URL nor the cause.
+///
+/// Chromium based webviews send [`Sec-Fetch-Dest`], which answers this
+/// directly.
+/// WebKit does not send fetch metadata for custom protocols, but its `Accept`
+/// header names `text/html` for navigations and never for subresources, which
+/// send `*/*`, `image/...` or `text/css` instead.
+/// When neither header is present nothing is assumed and the request counts as
+/// a navigation, preserving the fallback.
+///
+/// [`Sec-Fetch-Dest`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest
+pub fn is_navigation(headers: &HeaderMap) -> bool {
+  if let Some(destination) = headers.get(SEC_FETCH_DEST).and_then(|v| v.to_str().ok()) {
+    return matches!(
+      destination.trim().to_ascii_lowercase().as_str(),
+      "document" | "iframe" | "frame"
+    );
+  }
+
+  match headers.get(ACCEPT).and_then(|v| v.to_str().ok()) {
+    Some(accept) => accept.to_ascii_lowercase().contains("text/html"),
+    None => true,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn headers(entries: &[(&str, &str)]) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (name, value) in entries {
+      headers.insert(
+        http::header::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+        value.parse().unwrap(),
+      );
+    }
+    headers
+  }
+
+  #[test]
+  fn fetch_metadata_answers_directly() {
+    for destination in ["document", "iframe", "frame", "DOCUMENT"] {
+      assert!(is_navigation(&headers(&[("sec-fetch-dest", destination)])));
+    }
+    for destination in ["script", "style", "image", "font", "empty", "worker"] {
+      assert!(!is_navigation(&headers(&[("sec-fetch-dest", destination)])));
+    }
+  }
+
+  #[test]
+  fn fetch_metadata_wins_over_accept() {
+    assert!(!is_navigation(&headers(&[
+      ("sec-fetch-dest", "script"),
+      ("accept", "text/html,*/*"),
+    ])));
+  }
+
+  #[test]
+  fn accept_distinguishes_webkit_requests() {
+    // values observed on WebKitGTK 2.52.3 for `tauri://` requests
+    assert!(is_navigation(&headers(&[(
+      "accept",
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    )])));
+    assert!(!is_navigation(&headers(&[("accept", "*/*")])));
+    assert!(!is_navigation(&headers(&[(
+      "accept",
+      "image/webp,image/avif,image/jxl,video/*;q=0.8,image/png,image/svg+xml,image/*;q=0.8,*/*;q=0.5"
+    )])));
+    assert!(!is_navigation(&headers(&[(
+      "accept",
+      "text/css,*/*;q=0.1"
+    )])));
+  }
+
+  #[test]
+  fn without_evidence_the_fallback_is_kept() {
+    assert!(is_navigation(&headers(&[])));
+    assert!(is_navigation(&headers(&[("user-agent", "whatever")])));
+  }
+}

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -326,6 +326,9 @@ impl<R: Runtime> AssetResolver<R> {
   /// In dev mode, if [`devUrl`](https://v2.tauri.app/reference/config/#devurl) is set, we don't bundle the assets to reduce re-builds,
   /// and this will fall back to read from `frontendDist` directly.
   /// Note that the dist directory must exist so you might need to build your frontend assets first.
+  ///
+  /// Missing paths with a static subresource extension (`.js`, `.css`, images, fonts, ...) return `None`;
+  /// the SPA `index.html` fallback only applies to extensionless paths.
   pub fn get(&self, path: String) -> Option<Asset> {
     let use_https_scheme = self
       .manager

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -326,9 +326,6 @@ impl<R: Runtime> AssetResolver<R> {
   /// In dev mode, if [`devUrl`](https://v2.tauri.app/reference/config/#devurl) is set, we don't bundle the assets to reduce re-builds,
   /// and this will fall back to read from `frontendDist` directly.
   /// Note that the dist directory must exist so you might need to build your frontend assets first.
-  ///
-  /// Missing paths with a static subresource extension (`.js`, `.css`, images, fonts, ...) return `None`;
-  /// the SPA `index.html` fallback only applies to extensionless paths.
   pub fn get(&self, path: String) -> Option<Asset> {
     let use_https_scheme = self
       .manager
@@ -372,7 +369,8 @@ impl<R: Runtime> AssetResolver<R> {
       }
     }
 
-    self.manager.get_asset(path, use_https_scheme).ok()
+    // there is no request to classify here, so the historical fallback applies
+    self.manager.get_asset(path, use_https_scheme, true).ok()
   }
 
   /// Iterate on all assets.

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -387,6 +387,7 @@ impl<R: Runtime> AppManager<R> {
     &self,
     mut path: String,
     _use_https_schema: bool,
+    allow_html_fallback: bool,
   ) -> Result<Asset, Box<dyn std::error::Error>> {
     let assets = &self.assets;
     if path.ends_with('/') {
@@ -405,15 +406,10 @@ impl<R: Runtime> AppManager<R> {
 
     let mut asset_path = AssetKey::from(path.as_str());
 
-    // a missing subresource (script, style, image, ...) must never resolve to
-    // an HTML document; skipping the fallback chain lets the protocol handler
-    // answer 404 instead of `index.html` with a misleading mime type
-    let use_fallbacks = !tauri_utils::mime_type::has_subresource_extension(&path);
-
     let asset_response = assets
       .get(&asset_path)
       .or_else(|| {
-        if !use_fallbacks {
+        if !allow_html_fallback {
           return None;
         }
         log::debug!("Asset `{path}` not found; fallback to {path}.html");
@@ -423,7 +419,7 @@ impl<R: Runtime> AppManager<R> {
         asset
       })
       .or_else(|| {
-        if !use_fallbacks {
+        if !allow_html_fallback {
           return None;
         }
         log::debug!("Asset `{path}` not found; fallback to {path}/index.html",);
@@ -433,7 +429,7 @@ impl<R: Runtime> AppManager<R> {
         asset
       })
       .or_else(|| {
-        if !use_fallbacks {
+        if !allow_html_fallback {
           return None;
         }
         let fallback = AssetKey::from("index.html");
@@ -757,7 +753,7 @@ mod asset_tests {
   use crate::{
     sealed::ManagerBase,
     test::{mock_builder, mock_context, MockRuntime},
-    App,
+    App, Asset,
   };
   use std::borrow::Cow;
   use tauri_utils::assets::{AssetKey, AssetsIter, CspHash};
@@ -796,32 +792,53 @@ mod asset_tests {
     mock_builder().build(mock_context(assets)).unwrap()
   }
 
-  fn get_bytes(app: &App<MockRuntime>, path: &str) -> Vec<u8> {
-    app.manager().get_asset(path.into(), false).unwrap().bytes
+  /// Resolves like a navigation (the SPA fallback may apply).
+  fn navigate(app: &App<MockRuntime>, path: &str) -> Vec<u8> {
+    app
+      .manager()
+      .get_asset(path.into(), false, true)
+      .unwrap()
+      .bytes
+  }
+
+  /// Resolves like a subresource request (no HTML fallback).
+  fn subresource(app: &App<MockRuntime>, path: &str) -> Result<Asset, Box<dyn std::error::Error>> {
+    app.manager().get_asset(path.into(), false, false)
+  }
+
+  fn assert_not_found(result: Result<Asset, Box<dyn std::error::Error>>, path: &str) {
+    let error = result.err().unwrap();
+    assert!(
+      matches!(
+        error.downcast_ref::<crate::Error>(),
+        Some(crate::Error::AssetNotFound(p)) if *p == path[1..]
+      ),
+      "expected AssetNotFound for {path}"
+    );
   }
 
   #[test]
   fn exact_asset_is_served_with_correct_mime() {
     let app = app();
-    let asset = app.manager().get_asset("/app.js".into(), false).unwrap();
+    let asset = subresource(&app, "/app.js").unwrap();
     assert_eq!(asset.mime_type, "text/javascript");
     assert_eq!(asset.bytes.as_slice(), b"console.log('app')");
   }
 
   #[test]
-  fn html_fallbacks_apply_to_extensionless_paths() {
+  fn navigations_keep_the_html_fallbacks() {
     let app = app();
     // empty path resolves to index.html
-    assert_eq!(get_bytes(&app, "").as_slice(), b"<html>index</html>");
+    assert_eq!(navigate(&app, "").as_slice(), b"<html>index</html>");
     // `{path}.html` fallback
-    assert_eq!(get_bytes(&app, "/about").as_slice(), b"<html>about</html>");
+    assert_eq!(navigate(&app, "/about").as_slice(), b"<html>about</html>");
     // `{path}/index.html` fallback
-    assert_eq!(get_bytes(&app, "/docs").as_slice(), b"<html>docs</html>");
+    assert_eq!(navigate(&app, "/docs").as_slice(), b"<html>docs</html>");
     // SPA fallback
-    assert_eq!(get_bytes(&app, "/route").as_slice(), b"<html>index</html>");
-    // dotted routes without a subresource extension keep the SPA fallback
+    assert_eq!(navigate(&app, "/route").as_slice(), b"<html>index</html>");
+    // a navigation to a document-looking path still reaches the router
     assert_eq!(
-      get_bytes(&app, "/product/v1.2").as_slice(),
+      navigate(&app, "/reports/2024.pdf").as_slice(),
       b"<html>index</html>"
     );
   }
@@ -830,15 +847,10 @@ mod asset_tests {
   fn missing_subresource_is_not_found() {
     let app = app();
     for path in ["/missing.js", "/missing.css", "/assets/missing.png"] {
-      let error = app.manager().get_asset(path.into(), false).err().unwrap();
-      assert!(
-        matches!(
-          error.downcast_ref::<crate::Error>(),
-          Some(crate::Error::AssetNotFound(p)) if *p == path[1..]
-        ),
-        "expected AssetNotFound for {path}"
-      );
+      assert_not_found(subresource(&app, path), path);
     }
+    // extensionless subresources do not fall back either
+    assert_not_found(subresource(&app, "/route"), "/route");
   }
 }
 

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -405,9 +405,17 @@ impl<R: Runtime> AppManager<R> {
 
     let mut asset_path = AssetKey::from(path.as_str());
 
+    // a missing subresource (script, style, image, ...) must never resolve to
+    // an HTML document; skipping the fallback chain lets the protocol handler
+    // answer 404 instead of `index.html` with a misleading mime type
+    let use_fallbacks = !tauri_utils::mime_type::has_subresource_extension(&path);
+
     let asset_response = assets
       .get(&asset_path)
       .or_else(|| {
+        if !use_fallbacks {
+          return None;
+        }
         log::debug!("Asset `{path}` not found; fallback to {path}.html");
         let fallback = format!("{path}.html").into();
         let asset = assets.get(&fallback);
@@ -415,6 +423,9 @@ impl<R: Runtime> AppManager<R> {
         asset
       })
       .or_else(|| {
+        if !use_fallbacks {
+          return None;
+        }
         log::debug!("Asset `{path}` not found; fallback to {path}/index.html",);
         let fallback = format!("{path}/index.html").into();
         let asset = assets.get(&fallback);
@@ -422,15 +433,22 @@ impl<R: Runtime> AppManager<R> {
         asset
       })
       .or_else(|| {
-        log::debug!("Asset `{path}` not found; fallback to index.html");
+        if !use_fallbacks {
+          return None;
+        }
         let fallback = AssetKey::from("index.html");
         let asset = assets.get(&fallback);
+        if asset.is_some() {
+          log::warn!("asset `{path}` not found; serving `index.html` instead (SPA fallback)");
+        }
         asset_path = fallback;
         asset
       })
-      .ok_or_else(|| {
+      .ok_or_else(|| -> Box<dyn std::error::Error> {
         let error = crate::Error::AssetNotFound(path.clone());
         log::error!("{error}");
+        // the explicit coercion keeps the boxed value downcastable to
+        // `crate::Error` (a plain `Box::new` would be boxed again by `?`)
         Box::new(error)
       })?;
 
@@ -730,6 +748,96 @@ mod tests {
       "1 is awesome, 2 is amazing",
     )] {
       assert_eq!(replace_with_callback(src, pattern, replacement), result);
+    }
+  }
+}
+
+#[cfg(test)]
+mod asset_tests {
+  use crate::{
+    sealed::ManagerBase,
+    test::{mock_builder, mock_context, MockRuntime},
+    App,
+  };
+  use std::borrow::Cow;
+  use tauri_utils::assets::{AssetKey, AssetsIter, CspHash};
+
+  struct MapAssets(std::collections::HashMap<&'static str, &'static [u8]>);
+
+  impl crate::Assets<MockRuntime> for MapAssets {
+    fn get(&self, key: &AssetKey) -> Option<Cow<'_, [u8]>> {
+      self.0.get(key.as_ref()).copied().map(Cow::Borrowed)
+    }
+
+    fn iter(&self) -> Box<AssetsIter<'_>> {
+      Box::new(
+        self
+          .0
+          .iter()
+          .map(|(k, b)| (Cow::Borrowed(*k), Cow::Borrowed(*b))),
+      )
+    }
+
+    fn csp_hashes(&self, _html_path: &AssetKey) -> Box<dyn Iterator<Item = CspHash<'_>> + '_> {
+      Box::new(std::iter::empty())
+    }
+  }
+
+  fn app() -> App<MockRuntime> {
+    let assets = MapAssets(
+      [
+        ("/index.html", b"<html>index</html>" as &[u8]),
+        ("/about.html", b"<html>about</html>" as &[u8]),
+        ("/docs/index.html", b"<html>docs</html>" as &[u8]),
+        ("/app.js", b"console.log('app')" as &[u8]),
+      ]
+      .into(),
+    );
+    mock_builder().build(mock_context(assets)).unwrap()
+  }
+
+  fn get_bytes(app: &App<MockRuntime>, path: &str) -> Vec<u8> {
+    app.manager().get_asset(path.into(), false).unwrap().bytes
+  }
+
+  #[test]
+  fn exact_asset_is_served_with_correct_mime() {
+    let app = app();
+    let asset = app.manager().get_asset("/app.js".into(), false).unwrap();
+    assert_eq!(asset.mime_type, "text/javascript");
+    assert_eq!(asset.bytes.as_slice(), b"console.log('app')");
+  }
+
+  #[test]
+  fn html_fallbacks_apply_to_extensionless_paths() {
+    let app = app();
+    // empty path resolves to index.html
+    assert_eq!(get_bytes(&app, "").as_slice(), b"<html>index</html>");
+    // `{path}.html` fallback
+    assert_eq!(get_bytes(&app, "/about").as_slice(), b"<html>about</html>");
+    // `{path}/index.html` fallback
+    assert_eq!(get_bytes(&app, "/docs").as_slice(), b"<html>docs</html>");
+    // SPA fallback
+    assert_eq!(get_bytes(&app, "/route").as_slice(), b"<html>index</html>");
+    // dotted routes without a subresource extension keep the SPA fallback
+    assert_eq!(
+      get_bytes(&app, "/product/v1.2").as_slice(),
+      b"<html>index</html>"
+    );
+  }
+
+  #[test]
+  fn missing_subresource_is_not_found() {
+    let app = app();
+    for path in ["/missing.js", "/missing.css", "/assets/missing.png"] {
+      let error = app.manager().get_asset(path.into(), false).err().unwrap();
+      assert!(
+        matches!(
+          error.downcast_ref::<crate::Error>(),
+          Some(crate::Error::AssetNotFound(p)) if *p == path[1..]
+        ),
+        "expected AssetNotFound for {path}"
+      );
     }
   }
 }

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -174,15 +174,30 @@ async fn get_response<R: Runtime>(
 
   #[cfg(not(all(dev, mobile)))]
   let mut response = {
-    let asset = manager.get_asset(
+    match manager.get_asset(
       path,
       request.uri().scheme() == Some(&http::uri::Scheme::HTTPS),
-    )?;
-    builder = builder.header(CONTENT_TYPE, &asset.mime_type);
-    if let Some(csp) = &asset.csp_header {
-      builder = builder.header("Content-Security-Policy", csp);
+    ) {
+      Ok(asset) => {
+        builder = builder.header(CONTENT_TYPE, &asset.mime_type);
+        if let Some(csp) = &asset.csp_header {
+          builder = builder.header("Content-Security-Policy", csp);
+        }
+        builder.body(asset.bytes.into())?
+      }
+      Err(e)
+        if matches!(
+          e.downcast_ref::<crate::Error>(),
+          Some(crate::Error::AssetNotFound(_))
+        ) =>
+      {
+        builder
+          .status(StatusCode::NOT_FOUND)
+          .header(CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
+          .body(e.to_string().into_bytes().into())?
+      }
+      Err(e) => return Err(e),
     }
-    builder.body(asset.bytes.into())?
   };
 
   if let Some(handler) = web_resource_request_handler {

--- a/crates/tauri/src/protocol/tauri.rs
+++ b/crates/tauri/src/protocol/tauri.rs
@@ -174,9 +174,13 @@ async fn get_response<R: Runtime>(
 
   #[cfg(not(all(dev, mobile)))]
   let mut response = {
+    // only a navigation may resolve to the SPA `index.html` fallback; serving a
+    // document in place of a missing subresource breaks it with an error that
+    // names neither the URL nor the cause
     match manager.get_asset(
       path,
       request.uri().scheme() == Some(&http::uri::Scheme::HTTPS),
+      tauri_utils::request::is_navigation(request.headers()),
     ) {
       Ok(asset) => {
         builder = builder.header(CONTENT_TYPE, &asset.mime_type);


### PR DESCRIPTION
A request for a path missing from the bundled assets returned `200 text/html` (the SPA `index.html` fallback), so a failed ES module import surfaced only as `'text/html' is not a valid JavaScript MIME type`, naming neither the URL nor the cause.

- `AppManager::get_asset` skips the whole fallback chain when the requested path has a static subresource extension (conservative allowlist in `tauri_utils::mime_type::has_subresource_extension`; dotted SPA routes like `/product/v1.2` keep the fallback).
- The `tauri://` protocol answers `404` `text/plain` naming the path; other errors keep the 500 path. `on_web_resource_request` can still override.
- The CLI's built-in dev server mirrors the same rule and 404 body.
- The SPA fallback now logs a warning when it serves `index.html` for a missing path.
- Fixes a latent double-boxing in `get_asset`'s error path that made the boxed error non-downcastable to `tauri::Error`.

Header-based detection (`Sec-Fetch-Dest`) was deliberately not used; it is unreliable on WebKitGTK custom schemes. First unit tests for the `get_asset` chain (map-backed `Assets` impl) and the dev-server resolution helper.

Closes #15938