### PR TITLE
fix(cli): associate Windows beforeDevCommand with kill-on-close job object (fix #15930)

### DIFF
--- a/.changes/windows-before-dev-job-object.md
+++ b/.changes/windows-before-dev-job-object.md
@@ -1,0 +1,5 @@
+---
+"tauri-cli": "patch:bug"
+---
+
+Associate the Windows `beforeDevCommand` child process tree with a kill-on-close job object so processes are cleanly terminated when `tauri dev` is closed or terminated.

--- a/crates/tauri-cli/Cargo.toml
+++ b/crates/tauri-cli/Cargo.toml
@@ -123,10 +123,13 @@ pretty_assertions = "1"
 [target."cfg(windows)".dependencies.windows-sys]
 version = "0.61"
 features = [
+  "Win32_Foundation",
   "Win32_Security",
   "Win32_Storage_FileSystem",
   "Win32_System_IO",
   "Win32_System_Console",
+  "Win32_System_JobObjects",
+  "Win32_System_Threading",
 ]
 
 [target."cfg(unix)".dependencies]

--- a/crates/tauri-cli/src/dev.rs
+++ b/crates/tauri-cli/src/dev.rs
@@ -34,6 +34,28 @@ mod builtin_dev_server;
 static BEFORE_DEV: OnceLock<SharedChild> = OnceLock::new();
 static KILL_BEFORE_DEV_FLAG: AtomicBool = AtomicBool::new(false);
 
+#[cfg(windows)]
+struct JobObject(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+unsafe impl Send for JobObject {}
+#[cfg(windows)]
+unsafe impl Sync for JobObject {}
+
+#[cfg(windows)]
+impl Drop for JobObject {
+  fn drop(&mut self) {
+    if !self.0.is_null() && self.0 != windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+      unsafe {
+        windows_sys::Win32::Foundation::CloseHandle(self.0);
+      }
+    }
+  }
+}
+
+#[cfg(windows)]
+static BEFORE_DEV_JOB: OnceLock<JobObject> = OnceLock::new();
+
 #[cfg(unix)]
 const KILL_CHILDREN_SCRIPT: &[u8] = include_bytes!("../scripts/kill-children.sh");
 
@@ -205,6 +227,64 @@ pub fn setup(
 
         let child = SharedChild::spawn(&mut command)
           .unwrap_or_else(|_| panic!("failed to run `{before_dev}`"));
+
+        #[cfg(windows)]
+        {
+          unsafe {
+            use windows_sys::Win32::{
+              Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+              System::{
+                JobObjects::{
+                  AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+                  SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+                  JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                },
+                Threading::{OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE},
+              },
+            };
+
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if !job.is_null() && job != INVALID_HANDLE_VALUE {
+              let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+              info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+              let set_info_ok = SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const _,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+              );
+
+              if set_info_ok != 0 {
+                let process = OpenProcess(
+                  PROCESS_SET_QUOTA | PROCESS_TERMINATE,
+                  0,
+                  child.id(),
+                );
+
+                if !process.is_null() && process != INVALID_HANDLE_VALUE {
+                  let assign_ok = AssignProcessToJobObject(job, process);
+                  CloseHandle(process);
+
+                  if assign_ok != 0 {
+                    BEFORE_DEV_JOB.get_or_init(move || JobObject(job));
+                  } else {
+                    log::debug!("Failed to assign beforeDevCommand process to job object");
+                    CloseHandle(job);
+                  }
+                } else {
+                  log::debug!("Failed to open beforeDevCommand process handle for job object");
+                  CloseHandle(job);
+                }
+              } else {
+                log::debug!("Failed to configure kill-on-close limit on job object");
+                CloseHandle(job);
+              }
+            } else {
+              log::debug!("Failed to create job object for beforeDevCommand");
+            }
+          }
+        }
 
         let child = BEFORE_DEV.get_or_init(move || child);
         std::thread::spawn(move || {


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### Description

Closes #15930

On Windows, terminating the `tauri dev` process (e.g., via IDE stop buttons, `taskkill /F`, process wrappers like `concurrently`/nodemon, or libuv parent process exits) terminates the CLI process without executing the graceful Ctrl-C cleanup handler (`kill_before_dev_process`). Because Windows does not have POSIX process groups or `SIGTERM`, the `beforeDevCommand` process tree (`cmd.exe` -> `npm` -> `node vite.js` -> `esbuild.exe`) survives as orphaned processes. The lingering Vite server keeps `localhost:1420` listening, causing subsequent `tauri dev` invocations to fail with `Port 1420 is already in use`.

### Solution

This PR associates the spawned `beforeDevCommand` process with an anonymous Windows Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`:

1. When `beforeDevCommand` is spawned on Windows, an anonymous Job Object is created via `CreateJobObjectW`.
2. The job object is configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` via `SetInformationJobObject`.
3. The child process handle is opened (`PROCESS_SET_QUOTA | PROCESS_TERMINATE`) and assigned to the job object via `AssignProcessToJobObject`.
4. The job object handle is retained in a static `OnceLock<JobObject>` for the lifetime of the CLI process.
5. When the `tauri dev` process exits or is terminated for any reason (including `TerminateProcess`, crashes, taskkill, or normal termination), the Windows kernel automatically closes the job handle and terminates all processes within the job object.
6. The existing graceful Ctrl-C / normal exit `kill_before_dev_process` logic remains intact. If job object creation or assignment fails (e.g., on older or restricted environments), it logs a debug message and gracefully falls back to the existing behavior.

Added `.changes/windows-before-dev-job-object.md` following the covector release guidelines.
Commit is cryptographically signed with Ed25519 SSH key.
