### PR TITLE
fix(cli): plugin init template ts 6/7 `rootDir`

### DIFF
--- a/.changes/plugin-template-ts7.md
+++ b/.changes/plugin-template-ts7.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:deps
+"@tauri-apps/cli": patch:deps
+---
+
+Update typescript to v7 in `tauri plugin init` template. Also fixes the default `rootDir` in the template `tsconfig.json`

--- a/crates/tauri-cli/templates/plugin/package.json
+++ b/crates/tauri-cli/templates/plugin/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.0.0",
     "rollup": "^4.9.6",
-    "typescript": "^6.0.0",
+    "typescript": "^7.0.2",
     "tslib": "^2.6.2"
   }
 }

--- a/crates/tauri-cli/templates/plugin/tsconfig.json
+++ b/crates/tauri-cli/templates/plugin/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": "guest-js",
     "target": "es2021",
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
Update typescript to v7 in `tauri plugin init` template (split from #15703). Also fixes the default `rootDir` in the template `tsconfig.json`

Closes #15953 (regession from #15158)