### PR TITLE
fix: surface commands that are unreachable due to missing permissions

### DIFF
--- a/.changes/surface-unreachable-commands.md
+++ b/.changes/surface-unreachable-commands.md
@@ -1,0 +1,8 @@
+---
+"tauri": patch:enhance
+"tauri-macros": patch:enhance
+"tauri-utils": patch:enhance
+---
+
+Commands rejected by the ACL are now also logged on the host side via `log::error!`; previously only the webview's rejected promise carried the reason.
+`generate_handler!` prints a build-time warning when a registered command is not referenced by any permission of the crate (plugin `COMMANDS` list or hand-written permission files), which previously made the command silently unreachable.

--- a/.changes/surface-unreachable-commands.md
+++ b/.changes/surface-unreachable-commands.md
@@ -4,5 +4,4 @@
 "tauri-utils": patch:enhance
 ---
 
-Commands rejected by the ACL are now also logged on the host side via `log::error!`; previously only the webview's rejected promise carried the reason.
-`generate_handler!` prints a build-time warning when a registered command is not referenced by any permission of the crate (plugin `COMMANDS` list or hand-written permission files), which previously made the command silently unreachable.
+Commands rejected by the ACL are now also logged on the host side via `log::error!`; previously only the webview's rejected promise carried the reason. `generate_handler!` prints a build-time warning when a registered command is not referenced by any permission of the crate (plugin `COMMANDS` list or hand-written permission files), which previously made the command silently unreachable.

--- a/crates/tauri-macros/src/command/handler.rs
+++ b/crates/tauri-macros/src/command/handler.rs
@@ -38,7 +38,8 @@ impl Parse for Handler {
       .into_iter()
       .collect();
 
-    filter_unused_commands(plugin_name, &mut command_defs);
+    filter_unused_commands(&plugin_name, &mut command_defs);
+    warn_unreferenced_commands(&plugin_name, &command_defs);
     let mut commands = Vec::new();
     let mut wrappers = Vec::new();
 
@@ -89,7 +90,7 @@ fn try_get_plugin_name(input: &ParseBuffer<'_>) -> Result<Option<String>, syn::E
   )
 }
 
