### PR TITLE
fix(cef): prepare early AppKit UI and retain closing windows

### DIFF
--- a/.changes/cef-native-startup-ui.md
+++ b/.changes/cef-native-startup-ui.md
@@ -1,0 +1,5 @@
+---
+'tauri-runtime-cef': 'patch:enhance'
+---
+
+Expose macOS CEF application preparation so native recovery dialogs can open before the runtime or browser profile initializes, without creating an incompatible AppKit application singleton.

--- a/.changes/cef-native-startup-ui.md
+++ b/.changes/cef-native-startup-ui.md
@@ -3,3 +3,5 @@
 ---
 
 Expose macOS CEF application preparation so native recovery dialogs can open before the runtime or browser profile initializes, without creating an incompatible AppKit application singleton.
+
+Retain browser windows until CEF acknowledges application shutdown, so queued native child-view destruction can complete and the process can exit. Close attached DevTools as part of that shutdown.

--- a/crates/tauri-runtime-cef/Cargo.toml
+++ b/crates/tauri-runtime-cef/Cargo.toml
@@ -11,6 +11,10 @@ license.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
+[[test]]
+name = "macos-application-bootstrap"
+harness = false
+
 [dependencies]
 tauri = { workspace = true }
 tauri-macros = { workspace = true }

--- a/crates/tauri-runtime-cef/src/lib.rs
+++ b/crates/tauri-runtime-cef/src/lib.rs
@@ -16,6 +16,8 @@ mod window_builder;
 mod window_handle;
 
 pub use cef::sys::CEF_API_VERSION_LAST;
+#[cfg(target_os = "macos")]
+pub use platform::macos::setup_application as prepare_macos_application;
 pub use runtime::*;
 pub use tauri_ext::*;
 /// Marks the application entry point so non-browser CEF processes (renderer, GPU, ...) are handled.

--- a/crates/tauri-runtime-cef/src/platform/macos/application.rs
+++ b/crates/tauri-runtime-cef/src/platform/macos/application.rs
@@ -243,9 +243,19 @@ pub(crate) fn activate_application() {
   }
 }
 
+/// Creates the CEF-compatible AppKit application before displaying native startup UI.
+///
+/// Call this on the main thread before any code creates an `NSApplication`, for example
+/// before presenting a recovery dialog. It does not initialize CEF, its event loop, or
+/// a browser profile. Repeated calls, including later runtime initialization, are safe.
+///
+/// # Panics
+///
+/// Panics outside the main thread or if another application class already owns the
+/// AppKit singleton.
 pub fn setup_application() {
-  let _ = CefWinitApplication::shared_application();
   let mtm = MainThreadMarker::new().expect("macOS application must start on the main thread");
+  let _ = CefWinitApplication::shared_application();
   assert!(NSApp(mtm).isKindOfClass(CefWinitApplication::class()));
 }
 

