### PR TITLE
fix(bundler): don't inherit stdin for captured commands (fix #15315)

### DIFF
--- a/.changes/bundler-captured-command-stdin.md
+++ b/.changes/bundler-captured-command-stdin.md
@@ -1,0 +1,5 @@
+---
+"tauri-bundler": "patch:bug"
+---
+
+Run the commands whose output the bundler captures with an empty stdin instead of the inherited one. Under the Node.js CLI the inherited descriptor is close-on-exec, so `actool` started with no stdin at all and crashed on macOS (`-[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object`), failing the bundle of any app with a `.icon` with `failed to run actool`.

--- a/crates/tauri-bundler/src/utils/mod.rs
+++ b/crates/tauri-bundler/src/utils/mod.rs
@@ -49,6 +49,15 @@ impl CommandExt for Command {
     let program = self.get_program().to_string_lossy().into_owned();
     log::debug!(action = "Running"; "Command `{} {}`", program, self.get_args().map(|arg| arg.to_string_lossy()).fold(String::new(), |acc, arg| format!("{acc} {arg}")));
 
+    // Nothing run this way can answer a prompt, so give it no stdin rather
+    // than the inherited one. Under the Node.js CLI every descriptor the
+    // process inherited is close-on-exec (libuv's
+    // `uv_disable_stdio_inheritance`), so a child that inherits stdin starts
+    // with fd 0 closed — stdout and stderr survive because piping them dup2s
+    // fresh descriptors in — and actool's helper (ibtoold) crashes on that
+    // (`-[__NSPlaceholderArray initWithObjects:count:]: attempt to insert
+    // nil object`) instead of compiling the icon.
+    self.stdin(Stdio::null());
     self.stdout(Stdio::piped());
     self.stderr(Stdio::piped());
 

--- a/crates/tauri-bundler/src/utils/mod.rs
+++ b/crates/tauri-bundler/src/utils/mod.rs
@@ -49,14 +49,10 @@ impl CommandExt for Command {
     let program = self.get_program().to_string_lossy().into_owned();
     log::debug!(action = "Running"; "Command `{} {}`", program, self.get_args().map(|arg| arg.to_string_lossy()).fold(String::new(), |acc, arg| format!("{acc} {arg}")));
 
-    // Nothing run this way can answer a prompt, so give it no stdin rather
-    // than the inherited one. Under the Node.js CLI every descriptor the
-    // process inherited is close-on-exec (libuv's
-    // `uv_disable_stdio_inheritance`), so a child that inherits stdin starts
-    // with fd 0 closed — stdout and stderr survive because piping them dup2s
-    // fresh descriptors in — and actool's helper (ibtoold) crashes on that
-    // (`-[__NSPlaceholderArray initWithObjects:count:]: attempt to insert
-    // nil object`) instead of compiling the icon.
+    // Nothing run this way can answer a prompt, so no stdin rather than the
+    // inherited one: under the Node.js CLI that descriptor is close-on-exec
+    // and the child would start with fd 0 closed, which actool cannot take
+    // (#15315).
     self.stdin(Stdio::null());
     self.stdout(Stdio::piped());
     self.stderr(Stdio::piped());


### PR DESCRIPTION
`create_assets_car_file` runs `actool` through `CommandExt::output_ok`, which pipes stdout and stderr and leaves stdin inherited. Under the Node CLI that inherited descriptor is close-on-exec, so `actool` starts with fd 0 closed, and its helper `ibtoold` falls over on that:

```
error: Exception while running actool: *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[0]
```

That is the crash in #15315. It looked non-deterministic there because `ibtoold` stays alive after the first failure and keeps failing on every later invocation until it is killed (`killall ibtoold`), which also explains the manual reruns in that thread that sometimes worked and sometimes didn't.

**Where the closed descriptor comes from.** Node calls libuv's `uv_disable_stdio_inheritance()` at startup ([node.cc](https://github.com/nodejs/node/blob/main/src/node.cc), "Make inherited handles noninheritable"), which sets `FD_CLOEXEC` on every descriptor the process inherited — that is what lets `child_process` hand a child exactly the stdio it asked for. The Rust CLI runs inside that process, so a `Command` it spawns with stdin inherited loses fd 0 at exec. stdout and stderr survive only because `output_ok` pipes them, which dup2s fresh descriptors into the child; `piped()` dups all three explicitly for the same reason. `cargo tauri build` never hits this: no libuv there, and Rust's own runtime reopens a closed fd 0 on `/dev/null` at startup, so `cargo tauri build <&-` doesn't reproduce it either. The same should hold for the bundler's children on Linux; they just don't mind a missing stdin.

**What I saw.** On a self-hosted macOS runner (macOS 26.6.2, Xcode 26.6) every `tauri build` of an app with a `.icon` failed this way with `@tauri-apps/cli` 2.11.4, while the same `actool` command line copied from the verbose log succeeded in a shell. With an `actool` shim on the PATH that reports `fstat(0)` before exec'ing the real one, and `killall ibtoold` before each run:

- the published 2.11.4, and the CLI built from `dev`: `fd0 [Errno 9] Bad file descriptor` on both actool calls (the `--version` probe and the compile), the crash, no `Assets.car` — twice each;
- the CLI built from this branch: fd 0 open, `Assets.car` compiled — twice;
- a probe build printing `fcntl(0, F_GETFD)` as the first line of `try_run` already shows `FD_CLOEXEC` set, while `lsof` shows node's own fd 0 as an open pipe.

Standalone, `actool … <&-` reproduces the crash on a fresh `ibtoold`, and `actool … </dev/null` compiles.

**The change** is in `output_ok` rather than at the `actool` call: nothing that goes through it can answer a prompt anyway, so a command that tries to read stdin now gets EOF instead of hanging or inheriting a closed descriptor. `piped()` is untouched.

closes #15315
