### PR TITLE
feat(tauri): opt-in forwarding of webview console output and page errors to the log crate

### DIFF
--- a/.changes/webview-console-forwarding.md
+++ b/.changes/webview-console-forwarding.md
@@ -1,0 +1,6 @@
+---
+"tauri": minor:feat
+---
+
+Add `Builder::forward_webview_console(bool)` to opt in to forwarding webview `console.*` output, uncaught errors (including capture-phase resource load errors) and unhandled promise rejections to the `log` crate under the `webview:{label}` target.
+Disabled by default; when disabled the capture script is not injected and forwarded messages are ignored.

--- a/.changes/webview-console-forwarding.md
+++ b/.changes/webview-console-forwarding.md
@@ -2,5 +2,4 @@
 "tauri": minor:feat
 ---
 
-Add `Builder::forward_webview_console(bool)` to opt in to forwarding webview `console.*` output, uncaught errors (including capture-phase resource load errors) and unhandled promise rejections to the `log` crate under the `webview:{label}` target.
-Disabled by default; when disabled the capture script is not injected and forwarded messages are ignored.
+Add `Builder::forward_webview_console(bool)` to opt in to forwarding webview `console.*` output, uncaught errors (including capture-phase resource load errors) and unhandled promise rejections to the `log` crate under the `webview:{label}` target. Disabled by default; when disabled the capture script is not injected and forwarded messages are ignored.

--- a/crates/tauri/build.rs
+++ b/crates/tauri/build.rs
@@ -149,6 +149,7 @@ const PLUGINS: &[(&str, &[(&str, bool)])] = &[
       ("set_webview_background_color", false),
       // internal
       ("internal_toggle_devtools", true),
+      ("internal_log", true),
     ],
   ),
   (

--- a/crates/tauri/permissions/webview/autogenerated/reference.md
+++ b/crates/tauri/permissions/webview/autogenerated/reference.md
@@ -8,6 +8,7 @@ Default permissions for the plugin.
 - `allow-webview-position`
 - `allow-webview-size`
 - `allow-internal-toggle-devtools`
+- `allow-internal-log`
 
 ## Permission Table
 
@@ -118,6 +119,32 @@ Enables the get_all_webviews command without any pre-configured scope.
 <td>
 
 Denies the get_all_webviews command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`core:webview:allow-internal-log`
+
+</td>
+<td>
+
+Enables the internal_log command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`core:webview:deny-internal-log`
+
+</td>
+<td>
+
+Denies the internal_log command without any pre-configured scope.
 
 </td>
 </tr>

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -1553,6 +1553,9 @@ pub struct Builder<R: Runtime> {
   /// The device event filter.
   device_event_filter: DeviceEventFilter,
 
+  /// Whether webview console output and page errors are forwarded to the log crate.
+  forward_webview_console: bool,
+
   pub(crate) invoke_key: String,
 }
 
@@ -1621,6 +1624,7 @@ impl<R: Runtime> Builder<R> {
       window_event_listeners: Vec::new(),
       webview_event_listeners: Vec::new(),
       device_event_filter: Default::default(),
+      forward_webview_console: false,
       invoke_key,
     }
   }
@@ -1785,6 +1789,34 @@ tauri::Builder::default()
     F: Fn(&Webview<R>, &PageLoadPayload<'_>) + Send + Sync + 'static,
   {
     self.on_page_load.replace(Arc::new(on_page_load));
+    self
+  }
+
+  /// Forwards webview `console.*` output, uncaught errors (including
+  /// capture-phase resource load errors, e.g. a `<script>` that fails to load)
+  /// and unhandled promise rejections to the [`log`] crate, using the
+  /// `webview:{label}` target.
+  ///
+  /// Console levels map to log levels: `error`, `warn`, `debug` as-is,
+  /// everything else to `info`.
+  ///
+  /// Disabled by default.
+  /// When disabled, the capture script is not injected and forwarded messages
+  /// are ignored.
+  ///
+  /// # Security
+  ///
+  /// When enabled, any JavaScript running in the webview can write to the
+  /// host application's log.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// tauri::Builder::default().forward_webview_console(true);
+  /// ```
+  #[must_use]
+  pub fn forward_webview_console(mut self, enabled: bool) -> Self {
+    self.forward_webview_console = enabled;
     self
   }
 
@@ -2315,6 +2347,7 @@ tauri::Builder::default()
       HashMap::new(),
       self.invoke_initialization_script,
       self.channel_interceptor,
+      self.forward_webview_console,
       self.invoke_key,
     ));
 