-fn filter_unused_commands(plugin_name: Option<String>, command_defs: &mut Vec<CommandDef>) {
+fn filter_unused_commands(plugin_name: &Option<String>, command_defs: &mut Vec<CommandDef>) {
   let allowed_commands = tauri_utils::acl::read_allowed_commands();
   let Some(allowed_commands) = allowed_commands else {
     return;
@@ -111,7 +112,7 @@ fn filter_unused_commands(plugin_name: Option<String>, command_defs: &mut Vec<Co
 
   let mut unused_commands = Vec::new();
 
-  let command_prefix = if let Some(plugin_name) = &plugin_name {
+  let command_prefix = if let Some(plugin_name) = plugin_name {
     format!("plugin:{plugin_name}|")
   } else {
     "".into()
@@ -138,6 +139,75 @@ fn filter_unused_commands(plugin_name: Option<String>, command_defs: &mut Vec<Co
     let plugin_display_name = plugin_name.as_deref().unwrap_or("application");
     let unused_commands_display = unused_commands.join(", ");
     println!("Removed unused commands from {plugin_display_name}: {unused_commands_display}",);
+  }
+}
+
+/// Warns about handler commands that no permission of the current crate
+/// references, since such commands cannot be granted by any capability and
+/// every invoke is rejected at runtime.
+fn warn_unreferenced_commands(plugin_name: &Option<String>, command_defs: &[CommandDef]) {
+  // the REMOVE_UNUSED_COMMANDS flow resolves the actual capability set and
+  // already reports the commands it removes
+  if tauri_utils::acl::read_allowed_commands().is_some() {
+    return;
+  }
+
+  // TODO: Remove this in v3
+  if plugin_name.as_deref() == Some("__TAURI_CHANNEL__") {
+    return;
+  }
+
+  let Some(permission_files) = find_defined_permission_files(plugin_name.as_deref()) else {
+    return;
+  };
+  // a crate without any defined permission is not ACL-enabled; stay silent
+  if permission_files.is_empty() {
+    return;
+  }
+
+  let mut known = std::collections::HashSet::new();
+  for file in &permission_files {
+    for permission in &file.permission {
+      known.extend(permission.commands.allow.iter().cloned());
+      known.extend(permission.commands.deny.iter().cloned());
+    }
+  }
+
+  for command_def in command_defs {
+    let mut wrapper = command_def.path.clone();
+    let command_name = super::path_to_command(&mut wrapper).ident.to_string();
+    if !known.contains(&command_name) {
+      let display_name = plugin_name.as_deref().unwrap_or("the application");
+      println!(
+        "tauri: command `{command_name}` (registered in `generate_handler!`) is not referenced by any permission of {display_name}, so it cannot be invoked from the frontend. Add it to the COMMANDS list in build.rs or reference it in a permission file. If the command is renamed with `#[command(rename = \"...\")]` and the renamed command has a permission, ignore this warning."
+      );
+    }
+  }
+}
+
+/// Locates the permission files defined by the current crate's build script,
+/// probing the locations used by tauri-plugin (external plugin crates),
+/// tauri-build (inlined plugins and the app manifest) and the tauri crate
+/// itself (core plugins).
+fn find_defined_permission_files(
+  plugin_name: Option<&str>,
+) -> Option<Vec<tauri_utils::acl::manifest::PermissionFile>> {
+  use tauri_utils::acl::read_defined_permission_files;
+
+  match plugin_name {
+    Some(name) => {
+      let pkg_name = std::env::var("CARGO_PKG_NAME").ok()?;
+      read_defined_permission_files(&format!("{pkg_name}-permission-files"))
+        .or_else(|| {
+          read_defined_permission_files(&format!("plugins/{name}/{name}-permission-files"))
+        })
+        .or_else(|| {
+          (pkg_name == "tauri")
+            .then(|| read_defined_permission_files(&format!("tauri-{name}-permission-files")))
+            .flatten()
+        })
+    }
+    None => read_defined_permission_files("app-manifest/__app__-permission-files"),
   }
 }
 

--- a/crates/tauri-utils/src/acl/mod.rs
+++ b/crates/tauri-utils/src/acl/mod.rs
@@ -420,9 +420,60 @@ pub fn read_allowed_commands() -> Option<AllowedCommands> {
   Some(json)
 }
 
+/// Reads and parses the permission files listed in `$OUT_DIR/{relative_path}`,
+/// as written by the build script (`define_permissions`).
+///
+/// Returns `None` when the list or any referenced permission file is missing
+/// or cannot be parsed.
+pub fn read_defined_permission_files(relative_path: &str) -> Option<Vec<manifest::PermissionFile>> {
+  let list_path = std::env::var("OUT_DIR")
+    .map(PathBuf::from)
+    .ok()?
+    .join(relative_path);
+  let paths: Vec<PathBuf> = serde_json::from_str(&fs::read_to_string(list_path).ok()?).ok()?;
+
+  let mut permission_files = Vec::new();
+  for path in paths {
+    let contents = fs::read_to_string(&path).ok()?;
+    let permission_file = match path.extension().and_then(|e| e.to_str()) {
+      Some("toml") => toml::from_str(&contents).ok()?,
+      Some("json") => serde_json::from_str(&contents).ok()?,
+      _ => return None,
+    };
+    permission_files.push(permission_file);
+  }
+  Some(permission_files)
+}
+
 #[cfg(test)]
 mod tests {
   use crate::acl::RemoteUrlPattern;
+
+  #[test]
+  #[serial_test::serial(out_dir)]
+  fn reads_defined_permission_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let permission_path = dir.path().join("ping.toml");
+    std::fs::write(
+      &permission_path,
+      "[[permission]]\nidentifier = \"allow-ping\"\n[permission.commands]\nallow = [\"ping\"]\n",
+    )
+    .unwrap();
+    std::fs::write(
+      dir.path().join("my-plugin-permission-files"),
+      serde_json::to_string(&vec![&permission_path]).unwrap(),
+    )
+    .unwrap();
+
+    std::env::set_var("OUT_DIR", dir.path());
+    let files = super::read_defined_permission_files("my-plugin-permission-files").unwrap();
+    let missing = super::read_defined_permission_files("other-permission-files");
+    std::env::remove_var("OUT_DIR");
+
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].permission[0].commands.allow, vec!["ping"]);
+    assert!(missing.is_none());
+  }
 
   #[test]
   fn url_pattern_domain_wildcard() {

--- a/crates/tauri/src/webview/mod.rs
+++ b/crates/tauri/src/webview/mod.rs
@@ -1956,28 +1956,27 @@ tauri::Builder::default()
       && invoke.acl.is_none()
     {
       #[cfg(debug_assertions)]
-      {
+      let message = {
         let (key, command_name) = plugin_command
           .clone()
           .unwrap_or_else(|| (tauri_utils::acl::APP_ACL_KEY, request.cmd.clone()));
-        invoke.resolver.reject(
-          manager
-            .runtime_authority
-            .lock()
-            .unwrap()
-            .resolve_access_message(
-              key,
-              &command_name,
-              invoke.message.webview.window().label(),
-              invoke.message.webview.label(),
-              &acl_origin,
-            ),
-        );
-      }
+        manager
+          .runtime_authority
+          .lock()
+          .unwrap()
+          .resolve_access_message(
+            key,
+            &command_name,
+            invoke.message.webview.window().label(),
+            invoke.message.webview.label(),
+            &acl_origin,
+          )
+      };
       #[cfg(not(debug_assertions))]
-      invoke
-        .resolver
-        .reject(format!("Command {} not allowed by ACL", request.cmd));
+      let message = format!("Command {} not allowed by ACL", request.cmd);
+
+      log::error!("{message}");
+      invoke.resolver.reject(message);
       return;
     }
 


### PR DESCRIPTION
A command listed in `generate_handler!` but missing from the plugin's `COMMANDS` build-script list is silently unreachable: no permission is generated, so no capability can grant it, and every invoke is rejected at runtime with nothing on the host side.

Two changes:
- `generate_handler!` prints a build-time warning when a registered command is not referenced by any permission of the crate (plugin `COMMANDS` or hand-written permission files). Fail-open: crates without defined permissions stay silent, `REMOVE_UNUSED_COMMANDS` flow unchanged, renamed commands called out in the message. Probes the permission-file lists written by tauri-plugin (external plugins), tauri-build (inlined plugins, app manifest) and the tauri crate (core plugins).
- ACL denials are now logged host-side via `log::error!` (rich `resolve_access_message` in debug builds, short message in release); previously the reason lived only in the webview's rejected promise, which frontends routinely swallow.

Closes #15940