--- a/crates/tauri-runtime-cef/src/runtime.rs
+++ b/crates/tauri-runtime-cef/src/runtime.rs
@@ -603,10 +603,10 @@ impl<T: UserEvent> WinitCefApp<T> {
     match message {
       Message::EventLoop(message) => self.handle_event_loop_message(event_loop, message),
       Message::BrowserClosed(_window_id, webview_id) => {
-        // Standalone webview.close() keeps the child in state until this
-        // callback, so cleanup happens here. Window/app teardown removes child
-        // bookkeeping before asking CEF to close; then this message is only the
-        // lifecycle acknowledgement that lets live_browsers drain.
+        // Standalone webview.close() and app shutdown keep the child in state
+        // until this callback, so cleanup happens here. Individual window
+        // teardown removes child bookkeeping first; then this message is only
+        // the lifecycle acknowledgement that lets live_browsers drain.
         //
         // The window_id baked into the browser's handlers can be stale after a
         // reparent, so locate the webview by its process-unique id across every
@@ -943,17 +943,16 @@ impl<T: UserEvent> WinitCefApp<T> {
   }
 
   fn close_all_browsers(&mut self) {
-    // App shutdown follows the same eager bookkeeping cleanup as window
-    // teardown. live_browsers keeps the loop alive until CEF confirms every
-    // browser close through BrowserClosed.
+    // Keep each child reachable until CEF acknowledges its close. On macOS and
+    // Windows, do_close queues DestroyWebviewHostWindow, which needs this state
+    // to destroy the native child view and trigger on_before_close. Dropping
+    // the windows here can strand live_browsers and prevent process exit.
     for appwindow in self.state.windows.values() {
       for child in &appwindow.children {
-        self.remove_scheme_handler_entries(child);
+        child.host.close_dev_tools();
         child.host.close_browser(1);
       }
     }
-    self.state.windows.clear();
-    self.state.winid_id_to_window_id_map.clear();
   }
 
   #[cfg(target_os = "macos")]

--- a/crates/tauri-runtime-cef/tests/macos-application-bootstrap.rs
+++ b/crates/tauri-runtime-cef/tests/macos-application-bootstrap.rs
@@ -1,0 +1,56 @@
+// Copyright 2019-2024 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+// AppKit requires the process main thread, which the standard test harness does not use.
+#[cfg(target_os = "macos")]
+fn main() {
+  use objc2::{ClassType, MainThreadMarker, msg_send, runtime::Bool};
+  use objc2_app_kit::NSApplication;
+
+  let mtm = MainThreadMarker::new().expect("test must run on the main thread");
+  if std::env::args().nth(1).as_deref() == Some("--existing-application") {
+    let _ = NSApplication::sharedApplication(mtm);
+    assert!(std::panic::catch_unwind(tauri_runtime_cef::prepare_macos_application).is_err());
+    return;
+  }
+  assert!(
+    std::process::Command::new(std::env::current_exe().unwrap())
+      .arg("--existing-application")
+      .status()
+      .unwrap()
+      .success()
+  );
+
+  assert!(
+    std::thread::spawn(tauri_runtime_cef::prepare_macos_application)
+      .join()
+      .is_err()
+  );
+
+  tauri_runtime_cef::prepare_macos_application();
+  let application = NSApplication::sharedApplication(mtm);
+  assert!(!std::ptr::eq(application.class(), NSApplication::class()));
+
+  // Native startup UI can now request the singleton without replacing CEF's application.
+  let native_application = NSApplication::sharedApplication(mtm);
+  assert!(std::ptr::eq(&*application, &*native_application));
+  tauri_runtime_cef::prepare_macos_application();
+  assert!(std::ptr::eq(
+    &*application,
+    &*NSApplication::sharedApplication(mtm)
+  ));
+
+  // CEF's event scopes use these selectors even before an event-loop delegate exists.
+  unsafe {
+    let handling: Bool = msg_send![&*application, isHandlingSendEvent];
+    assert!(!handling.as_bool());
+    let _: () = msg_send![&*application, setHandlingSendEvent: Bool::YES];
+    let handling: Bool = msg_send![&*application, isHandlingSendEvent];
+    assert!(handling.as_bool());
+    let _: () = msg_send![&*application, setHandlingSendEvent: Bool::NO];
+  }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {}


### PR DESCRIPTION
## Summary

Native recovery dialogs can create an `NSApplication` object before the Chromium Embedded Framework (CEF) runtime starts. CEF then rejects the incompatible application class and stops startup.

This change exports `tauri_runtime_cef::prepare_macos_application`. Applications call this function on the main thread before displaying native startup dialogs. The function prepares AppKit, the macOS UI framework. It does not start CEF, run the event loop, or open a browser profile. Repeated calls use the same application object. The function checks the current thread before calling AppKit.

During application exit, the runtime keeps browser and window records until CEF confirms closure. The runtime also closes attached DevTools windows. Previously, the runtime removed these records before native window cleanup completed. On macOS and Windows, cleanup could then fail to find the webview and leave the process running.

## Testing

The existing validation record reports these results on macOS arm64:

- `cargo clippy -p tauri-runtime-cef --all-features`: passed.
- `cargo test -p tauri-runtime-cef --all-features`: passed, including the native application preparation test and three documentation tests.
- `cargo fmt --all`: completed successfully.

The native test runs on the main thread. It checks that early and repeated preparation use the same application object. It also checks the CEF event-state methods. The test confirms that preparation rejects a background thread and an incompatible application object. A separate process tests the incompatible object. The test catches the expected failures.

## Manual Testing

1. On macOS, call `prepare_macos_application()` before opening a native recovery dialog. Confirm that AppKit uses the CEF application class.
2. Dismiss the dialog and start the CEF runtime. Confirm that startup uses the same application object and completes without the class assertion failure.
3. Open a browser window and its DevTools window. Quit the application. Confirm that both windows close and the process exits without forced termination.
4. Repeat the shutdown check on Windows. Confirm that native child-window cleanup completes and the process exits.

Earlier tests in a signed macOS arm64 application reproduced the startup failure. Tests with a separate runtime backport then completed restart and quit without forced termination. The restart tests also included an application launcher fix. These results support the diagnosis. They do not establish application-level validation of this PR revision or Windows behavior.