--- a/crates/tauri/src/ipc/protocol.rs
+++ b/crates/tauri/src/ipc/protocol.rs
@@ -579,6 +579,7 @@ mod tests {
       Default::default(),
       "".into(),
       None,
+      false,
       crate::generate_invoke_key().unwrap(),
     );
 
@@ -698,6 +699,7 @@ mod tests {
       Default::default(),
       "".into(),
       None,
+      false,
       crate::generate_invoke_key().unwrap(),
     );
 

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -272,6 +272,7 @@ impl<R: Runtime> AppManager<R> {
     >,
     invoke_initialization_script: String,
     channel_interceptor: Option<ChannelInterceptor<R>>,
+    forward_console: bool,
     invoke_key: String,
   ) -> Self {
     // generate a random isolation key at runtime
@@ -297,6 +298,7 @@ impl<R: Runtime> AppManager<R> {
         uri_scheme_protocols: Mutex::new(uri_scheme_protocols),
         event_listeners: Arc::new(webview_event_listeners),
         invoke_initialization_script,
+        forward_console,
         invoke_key: invoke_key.clone(),
       },
       #[cfg(all(desktop, feature = "tray-icon"))]
@@ -785,6 +787,7 @@ mod test {
       Default::default(),
       "".into(),
       None,
+      false,
       crate::generate_invoke_key().unwrap(),
     );
 

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -86,6 +86,9 @@ pub struct WebviewManager<R: Runtime> {
   /// The script that initializes the invoke system.
   pub invoke_initialization_script: String,
 
+  /// Whether webview console output and page errors are forwarded to the log crate.
+  pub(crate) forward_console: bool,
+
   /// A runtime generated invoke key.
   pub(crate) invoke_key: String,
 }
@@ -200,6 +203,15 @@ impl<R: Runtime> WebviewManager<R> {
       &pattern_init.into_string(),
       use_https_scheme,
     )?));
+
+    // placed after the invoke system is set up (its queue buffers messages
+    // until the IPC bridge is ready) and before any plugin or user script, so
+    // their console output is captured as well
+    if self.forward_console {
+      all_initialization_scripts.push(main_frame_script(
+        include_str!("../webview/scripts/console-forward.js").to_owned(),
+      ));
+    }
 
     all_initialization_scripts.extend(plugin_init_scripts);
 

--- a/crates/tauri/src/webview/plugin.rs
+++ b/crates/tauri/src/webview/plugin.rs
@@ -31,6 +31,66 @@ async fn get_all_webviews<R: Runtime>(app: AppHandle<R>) -> Vec<WebviewRef> {
     .collect()
 }
 
