### PR TITLE
fix(android): register result launchers per activity

### DIFF
--- a/.changes/android-plugin-manager-relaunch.md
+++ b/.changes/android-plugin-manager-relaunch.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+On Android, fixed a crash when an activity is destroyed while another one is already running — installing an APK over the running app is the common way to hit it. The plugin manager tried to move its activity result launchers to the surviving activity, and `registerForActivityResult` rejects that with `IllegalStateException: LifecycleOwner ... is attempting to register while current state is RESUMED`. Each activity now registers its own launchers when it is created.

--- a/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginManager.kt
+++ b/crates/tauri/mobile/android/src/main/java/app/tauri/plugin/PluginManager.kt
@@ -34,12 +34,18 @@ object PluginManager {
     fun onResult(result: ActivityResult)
   }
 
-  private val activities: HashSet<AppCompatActivity> = HashSet()
+  /** The result launchers belonging to one activity. */
+  private class ResultLaunchers(
+    val startActivityForResult: ActivityResultLauncher<Intent>,
+    val startIntentSenderForResult: ActivityResultLauncher<IntentSenderRequest>,
+    val requestPermissions: ActivityResultLauncher<Array<String>>
+  )
+
+  // Insertion ordered, so the activity taken over when the current one goes away is the oldest
+  // surviving one rather than an arbitrary member of a hash set.
+  private val launchers: LinkedHashMap<AppCompatActivity, ResultLaunchers> = LinkedHashMap()
   var activity: AppCompatActivity? = null
   private val plugins: HashMap<String, PluginHandle> = HashMap()
-  private var startActivityForResultLauncher: ActivityResultLauncher<Intent>? = null
-  private var startIntentSenderForResultLauncher: ActivityResultLauncher<IntentSenderRequest>? = null
-  private var requestPermissionsLauncher: ActivityResultLauncher<Array<String>>? = null
   private var requestPermissionsCallback: RequestPermissionsCallback? = null
   private var startActivityForResultCallback: ActivityResultCallback? = null
   private var startIntentSenderForResultCallback: ActivityResultCallback? = null
@@ -57,39 +63,36 @@ object PluginManager {
   }
 
   fun onCreate(activity: AppCompatActivity) {
-    // Record the activity, and if that's the only activity we got, register result launchers
-    activities.add(activity)
+    // Every activity gets its own launchers, and gets them here: registerForActivityResult must
+    // be called before its owner reaches STARTED, so an activity that is already running can
+    // never be given launchers later.
+    launchers[activity] = registerResultLaunchers(activity)
     if (this.activity == null) {
       this.activity = activity
-      registerResultLaunchers(activity)
     }
   }
 
-  private fun registerResultLaunchers(activity: AppCompatActivity) {
-    startActivityForResultLauncher =
+  private fun registerResultLaunchers(activity: AppCompatActivity): ResultLaunchers =
+    ResultLaunchers(
       activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()
       ) { result ->
-        if (startActivityForResultCallback != null) {
-          startActivityForResultCallback!!.onResult(result)
-        }
-      }
+        startActivityForResultCallback?.onResult(result)
+      },
 
-    startIntentSenderForResultLauncher =
       activity.registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()
       ) { result ->
-        if (startIntentSenderForResultCallback != null) {
-          startIntentSenderForResultCallback!!.onResult(result)
-        }
-      }
+        startIntentSenderForResultCallback?.onResult(result)
+      },
 
-    requestPermissionsLauncher =
       activity.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()
       ) { result ->
-        if (requestPermissionsCallback != null) {
-          requestPermissionsCallback!!.onResult(result)
-        }
+        requestPermissionsCallback?.onResult(result)
       }
-  }
+    )
+
+  private val currentLaunchers: ResultLaunchers
+    get() = launchers[activity]
+      ?: throw IllegalStateException("the plugin manager has no activity to launch from")
 
   fun onNewIntent(intent: Intent) {
     for (plugin in plugins.values) {
@@ -126,18 +129,12 @@ object PluginManager {
       plugin.instance.triggerOnDestroy(activity)
     }
 
-    activities.remove(activity)
-    val nextActivity = activities.firstOrNull()
-    if (nextActivity != null) {
-      if (this.activity == activity) {
-        this.activity = nextActivity
-        registerResultLaunchers(nextActivity)
-      }
-    } else {
-      this.activity = null
-      this.startActivityForResultLauncher = null
-      this.startIntentSenderForResultLauncher = null
-      this.requestPermissionsLauncher = null
+    launchers.remove(activity)
+    if (this.activity == activity) {
+      // Whatever is left already holds its own launchers, registered when it was created. Moving
+      // this activity's launchers over instead would mean registering against an activity that is
+      // already running, which registerForActivityResult rejects with an IllegalStateException.
+      this.activity = launchers.keys.firstOrNull()
     }
   }
 
@@ -149,12 +146,12 @@ object PluginManager {
 
   fun startActivityForResult(intent: Intent, callback: ActivityResultCallback) {
     startActivityForResultCallback = callback
-    startActivityForResultLauncher!!.launch(intent)
+    currentLaunchers.startActivityForResult.launch(intent)
   }
 
   fun startIntentSenderForResult(intent: IntentSenderRequest, callback: ActivityResultCallback) {
     startIntentSenderForResultCallback = callback
-    startIntentSenderForResultLauncher!!.launch(intent)
+    currentLaunchers.startIntentSenderForResult.launch(intent)
   }
 
   fun requestPermissions(
@@ -162,7 +159,7 @@ object PluginManager {
     callback: RequestPermissionsCallback
   ) {
     requestPermissionsCallback = callback
-    requestPermissionsLauncher!!.launch(permissionStrings)
+    currentLaunchers.requestPermissions.launch(permissionStrings)
   }
 
   @JniMethod


### PR DESCRIPTION
Closes #15948.

`PluginManager.onDestroy` moved the manager's activity result launchers to whichever activity was left, by calling `registerResultLaunchers` on it. That activity is by definition already running, and `registerForActivityResult` may only be called before its owner reaches STARTED, so the branch threw an `IllegalStateException` every time it was taken — there is no moment during another activity's teardown at which the call is legal. The launchers therefore stop being a property of the manager that migrates: each activity registers its own set while it is being created, which is the one point where registering is allowed, and `onDestroy` only has to drop the entry and point at whatever remains, which already has launchers of its own.

- register result launchers per activity in `onCreate` instead of once for the first one
- keep them in a `LinkedHashMap` keyed by activity, so the activity taken over when the current one goes away is the oldest survivor rather than an arbitrary member of a hash set
- `onDestroy` removes the entry and re-points `activity`; it no longer registers anything
- the three launch call sites read the current activity's set, so a missing one reports what went wrong instead of throwing an NPE from `!!`

### Testing

Reproduced on a Pixel 8 Pro (Android 17) by installing an APK over the running app, which momentarily leaves the new activity resumed while the old one is destroyed: the app crashed on every attempt before this change. With it, six consecutive `adb install -r` over the running app produced no crash and the app relaunched normally each time.
