### PR TITLE
feat(bundler): Adding Gstreamer plugin to Linux bundler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "asset-streaming"
+version = "0.1.0"
+dependencies = [
+ "tauri",
+ "tauri-build",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
   "examples/resources/src-tauri",
   "examples/api/src-tauri",
   "examples/api/src-tauri/tauri-plugin-sample",
+  "examples/asset-streaming/src-tauri",
 ]
 resolver = "2"
 

--- a/crates/tauri-bundler/src/bundle.rs
+++ b/crates/tauri-bundler/src/bundle.rs
@@ -27,10 +27,11 @@ use tauri_utils::{display_path, platform::Target as TargetPlatform};
 pub use {
   category::AppCategory,
   settings::{
-    AppImageSettings, BundleBinary, BundleSettings, CustomSignCommandSettings, DebianSettings,
-    DmgSettings, Entitlements, IosSettings, MacOsSettings, NsisSettings, PackageSettings,
-    PackageType, PlistKind, Position, RpmSettings, Settings, SettingsBuilder, Size,
-    UpdaterSettings, WindowsSettings, WixLanguage, WixLanguageConfig, WixSettings,
+    AppImageSettings, AssetGstPluginSettings, BundleBinary, BundleSettings,
+    CustomSignCommandSettings, DebianSettings, DmgSettings, Entitlements, IosSettings,
+    MacOsSettings, NsisSettings, PackageSettings, PackageType, PlistKind, Position, RpmSettings,
+    Settings, SettingsBuilder, Size, UpdaterSettings, WindowsSettings, WixLanguage,
+    WixLanguageConfig, WixSettings,
   },
   windows::vswhere_path,
 };

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -183,6 +183,12 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
   ]);
   if settings.appimage().bundle_media_framework {
     cmd.args(["--plugin", "gstreamer"]);
+  } else if settings.asset_gst_plugin().active {
+    log::warn!(
+      "`bundle > linux > assetGstPlugin` is enabled but `bundle > linux > appimage > bundleMediaFramework` is not. \
+       The plugin links against the GStreamer libraries, which only get deployed into the AppImage by the media \
+       framework, so it will fail to load at runtime."
+    );
   }
   cmd.args(["--output", "appimage"]);
 

--- a/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
+++ b/crates/tauri-bundler/src/bundle/linux/appimage/linuxdeploy.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use super::{super::debian, write_and_make_executable};
+use super::{
+  super::{debian, tools_directory},
+  write_and_make_executable,
+};
 use crate::{
   bundle::settings::Arch,
   error::Context,
@@ -43,12 +46,7 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
     fs::remove_dir_all(&output_path)?;
   }
 
-  let tools_path = settings
-    .local_tools_directory()
-    .map(|d| d.join(".tauri"))
-    .unwrap_or_else(|| {
-      dirs::cache_dir().map_or_else(|| output_path.to_path_buf(), |p| p.join("tauri"))
-    });
+  let tools_path = tools_directory(settings, &output_path);
 
   fs::create_dir_all(&tools_path)?;
 

--- a/crates/tauri-bundler/src/bundle/linux/debian.rs
+++ b/crates/tauri-bundler/src/bundle/linux/debian.rs
@@ -23,7 +23,7 @@
 // metadata, as well as generating the md5sums file.  Currently we do not
 // generate postinst or prerm files.
 