+/// A console message or page error forwarded by the console capture script.
+#[derive(serde::Deserialize)]
+pub struct JsLogPayload {
+  /// The console level (`error`, `warn`, `info`, `log`, `debug`, ...).
+  pub level: String,
+  /// The stringified message.
+  pub message: String,
+  /// The source URL, when available.
+  #[serde(default)]
+  pub url: Option<String>,
+  /// The source line, when available.
+  #[serde(default)]
+  pub line: Option<u32>,
+  /// The source column, when available.
+  #[serde(default)]
+  pub col: Option<u32>,
+  /// The error stack, when available.
+  #[serde(default)]
+  pub stack: Option<String>,
+}
+
+fn js_log_level(level: &str) -> log::Level {
+  match level {
+    "error" => log::Level::Error,
+    "warn" => log::Level::Warn,
+    "debug" => log::Level::Debug,
+    "trace" => log::Level::Trace,
+    _ => log::Level::Info,
+  }
+}
+
+fn log_js_message(label: &str, payload: &JsLogPayload) {
+  let location = match (&payload.url, payload.line, payload.col) {
+    (Some(url), Some(line), Some(col)) => format!(" ({url}:{line}:{col})"),
+    (Some(url), Some(line), None) => format!(" ({url}:{line})"),
+    (Some(url), None, _) => format!(" ({url})"),
+    _ => String::new(),
+  };
+  let stack = payload
+    .stack
+    .as_deref()
+    .map(|stack| format!("\n{stack}"))
+    .unwrap_or_default();
+
+  log::log!(
+    target: &format!("webview:{label}"),
+    js_log_level(&payload.level),
+    "{}{location}{stack}",
+    payload.message
+  );
+}
+
+#[command(root = "crate")]
+fn internal_log<R: Runtime>(webview: crate::Webview<R>, payload: JsLogPayload) {
+  if !webview.manager().webview.forward_console {
+    return;
+  }
+  log_js_message(webview.label(), &payload);
+}
+
 #[command(root = "crate")]
 async fn create_webview_window<R: Runtime>(
   app: AppHandle<R>,
@@ -233,6 +293,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
       #![plugin(webview)]
       create_webview_window,
       get_all_webviews,
+      internal_log,
       #[cfg(desktop)] desktop_commands::create_webview,
       // getters
       #[cfg(desktop)] desktop_commands::webview_position,
@@ -254,4 +315,36 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
       desktop_commands::internal_toggle_devtools,
     ])
     .build()
+}
+
+#[cfg(test)]
+mod tests {
+  #[test]
+  fn maps_js_console_levels() {
+    use super::js_log_level;
+    assert_eq!(js_log_level("error"), log::Level::Error);
+    assert_eq!(js_log_level("warn"), log::Level::Warn);
+    assert_eq!(js_log_level("debug"), log::Level::Debug);
+    assert_eq!(js_log_level("trace"), log::Level::Trace);
+    assert_eq!(js_log_level("log"), log::Level::Info);
+    assert_eq!(js_log_level("info"), log::Level::Info);
+    assert_eq!(js_log_level("anything"), log::Level::Info);
+  }
+
+  #[test]
+  fn forward_console_flag_is_threaded() {
+    use crate::{
+      sealed::ManagerBase,
+      test::{mock_builder, mock_context, noop_assets},
+    };
+
+    let app = mock_builder()
+      .forward_webview_console(true)
+      .build(mock_context(noop_assets()))
+      .unwrap();
+    assert!(app.manager().webview.forward_console);
+
+    let app = mock_builder().build(mock_context(noop_assets())).unwrap();
+    assert!(!app.manager().webview.forward_console);
+  }
 }

