### PR TITLE
fix: inefficient regular expression in node binary test

### DIFF
--- a/packages/cli/tauri.js
+++ b/packages/cli/tauri.js
@@ -20,7 +20,7 @@ if (globalThis.navigator?.userAgent?.includes('Deno')) {
 }
 // Even if started by a package manager, the binary will be NodeJS.
 // Some distribution still use "nodejs" as the binary name.
-else if (binStem.match(/(nodejs|node|bun|electron)\-?([0-9]*)*$/g)) {
+else if (/(nodejs|node|bun|electron)-?[0-9]*$/.test(binStem)) {
   const managerStem = process.env.npm_execpath
     ? path.parse(process.env.npm_execpath).name.toLowerCase()
     : null


### PR DESCRIPTION
Fix https://github.com/tauri-apps/tauri/security/code-scanning/36