-use super::freedesktop;
+use super::{freedesktop, gst_plugin};
 use crate::{
   bundle::settings::Arch,
   error::{Context, ErrorExt},
@@ -125,6 +125,9 @@ pub fn generate_data(
   }
 
   copy_resource_files(settings, &data_dir).with_context(|| "Failed to copy resource files")?;
+
+  copy_gst_plugin(settings, &data_dir)
+    .with_context(|| "Failed to copy the asset GStreamer plugin")?;
 
   settings
     .copy_binaries(&bin_dir)
@@ -329,6 +332,16 @@ fn generate_md5sums(control_dir: &Path, data_dir: &Path) -> crate::Result<()> {
 fn copy_resource_files(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
   let resource_dir = data_dir.join("usr/lib").join(settings.product_name());
   settings.copy_resources(&resource_dir)
+}
+
+fn copy_gst_plugin(settings: &Settings, data_dir: &Path) -> crate::Result<()> {
+  if let Some(plugin) = gst_plugin::resolve(settings)? {
+    let dest = data_dir
+      .join(gst_plugin::plugin_dir(settings.product_name()))
+      .join(gst_plugin::PLUGIN_FILE_NAME);
+    fs_utils::copy_file(&plugin, &dest)?;
+  }
+  Ok(())
 }
 
 /// Create an empty file at the given path, creating any parent directories as

--- a/crates/tauri-bundler/src/bundle/linux/gst_plugin.rs
+++ b/crates/tauri-bundler/src/bundle/linux/gst_plugin.rs
@@ -1,0 +1,154 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+//! Resolves the GStreamer plugin for having `asset://` work for audio/video.
+
+use super::tools_directory;
+use crate::{bundle::settings::Arch, error::Context, utils::http_utils::download, Settings};
+use std::{
+  fs,
+  path::{Path, PathBuf},
+};
+
+/// File name of the GStreamer plugin
+pub const PLUGIN_FILE_NAME: &str = "libgsttauriasset.so";
+
+/// Release the prebuilt plugins are downloaded from.
+/// TODO: this actually doesn't exist !
+const PLUGIN_RELEASE_URL: &str =
+  "https://github.com/tauri-apps/binary-releases/releases/download/tauri-asset-gst-plugin-v0.1.0";
+
+/// Directory the plugin is installed to, relative to the bundle root.
+///
+/// This is a private per-app directory rather than the system-wide
+/// `gstreamer-1.0` one, so that bundles cannot collide with distribution
+/// packages or with each other. GStreamer only scans directories listed in
+/// `GST_PLUGIN_PATH`, which the Tauri runtime points here on startup.
+pub fn plugin_dir(product_name: &str) -> PathBuf {
+  Path::new("usr/lib")
+    .join(product_name)
+    .join("gstreamer-1.0")
+}
+
+/// Resolves the plugin to bundle, or `None` when it is not enabled.
+pub fn resolve(settings: &Settings) -> crate::Result<Option<PathBuf>> {
+  let config = settings.asset_gst_plugin();
+  if !config.active {
+    return Ok(None);
+  }
+
+  match &config.path {
+    Some(path) => {
+      if !path.is_file() {
+        crate::error::bail!(
+          "`bundle > linux > assetGstPlugin > path` is not a file: {}",
+          path.display()
+        );
+      }
+      Ok(Some(path.clone()))
+    }
+    None => download_plugin(settings).map(Some),
+  }
+}
+
+/// Downloads the prebuilt plugin for the target architecture, caching it in the
+/// tools directory alongside the AppImage tooling.
+fn download_plugin(settings: &Settings) -> crate::Result<PathBuf> {
+  let arch = match settings.binary_arch() {
+    Arch::X86_64 => "x86_64",
+    Arch::X86 => "i686",
+    Arch::AArch64 => "aarch64",
+    Arch::Armhf => "armhf",
+    target => {
+      return Err(crate::Error::ArchError(format!(
+        "the asset GStreamer plugin is not available for {target:?}"
+      )))
+    }
+  };
+
+  let tools_path = tools_directory(settings, settings.project_out_directory());
+  fs::create_dir_all(&tools_path)?;
+
+  let file_name = format!("libgsttauriasset-{arch}.so");
+  let cached = tools_path.join(&file_name);
+  if cached.exists() {
+    return Ok(cached);
+  }
+
+  let data = download(&format!("{PLUGIN_RELEASE_URL}/{file_name}")).with_context(|| {
+    format!("failed to download {file_name}; build the plugin yourself and point `bundle > linux > assetGstPlugin > path` at the resulting {PLUGIN_FILE_NAME}")
+  })?;
+  fs::write(&cached, data)?;
+
+  Ok(cached)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::bundle::settings::{
+    AssetGstPluginSettings, BundleSettings, PackageSettings, SettingsBuilder,
+  };
+
+  fn settings(active: bool, path: Option<PathBuf>, out: &Path) -> Settings {
+    SettingsBuilder::new()
+      .project_out_directory(out)
+      .package_settings(PackageSettings {
+        product_name: "My App".into(),
+        version: "0.1.0".into(),
+        description: String::new(),
+        homepage: None,
+        authors: None,
+        default_run: None,
+      })
+      .bundle_settings(BundleSettings {
+        asset_gst_plugin: AssetGstPluginSettings { active, path },
+        ..Default::default()
+      })
+      .build()
+      .unwrap()
+  }
+
+  #[test]
+  fn plugin_dir_is_private_to_the_app() {
+    assert_eq!(
+      plugin_dir("My App"),
+      PathBuf::from("usr/lib/My App/gstreamer-1.0")
+    );
+  }
+
+  #[test]
+  fn inactive_resolves_to_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    // a path is set but must be ignored while inactive
+    let so = tmp.path().join(PLUGIN_FILE_NAME);
+    fs::write(&so, b"x").unwrap();
+    let s = settings(false, Some(so), tmp.path());
+    assert!(resolve(&s).unwrap().is_none());
+  }
+
+  #[test]
+  fn explicit_path_is_used_verbatim() {
+    let tmp = tempfile::tempdir().unwrap();
+    let so = tmp.path().join(PLUGIN_FILE_NAME);
+    fs::write(&so, b"x").unwrap();
+    let s = settings(true, Some(so.clone()), tmp.path());
+    assert_eq!(resolve(&s).unwrap(), Some(so));
+  }
+
+  #[test]
+  fn missing_explicit_path_errors_without_downloading() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = settings(true, Some(tmp.path().join("nope.so")), tmp.path());
+    let err = resolve(&s).unwrap_err().to_string();
+    assert!(err.contains("assetGstPlugin"), "unhelpful error: {err}");
+  }
+
+  #[test]
+  fn a_directory_is_not_accepted_as_the_plugin() {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = settings(true, Some(tmp.path().to_path_buf()), tmp.path());
+    assert!(resolve(&s).is_err());
+  }
+}