--- a/crates/tauri/src/webview/scripts/console-forward.js
+++ b/crates/tauri/src/webview/scripts/console-forward.js
@@ -1,0 +1,146 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+;(function () {
+  if (window.__TAURI_CONSOLE_FORWARDER__) {
+    return
+  }
+  window.__TAURI_CONSOLE_FORWARDER__ = true
+
+  const MAX_ARG_LENGTH = 8 * 1024
+  const MAX_MESSAGE_LENGTH = 32 * 1024
+
+  const original = {
+    error: console.error.bind(console),
+    warn: console.warn.bind(console),
+    info: console.info.bind(console),
+    log: console.log.bind(console),
+    debug: console.debug.bind(console)
+  }
+
+  let reported = false
+  function reportOnce(error) {
+    if (!reported) {
+      reported = true
+      original.warn('failed to forward console message to the host:', error)
+    }
+  }
+
+  function truncate(str, max) {
+    return str.length > max ? str.slice(0, max) + '…' : str
+  }
+
+  function serializeArg(arg) {
+    if (typeof arg === 'string') {
+      return arg
+    }
+    if (arg instanceof Error) {
+      // WebKit stacks do not repeat name and message, so always prefix them
+      return arg.stack
+        ? `${arg.name}: ${arg.message}\n${arg.stack}`
+        : `${arg.name}: ${arg.message}`
+    }
+    try {
+      const seen = new WeakSet()
+      const json = JSON.stringify(arg, (_, value) => {
+        if (typeof value === 'object' && value !== null) {
+          if (seen.has(value)) {
+            return '[circular]'
+          }
+          seen.add(value)
+        }
+        if (typeof value === 'bigint') {
+          return String(value)
+        }
+        return value
+      })
+      return json === undefined ? String(arg) : json
+    } catch (_) {
+      return String(arg)
+    }
+  }
+
+  let forwarding = false
+  function send(level, message, extra) {
+    if (forwarding) {
+      return
+    }
+    forwarding = true
+    try {
+      const payload = Object.assign(
+        { level, message: truncate(message, MAX_MESSAGE_LENGTH) },
+        extra
+      )
+      // the attached catch keeps a failing invoke from re-entering through
+      // the unhandledrejection listener
+      window.__TAURI_INTERNALS__
+        .invoke('plugin:webview|internal_log', { payload })
+        .catch(reportOnce)
+    } catch (error) {
+      reportOnce(error)
+    } finally {
+      forwarding = false
+    }
+  }
+
+  for (const level of ['error', 'warn', 'info', 'log', 'debug']) {
+    console[level] = function (...args) {
+      original[level](...args)
+      send(
+        level,
+        args
+          .map((arg) => truncate(serializeArg(arg), MAX_ARG_LENGTH))
+          .join(' '),
+        { kind: 'console' }
+      )
+    }
+  }
+
+  // capture phase: failed <script>/<link>/<img> loads fire on the element and
+  // never bubble to a window listener
+  window.addEventListener(
+    'error',
+    (event) => {
+      const target = event.target
+      if (target && target !== window && (target.src || target.href)) {
+        const url = String(target.src || target.href)
+        send(
+          'error',
+          `failed to load <${target.tagName.toLowerCase()}> resource: ${url}`,
+          {
+            kind: 'resourceError'
+          }
+        )
+      } else {
+        send('error', event.message || 'uncaught error', {
+          kind: 'error',
+          url: event.filename || undefined,
+          line: event.lineno || undefined,
+          col: event.colno || undefined,
+          stack:
+            event.error && event.error.stack
+              ? String(event.error.stack)
+              : undefined
+        })
+      }
+    },
+    true
+  )
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason
+    const message =
+      reason instanceof Error
+        ? `${reason.name}: ${reason.message}`
+        : serializeArg(reason)
+    send(
+      'error',
+      `unhandled promise rejection: ${truncate(message, MAX_ARG_LENGTH)}`,
+      {
+        kind: 'unhandledRejection',
+        stack: reason && reason.stack ? String(reason.stack) : undefined
+      }
+    )
+  })
+})()


### PR DESCRIPTION
There is no supported way to get webview console output and uncaught errors into the host process log; hand-rolled versions hit three ordering hazards (buffering before IPC is ready, capture-phase resource errors, swallowed invoke rejections).

`Builder::forward_webview_console(bool)`, disabled by default:
- Injects `console-forward.js` after the invoke system (its queue buffers until the IPC bridge is up - hazard 1 solved by construction) and before plugin/user scripts.
- Wraps `console.*` (original called first), captures `error` in the capture phase (failed `<script>`/`<link>`/`<img>` loads never bubble - hazard 2) and `unhandledrejection` without `preventDefault()`.
- The forwarding invoke carries its own `.catch` reporting once through the original console, so failures never loop (hazard 3); payloads are size-capped and cycle-guarded.
- Rust side: new internal `core:webview` command `internal_log` (enabled in the default set, same pipeline as `internal_toggle_devtools`), mapping to `log::log!` with target `webview:{label}`; no-op when the flag is off.

Per-webview granularity and a config-file flag are possible additive follow-ups; log-only output keeps v1 minimal (apps can count errors via a wrapping `log::Log`).

Closes #15942