### PR TITLE
fix(runtime-wry): update Wry to 0.57

### DIFF
--- a/.changes/runtime-wry-wry-057.md
+++ b/.changes/runtime-wry-wry-057.md
@@ -1,0 +1,5 @@
+---
+"tauri-runtime-wry": patch:deps
+---
+
+Updated Wry to `0.57`, which avoids installing the browser IPC bridge unless an IPC handler is explicitly configured.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d57d423b3c82e89b9a24ca3091fee61f456a26edbd28d26c65906f4bc1dcd8f"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8890,7 +8899,7 @@ dependencies = [
  "url",
  "uuid",
  "webkit2gtk",
- "webview2-com",
+ "webview2-com 0.38.0",
  "window-vibrancy",
  "windows 0.61.1",
 ]
@@ -9219,7 +9228,7 @@ dependencies = [
  "thiserror 2.0.12",
  "url",
  "webkit2gtk",
- "webview2-com",
+ "webview2-com 0.38.0",
  "windows 0.61.1",
 ]
 
@@ -9243,7 +9252,7 @@ dependencies = [
  "tracing",
  "url",
  "webkit2gtk",
- "webview2-com",
+ "webview2-com 0.38.0",
  "windows 0.61.1",
  "wry",
 ]
@@ -10528,7 +10537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
- "webview2-com-sys",
+ "webview2-com-sys 0.38.0",
  "windows 0.61.1",
  "windows-core 0.61.0",
  "windows-implement",
@@ -10536,10 +10545,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "webview2-com-macros"
-version = "0.8.0"
+name = "webview2-com"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
+checksum = "3f89fca7a704cee10dcb3654c1dbb8941d1783132f1917358af75bec37a7d7e6"
+dependencies = [
+ "webview2-com-macros",
+ "webview2-com-sys 0.39.1",
+ "windows 0.62.0",
+ "windows-core 0.62.0",
+]
+
+[[package]]
+name = "webview2-com-macros"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10555,6 +10576,17 @@ dependencies = [
  "thiserror 2.0.12",
  "windows 0.61.1",
  "windows-core 0.61.0",
+]
+
+[[package]]
+name = "webview2-com-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a07132775117d6065853d9d1178157b8c90e228de47129d6bce2c7edebedfb"
+dependencies = [
+ "thiserror 2.0.12",
+ "windows 0.62.0",
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -11269,15 +11301,15 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1730ab21a962e7ff44df17d20804572beee66d998afc7fcbc3f846a3a12dbda7"
+checksum = "a819957a01b3119af85e638a38d242af76dbc87d130dca67bfd0441072e21ff0"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
- "dirs 6.0.0",
+ "dirs 7.0.0",
  "dom_query",
  "dpi",
  "dunce",
@@ -11305,9 +11337,9 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
- "webview2-com",
- "windows 0.61.1",
- "windows-core 0.61.0",
+ "webview2-com 0.39.1",
+ "windows 0.62.0",
+ "windows-core 0.62.0",
  "windows-version",
  "x11-dl",
 ]

--- a/crates/tauri-runtime-wry/Cargo.toml
+++ b/crates/tauri-runtime-wry/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-wry = { version = "0.56.0", default-features = false, features = [
+wry = { version = "0.57.0", default-features = false, features = [
   "os-webview",
   "linux-body",
 ] }


### PR DESCRIPTION
Updates `tauri-runtime-wry` to Wry 0.57.

Wry 0.57 makes native IPC-handler registration conditional. The Linux WebKitGTK browser-stub follow-up is tracked separately in tauri-apps/wry#1839; downstream isolation users can pin that exact revision until a Wry patch release is available.

Coordinated with zackees/kernal-api#18.