--- a/crates/tauri-bundler/src/bundle/linux/gst_plugin.rs
+++ b/crates/tauri-bundler/src/bundle/linux/gst_plugin.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// Copyright 2019-2026 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 

--- a/crates/tauri-bundler/src/bundle/linux/mod.rs
+++ b/crates/tauri-bundler/src/bundle/linux/mod.rs
@@ -6,4 +6,21 @@
 pub mod appimage;
 pub mod debian;
 pub mod freedesktop;
+pub mod gst_plugin;
 pub mod rpm;
+
+use crate::Settings;
+use std::path::{Path, PathBuf};
+
+/// Directory downloaded bundling tools are cached in.
+///
+/// `fallback` is only used when the user has not configured a local tools
+/// directory and the platform has no cache directory.
+pub fn tools_directory(settings: &Settings, fallback: &Path) -> PathBuf {
+  settings
+    .local_tools_directory()
+    .map(|d| d.join(".tauri"))
+    .unwrap_or_else(|| {
+      dirs::cache_dir().map_or_else(|| fallback.to_path_buf(), |p| p.join("tauri"))
+    })
+}

--- a/crates/tauri-bundler/src/bundle/linux/rpm.rs
+++ b/crates/tauri-bundler/src/bundle/linux/rpm.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use tauri_utils::config::RpmCompression;
 
-use super::freedesktop;
+use super::{freedesktop, gst_plugin};
 
 /// Bundles the project.
 /// Returns a vector of PathBuf that shows where the RPM was created.
@@ -196,6 +196,28 @@ pub fn bundle_project(settings: &Settings) -> crate::Result<Vec<PathBuf>> {
       let dest = resource_dir.join(resource.target());
       builder = builder.with_file(resource.path(), FileOptions::new(dest.to_string_lossy()))?;
     }
+  }
+
+  // Add the `asset://` GStreamer plugin
+  if let Some(plugin) = gst_plugin::resolve(settings)? {
+    let plugin_dir = Path::new("/").join(gst_plugin::plugin_dir(product_name));
+    // Create an empty file, needed to add a directory to the RPM package
+    // (cf https://github.com/rpm-rs/rpm/issues/177)
+    let empty_file_path = &package_dir.join("empty");
+    File::create(empty_file_path)?;
+    builder = builder.with_file(
+      empty_file_path,
+      FileOptions::new(plugin_dir.to_string_lossy()).mode(FileMode::Dir { permissions: 0o755 }),
+    )?;
+    builder = builder.with_file(
+      &plugin,
+      FileOptions::new(
+        plugin_dir
+          .join(gst_plugin::PLUGIN_FILE_NAME)
+          .to_string_lossy(),
+      )
+      .mode(FileMode::Regular { permissions: 0o755 }),
+    )?;
   }
 
   // Add Desktop entry file

--- a/crates/tauri-bundler/src/bundle/settings.rs
+++ b/crates/tauri-bundler/src/bundle/settings.rs
@@ -230,6 +230,17 @@ pub struct AppImageSettings {
   pub bundle_xdg_open: bool,
 }
 
