### PR TITLE
fix(cef) pin winit to 0.31.0-beta.2

### DIFF
--- a/crates/tauri-runtime-cef/Cargo.toml
+++ b/crates/tauri-runtime-cef/Cargo.toml
@@ -29,7 +29,7 @@ tauri-utils = { version = "2.9.2", path = "../tauri-utils", features = [
   "html-manipulation",
 ] }
 url = "2"
-winit = "0.31.0-beta.2"
+winit = "=0.31.0-beta.2"
 
 [target."cfg(windows)".dependencies]
 softbuffer = { version = "0.4", default-features = false }


### PR DESCRIPTION
The recently released `0.31.0-beta.3` of Winit breaks the build when pulled in. This patch pins the last compatible version until tauri-runtime-cef is made compatible with the drag and drop API changes in that new version.

Fixes https://github.com/tauri-apps/tauri/issues/15988

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
