### PR TITLE
fix(ci): give audit permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -31,6 +31,8 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
+  checks: write
 
 jobs:
   audit-rust:


### PR DESCRIPTION
Regression from #15967, so weird https://github.com/tauri-apps/tauri/actions/runs/33723571286/job/100547585355 succeed while https://github.com/tauri-apps/tauri/actions/runs/33738215194/job/100593747224 didn't