+/// The `asset://` GStreamer plugin settings, shared by all Linux bundle formats.
+#[derive(Clone, Debug, Default)]
+pub struct AssetGstPluginSettings {
+  /// Whether to bundle the plugin.
+  pub active: bool,
+  /// Path to a prebuilt `libgsttauriasset.so`.
+  ///
+  /// When `None`, the bundler downloads a prebuilt plugin for the target architecture.
+  pub path: Option<PathBuf>,
+}
+
 /// The RPM bundle settings.
 #[derive(Clone, Debug, Default)]
 pub struct RpmSettings {
@@ -716,6 +727,8 @@ pub struct BundleSettings {
   pub appimage: AppImageSettings,
   /// Rpm-specific settings.
   pub rpm: RpmSettings,
+  /// `asset://` GStreamer plugin settings (Linux bundle only).
+  pub asset_gst_plugin: AssetGstPluginSettings,
   /// DMG-specific settings.
   pub dmg: DmgSettings,
   /// iOS-specific settings.
@@ -1320,6 +1333,11 @@ impl Settings {
   /// Returns the RPM settings.
   pub fn rpm(&self) -> &RpmSettings {
     &self.bundle_settings.rpm
+  }
+
+  /// Returns the `asset://` GStreamer plugin settings.
+  pub fn asset_gst_plugin(&self) -> &AssetGstPluginSettings {
+    &self.bundle_settings.asset_gst_plugin
   }
 
   /// Returns the DMG settings.

--- a/crates/tauri-cli/config.schema.json
+++ b/crates/tauri-cli/config.schema.json
@@ -100,6 +100,9 @@
             "bundleMediaFramework": false,
             "files": {}
           },
+          "assetGstPlugin": {
+            "active": false
+          },
           "deb": {
             "files": {}
           },
@@ -2293,6 +2296,9 @@
               "bundleMediaFramework": false,
               "files": {}
             },
+            "assetGstPlugin": {
+              "active": false
+            },
             "deb": {
               "files": {}
             },
@@ -3291,6 +3297,17 @@
               "$ref": "#/definitions/RpmConfig"
             }
           ]
+        },
+        "assetGstPlugin": {
+          "description": "Configuration for the `asset://` GStreamer plugin, shared by all Linux bundle formats.",
+          "default": {
+            "active": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/AssetGstPluginConfig"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -3670,6 +3687,25 @@
           "additionalProperties": false
         }
       ]
+    },
+    "AssetGstPluginConfig": {
+      "description": "Configuration for the `asset://` GStreamer plugin for Linux.",
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "Whether to bundle the plugin. Defaults to `false`.",
+          "default": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "Path to a prebuilt `libgsttauriasset.so`.\n When unset, the bundler downloads a prebuilt plugin for the target architecture.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "MacConfig": {
       "description": "Configuration for the macOS bundles.\n\n See more: <https://v2.tauri.app/reference/config/#macconfig>",

--- a/crates/tauri-cli/src/interface/rust.rs
+++ b/crates/tauri-cli/src/interface/rust.rs
@@ -21,9 +21,9 @@ use notify::RecursiveMode;
 use notify_debouncer_full::new_debouncer;
 use serde::{Deserialize, Deserializer};
 use tauri_bundler::{
-  AppCategory, AppImageSettings, BundleBinary, BundleSettings, DebianSettings, DmgSettings,
-  IosSettings, MacOsSettings, PackageSettings, Position, RpmSettings, Size, UpdaterSettings,
-  WindowsSettings,
+  AppCategory, AppImageSettings, AssetGstPluginSettings, BundleBinary, BundleSettings,
+  DebianSettings, DmgSettings, IosSettings, MacOsSettings, PackageSettings, Position, RpmSettings,
+  Size, UpdaterSettings, WindowsSettings,
 };
 use tauri_utils::config::{parse::is_configuration_file, DeepLinkProtocol, RunnerConfig, Updater};
 
@@ -1585,6 +1585,10 @@ fn tauri_config_to_bundle_settings(
       pre_remove_script: config.linux.rpm.pre_remove_script,
       post_remove_script: config.linux.rpm.post_remove_script,
       compression: config.linux.rpm.compression,
+    },
+    asset_gst_plugin: AssetGstPluginSettings {
+      active: config.linux.asset_gst_plugin.active,
+      path: config.linux.asset_gst_plugin.path,
     },
     dmg: DmgSettings {
       background: config.macos.dmg.background,

--- a/crates/tauri-schema-generator/schemas/config.schema.json
+++ b/crates/tauri-schema-generator/schemas/config.schema.json
@@ -100,6 +100,9 @@
             "bundleMediaFramework": false,
             "files": {}
           },
+          "assetGstPlugin": {
+            "active": false
+          },
           "deb": {
             "files": {}
           },
@@ -2293,6 +2296,9 @@
               "bundleMediaFramework": false,
               "files": {}
             },
