### PR TITLE
feat(tray): expose a stable Windows GUID identity via TrayIconBuilder::guid

### DIFF
--- a/.changes/tray-icon-guid.md
+++ b/.changes/tray-icon-guid.md
@@ -1,0 +1,5 @@
+---
+"tauri": minor:feat
+---
+
+Add `TrayIconBuilder::guid` to register the tray icon with a stable `NOTIFYICONDATA.guidItem` on Windows, so the user's "always show in the taskbar" setting survives updates that move the executable. Bumps `tray-icon` to 0.25.

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -89,7 +89,7 @@ muda = { version = "0.19", default-features = false, features = [
   "serde",
   "gtk",
 ] }
-tray-icon = { version = "0.24", default-features = false, features = [
+tray-icon = { version = "0.25", default-features = false, features = [
   "serde",
   "gtk",
 ], optional = true }

--- a/crates/tauri/src/tray/mod.rs
+++ b/crates/tauri/src/tray/mod.rs
@@ -267,6 +267,27 @@ impl<R: Runtime> TrayIconBuilder<R> {
     self
   }
 
+  /// Set a stable identity GUID for this tray icon, as a UUID in `u128` form.
+  ///
+  /// Windows keys per-icon user settings (most importantly whether the icon is
+  /// pinned to the taskbar or hidden in the overflow) on the icon's identity.
+  /// Without a GUID that identity is the executable path, so the setting is
+  /// lost whenever an update moves the binary (for example installers that use
+  /// per-version directories). With a GUID, and an executable that is
+  /// Authenticode-signed by the same publisher across versions, the setting
+  /// survives.
+  ///
+  /// Use one fixed GUID per tray icon and never share it between two icons
+  /// that can be alive at the same time.
+  ///
+  /// ## Platform-specific:
+  ///
+  /// - **Linux / macOS:** Unsupported.
+  pub fn guid(mut self, guid: u128) -> Self {
+    self.inner = self.inner.with_guid(guid);
+    self
+  }
+
   /// Set the tray icon title.
   ///
   /// ## Platform-specific


### PR DESCRIPTION
## What

Adds `TrayIconBuilder::guid(u128)`, a passthrough for `tray_icon::TrayIconBuilder::with_guid` added in tauri-apps/tray-icon#366, and bumps `tray-icon` to `0.25`.

## Why

Windows keys the per-icon "always show in the taskbar" setting on the icon's identity. Without `NIF_GUID` that identity is the executable path, so any update that moves the binary (installers with per-version directories such as Scoop, Squirrel) turns the icon into a new one and it drops back into the overflow. With a fixed GUID and a same-publisher Authenticode signature, Windows preserves the setting ([NOTIFYICONDATA troubleshooting](https://learn.microsoft.com/windows/win32/api/shellapi/ns-shellapi-notifyicondataw#troubleshooting)). Electron exposes the same knob as `Tray`'s `guid` option.

## Status

**Draft until tray-icon 0.25.0 is published** (release PR tauri-apps/tray-icon#353). The `Cargo.toml` bump will not resolve before then.

Runtime-tested in the Echophrase desktop app through a Cargo patch of both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)