### PR TITLE
refactor(runtime): use typed runtime-specific init attrs

### DIFF
--- a/crates/tauri-runtime-cef/src/runtime.rs
+++ b/crates/tauri-runtime-cef/src/runtime.rs
@@ -76,25 +76,24 @@ use winit::platform::x11::EventLoopBuilderExtX11;
 /// in minor releases when a known breaking change is discovered.
 pub use cef;
 
-/// Platform-specific runtime init attributes.
-#[derive(Clone, Debug)]
-pub enum RuntimeInitAttribute {
+/// CEF runtime initialization attributes.
+#[derive(Clone, Debug, Default)]
+pub struct RuntimeInitAttrs {
   /// Command line arguments passed to CEF.
-  CommandLineArgs { args: Vec<(String, Option<String>)> },
+  pub command_line_args: Vec<(String, Option<String>)>,
   /// Deep link schemes.
-  DeepLinkSchemes { schemes: Vec<String> },
+  pub deep_link_schemes: Vec<String>,
   /// Directory used for CEF disk cache (`Settings::cache_path`).
   ///
   /// If unspecified, defaults to `{user cache}/{app identifier}/cef`.
-  CachePath { path: PathBuf },
+  pub cache_path: Option<PathBuf>,
   /// CEF API version this process declares (`cef_api_hash`), defaulting to
   /// `cef::sys::CEF_API_VERSION_LAST`.
-  ApiVersion { version: i32 },
+  pub api_version: Option<i32>,
 }
 
-impl tauri_runtime::InitAttribute for RuntimeInitAttribute {
-  fn new(config: &tauri_utils::config::Config) -> Result<Vec<Self>> {
-    let mut attrs = Vec::new();
+impl tauri_runtime::RuntimeSpecificInitAttrs for RuntimeInitAttrs {
+  fn apply_config(&mut self, config: &tauri_utils::config::Config) -> Result<()> {
     if let Some(plugin_config) = config
       .plugins
       .0
@@ -118,9 +117,9 @@ impl tauri_runtime::InitAttribute for RuntimeInitAttribute {
           .collect(),
       };
 
-      attrs.push(RuntimeInitAttribute::DeepLinkSchemes { schemes });
+      self.deep_link_schemes.extend(schemes);
     }
-    Ok(attrs)
+    Ok(())
   }
 }
 
@@ -1324,7 +1323,7 @@ impl TerminationSignals {
 impl<T: UserEvent> CefRuntime<T> {
   fn init(
     mut event_loop_builder: EventLoopBuilder,
-    runtime_args: RuntimeInitArgs<RuntimeInitAttribute>,
+    runtime_args: RuntimeInitArgs<RuntimeInitAttrs>,
   ) -> Result<Self> {
     // Snapshot before CEF can touch anything, so we can tell an embedder's own
     // signal policy apart from the handlers CEF installs in `cef::initialize`.
@@ -1370,12 +1369,9 @@ impl<T: UserEvent> CefRuntime<T> {
     // The CEF API version table must be initialized before any other CEF call
     // (e.g. `args.as_cmd_line()` below), otherwise the process crashes with no
     // diagnostics.
-    let mut pl_attrs = runtime_args.platform_specific_attributes.iter();
-    let version = pl_attrs
-      .find_map(|attribute| match attribute {
-        RuntimeInitAttribute::ApiVersion { version } => Some(*version),
-        _ => None,
-      })
+    let version = runtime_args
+      .runtime_init_attrs
+      .api_version
       .unwrap_or(sys::CEF_API_VERSION_LAST);
     let _ = cef::api_hash(version, 0);
 
@@ -1400,18 +1396,13 @@ impl<T: UserEvent> CefRuntime<T> {
       std::process::exit(ret.max(0));
     }
 
-    let mut command_line_args = Vec::new();
-    let mut deep_link_schemes = Vec::new();
-    let mut cache_path_override = None::<PathBuf>;
-    for arg in runtime_args.platform_specific_attributes {
-      match arg {
-        RuntimeInitAttribute::CommandLineArgs { args } => command_line_args.extend(args),
-        RuntimeInitAttribute::DeepLinkSchemes { schemes } => deep_link_schemes.extend(schemes),
-        RuntimeInitAttribute::CachePath { path } => cache_path_override = Some(path),
-        // Already applied, above, before the first CEF call.
-        RuntimeInitAttribute::ApiVersion { .. } => {}
-      }
-    }
+    let RuntimeInitAttrs {
+      mut command_line_args,
+      deep_link_schemes,
+      cache_path: cache_path_override,
+      // Already applied, above, before the first CEF call.
+      api_version: _,
+    } = runtime_args.runtime_init_attrs;
 
     let cache_path = cache_path_override.unwrap_or_else(|| {
       let cache_base = dirs::cache_dir().unwrap_or_else(std::env::temp_dir);
@@ -1560,10 +1551,10 @@ impl<T: UserEvent> Runtime<T> for CefRuntime<T> {
   type EventLoopProxy = EventProxy<T>;
   type PlatformSpecificWebviewAttribute = WebviewAtribute;
   type Webview = Webview;
-  type PlatformSpecificInitAttribute = RuntimeInitAttribute;
+  type RuntimeInitAttrs = RuntimeInitAttrs;
   type WindowOpener = NewWindowOpener;
 
-  fn new(args: RuntimeInitArgs<Self::PlatformSpecificInitAttribute>) -> Result<Self> {
+  fn new(args: RuntimeInitArgs<Self::RuntimeInitAttrs>) -> Result<Self> {
     Self::init(EventLoopBuilder::default(), args)
   }
 
@@ -1575,7 +1566,7 @@ impl<T: UserEvent> Runtime<T> for CefRuntime<T> {
     target_os = "netbsd",
     target_os = "openbsd"
   ))]
-  fn new_any_thread(args: RuntimeInitArgs<Self::PlatformSpecificInitAttribute>) -> Result<Self> {
+  fn new_any_thread(args: RuntimeInitArgs<Self::RuntimeInitAttrs>) -> Result<Self> {
     let mut event_loop_builder = EventLoopBuilder::default();
     event_loop_builder.with_any_thread(true);
     Self::init(event_loop_builder, args)

--- a/crates/tauri-runtime-cef/src/runtime.rs
+++ b/crates/tauri-runtime-cef/src/runtime.rs
@@ -79,17 +79,66 @@ pub use cef;
 /// CEF runtime initialization attributes.
 #[derive(Clone, Debug, Default)]
 pub struct RuntimeInitAttrs {
+  command_line_args: Vec<(String, Option<String>)>,
+  deep_link_schemes: Vec<String>,
+  cache_path: Option<PathBuf>,
+  api_version: Option<i32>,
+}
+
+impl RuntimeInitAttrs {
+  /// Appends one command line argument to the CEF command line.
+  #[must_use]
+  pub fn command_line_arg<K: Into<String>, V: Into<String>>(
+    mut self,
+    key: K,
+    value: Option<V>,
+  ) -> Self {
+    self
+      .command_line_args
+      .push((key.into(), value.map(Into::into)));
+    self
+  }
+
   /// Command line arguments passed to CEF.
-  pub command_line_args: Vec<(String, Option<String>)>,
+  #[must_use]
+  pub fn command_line_args<K: Into<String>, V: Into<String>>(
+    mut self,
+    args: impl IntoIterator<Item = (K, Option<V>)>,
+  ) -> Self {
+    self
+      .command_line_args
+      .extend(args.into_iter().map(|(k, v)| (k.into(), v.map(Into::into))));
+    self
+  }
+
   /// Deep link schemes.
-  pub deep_link_schemes: Vec<String>,
+  #[must_use]
+  pub fn deep_link_schemes<S: Into<String>>(
+    mut self,
+    schemes: impl IntoIterator<Item = S>,
+  ) -> Self {
+    self
+      .deep_link_schemes
+      .extend(schemes.into_iter().map(Into::into));
+    self
+  }
+
   /// Directory used for CEF disk cache (`Settings::cache_path`).
   ///
   /// If unspecified, defaults to `{user cache}/{app identifier}/cef`.
-  pub cache_path: Option<PathBuf>,
+  #[must_use]
+  pub fn root_cache_path<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
+    self.cache_path = Some(path.as_ref().to_path_buf());
+    self
+  }
+
   /// CEF API version this process declares (`cef_api_hash`), defaulting to
   /// `cef::sys::CEF_API_VERSION_LAST`.
-  pub api_version: Option<i32>,
+  #[must_use]
+  pub fn cef_api_version(mut self, version: i32) -> Self {
+    self.api_version = Some(version);
+    self
+  }
 }
 
 impl tauri_runtime::RuntimeSpecificInitAttrs for RuntimeInitAttrs {

--- a/crates/tauri-runtime-cef/src/runtime.rs
+++ b/crates/tauri-runtime-cef/src/runtime.rs
@@ -86,7 +86,7 @@ pub struct RuntimeInitAttrs {
 }
 
 impl RuntimeInitAttrs {
-  /// Appends one command line argument to the CEF command line.
+  /// Appends one command line argument passed to CEF.
   #[must_use]
   pub fn command_line_arg<K: Into<String>, V: Into<String>>(
     mut self,
@@ -99,7 +99,7 @@ impl RuntimeInitAttrs {
     self
   }
 
-  /// Command line arguments passed to CEF.
+  /// Appends a list of command line arguments passed to CEF.
   #[must_use]
   pub fn command_line_args<K: Into<String>, V: Into<String>>(
     mut self,
@@ -111,7 +111,9 @@ impl RuntimeInitAttrs {
     self
   }
 
-  /// Deep link schemes.
+  /// Appends a list of deep link schemes detected by CEF's on_already_running_app_relaunch hook.
+  ///
+  /// Deep links defined by the core deep-link plugin on the Tauri configuration are automatically added.
   #[must_use]
   pub fn deep_link_schemes<S: Into<String>>(
     mut self,

--- a/crates/tauri-runtime-wry/src/lib.rs
+++ b/crates/tauri-runtime-wry/src/lib.rs
@@ -2993,7 +2993,7 @@ impl<T: UserEvent> Runtime<T> for Wry<T> {
 
   type EventLoopProxy = EventProxy<T>;
   type PlatformSpecificWebviewAttribute = WebviewAttribute;
-  type PlatformSpecificInitAttribute = ();
+  type RuntimeInitAttrs = ();
   type WindowOpener = NewWindowOpener;
   type Webview = Webview;
 

--- a/crates/tauri-runtime/src/lib.rs
+++ b/crates/tauri-runtime/src/lib.rs
@@ -408,24 +408,18 @@ pub struct RuntimeInitArgs<A> {
   pub msg_hook: Option<Box<dyn FnMut(*const std::ffi::c_void) -> bool + 'static>>,
   pub identifier: String,
   pub custom_schemes: Vec<String>,
-  pub platform_specific_attributes: Vec<A>,
+  pub runtime_init_attrs: A,
 }
 
-/// Builds platform-specific init attributes from config. These are merged with
-/// user-provided attributes before runtime creation. Implement for the runtime's
-/// [`Runtime::PlatformSpecificInitAttribute`]; default is to return none (implement for `()`).
-pub trait InitAttribute: Send + Sync + 'static {
-  /// Returns attributes derived from config (e.g. deep-link schemes). Merged with user attrs by the app.
-  fn new(config: &tauri_utils::config::Config) -> Result<Vec<Self>>
-  where
-    Self: Sized;
-}
-
-impl InitAttribute for () {
-  fn new(_config: &tauri_utils::config::Config) -> Result<Vec<Self>> {
-    Ok(vec![])
+/// Runtime-specific initialization attributes.
+pub trait RuntimeSpecificInitAttrs: Default + Send + Sync + 'static {
+  /// Applies attributes derived from the application configuration.
+  fn apply_config(&mut self, _config: &tauri_utils::config::Config) -> Result<()> {
+    Ok(())
   }
 }
+
+impl RuntimeSpecificInitAttrs for () {}
 
 /// The webview runtime interface.
 pub trait Runtime<T: UserEvent>: Debug + Sized + 'static {
@@ -444,13 +438,13 @@ pub trait Runtime<T: UserEvent>: Debug + Sized + 'static {
   /// This is the runtime-specific type the user interacts with to reach the
   /// underlying platform webview APIs.
   type Webview: 'static;
-  /// The platform specific runtime init arguments. Must implement [`InitAttribute`].
-  type PlatformSpecificInitAttribute: InitAttribute + Send + Sync + 'static;
+  /// Runtime-specific initialization attributes.
+  type RuntimeInitAttrs: crate::RuntimeSpecificInitAttrs;
   /// Data about the window that requested the new window for [`PendingWebview::new_window_handler`].
   type WindowOpener: Send + Sync + Debug;
 
   /// Creates a new webview runtime. Must be used on the main thread.
-  fn new(args: RuntimeInitArgs<Self::PlatformSpecificInitAttribute>) -> Result<Self>;
+  fn new(args: RuntimeInitArgs<Self::RuntimeInitAttrs>) -> Result<Self>;
 
   /// Creates a new webview runtime on any thread.
   #[cfg(any(
@@ -472,7 +466,7 @@ pub trait Runtime<T: UserEvent>: Debug + Sized + 'static {
       target_os = "openbsd"
     )))
   )]
-  fn new_any_thread(args: RuntimeInitArgs<Self::PlatformSpecificInitAttribute>) -> Result<Self>;
+  fn new_any_thread(args: RuntimeInitArgs<Self::RuntimeInitAttrs>) -> Result<Self>;
 
   /// Creates an `EventLoopProxy` that can be used to dispatch user events to the main event loop.
   fn create_proxy(&self) -> Self::EventLoopProxy;

--- a/crates/tauri/src/app.rs
+++ b/crates/tauri/src/app.rs
@@ -32,7 +32,7 @@ use tauri_macros::default_runtime;
 #[cfg(desktop)]
 use tauri_runtime::EventLoopProxy;
 use tauri_runtime::{
-  InitAttribute, RuntimeInitArgs,
+  RuntimeInitArgs, RuntimeSpecificInitAttrs,
   dpi::{PhysicalPosition, PhysicalSize},
   window::DragDropEvent,
 };
@@ -1554,7 +1554,7 @@ pub struct Builder<R: Runtime> {
 
   pub(crate) invoke_key: String,
 
-  platform_specific_attributes: Vec<R::PlatformSpecificInitAttribute>,
+  runtime_init_attrs: R::RuntimeInitAttrs,
 }
 
 #[derive(Template)]
@@ -1632,72 +1632,14 @@ impl<R: Runtime> Builder<R> {
       webview_event_listeners: Vec::new(),
       device_event_filter: Default::default(),
       invoke_key,
-      platform_specific_attributes: Vec::new(),
+      runtime_init_attrs: Default::default(),
     }
   }
-}
 
-/// Helper so `Builder<R>` can merge user-provided platform attributes with config-derived ones
-/// ([`InitAttribute::new`]). User attrs come first, then config-derived.
-pub(crate) trait PlatformSpecificAttributesHelper {
-  type Attr: Send + Sync + 'static;
-  fn process_platform_specific_attributes(
-    user_attrs: Vec<Self::Attr>,
-    config: &Config,
-  ) -> crate::Result<Vec<Self::Attr>>;
-}
-
-impl<R: Runtime> PlatformSpecificAttributesHelper for Builder<R> {
-  type Attr = R::PlatformSpecificInitAttribute;
-  fn process_platform_specific_attributes(
-    mut user_attrs: Vec<Self::Attr>,
-    config: &Config,
-  ) -> crate::Result<Vec<Self::Attr>> {
-    let from_config = R::PlatformSpecificInitAttribute::new(config).map_err(crate::Error::from)?;
-    user_attrs.extend(from_config);
-    Ok(user_attrs)
-  }
-}
-
-#[cfg(feature = "cef")]
-impl Builder<crate::Cef> {
-  /// Appends command line arguments to the CEF command line.
-  #[cfg(feature = "cef")]
-  pub fn command_line_args<K: Into<String>, V: Into<String>>(
-    mut self,
-    args: impl IntoIterator<Item = (K, Option<V>)>,
-  ) -> Self {
-    self.platform_specific_attributes.push(
-      tauri_runtime_cef::RuntimeInitAttribute::CommandLineArgs {
-        args: args
-          .into_iter()
-          .map(|(k, v)| (k.into(), v.map(Into::into)))
-          .collect::<Vec<_>>(),
-      },
-    );
-    self
-  }
-
-  /// Sets the disk cache directory for CEF (`Settings::cache_path`).
-  ///
-  /// Calling this more than once keeps the path from the last call.
-  /// If omitted, the cache defaults to `{user cache directory}/{identifier}/cef`.
-  #[cfg(feature = "cef")]
-  pub fn root_cache_path<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
-    self
-      .platform_specific_attributes
-      .push(tauri_runtime_cef::RuntimeInitAttribute::CachePath {
-        path: path.as_ref().to_path_buf(),
-      });
-    self
-  }
-
-  /// Sets the CEF API version this process declares (`cef_api_hash`).
-  #[cfg(feature = "cef")]
-  pub fn cef_api_version(mut self, version: i32) -> Self {
-    self
-      .platform_specific_attributes
-      .push(tauri_runtime_cef::RuntimeInitAttribute::ApiVersion { version });
+  /// Sets the runtime-specific initialization attributes.
+  #[must_use]
+  pub fn runtime_init_attrs(mut self, attrs: R::RuntimeInitAttrs) -> Self {
+    self.runtime_init_attrs = attrs;
     self
   }
 }
@@ -1707,7 +1649,7 @@ impl<R: Runtime> Builder<R> {
   fn build_runtime_init_args(
     identifier: &str,
     custom_schemes: Vec<String>,
-    platform_specific_attributes: Vec<R::PlatformSpecificInitAttribute>,
+    runtime_init_attrs: R::RuntimeInitAttrs,
     #[cfg(any(
       target_os = "linux",
       target_os = "dragonfly",
@@ -1717,11 +1659,11 @@ impl<R: Runtime> Builder<R> {
     ))]
     app_id: Option<String>,
     #[cfg(windows)] msg_hook: Option<Box<dyn FnMut(*const std::ffi::c_void) -> bool + 'static>>,
-  ) -> RuntimeInitArgs<R::PlatformSpecificInitAttribute> {
+  ) -> RuntimeInitArgs<R::RuntimeInitAttrs> {
     RuntimeInitArgs {
       identifier: identifier.to_string(),
       custom_schemes,
-      platform_specific_attributes,
+      runtime_init_attrs,
       #[cfg(any(
         target_os = "linux",
         target_os = "dragonfly",
@@ -2404,11 +2346,10 @@ tauri::Builder::<tauri::Wry>::new()
     }
 
     let config = context.config();
-    let attrs = self.platform_specific_attributes;
-    let platform_specific_attributes =
-      <Self as PlatformSpecificAttributesHelper>::process_platform_specific_attributes(
-        attrs, config,
-      )?;
+    self
+      .runtime_init_attrs
+      .apply_config(config)
+      .map_err(crate::Error::from)?;
 
     let manager = Arc::new(AppManager::with_handlers(
       context,
@@ -2455,7 +2396,7 @@ tauri::Builder::<tauri::Wry>::new()
     let runtime_args = Self::build_runtime_init_args(
       &manager.config.identifier,
       custom_schemes,
-      platform_specific_attributes,
+      self.runtime_init_attrs,
       #[cfg(any(
         target_os = "linux",
         target_os = "dragonfly",

--- a/crates/tauri/src/lib.rs
+++ b/crates/tauri/src/lib.rs
@@ -152,6 +152,11 @@ pub use tauri_runtime_cef::DevToolsProtocol as CefDevToolsProtocol;
 #[cfg_attr(docsrs, doc(cfg(feature = "cef")))]
 pub use tauri_runtime_cef::CEF_API_VERSION_LAST;
 
+/// The runtime initialization attributes.
+#[cfg(feature = "cef")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cef")))]
+pub use tauri_runtime_cef::RuntimeInitAttrs as CefRuntimeAttributes;
+
 #[cfg(all(feature = "wry", target_os = "android"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "wry", target_os = "android"))))]
 #[doc(hidden)]

--- a/crates/tauri/src/test/mock_runtime.rs
+++ b/crates/tauri/src/test/mock_runtime.rs
@@ -1218,7 +1218,7 @@ impl<T: UserEvent> Runtime<T> for MockRuntime {
   type Handle = MockRuntimeHandle;
   type EventLoopProxy = EventProxy;
   type PlatformSpecificWebviewAttribute = ();
-  type PlatformSpecificInitAttribute = ();
+  type RuntimeInitAttrs = ();
   type WindowOpener = ();
   type Webview = ();
 


### PR DESCRIPTION
Replace the platform-specific init attribute vector with a single runtime-owned associated type.

This lets each runtime model replacement and accumulation semantics directly, avoids scanning enum variants during initialization, and allows Tauri to pass runtime configuration without knowing its contents.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