+            "assetGstPlugin": {
+              "active": false
+            },
             "deb": {
               "files": {}
             },
@@ -3291,6 +3297,17 @@
               "$ref": "#/definitions/RpmConfig"
             }
           ]
+        },
+        "assetGstPlugin": {
+          "description": "Configuration for the `asset://` GStreamer plugin, shared by all Linux bundle formats.",
+          "default": {
+            "active": false
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/AssetGstPluginConfig"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -3670,6 +3687,25 @@
           "additionalProperties": false
         }
       ]
+    },
+    "AssetGstPluginConfig": {
+      "description": "Configuration for the `asset://` GStreamer plugin for Linux.",
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "Whether to bundle the plugin. Defaults to `false`.",
+          "default": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "Path to a prebuilt `libgsttauriasset.so`.\n When unset, the bundler downloads a prebuilt plugin for the target architecture.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "MacConfig": {
       "description": "Configuration for the macOS bundles.\n\n See more: <https://v2.tauri.app/reference/config/#macconfig>",

--- a/crates/tauri-utils/src/config.rs
+++ b/crates/tauri-utils/src/config.rs
@@ -328,6 +328,20 @@ pub struct AppImageConfig {
   pub files: HashMap<PathBuf, PathBuf>,
 }
 
+/// Configuration for the `asset://` GStreamer plugin for Linux.
+#[skip_serializing_none]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AssetGstPluginConfig {
+  /// Whether to bundle the plugin. Defaults to `false`.
+  #[serde(default)]
+  pub active: bool,
+  /// Path to a prebuilt `libgsttauriasset.so`.
+  /// When unset, the bundler downloads a prebuilt plugin for the target architecture.
+  pub path: Option<PathBuf>,
+}
+
 /// Configuration for Debian (.deb) bundles.
 ///
 /// See more: <https://v2.tauri.app/reference/config/#debconfig>
@@ -397,6 +411,9 @@ pub struct LinuxConfig {
   /// Configuration for the RPM bundle.
   #[serde(default)]
   pub rpm: RpmConfig,
+  /// Configuration for the `asset://` GStreamer plugin, shared by all Linux bundle formats.
+  #[serde(default, alias = "asset-gst-plugin")]
+  pub asset_gst_plugin: AssetGstPluginConfig,
 }
 
 /// Compression algorithms used when bundling RPM packages.

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -2382,6 +2382,33 @@ tauri::Builder::default()
       }
     }
 
