### PR TITLE
fix(cli): preserve iOS prerelease numbers with build metadata

### DIFF
--- a/.changes/fix-ios-prerelease-build-metadata.md
+++ b/.changes/fix-ios-prerelease-build-metadata.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": "patch:bug"
+"@tauri-apps/cli": "patch:bug"
+---
+
+Fix iOS builds failing when the app version contains both a prerelease tag and build metadata.

--- a/crates/tauri-cli/src/helpers/mod.rs
+++ b/crates/tauri-cli/src/helpers/mod.rs
@@ -132,15 +132,12 @@ pub fn strip_semver_prerelease_tag(version: &mut semver::Version) -> crate::Resu
   if !version.pre.is_empty() {
     if let Some((_prerelease_tag, number)) = version.pre.as_str().to_string().split_once('.') {
       version.pre = semver::Prerelease::EMPTY;
-      version.build = semver::BuildMetadata::new(&format!(
-        "{prefix}{number}",
-        prefix = if version.build.is_empty() {
-          "".to_string()
-        } else {
-          format!(".{}", version.build.as_str())
-        }
-      ))
-      .with_context(|| {
+      let build = if version.build.is_empty() {
+        number.to_string()
+      } else {
+        format!("{}.{number}", version.build)
+      };
+      version.build = semver::BuildMetadata::new(&build).with_context(|| {
         format!(
           "failed to parse {version} as semver: bundle version {number:?} prerelease is invalid"
         )
@@ -149,4 +146,24 @@ pub fn strip_semver_prerelease_tag(version: &mut semver::Version) -> crate::Resu
   }
 
   Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+  use super::strip_semver_prerelease_tag;
+
+  #[test]
+  fn strips_semver_prerelease_tag() {
+    for (input, expected) in [
+      ("1.2.3-beta.4", "1.2.3+4"),
+      ("1.2.3-beta.4+5", "1.2.3+5.4"),
+      ("1.2.3-rc.7+10", "1.2.3+10.7"),
+    ] {
+      let mut version = semver::Version::parse(input).unwrap();
+
+      strip_semver_prerelease_tag(&mut version).unwrap();
+
+      assert_eq!(version.to_string(), expected);
+    }
+  }
 }


### PR DESCRIPTION


Fix iOS version conversion when a valid SemVer contains both a prerelease tag and build metadata.

For example:

```text
1.2.3-beta.4+5
```

When generating iOS bundle versions, `strip_semver_prerelease_tag()` removes the prerelease tag and converts its numeric suffix into build metadata.

The previous implementation constructed the new metadata in the wrong order:

```text
.54
```

This is invalid SemVer and caused `tauri ios build` to fail with an error similar to:

```text
failed to parse ... as semver: bundle version "4" prerelease is invalid
```
