### PR TITLE
fix(cli): install npm plugin packages in the frontend directory (fix #16001)

### DIFF
--- a/.changes/fix-cli-add-npm-frontend-dir.md
+++ b/.changes/fix-cli-add-npm-frontend-dir.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Fix `tauri add` / `tauri remove` installing npm plugin packages into `src-tauri` instead of the frontend directory.

--- a/crates/tauri-cli/src/add.rs
+++ b/crates/tauri-cli/src/add.rs
@@ -116,7 +116,7 @@ pub fn run(options: Options, dirs: &Dirs) -> Result<()> {
         (None, None, None, None) => npm_name,
         _ => crate::error::bail!("Only one of --tag, --rev and --branch can be specified"),
       };
-      manager.install(&[npm_spec], dirs.tauri)?;
+      manager.install(&[npm_spec], dirs.frontend)?;
     }
 
     let _ = acl::permission::add::command(acl::permission::add::Options {

--- a/crates/tauri-cli/src/remove.rs
+++ b/crates/tauri-cli/src/remove.rs
@@ -46,7 +46,7 @@ pub fn command(options: Options) -> Result<()> {
   if !metadata.rust_only {
     if let Some(manager) = frontend_dir.map(PackageManager::from_project) {
       let npm_name = format!("@tauri-apps/plugin-{plugin}");
-      manager.remove(&[npm_name], dirs.tauri)?;
+      manager.remove(&[npm_name], dirs.frontend)?;
     }
 
     acl::permission::rm::command(acl::permission::rm::Options {


### PR DESCRIPTION
`tauri add` / `tauri remove` used `dirs.tauri` as the npm cwd, so pnpm created `package.json` under `src-tauri` instead of the project root.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix(windows): fix race condition in event loop
    - docs: update example for `App::show`
    - feat: add `Window::set_fullscreen`

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/tauri/blob/dev/.changes/README.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` and `cargo clippy` passes.
6. Propose your changes as a draft PR if your work is still in progress.
-->
#### Summary
- `tauri add` / `tauri remove` used `dirs.tauri` as the npm cwd, so pnpm created `package.json`, `pnpm-lock.yaml`, and `node_modules` under `src-tauri` instead of the frontend directory.
- Install and remove npm plugin packages in `dirs.frontend` instead.

Closes #16001