### PR TITLE
fix: percent-encode HTML when re-serializing CSP-injected `data:` URLs

### DIFF
--- a/.changes/data-url-csp-percent-encode.md
+++ b/.changes/data-url-csp-percent-encode.md
@@ -1,0 +1,5 @@
+---
+tauri: patch:bug
+---
+
+Percent-encode the HTML when a `data:` URL is re-serialized after CSP injection. A `#` anywhere in the document (a hex color, an SVG `url(#id)` reference) previously turned the rest of the markup into a URL fragment, so the webview loaded a truncated document and rendered blank. Line breaks and tabs were dropped from the document for the same reason, which could swallow the rest of an inline script after a `//` comment.

--- a/crates/tauri/src/manager/webview.rs
+++ b/crates/tauri/src/manager/webview.rs
@@ -517,7 +517,7 @@ impl<R: Runtime> WebviewManager<R> {
           if html.contains('<') && html.contains('>') {
             let document = tauri_utils::html2::parse_doc(html);
             tauri_utils::html2::inject_csp(&document, &csp.to_string());
-            url.set_path(&format!("{},{}", mime::TEXT_HTML, document.html()));
+            set_html_data_url(&mut url, &document.html());
           }
         }
       }
@@ -775,6 +775,28 @@ fn is_local_network_url(url: &url::Url) -> bool {
   }
 }
 
+// the fragment percent-encode set, plus `#`, `%` and `?` which would otherwise be read back as a
+// fragment separator, an escape sequence and a query separator
+#[cfg(feature = "webview-data-url")]
+const DATA_URL_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+  .add(b' ')
+  .add(b'"')
+  .add(b'#')
+  .add(b'%')
+  .add(b'<')
+  .add(b'>')
+  .add(b'?')
+  .add(b'`');
+
+#[cfg(feature = "webview-data-url")]
+fn set_html_data_url(url: &mut Url, html: &str) {
+  url.set_path(&format!(
+    "{},{}",
+    mime::TEXT_HTML,
+    percent_encoding::utf8_percent_encode(html, DATA_URL_ENCODE_SET)
+  ));
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -790,5 +812,23 @@ mod tests {
     ));
 
     assert!(!is_local_network_url(&"https://tauri.app".parse().unwrap()));
+  }
+
+  #[cfg(feature = "webview-data-url")]
+  #[test]
+  fn html_data_url_survives_serialization() {
+    let html = "<html><head><style>body{background:#09090b}</style></head>\n\t<body>50%3Coff привет</body></html>";
+
+    let mut url = Url::parse("data:text/html,placeholder").unwrap();
+    set_html_data_url(&mut url, html);
+
+    let url = Url::parse(url.as_str()).unwrap();
+    assert_eq!(url.fragment(), None);
+
+    let (body, _) = data_url::DataUrl::process(url.as_str())
+      .unwrap()
+      .decode_to_vec()
+      .unwrap();
+    assert_eq!(String::from_utf8(body).unwrap(), html);
   }
 }


### PR DESCRIPTION
Closes #15966

After CSP injection the re-serialized document was written straight into the `data:` URL path. `Url::set_path` stores it verbatim, so the URL only looks intact until something parses it back: the first `#` in the markup then starts the fragment and the webview gets a truncated document. A hex color like `background:#09090b` or an SVG `fill="url(#gradient)"` is enough, and the window just comes up blank. A literal `%` corrupts the body the same way, since the payload gets percent-decoded on the way out.

Percent-encoding the HTML before it goes into the path keeps the URL stable across a serialize/parse round trip.

Verify:

```
cargo test -p tauri --features webview-data-url --lib manager::webview
```