+    // GStreamer only scans directories listed in `GST_PLUGIN_PATH`, and WebKit
+    // inherits the environment when it spawns its web and media processes, so
+    // this must happen before the Runtime is created.
+    #[cfg(target_os = "linux")]
+    {
+      if let Some(plugin_dir) = crate::utils::platform::current_exe().ok().and_then(|exe| {
+        let lib_dir = exe.parent()?.join("../lib");
+        // Mirrors the directory the bundler installs the plugin into:
+        // `<prefix>/lib/<product name>/gstreamer-1.0`. The bundler falls back
+        // to the crate name when `productName` is unset, which is also what
+        // the executable is named, so try both.
+        [
+          manager.config.product_name.clone(),
+          exe.file_name().map(|n| n.to_string_lossy().into_owned()),
+        ]
+        .into_iter()
+        .flatten()
+        .map(|name| lib_dir.join(name).join("gstreamer-1.0"))
+        .find(|dir| dir.is_dir())
+      }) {
+        std::env::set_var("GST_PLUGIN_PATH", plugin_dir);
+      } else {
+        #[cfg(debug_assertions)]
+        eprintln!("failed to resolve GStreamer plugin directory; media playback may not work.");
+      }
+    }
+
     #[cfg(any(windows, target_os = "linux"))]
     let mut runtime = if self.runtime_any_thread {
       R::new_any_thread(runtime_args)?

--- a/examples/asset-streaming/.gitignore
+++ b/examples/asset-streaming/.gitignore
@@ -1,0 +1,1 @@
+/src-tauri/gen/schemas

--- a/examples/asset-streaming/public/index.html
+++ b/examples/asset-streaming/public/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body {
+      margin: 0;
+      background: #111;
+    }
+
+    video {
+      width: 100vw;
+      height: 100vh;
+    }
+  </style>
+</head>
+
+<body>
+  <video controls autoplay></video>
+  <script>
+    const { invoke, convertFileSrc } = window.__TAURI__.core
+    invoke('video_path').then((path) => {
+      document.querySelector('video').src = convertFileSrc(path)
+    })
+  </script>
+</body>
+
+</html>

--- a/examples/asset-streaming/src-tauri/Cargo.toml
+++ b/examples/asset-streaming/src-tauri/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "asset-streaming"
+version = "0.1.0"
+description = "Plays a video over the asset:// protocol"
+edition = "2021"
+rust-version = "1.90"
+publish = false
+
+[build-dependencies]
+tauri-build = { workspace = true, default-features = true }
+
+[dependencies]
+tauri = { workspace = true, default-features = true, features = ["protocol-asset"] }

--- a/examples/asset-streaming/src-tauri/build.rs
+++ b/examples/asset-streaming/src-tauri/build.rs
@@ -1,0 +1,7 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+fn main() {
+  tauri_build::build()
+}

--- a/examples/asset-streaming/src-tauri/build.rs
+++ b/examples/asset-streaming/src-tauri/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// Copyright 2019-2026 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 

--- a/examples/asset-streaming/src-tauri/src/main.rs
+++ b/examples/asset-streaming/src-tauri/src/main.rs
@@ -1,0 +1,45 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+//! Plays a video over the `asset://` protocol.
+//!
+//! WebKitGTK hands `<video>` sources to GStreamer instead of the custom
+//! protocol handler, so this only plays when a GStreamer plugin providing an
+//! `asset://` URI handler is reachable.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use std::{path::PathBuf, process::Command};
+
+const VIDEO_FILE: &str = "streaming_example_test_video.mp4";
+const VIDEO_URL: &str =
+  "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/720/Big_Buck_Bunny_720_10s_1MB.mp4";
+
+fn video_file() -> PathBuf {
+  std::env::temp_dir().join(VIDEO_FILE)
+}
+
+#[tauri::command]
+fn video_path() -> String {
+  video_file().to_string_lossy().into_owned()
+}
+
+fn main() {
+  let path = video_file();
+  if !path.exists() {
+    println!("Downloading {VIDEO_URL} to {}", path.display());
+    let status = Command::new("curl")
+      .args(["-L", "-o"])
+      .arg(&path)
+      .arg(VIDEO_URL)
+      .status()
+      .expect("failed to run curl");
+    assert!(status.success(), "failed to download the video");
+  }
+
+  tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![video_path])
+    .run(tauri::generate_context!())
+    .expect("error while running tauri application");
+}

--- a/examples/asset-streaming/src-tauri/src/main.rs
+++ b/examples/asset-streaming/src-tauri/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// Copyright 2019-2026 Tauri Programme within The Commons Conservancy
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 

--- a/examples/asset-streaming/src-tauri/tauri.conf.json
+++ b/examples/asset-streaming/src-tauri/tauri.conf.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "../../../crates/tauri-schema-generator/schemas/config.schema.json",
+  "productName": "Asset Streaming",
+  "version": "0.1.0",
+  "identifier": "com.tauri.asset-streaming",
+  "build": {
+    "frontendDist": "../public",
+    "beforeDevCommand": "",
+    "beforeBuildCommand": ""
+  },
+  "app": {
+    "withGlobalTauri": true,
+    "windows": [
+      {
+        "title": "Play a video over asset://",
+        "width": 800,
+        "height": 600
+      }
+    ],
+    "security": {
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost; media-src asset: http://asset.localhost",
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "**/streaming_example_test_video.mp4"
+        ]
+      }
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "../../.icons/32x32.png",
+      "../../.icons/128x128.png",
+      "../../.icons/128x128@2x.png",
+      "../../.icons/icon.icns",
+      "../../.icons/icon.ico"
+    ],
+    "linux": {
+      "assetGstPlugin": {
+        "active": true,
+        "path": "../../../target/release/libgsttauriasset.so"
+      },
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
This complete #14402 by having the logic to include Gstreamer Plugin to Linux bundles (deb, rpm, AppImage).

This has been tested with rpm on fedora and it works.