### PR TITLE
fix(runtime-cef): pass --no-first-run to avoid Chromium's Linux EULA flow

### DIFF
--- a/.changes/cef-no-first-run.md
+++ b/.changes/cef-no-first-run.md
@@ -1,0 +1,5 @@
+---
+'tauri-runtime-cef': 'patch:bug'
+---
+
+Fixed CEF failing to start on Linux with `ContentMainRun failed with exit code 28` by passing `--no-first-run` to Chromium.

--- a/crates/tauri-runtime-cef/src/runtime.rs
+++ b/crates/tauri-runtime-cef/src/runtime.rs
@@ -1531,6 +1531,7 @@ impl<T: UserEvent> CefRuntime<T> {
     };
 
     command_line_args.push(("--enable-media-stream".to_string(), None));
+    command_line_args.push(("--no-first-run".to_string(), None));
     let mut app = TauriCefApp::new(
       context.clone(),
       context_initialized.clone(),


### PR DESCRIPTION
CEF apps on Linux can fail to start with `ContentMainRun failed with exit code 28`, Chromium's `CHROME_RESULT_CODE_EULA_REFUSED`. Chromium 151 made the Linux first-run flow, and its EULA prompt, required by default, and `tauri-runtime-cef` never passed `--no-first-run`, so a clean CEF cache trips it on startup.

`no-first-run` is a long-standing Chromium switch (`chrome_switches.cc`) that skips first-run tasks entirely, the standard way embedders avoid this flow. Added it next to the existing `--enable-media-stream` push in `CefRuntime::new`, unconditionally rather than Linux-only, since a bundled Tauri app never wants Chrome's first-run wizard on any platform.

closes #15979
