### PR TITLE
fix(windows): use cached focus states for `is_focused`

### DIFF
--- a/.changes/windows-multiwebview-cached-focused-states.md
+++ b/.changes/windows-multiwebview-cached-focused-states.md
@@ -1,0 +1,6 @@
+---
+tauri: patch:bug
+tauri-runtime-wry: patch:bug
+---
+
+On Windows, fixed `Window::is_focused` always returns `false` in multi-webview mode

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -3317,9 +3317,12 @@ fn handle_user_message<T: UserEvent>(
           w.webviews.clone(),
           w.has_children.load(Ordering::Relaxed),
           w.window_event_listeners.clone(),
+          w.focused_webview.clone(),
         )
       });
-      if let Some((Some(window), webviews, has_children, window_event_listeners)) = w {
+      if let Some((Some(window), webviews, has_children, window_event_listeners, focused_webview)) =
+        w
+      {
         match window_message {
           WindowMessage::AddEventListener(id, listener) => {
             window_event_listeners.lock().unwrap().insert(id, listener);
@@ -3348,7 +3351,19 @@ fn handle_user_message<T: UserEvent>(
           WindowMessage::IsFullscreen(tx) => tx.send(window.fullscreen().is_some()).unwrap(),
           WindowMessage::IsMinimized(tx) => tx.send(window.is_minimized()).unwrap(),
           WindowMessage::IsMaximized(tx) => tx.send(window.is_maximized()).unwrap(),
-          WindowMessage::IsFocused(tx) => tx.send(window.is_focused()).unwrap(),
+          WindowMessage::IsFocused(tx) => {
+            let focused = if has_children {
+              // on multiwebview mode, get the focused state from cache,
+              // as the window might not have direct focus
+              matches!(
+                *focused_webview.lock().unwrap(),
+                FocusState::WindowFocused | FocusState::WebviewFocused { .. }
+              )
+            } else {
+              window.is_focused()
+            };
+            tx.send(focused).unwrap()
+          }
           WindowMessage::IsDecorated(tx) => tx.send(window.is_decorated()).unwrap(),
           WindowMessage::IsResizable(tx) => tx.send(window.is_resizable()).unwrap(),
           WindowMessage::IsMaximizable(tx) => tx.send(window.is_maximizable()).unwrap(),

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -651,7 +651,8 @@ impl<R: Runtime> AppManager<R> {
       .window
       .windows_lock()
       .values()
-      .find(|w| w.is_focused().unwrap_or(false)).cloned()
+      .find(|w| w.is_focused().unwrap_or(false))
+      .cloned()
   }
 
   pub(crate) fn on_window_close(&self, label: &str) {

--- a/crates/tauri/src/manager/mod.rs
+++ b/crates/tauri/src/manager/mod.rs
@@ -650,9 +650,8 @@ impl<R: Runtime> AppManager<R> {
     self
       .window
       .windows_lock()
-      .iter()
-      .find(|w| w.1.is_focused().unwrap_or(false))
-      .map(|w| w.1.clone())
+      .values()
+      .find(|w| w.is_focused().unwrap_or(false)).cloned()
   }
 
   pub(crate) fn on_window_close(&self, label: &str) {


### PR DESCRIPTION
Fix #15903
Closes #15904

Fix `Window::is_focused` always returns `false` in multi-webview mode